### PR TITLE
Fix calendar background overriding problem

### DIFF
--- a/common.css
+++ b/common.css
@@ -609,31 +609,6 @@ a.grouptrigger:visited{
 
 /* Skin */
 
-/* new jquery tabs */
-.ui-state-default {
-  background: none !important;
-  background-color: #4d75ca !important;
-}
-
-.ui-state-active, .ui-state-hover {
-  background: none !important;
-  background-color: #ffffff !important;
-}
-
-.ui-corner-top a {
-  color: #000000 !important;
-  font-size: 12px !important;
-  font-weight: bold !important;
-  line-height: 1.2 !important;
-  text-align: center !important;
-  white-space: nowrap !important;
-}
-
-.ui-widget-header {
-  background: none !important;
-  background-color: #ececec !important;
-}
-
 /* old jquery tabs */
 
 .tabs-nav {


### PR DESCRIPTION
In common.css, !important is used to override the properties of
jquery-ui CSS settings. However, these break the theme and calendar
is not visible. See the following e-mail for details:

http://public.kitware.com/pipermail/cdash/2015-January/001541.html