### PR TITLE
Introduce the concept of parent builds

### DIFF
--- a/cdash/sendemail.php
+++ b/cdash/sendemail.php
@@ -135,7 +135,7 @@ function check_email_errors($buildid,$checktesttimeingchanged,$testtimemaxstatus
   // Configure errors
   $BuildConfigure = new BuildConfigure();
   $BuildConfigure->BuildId = $buildid;
-  $errors['configure_errors'] = $BuildConfigure->GetNumberOfErrors();
+  $errors['configure_errors'] = $BuildConfigure->ComputeErrors();
 
   // Build errors and warnings
   $Build = new Build();

--- a/coverageRow.xsl
+++ b/coverageRow.xsl
@@ -6,22 +6,55 @@
 <xsl:template name="coverageRow">
    <tr class="child_row">
       <td align="left" class="paddt"><xsl:value-of select="site"/></td>
-      <td align="left" class="paddt"><xsl:value-of select="buildname"/></td>
+
+      <td align="left" class="paddt">
+      <xsl:choose>
+        <xsl:when test="childlink">
+          <a>
+            <xsl:attribute name="href">
+              <xsl:value-of select="childlink"/>
+            </xsl:attribute>
+            <xsl:value-of select="buildname"/>
+          </a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="buildname"/>
+        </xsl:otherwise>
+      </xsl:choose>
+      </td>
+
       <td align="center">
         <xsl:attribute name="class">
-        <xsl:choose>
-          <xsl:when test="percentage >= percentagegreen">
-            normal
-            </xsl:when>
-          <xsl:otherwise>
-            warning
-           </xsl:otherwise>
-        </xsl:choose>
+          <xsl:choose>
+            <xsl:when test="percentage >= percentagegreen">
+              normal
+              </xsl:when>
+            <xsl:otherwise>
+              warning
+             </xsl:otherwise>
+          </xsl:choose>
         </xsl:attribute>
-      <a><xsl:attribute name="href">viewCoverage.php?buildid=<xsl:value-of select="buildid"/></xsl:attribute><xsl:value-of select="percentage"/>%</a>
-      <xsl:if test="percentagediff > 0"><sub>+<xsl:value-of select="percentagediff"/>%</sub></xsl:if>
-      <xsl:if test="percentagediff &lt; 0"><sub><xsl:value-of select="percentagediff"/>%</sub></xsl:if>
+        <a>
+          <xsl:attribute name="href">
+            <xsl:choose>
+              <xsl:when test="childlink">
+                <xsl:value-of select="childlink"/>
+              </xsl:when>
+              <xsl:otherwise>
+                viewCoverage.php?buildid=<xsl:value-of select="buildid"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:attribute>
+          <xsl:value-of select="percentage"/>%
+        </a>
+        <xsl:if test="percentagediff > 0">
+          <sub>+<xsl:value-of select="percentagediff"/>%</sub>
+        </xsl:if>
+        <xsl:if test="percentagediff &lt; 0">
+          <sub><xsl:value-of select="percentagediff"/>%</sub>
+        </xsl:if>
       </td>
+
       <td align="center" ><xsl:value-of select="pass"/>
       <xsl:if test="passdiff > 0"><sub>+<xsl:value-of select="passdiff"/></sub></xsl:if>
       <xsl:if test="passdiff &lt; 0"><sub><xsl:value-of select="passdiff"/></sub></xsl:if>

--- a/coverageRow.xsl
+++ b/coverageRow.xsl
@@ -44,7 +44,8 @@
       <xsl:if test="/cdash/dashboard/displaylabels=1">
         <td class="nob" align="left">
         <xsl:if test="count(labels/label)=0">(none)</xsl:if>
-        <xsl:if test="count(labels/label)!=0"><xsl:value-of select="labels/label"/></xsl:if>
+        <xsl:if test="count(labels/label)=1"><xsl:value-of select="labels/label"/></xsl:if>
+        <xsl:if test="count(labels/label)>1">(<xsl:value-of select="count(labels/label)"/> labels)</xsl:if>
         </td>
       </xsl:if>
    </tr>

--- a/index.php
+++ b/index.php
@@ -625,7 +625,9 @@ function generate_main_dashboard_XML($project_instance, $date)
   if(isset($_GET["parentid"]))
     {
     // If we have a parentid, then we should only show children of that build.
+    // Date becomes irrelevant in this case.
     $parent_clause ="AND (b.parentid = " . qnum($_GET["parentid"]) . ") ";
+    $date_clause = "";
     }
   else
     {

--- a/index.php
+++ b/index.php
@@ -201,7 +201,7 @@ function add_buildgroup_sortlist($groupname)
 }
 
 /** Get a link to a page showing the children of a given parent build. */
-function get_child_builds_hyperlink($parentid, $filterdata, $date)
+function get_child_builds_hyperlink($parentid, $filterdata)
 {
   $baseurl = $_SERVER['REQUEST_URI'];
 
@@ -249,7 +249,7 @@ function get_child_builds_hyperlink($parentid, $filterdata, $date)
     }
 
   // Construct & return our URL.
-  $url = "$baseurl&date=$date&parentid=$parentid";
+  $url = "$baseurl&parentid=$parentid";
   $url .= $existing_filter_params;
   return $url;
 }
@@ -1078,7 +1078,7 @@ function generate_main_dashboard_XML($project_instance, $date)
     if ($countchildren>0)
       {
       $xml .= add_XML_value("multiplebuildshyperlink",
-        get_child_builds_hyperlink($build_array["id"], $filterdata, $gmdate));
+        get_child_builds_hyperlink($build_array["id"], $filterdata));
       }
 
     $xml .= add_XML_value("type", strtolower($build_array["type"]));

--- a/index.xsl
+++ b/index.xsl
@@ -164,11 +164,11 @@
       </xsl:if>
       <div style="float: left; margin: 0px 4px;">
       <a class="buildinfo">
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <xsl:attribute name="href">buildSummary.php?buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
         <xsl:attribute name="href"><xsl:value-of select="multiplebuildshyperlink"/>
         </xsl:attribute>
         </xsl:if>
@@ -187,18 +187,18 @@
      <xsl:text>&#x20;</xsl:text>
 
       <div style="float:left;">
-      <xsl:if test="string-length(note)>0 and countbuildids=1">
+      <xsl:if test="string-length(note)>0 and countchildren=0">
         <a class="advancedviewitem" title="View notes"><xsl:attribute name="href">viewNotes.php?buildid=<xsl:value-of select="buildid"/> </xsl:attribute><img src="images/document.png" alt="Notes" class="icon"/></a>
       </xsl:if>
 
-      <xsl:if test="upload-file-count>0 and countbuildids=1">
+      <xsl:if test="upload-file-count>0 and countchildren=0">
       <a><xsl:attribute name="href">viewFiles.php?buildid=<xsl:value-of select="buildid"/> </xsl:attribute>
          <xsl:attribute name="title"><xsl:value-of select="upload-file-count" /> files uploaded with this build</xsl:attribute>
       <img src="images/package.png" alt="Files" class="icon"/></a>
       </xsl:if>
 
       <!-- If the build has errors or test failing -->
-      <xsl:if test="(compilation/error > 0 or test/fail > 0) and countbuildids=1">
+      <xsl:if test="(compilation/error > 0 or test/fail > 0) and countchildren=0">
       <a href="javascript:;">
       <xsl:attribute name="onclick">javascript:buildinfo_click(<xsl:value-of select="buildid"/>)</xsl:attribute>
       <img src="images/Info.png" alt="info" class="icon"></img>
@@ -214,7 +214,7 @@
       </xsl:if>
 
       <!-- Display the note icon -->
-      <xsl:if test="buildnote>0 and countbuildids=1">
+      <xsl:if test="buildnote>0 and countchildren=0">
       <a name="Build Notes" class="jTip">
       <xsl:attribute name="id">buildnote_<xsl:value-of select="buildid"/></xsl:attribute>
       <xsl:attribute name="href">ajax/buildnote.php?buildid=<xsl:value-of select="buildid"/>&amp;width=350&amp;link=buildSummary.php%3Fbuildid%3D<xsl:value-of select="buildid"/></xsl:attribute>
@@ -223,14 +223,14 @@
       </xsl:if>
 
       <!-- If we have error logs -->
-      <xsl:if test="nerrorlog>0 and countbuildids=1">
+      <xsl:if test="nerrorlog>0 and countchildren=0">
       <a class="tooltip">
       <xsl:attribute name="title"><xsl:value-of select="nerrorlog"/> errors in the CDash log</xsl:attribute>
       <xsl:attribute name="href">viewErrorLog.php?buildid=<xsl:value-of select="buildid"/>&amp;projectid=<xsl:value-of select="/cdash/dashboard/projectid"/>&amp;date=<xsl:value-of select="/cdash/dashboard/date"/></xsl:attribute><img src="images/warningsmall.png" alt="errorlogs" class="icon"/></a>
       </xsl:if>
 
       <!-- If user is admin of the project propose to group this build -->
-      <xsl:if test="/cdash/user/admin=1 and (countbuildids=1 or expected=1)">
+      <xsl:if test="/cdash/user/admin=1 and (countchildren=0 or expected=1)">
         <xsl:if test="string-length(buildid)>0">
         <a>
         <xsl:attribute name="href">javascript:buildgroup_click(<xsl:value-of select="buildid"/>)</xsl:attribute>
@@ -247,13 +247,13 @@
       </div>
 
 
-      <xsl:if test="string-length(buildid)>0 and countbuildids=1">
+      <xsl:if test="string-length(buildid)>0 and countchildren=0">
       <div>
       <xsl:attribute name="id">buildgroup_<xsl:value-of select="buildid"/></xsl:attribute>
       </div>
       </xsl:if>
 
-      <xsl:if test="string-length(expecteddivname)>0 and (countbuildids=1 or expected=1)">
+      <xsl:if test="string-length(expecteddivname)>0 and (countchildren=0 or expected=1)">
       <div>
       <xsl:attribute name="id">infoexpected_<xsl:value-of select="expecteddivname"/></xsl:attribute>
       </div>
@@ -281,14 +281,14 @@
             </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <xsl:if test="userupdates>0"><img src="images/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if><a>
         <xsl:attribute name="href">viewUpdate.php?buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="update/files"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="update/files"/>
         </xsl:if>
       </td>
@@ -310,14 +310,14 @@
            </xsl:when>
         </xsl:choose>
       </xsl:attribute>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewConfigure.php?buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="configure/error"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="configure/error"/>
         </xsl:if>
       <xsl:if test="string-length(configure/error)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
@@ -334,19 +334,19 @@
            </xsl:when>
         </xsl:choose>
       </xsl:attribute>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewConfigure.php?buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="configure/warning"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="configure/warning"/>
         </xsl:if>
       <xsl:if test="string-length(configure/warning)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="configure/nwarningdiff > 0 and countbuildids=1"><sub>+<xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
-      <xsl:if test="configure/nwarningdiff &lt; 0 and countbuildids=1"><sub><xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
+      <xsl:if test="configure/nwarningdiff > 0 and countchildren=0"><sub>+<xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
+      <xsl:if test="configure/nwarningdiff &lt; 0 and countchildren=0"><sub><xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
       </td>
 
 
@@ -373,24 +373,24 @@
        <xsl:if test="compilation/nerrordiffp > 0 or compilation/nerrordiffn > 0">
           <xsl:attribute name="class">valuewithsub</xsl:attribute>
        </xsl:if>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewBuildError.php?buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="compilation/error"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="compilation/error"/>
         </xsl:if>
       <xsl:if test="string-length(compilation/error)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="compilation/nerrordiffp > 0 and countbuildids=1">
+      <xsl:if test="compilation/nerrordiffp > 0 and countchildren=0">
       <a class="sup">
         <xsl:attribute name="href">viewBuildError.php?onlydeltap&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
         +<xsl:value-of select="compilation/nerrordiffp"/>
       </a>
       </xsl:if>
-      <xsl:if test="compilation/nerrordiffn > 0 and countbuildids=1">
+      <xsl:if test="compilation/nerrordiffn > 0 and countchildren=0">
       <a>
       <xsl:attribute name="href">viewBuildError.php?onlydeltan&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
       <span class="sub">-<xsl:value-of select="compilation/nerrordiffn"/></span>
@@ -414,24 +414,24 @@
           <xsl:attribute name="class">valuewithsub</xsl:attribute>
        </xsl:if>
 
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewBuildError.php?type=1&#38;buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="compilation/warning"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="compilation/warning"/>
         </xsl:if>
       <xsl:if test="string-length(compilation/warning)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="compilation/nwarningdiffp > 0 and countbuildids=1">
+      <xsl:if test="compilation/nwarningdiffp > 0 and countchildren=0">
       <a class="sup">
         <xsl:attribute name="href">viewBuildError.php?type=1&#38;onlydeltap&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
         +<xsl:value-of select="compilation/nwarningdiffp"/>
       </a>
       </xsl:if>
-      <xsl:if test="compilation/nwarningdiffn > 0 and countbuildids=1">
+      <xsl:if test="compilation/nwarningdiffn > 0 and countchildren=0">
       <a>
       <xsl:attribute name="href">viewBuildError.php?type=1&#38;onlydeltan&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
       <span class="sub">-<xsl:value-of select="compilation/nwarningdiffn"/></span>
@@ -463,24 +463,24 @@
        <xsl:if test="test/nnotrundiffp > 0 or test/nnotrundiffn > 0">
           <xsl:attribute name="class">valuewithsub</xsl:attribute>
        </xsl:if>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewTest.php?onlynotrun&#38;buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="test/notrun"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="test/notrun"/>
         </xsl:if>
       <xsl:if test="string-length(test/notrun)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="test/nnotrundiffp > 0 and countbuildids=1">
+      <xsl:if test="test/nnotrundiffp > 0 and countchildren=0">
       <a class="sup">
         <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
         +<xsl:value-of select="test/nnotrundiffp"/>
       </a>
       </xsl:if>
-      <xsl:if test="test/nnotrundiffn > 0 and countbuildids=1">
+      <xsl:if test="test/nnotrundiffn > 0 and countchildren=0">
       <span class="sub">-<xsl:value-of select="test/nnotrundiffn"/></span>
       </xsl:if>
       </div>
@@ -501,22 +501,22 @@
        <xsl:if test="test/nfaildiffp > 0 or test/nfaildiffn > 0">
           <xsl:attribute name="class">valuewithsub</xsl:attribute>
        </xsl:if>
-        <xsl:if test="countbuildids=1">
+        <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewTest.php?onlyfailed&#38;buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="test/fail"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="test/fail"/>
         </xsl:if>
       <xsl:if test="string-length(test/fail)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="test/nfaildiffp > 0 and countbuildids=1"><a class="sup">
+      <xsl:if test="test/nfaildiffp > 0 and countchildren=0"><a class="sup">
         <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
         +<xsl:value-of select="test/nfaildiffp"/></a>
       </xsl:if>
-      <xsl:if test="test/nfaildiffn > 0 and countbuildids=1"><span class="sub">-<xsl:value-of select="test/nfaildiffn"/></span>
+      <xsl:if test="test/nfaildiffn > 0 and countchildren=0"><span class="sub">-<xsl:value-of select="test/nfaildiffn"/></span>
       </xsl:if>
       </div>
       </td>
@@ -533,25 +533,25 @@
        <xsl:if test="test/npassdiffp > 0 or test/npassdiffn > 0">
           <xsl:attribute name="class">valuewithsub</xsl:attribute>
        </xsl:if>
-       <xsl:if test="countbuildids=1">
+       <xsl:if test="countchildren=0">
         <a>
         <xsl:attribute name="href">viewTest.php?onlypassed&#38;buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>
           <xsl:value-of select="test/pass"/>
         </a>
         </xsl:if>
-        <xsl:if test="countbuildids!=1">
+        <xsl:if test="countchildren!=0">
           <xsl:value-of select="test/pass"/>
         </xsl:if>
       <xsl:if test="string-length(test/fail)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-      <xsl:if test="test/npassdiffp > 0 and countbuildids=1">
+      <xsl:if test="test/npassdiffp > 0 and countchildren=0">
       <a class="sup">
         <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/>
         </xsl:attribute>+<xsl:value-of select="test/npassdiffp"/>
       </a>
       </xsl:if>
 
-      <xsl:if test="test/npassdiffn > 0 and countbuildids=1">
+      <xsl:if test="test/npassdiffn > 0 and countchildren=0">
       <span class="sub">-<xsl:value-of select="test/npassdiffn"/></span>
       </xsl:if>
       </div>
@@ -591,13 +591,13 @@
            <xsl:when test="string-length(test/timestatus)>0">
              <xsl:value-of select="test/time"/>
              <xsl:if test="string-length(test/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
-             <xsl:if test="test/ntimediffp > 0 and countbuildids=1">
+             <xsl:if test="test/ntimediffp > 0 and countchildren=0">
              <a class="sup">
               <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/>
               </xsl:attribute>+<xsl:value-of select="test/ntimediffp"/>
              </a>
              </xsl:if>
-             <xsl:if test="test/ntimediffn > 0 and countbuildids=1">
+             <xsl:if test="test/ntimediffn > 0 and countchildren=0">
               <span class="sub">-<xsl:value-of select="test/ntimediffn"/></span>
               </xsl:if>
            </xsl:when>

--- a/models/build.php
+++ b/models/build.php
@@ -31,6 +31,7 @@ class Build
   var $Id;
   var $SiteId;
   var $ProjectId;
+  var $ParentId;
   private $Stamp;
   var $Name;
   var $Type;
@@ -129,11 +130,12 @@ class Build
       return false;
       }
 
+    $this->SubProjectName = $subproject;
+
     if(pdo_num_rows($query)>0)
       {
       $query_array = pdo_fetch_array($query);
       $this->SubProjectId = $query_array['id'];
-      $this->SubProjectName = $subproject;
       return $this->SubProjectId;
       }
 
@@ -481,11 +483,25 @@ class Build
         $nbuildwarnings = -1;
         }
 
-      $query = "INSERT INTO build (".$id."siteid,projectid,stamp,name,type,generator,starttime,endtime,submittime,command,log,
-                                   builderrors,buildwarnings)
+      $parentId = 0;
+      $justCreatedParent = false;
+      if ($this->SubProjectName)
+        {
+        $parentId = $this->GetParentBuildId();
+        if ($parentId == 0)
+          {
+          // This is the first subproject to submit for a new build.
+          // Create a new parent build for it.
+          $parentId = $this->CreateParentBuild($nbuilderrors, $nbuildwarnings);
+          $justCreatedParent = true;
+          }
+        }
+      $this->ParentId = $parentId;
+
+      $query = "INSERT INTO build (".$id."siteid,projectid,stamp,name,type,generator,starttime,endtime,submittime,command,log,builderrors,buildwarnings,parentid)
                 VALUES (".$idvalue."'$this->SiteId','$this->ProjectId','$this->Stamp','$this->Name',
                         '$this->Type','$this->Generator','$this->StartTime',
-                        '$this->EndTime','$this->SubmitTime','$this->Command','$this->Log',$nbuilderrors,$nbuildwarnings)";
+                        '$this->EndTime','$this->SubmitTime','$this->Command','$this->Log',$nbuilderrors,$nbuildwarnings, $this->ParentId)";
       if(!pdo_query($query))
         {
         add_last_sql_error("Build Insert",$this->ProjectId,$this->Id);
@@ -505,6 +521,23 @@ class Build
           {
           add_last_sql_error("Build Insert",$this->ProjectId,$this->Id);
           return false;
+          }
+        // Associate the parent with this group too.
+        if ($this->ParentId > 0)
+          {
+          $result = pdo_query(
+            "SELECT groupid FROM build2group WHERE buildid=".qnum($this->ParentId));
+          if(pdo_num_rows($result) == 0)
+            {
+            $query =
+              "INSERT INTO build2group (groupid,buildid)
+               VALUES ('$this->GroupId','$this->ParentId')";
+            if(!pdo_query($query))
+              {
+              add_last_sql_error("Build Insert",$this->ProjectId,$this->ParentId);
+              return false;
+              }
+            }
           }
         }
 
@@ -539,6 +572,12 @@ class Build
         $this->Information->BuildId = $this->Id;
         $this->Information->Save();
         }
+
+      // Update parent's tally of total build errors & warnings.
+      if (!$justCreatedParent)
+        {
+        $this->UpdateParentBuild($nbuilderrors, $nbuildwarnings);
+        }
       }
     else
       {
@@ -571,6 +610,33 @@ class Build
           $nbuilderrors = -1;
           $nbuildwarnings = -1;
           }
+
+      if ($this->SubProjectName)
+        {
+        $newErrors = 0;
+        $newWarnings = 0;
+        if ($nbuilderrors > 0 || $nbuildwarnings > 0)
+          {
+          // If we are adding errors or warnings to this build we need to know
+          // how many builderrors & buildwarnings it had previously so we can
+          // update the parent's tally properly.
+          $priorResult = pdo_single_row_query(
+            "SELECT builderrors, buildwarnings FROM build
+             WHERE id=".qnum($this->Id));
+          if ($priorResult['builderrors'] == -1)
+            {
+            $priorResult['builderrors'] = 0;
+            }
+          if ($priorResult['buildwarnings'] == -1)
+            {
+            $priorResult['buildwarnings'] = 0;
+            }
+          $newErrors = $nbuilderrors - $priorResult['builderrors'];
+          $newWarnings = $nbuildwarnings - $priorResult['buildwarnings'];
+          }
+        $this->ParentId = $this->GetParentBuildId();
+        $this->UpdateParentBuild($newErrors, $newWarnings);
+        }
 
         include('cdash/config.php');
         if($CDASH_DB_TYPE == 'pgsql') // pgsql doesn't have concat...
@@ -686,6 +752,15 @@ class Build
       {
       return;
       }
+
+    // If this is a subproject build, we also have to update its parents test numbers.
+    $newFailed = $numberTestsFailed - $this->GetNumberOfFailedTests();
+    $newNotRun = $numberTestsNotRun - $this->GetNumberOfNotRunTests();
+    $newPassed = $numberTestsPassed - $this->GetNumberOfPassedTests();
+    $this->ParentId = $this->GetParentBuildId();
+    $this->UpdateParentTestNumbers($newFailed, $newNotRun, $newPassed);
+
+    // Update this build's test numbers.
     pdo_query("UPDATE build SET testnotrun='$numberTestsNotRun',
                                 testfailed='$numberTestsFailed',
                                 testpassed='$numberTestsPassed' WHERE id=".qnum($this->Id));
@@ -1445,5 +1520,257 @@ class Build
       }
     return $allUploadedFiles;
     }
+
+  /** Get the parent's build id */
+  function GetParentBuildId()
+    {
+    if(!$this->SiteId || !$this->Name || !$this->Stamp)
+      {
+      return 0;
+      }
+
+    $parent = pdo_single_row_query(
+      "SELECT id FROM build WHERE parentid=-1 AND
+       siteid='$this->SiteId' AND name='$this->Name' AND stamp='$this->Stamp'");
+
+    if ($parent && array_key_exists('id', $parent))
+      {
+      return $parent['id'];
+      }
+    return 0;
+    }
+
+  /** Create a new build as a parent of $this.
+    * Assumes many fields have been set prior to calling this function.
+    **/
+  function CreateParentBuild($numErrors, $numWarnings)
+    {
+    if ($numErrors < 0)
+      {
+      $numErrors = 0;
+      }
+    if ($numWarnings < 0)
+      {
+      $numWarnings = 0;
+      }
+
+    // Create the parent build here.  Note how parent builds
+    // are indicated by parentid == -1.
+    $query = "INSERT INTO build
+      (parentid, siteid, projectid, stamp, name, type, generator,
+       starttime, endtime, submittime, builderrors, buildwarnings)
+      VALUES
+      ('-1','$this->SiteId','$this->ProjectId','$this->Stamp',
+        '$this->Name','$this->Type','$this->Generator',
+        '$this->StartTime','$this->EndTime','$this->SubmitTime',
+        $numErrors,$numWarnings)";
+    if(!pdo_query($query))
+      {
+      add_last_sql_error("Build Insert Parent",$this->ProjectId,$this->Id);
+      return false;
+      }
+
+    $parentId = pdo_insert_id("build");
+
+    // Since we just created a parent we should also update any existing
+    // builds that should be a child of this parent but aren't yet.
+    // This happens when Update.xml is parsed first, because it doesn't
+    // contain info about what subproject it came from.
+    $query =
+      "UPDATE build SET parentid=$parentId
+       WHERE parentid=0 AND siteid='$this->SiteId' AND
+             name='$this->Name' AND stamp='$this->Stamp'";
+    if(!pdo_query($query))
+      {
+      add_last_sql_error(
+        "Build Insert Update Parent",$this->ProjectId,$parentid);
+      }
+
+    return $parentId;
+    }
+
+  /**
+   * Update our parent build so that it is an accurate summary
+   * of all of its subprojects.
+   **/
+  function UpdateParentBuild($newErrors, $newWarnings)
+    {
+    if ($this->ParentId < 1)
+      {
+      return;
+      }
+
+    $clauses = array();
+
+    $parent = pdo_single_row_query(
+      "SELECT builderrors, buildwarnings, starttime, endtime
+       FROM build WHERE id='$this->ParentId'");
+
+    // Check if we need to modify builderrors or buildwarnings.
+    if ($parent['builderrors'] == -1)
+      {
+      $parent['builderrors'] = 0;
+      }
+    if ($parent['buildwarnings'] == -1)
+      {
+      $parent['buildwarnings'] = 0;
+      }
+    if ($newErrors > 0)
+      {
+      $numErrors = $parent['builderrors'] + $newErrors;
+      $clauses[] = "`builderrors` = $numErrors";
+      }
+    if ($newWarnings > 0)
+      {
+      $numWarnings = $parent['buildwarnings'] + $newWarnings;
+      $clauses[] = "`buildwarnings` = $numWarnings";
+      }
+
+    // Check if we need to modify starttime or endtime.
+    if (strtotime($parent['starttime']) > strtotime($this->StartTime))
+      {
+      $clauses[] = "`starttime` = '$this->StartTime'";
+      }
+    if (strtotime($parent['endtime']) < strtotime($this->EndTime))
+      {
+      $clauses[] = "`endtime` = '$this->EndTime'";
+      }
+
+    $num_clauses = count($clauses);
+    if ($num_clauses > 0)
+      {
+      $query = "UPDATE `build` SET " . $clauses[0];
+      for ($i = 1; $i < $num_clauses; $i++)
+        {
+        $query .= ", " . $clauses[$i];
+        }
+      $query .= " WHERE `id` = '$this->ParentId'";
+      if(!pdo_query($query))
+        {
+        add_last_sql_error("UpdateParentBuild",$this->ProjectId,$this->ParentId);
+        return false;
+        }
+      }
+    }
+
+  /** Update the testing numbers for our parent build. */
+  function UpdateParentTestNumbers($newFailed, $newNotRun, $newPassed)
+    {
+    if ($this->ParentId < 1)
+      {
+      return;
+      }
+
+    $numFailed = 0;
+    $numNotRun = 0;
+    $numPassed = 0;
+
+    $parent = pdo_single_row_query(
+      "SELECT testfailed, testnotrun, testpassed
+       FROM build WHERE id=".qnum($this->ParentId));
+
+    // Don't let the -1 default value screw up our math.
+    if ($parent['testfailed'] == -1)
+      {
+      $parent['testfailed'] = 0;
+      }
+    if ($parent['testnotrun'] == -1)
+      {
+      $parent['testnotrun'] = 0;
+      }
+    if ($parent['testpassed'] == -1)
+      {
+      $parent['testpassed'] = 0;
+      }
+
+    $numFailed = $newFailed + $parent['testfailed'];
+    $numNotRun = $newNotRun + $parent['testnotrun'];
+    $numPassed = $newPassed + $parent['testpassed'];
+
+    pdo_query(
+      "UPDATE build SET testnotrun='$numNotRun',
+                        testfailed='$numFailed',
+                        testpassed='$numPassed'
+                    WHERE id=".qnum($this->ParentId));
+
+    add_last_sql_error("Build:UpdateParentTestNumbers",$this->ProjectId,$this->Id);
+
+    // NOTE: as far as I can tell, build.testtimestatusfailed isn't used,
+    // so for now it isn't being updated for parent builds.
+    }
+
+  /** Set number of configure warnings for this build. */
+  function SetNumberOfConfigureWarnings($numWarnings)
+    {
+    if(!$this->Id || !is_numeric($this->Id))
+      {
+      return;
+      }
+
+    pdo_query(
+      "UPDATE build SET configurewarnings='$numWarnings'
+                    WHERE id=".qnum($this->Id));
+
+    add_last_sql_error("Build:SetNumberOfConfigureWarnings",
+      $this->ProjectId,$this->Id);
+    }
+
+  /** Set number of configure errors for this build. */
+  function SetNumberOfConfigureErrors($numErrors)
+    {
+    if(!$this->Id || !is_numeric($this->Id))
+      {
+      return;
+      }
+
+    pdo_query(
+      "UPDATE build SET configureerrors='$numErrors'
+                    WHERE id=".qnum($this->Id));
+
+    add_last_sql_error("Build:SetNumberOfConfigureErrors",
+      $this->ProjectId,$this->Id);
+    }
+
+  /**
+    * Update the tally of configure errors & warnings for this build's
+    * parent.
+   **/
+  function UpdateParentConfigureNumbers($newWarnings, $newErrors)
+    {
+    $this->ParentId = $this->GetParentBuildId();
+    if ($this->ParentId < 1)
+      {
+      return;
+      }
+
+    $numErrors = 0;
+    $numWarnings = 0;
+
+    $parent = pdo_single_row_query(
+      "SELECT configureerrors, configurewarnings
+       FROM build WHERE id=".qnum($this->ParentId));
+
+    // Don't let the -1 default value screw up our math.
+    if ($parent['configureerrors'] == -1)
+      {
+      $parent['configureerrors'] = 0;
+      }
+    if ($parent['configurewarnings'] == -1)
+      {
+      $parent['configurewarnings'] = 0;
+      }
+
+    $numErrors = $newErrors + $parent['configureerrors'];
+    $numWarnings = $newWarnings + $parent['configurewarnings'];
+
+    pdo_query(
+      "UPDATE build SET configureerrors='$numErrors',
+                        configurewarnings='$numWarnings'
+                    WHERE id=".qnum($this->ParentId));
+
+    add_last_sql_error("Build:UpdateParentConfigureNumbers",
+      $this->ProjectId,$this->Id);
+    }
+
 } // end class Build
 ?>

--- a/models/build.php
+++ b/models/build.php
@@ -139,9 +139,22 @@ class Build
       return $this->SubProjectId;
       }
 
-    add_log('Could not retrieve SubProjectId for subproject: '.$subproject,'Build::SetSubProject',LOG_ERR,
-            $this->ProjectId,$this->Id,CDASH_OBJECT_BUILD,$this->Id);
-    return false;
+    // If the subproject wasn't found, add it here.
+    // A proper Project.xml file will still need to be uploaded later to
+    // load dependency data.
+    $subProject = new SubProject();
+    $subProject->SetProjectId($this->ProjectId);
+    $subProject->Name = $subproject;
+    $subProject->Save();
+
+    // Insert the label too.
+    $Label = new Label;
+    $Label->Text = $subProject->Name;
+    $Label->Insert();
+
+    add_log('New subproject detected: '.$subproject,'Build::SetSubProject',
+            LOG_INFO, $this->ProjectId,$this->Id,CDASH_OBJECT_BUILD,$this->Id);
+    return true;
     }
 
   /** Return the subproject id */

--- a/models/buildtest.php
+++ b/models/buildtest.php
@@ -32,13 +32,13 @@ class BuildTest
     {
     if(!$this->BuildId)
       {
-      add_log('BuildId is not set','BuildTest::Insert()',LOG_ERR,0,$buildid);
+      add_log('BuildId is not set','BuildTest::Insert()',LOG_ERR,0,0);
       return false;
       }
 
     if(!$this->TestId)
       {
-      add_log('TestId is not set','BuildTest::Insert()',LOG_ERR,0,$buildid);
+      add_log('TestId is not set','BuildTest::Insert()',LOG_ERR,0,$this->BuildId);
       return false;
       }
     

--- a/models/coveragefilelog.php
+++ b/models/coveragefilelog.php
@@ -26,6 +26,7 @@ class CoverageFileLog
   function __construct()
     {
     $this->Lines = array();
+    $this->Branches = array();
     }
 
   function AddLine($number,$code)

--- a/models/project.php
+++ b/models/project.php
@@ -930,7 +930,8 @@ class Project
     }
 
   /** Get the number of warning builds given a date range */
-  function GetNumberOfWarningBuilds($startUTCdate,$endUTCdate)
+  function GetNumberOfWarningBuilds($startUTCdate, $endUTCdate,
+                                    $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -938,14 +939,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT count(*) FROM build,build2group,buildgroup
-                          WHERE build.projectid=".qnum($this->Id).
-                          " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'
-                           AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.buildwarnings>0");
+    $query = "SELECT count(*) FROM build,build2group,buildgroup
+              WHERE build.projectid=".qnum($this->Id)."
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'
+              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND build.buildwarnings>0";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
 
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfWarningBuilds",$this->Id);
@@ -957,7 +963,8 @@ class Project
     }
 
   /** Get the number of error builds given a date range */
-  function GetNumberOfErrorBuilds($startUTCdate,$endUTCdate)
+  function GetNumberOfErrorBuilds($startUTCdate, $endUTCdate,
+                                  $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -966,14 +973,20 @@ class Project
       }
 
     // build failures
-    $project = pdo_query("SELECT count(*) FROM build,build2group,buildgroup
-                          WHERE build.projectid=".qnum($this->Id).
-                          " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'
-                           AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.builderrors>0");
+    $query =
+      "SELECT count(*) FROM build,build2group,buildgroup
+       WHERE build.projectid=".qnum($this->Id)."
+       AND build.starttime>'$startUTCdate'
+       AND build.starttime<='$endUTCdate'
+       AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+       AND buildgroup.includesubprojectotal=1
+       AND build.builderrors>0";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
 
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfErrorBuilds",$this->Id);
@@ -985,7 +998,8 @@ class Project
     }
 
   /** Get the number of failing builds given a date range */
-  function GetNumberOfPassingBuilds($startUTCdate,$endUTCdate)
+  function GetNumberOfPassingBuilds($startUTCdate, $endUTCdate,
+                                    $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -993,16 +1007,20 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT count(*) FROM build,build2group,buildgroup
-                          WHERE build.projectid=".qnum($this->Id).
-                          " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'
-                           AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.builderrors=0
-                           AND build.buildwarnings=0
-                           ");
+    $query = "SELECT count(*) FROM build,build2group,buildgroup
+              WHERE build.projectid=".qnum($this->Id)."
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'
+              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND build.builderrors=0
+              AND build.buildwarnings=0";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
 
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfPassingBuilds",$this->Id);
@@ -1013,7 +1031,8 @@ class Project
     }
 
   /** Get the number of failing configure given a date range */
-  function GetNumberOfWarningConfigures($startUTCdate,$endUTCdate)
+  function GetNumberOfWarningConfigures($startUTCdate, $endUTCdate,
+                                        $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1021,14 +1040,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT count(*) FROM build,configure,build2group,buildgroup
-                          WHERE  configure.buildid=build.id  AND build.projectid=".qnum($this->Id).
-                         " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'
-                           AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND  configure.warnings>0
-                           ");
+    $query = "SELECT count(*) FROM build,configure,build2group,buildgroup
+              WHERE  configure.buildid=build.id  AND build.projectid=".qnum($this->Id)."
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'
+              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND  configure.warnings>0";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfWarningConfigures",$this->Id);
@@ -1039,7 +1063,8 @@ class Project
     }
 
   /** Get the number of failing configure given a date range */
-  function GetNumberOfErrorConfigures($startUTCdate,$endUTCdate)
+  function GetNumberOfErrorConfigures($startUTCdate, $endUTCdate,
+                                      $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1047,13 +1072,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT count(*) FROM build,configure,buildgroup,build2group
-                          WHERE  configure.buildid=build.id  AND build.projectid=".qnum($this->Id).
-                         " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'
-                           AND configure.status='1'
-                          AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                          AND buildgroup.includesubprojectotal=1");
+    $query = "SELECT count(*) FROM build,configure,buildgroup,build2group
+              WHERE  configure.buildid=build.id  AND build.projectid=".qnum($this->Id)."
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'
+              AND configure.status='1'
+              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfErrorConfigures",$this->Id);
@@ -1064,7 +1095,8 @@ class Project
     }
 
   /** Get the number of failing configure given a date range */
-  function GetNumberOfPassingConfigures($startUTCdate,$endUTCdate)
+  function GetNumberOfPassingConfigures($startUTCdate, $endUTCdate,
+                                        $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1072,11 +1104,17 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT count(*) FROM configure,build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id).
-                         " AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND configure.buildid=build.id AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate' AND configure.status='0'");
+    $query = "SELECT count(*) FROM configure,build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id)."
+              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND configure.buildid=build.id AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate' AND configure.status='0'";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfPassingConfigures",$this->Id);
@@ -1087,7 +1125,8 @@ class Project
     }
 
   /** Get the number of tests given a date range */
-  function GetNumberOfPassingTests($startUTCdate,$endUTCdate)
+  function GetNumberOfPassingTests($startUTCdate, $endUTCdate,
+                                   $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1095,13 +1134,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT SUM(build.testpassed) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id).
-                         " AND build2group.buildid=build.id
-                           AND build.testpassed>=0
-                           AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'");
+    $query = "SELECT SUM(build.testpassed) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id)."
+              AND build2group.buildid=build.id
+              AND build.testpassed>=0
+              AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfPassingTests",$this->Id);
@@ -1112,7 +1157,8 @@ class Project
     }
 
   /** Get the number of tests given a date range */
-  function GetNumberOfFailingTests($startUTCdate,$endUTCdate)
+  function GetNumberOfFailingTests($startUTCdate, $endUTCdate,
+                                   $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1120,13 +1166,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT SUM(build.testfailed) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id).
-                         " AND build2group.buildid=build.id
-                           AND build.testfailed>=0
-                           AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'");
+    $query = "SELECT SUM(build.testfailed) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id)."
+              AND build2group.buildid=build.id
+              AND build.testfailed>=0
+              AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfFailingTests",$this->Id);
@@ -1137,7 +1189,8 @@ class Project
     }
 
   /** Get the number of tests given a date range */
-  function GetNumberOfNotRunTests($startUTCdate,$endUTCdate)
+  function GetNumberOfNotRunTests($startUTCdate, $endUTCdate,
+                                  $childrenOnly=false)
     {
     if(!$this->Id)
       {
@@ -1145,13 +1198,19 @@ class Project
       return false;
       }
 
-    $project = pdo_query("SELECT SUM(build.testnotrun) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id).
-                         " AND build2group.buildid=build.id
-                           AND build.testnotrun>=0
-                           AND build2group.groupid=buildgroup.id
-                           AND buildgroup.includesubprojectotal=1
-                           AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'");
+    $query = "SELECT SUM(build.testnotrun) FROM build,build2group,buildgroup WHERE build.projectid=".qnum($this->Id)."
+              AND build2group.buildid=build.id
+              AND build.testnotrun>=0
+              AND build2group.groupid=buildgroup.id
+              AND buildgroup.includesubprojectotal=1
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'";
+    if ($childrenOnly)
+      {
+      $query .= " AND build.parentid > 0";
+      }
+
+    $project = pdo_query($query);
     if(!$project)
       {
       add_last_sql_error("Project GetNumberOfNotRunTests",$this->Id);

--- a/overview.php
+++ b/overview.php
@@ -529,7 +529,8 @@ function gather_overview_data($start_date, $end_date, $group_id)
                    WHERE b.projectid = '$projectid'
                    AND b.starttime < '$end_date'
                    AND b.starttime >= '$start_date'
-                   AND b2g.groupid = '$group_id'";
+                   AND b2g.groupid = '$group_id'
+                   AND b.parentid > 0";
 
   $builds_array = pdo_query($builds_query);
   add_last_sql_error("gather_overview_data", $group_id);

--- a/overview.php
+++ b/overview.php
@@ -483,7 +483,7 @@ foreach($static_groups as $static_group)
   }
 
 $end = microtime_float();
-$xml .= "<generationtime>".round($end-$start,3)."</generationtime>";
+$xml .= "<generationtime>".round($end-$global_start,3)."</generationtime>";
 $xml .= "</cdash>";
 
 // Now do the xslt transition
@@ -517,20 +517,18 @@ function gather_overview_data($start_date, $end_date, $group_id)
     }
 
   $builds_query = "SELECT b.id, b.builderrors, b.buildwarnings, b.testfailed,
-                   c.status AS configurestatus, c.warnings AS configurewarnings,
+                   b.configureerrors, b.configurewarnings,
                    cs.loctested AS loctested, cs.locuntested AS locuntested,
                    sp.id AS subprojectid, sp.core AS subprojectcore
                    FROM build AS b
                    LEFT JOIN build2group AS b2g ON (b2g.buildid=b.id)
-                   LEFT JOIN configure AS c ON (c.buildid=b.id)
                    LEFT JOIN coveragesummary AS cs ON (cs.buildid=b.id)
                    LEFT JOIN subproject2build AS sp2b ON (sp2b.buildid = b.id)
                    LEFT JOIN subproject as sp ON (sp2b.subprojectid = sp.id)
                    WHERE b.projectid = '$projectid'
-                   AND b.starttime < '$end_date'
-                   AND b.starttime >= '$start_date'
+                   AND b.starttime BETWEEN '$start_date' AND '$end_date'
                    AND b2g.groupid = '$group_id'
-                   AND b.parentid > 0";
+                   AND b.parentid < 1";
 
   $builds_array = pdo_query($builds_query);
   add_last_sql_error("gather_overview_data", $group_id);
@@ -542,9 +540,9 @@ function gather_overview_data($start_date, $end_date, $group_id)
       $num_configure_warnings += $build_row["configurewarnings"];
       }
 
-    if ($build_row["configurestatus"] != 0)
+    if ($build_row["configureerrors"] > 0)
       {
-      $num_configure_errors++;
+      $num_configure_errors += $build_row["configureerrors"];
       }
 
     if ($build_row["buildwarnings"] > 0)

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -19,6 +19,7 @@ CREATE TABLE `build` (
   `id` int(11) NOT NULL auto_increment,
   `siteid` int(11) NOT NULL default '0',
   `projectid` int(11) NOT NULL default '0',
+  `parentid` int(11) NOT NULL default '0',
   `stamp` varchar(255) NOT NULL default '',
   `name` varchar(255) NOT NULL default '',
   `type` varchar(255) NOT NULL default '',
@@ -28,6 +29,8 @@ CREATE TABLE `build` (
   `submittime` timestamp NOT NULL default '1980-01-01 00:00:00',
   `command` text NOT NULL,
   `log` text NOT NULL,
+  `configureerrors` smallint(6) DEFAULT '-1',
+  `configurewarnings` smallint(6) DEFAULT '-1',
   `builderrors` smallint(6) DEFAULT '-1',
   `buildwarnings` smallint(6) DEFAULT '-1',
   `testnotrun` smallint(6) DEFAULT '-1',
@@ -41,7 +44,8 @@ CREATE TABLE `build` (
   KEY `siteid` (`siteid`),
   KEY `stamp` (`stamp`),
   KEY `type` (`type`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `parentid` (`parentid`)
 );
 
 

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -5,6 +5,7 @@ CREATE TABLE "build" (
   "id" serial NOT NULL,
   "siteid" bigint DEFAULT '0' NOT NULL,
   "projectid" bigint DEFAULT '0' NOT NULL,
+  "parentid" bigint DEFAULT '0' NOT NULL,
   "stamp" character varying(255) DEFAULT '' NOT NULL,
   "name" character varying(255) DEFAULT '' NOT NULL,
   "type" character varying(255) DEFAULT '' NOT NULL,
@@ -14,6 +15,8 @@ CREATE TABLE "build" (
   "submittime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
   "command" text NOT NULL,
   "log" text NOT NULL,
+  "configureerrors" smallint DEFAULT '-1',
+  "configurewarnings" smallint DEFAULT '-1',
   "builderrors" smallint DEFAULT '-1',
   "buildwarnings" smallint DEFAULT '-1',
   "testnotrun" smallint DEFAULT '-1',
@@ -29,6 +32,7 @@ CREATE INDEX "siteid" on "build" ("siteid");
 CREATE INDEX "stamp" on "build" ("stamp");
 CREATE INDEX "type" on "build" ("type");
 CREATE INDEX "name" on "build" ("name");
+CREATE INDEX "parentid" on "build" ("parentid");
 
 --
 -- Table: buildgroup

--- a/upgrade.php
+++ b/upgrade.php
@@ -897,7 +897,7 @@ if(isset($_GET['upgrade-2-2']))
   add_log("Upgrade done.","upgrade-2-2");
   return;
   }
-  
+
 // 2.4 Upgrade
 if(isset($_GET['upgrade-2-4']))
   {
@@ -910,7 +910,15 @@ if(isset($_GET['upgrade-2-4']))
   // Support for larger types
   ModifyTableField("buildfailure","workingdirectory","VARCHAR( 512)","VARCHAR( 512 )","",true,false);
   ModifyTableField("buildfailure","outputfile","VARCHAR( 512)","VARCHAR( 512 )","",true,false);
-  
+
+  // Support for parent builds
+  AddTableField('build', 'parentid', 'int(11)', 'int', '0');
+  AddTableIndex('build', 'parentid');
+
+  // Cache configure results similar to build & test
+  AddTableField('build', 'configureerrors', 'smallint(6)', 'smallint', '-1');
+  AddTableField('build', 'configurewarnings', 'smallint(6)', 'smallint', '-1');
+
   // Set the database version
   setVersion();
 

--- a/xml_handlers/configure_handler.php
+++ b/xml_handlers/configure_handler.php
@@ -113,11 +113,24 @@ class ConfigureHandler extends AbstractHandler
         $this->Configure->Delete();
         }
       $this->Configure->Insert();
+
       // Insert errors from the log file
+      $this->Configure->ComputeWarnings();
       $this->Configure->ComputeErrors();
 
       $this->Build->Id = $buildid;
       $this->Build->ComputeConfigureDifferences();
+
+      // Record the number of warnings & errors with the build.
+      $this->Build->SetNumberOfConfigureWarnings(
+        $this->Configure->NumberOfWarnings);
+      $this->Build->SetNumberOfConfigureErrors(
+        $this->Configure->NumberOfErrors);
+
+      // Update the tally of warnings & errors in the parent build,
+      // if applicable.
+      $this->Build->UpdateParentConfigureNumbers(
+        $this->Configure->NumberOfWarnings, $this->Configure->NumberOfErrors);
       }
     else if($name == 'LABEL')
       {


### PR DESCRIPTION
This changes the way that subprojects are handled.

Before this commit, the number of build errors, test failures, etc.
was accumulated across related subproject builds every time index.php
was rendered.

Now this math is only done once at the time of submission.  This
simplifies the logic in index.php, allowing it to render more quickly
while using less memory.  Going forward, it should also allow us to
introduce new subproject features, such as viewing all build errors
across packages for a particular build.