### PR TITLE
Prevent compiler output from becoming too long.

### DIFF
--- a/common.css
+++ b/common.css
@@ -1269,6 +1269,7 @@ textarea {
   font-family: Courier New, Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono, monospace;
   border: 1px inset #ccc;
   overflow-x:scroll;
+  max-height:350px;
 }
 
 /* used in overview.php */


### PR DESCRIPTION
Re-introduce scrollbars for stdout / stderr on viewBuildError.php if the output exceeds 350 pixels in height.
