### PR TITLE
New options to speedup submission processing.

### DIFF
--- a/cdash/config.php
+++ b/cdash/config.php
@@ -44,6 +44,8 @@ $CDASH_TESTING_MODE = false;
 $CDASH_TESTING_RENAME_LOGS = false;
 // Should we use asynchronous submission
 $CDASH_ASYNCHRONOUS_SUBMISSION = false;
+// How long to keep finished async submissions in the DB
+$CDASH_ASYNC_EXPIRATION_TIME = 691200; // 8 days.
 // Main title and subtitle for the index page
 $CDASH_MAININDEX_TITLE = 'CDash';
 $CDASH_MAININDEX_SUBTITLE = 'Projects';
@@ -152,6 +154,10 @@ $CDASH_LARGE_TEXT_LIMIT = '0';
 // for Google oauth2 support
 $GOOGLE_CLIENT_ID = '';
 $GOOGLE_CLIENT_SECRET = '';
+
+// Should we use CDash's feed feature?  Disabling this feature can improve
+// submission processing time.
+$CDASH_ENABLE_FEED = 1;
 
 /** DO NOT EDIT AFTER THIS LINE */
 $localConfig = dirname(__FILE__).'/config.local.php';

--- a/cdash/do_submit.php
+++ b/cdash/do_submit.php
@@ -95,8 +95,12 @@ function do_submit($filehandle, $projectid, $expected_md5='', $do_checksum=true,
     sendemail($handler, $projectid);
     }
 
-  // Create the RSS feed
-  CreateRSSFeed($projectid);
+  global $CDASH_ENABLE_FEED;
+  if ($CDASH_ENABLE_FEED)
+    {
+    // Create the RSS feed
+    CreateRSSFeed($projectid);
+    }
 }
 
 /** Asynchronous submission */

--- a/cdash/processsubmissions.php
+++ b/cdash/processsubmissions.php
@@ -395,20 +395,19 @@ function ProcessSubmissions($projectid)
 }
 
 
-// Retire submission records after a week. But keep them around for a week
-// to enable analyzing submission timings.
+// Retire submission records after a week (by default).
+// But keep them around for a week to enable analyzing submission timings.
 //
 function DeleteOldSubmissionRecords($projectid)
 {
-  // Number of seconds in an 8-day week:
-  //
-  $seconds = 691200; // == 60 * 60 * 24 * 8;
+  global $CDASH_ASYNC_EXPIRATION_TIME;
 
-  $one_week_ago_utc = gmdate(FMT_DATETIMESTD, time()-$seconds);
+  $delete_time =
+    gmdate(FMT_DATETIMESTD, time() - $CDASH_ASYNC_EXPIRATION_TIME);
 
   $ids = pdo_all_rows_query("SELECT id FROM submission WHERE ".
     "(status=2 OR status=3 OR status=4 OR status=5) AND ".
-    "projectid='$projectid' AND finished<'$one_week_ago_utc' AND ".
+    "projectid='$projectid' AND finished<'$delete_time' AND ".
     "finished!='1980-01-01 00:00:00'");
 
   $count = count($ids);

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -325,7 +325,6 @@ class GCovTarHandler
         }
 
       $this->Labels[$path] = $source["labels"];
-      file_put_contents("/tmp/zackdebug.txt", "labels[$path] just got " . print_r($source["labels"], true) . "\n", FILE_APPEND);
       }
     }
 

--- a/xml_handlers/build_handler.php
+++ b/xml_handlers/build_handler.php
@@ -136,8 +136,12 @@ class BuildHandler extends AbstractHandler
 
       $this->Build->ComputeDifferences();
 
-      // Insert the build into the feed
-      $this->Feed->InsertBuild($this->projectid,$this->Build->Id);
+      global $CDASH_ENABLE_FEED;
+      if ($CDASH_ENABLE_FEED)
+        {
+        // Insert the build into the feed
+        $this->Feed->InsertBuild($this->projectid,$this->Build->Id);
+        }
       }
     else if($name=='WARNING' || $name=='ERROR' || $name=='FAILURE')
       {

--- a/xml_handlers/testing_handler.php
+++ b/xml_handlers/testing_handler.php
@@ -284,8 +284,12 @@ class TestingHandler extends AbstractHandler
                                       $this->NumberTestsNotRun);
       $this->Build->ComputeTestTiming();
 
-      // Insert the build into the feed
-      $this->Feed->InsertTest($this->projectid,$this->Build->Id);
+      global $CDASH_ENABLE_FEED;
+      if ($CDASH_ENABLE_FEED)
+        {
+        // Insert the build into the feed
+        $this->Feed->InsertTest($this->projectid,$this->Build->Id);
+        }
       }
     } // end endElement
 

--- a/xml_handlers/update_handler.php
+++ b/xml_handlers/update_handler.php
@@ -110,8 +110,12 @@ class UpdateHandler extends AbstractHandler
       // Insert the update
       $this->Update->Insert();
 
-      // We need to work the magic here to have a good description
-      $this->Feed->InsertUpdate($this->projectid,$buildid);
+      global $CDASH_ENABLE_FEED;
+      if ($CDASH_ENABLE_FEED)
+        {
+        // We need to work the magic here to have a good description
+        $this->Feed->InsertUpdate($this->projectid,$buildid);
+        }
 
       // Compute the update statistics
       $this->Build->ComputeUpdateStatistics();


### PR DESCRIPTION
1) Disable feed.  This takes a relatively long time during the
submission process.

2) Shorten up the backlog of finished submissions.  If this table
gets too many rows, it can take a relatively long time to find the
next submission to process.