### PR TITLE
Fix missing overview dots for dynamic analysis

### DIFF
--- a/overview.php
+++ b/overview.php
@@ -668,12 +668,12 @@ function gather_static_data($start_date, $end_date, $group_id)
 
 function sanitize_string($input_string)
 {
-  // replace spaces with underscores
+  // replace various chars that trip up javascript with underscores.
   $retval = str_replace(" ", "_", $input_string);
-  // replace - with _
   $retval = str_replace("-", "_", $retval);
-  // replace . with _
   $retval = str_replace(".", "_", $retval);
+  $retval = str_replace("(", "_", $retval);
+  $retval = str_replace(")", "_", $retval);
   return $retval;
 }
 


### PR DESCRIPTION
This commit fixes a bug where no dots appear on the dynamic analysis plots when there are zero defects for a given day.
