### PR TITLE
Remove build name from default nightly sort list

### DIFF
--- a/index.php
+++ b/index.php
@@ -172,10 +172,10 @@ function add_default_buildgroup_sortlist($groupname)
   switch($st)
     {
     case 'SortAsNightly':
-      $xml .= add_XML_value("sortlist", "{sortlist: [[4,1],[7,1],[11,1],[10,1],[5,1],[8,1],[1,0]]}");
+      $xml .= add_XML_value("sortlist", "{sortlist: [[4,1],[7,1],[11,1],[10,1],[5,1],[8,1]]}");
         // Theoretically, most important to least important:
         //   configure errors DESC, build errors DESC, tests failed DESC, tests not run DESC,
-        //   configure warnings DESC, build warnings DESC, build name ASC
+        //   configure warnings DESC, build warnings DESC
       break;
 
     case 'SortByTime':


### PR DESCRIPTION
Before this commit, rows for expected builds that did not yet submit
were scattered throughout their group.  This is due to the fact that
by default, we are sorting by build name.  I'm not 100% sure, but
my guess is that this change in behavior from previous versions of
CDash is due to a jquery version upgrade.
