### PR TITLE
workaround for cdash mobile script issue

### DIFF
--- a/iphone/index.xsl
+++ b/iphone/index.xsl
@@ -11,7 +11,8 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
         <style type="text/css" media="screen">@import "iphone.css";</style>
          <script type="application/x-javascript" src="jquery-1.1.4.js"></script>
          <script type="application/x-javascript" src="jquery-iphone.js"></script>
-         <script type="application/x-javascript" src="iphone.js"></script>     
+         <script type="application/x-javascript" src="iphone.js"></script>
+         <script src="javascript/jquery.mobile-1.4.0.min.js" type="text/javascript" charset="utf-8"></script>
          </head><body orient="landscape">
 
     <h1 id="pageTitle">CDash</h1>

--- a/testDetails.xsl
+++ b/testDetails.xsl
@@ -42,7 +42,6 @@
   <xsl:call-template name="headscripts"/>
   <!-- Include JavaScript -->
   <script src="javascript/cdashTestGraph.js" type="text/javascript" charset="utf-8"></script>
-  <script src="javascript/jquery.mobile-1.4.0.min.js" type="text/javascript" charset="utf-8"></script>
   <script src="javascript/je_compare-1.0.0.min.js" type="text/javascript" charset="utf-8"></script>
   <link type="text/css" rel="stylesheet" href="javascript/je_compare_style-1.0.0.css" />
 </head>


### PR DESCRIPTION
see mail from mailinglist: http://public.kitware.com/pipermail/cdash/2015-January/001541.html

to sum:

clicking on previous in the top menu then clicking on "current" or "next" was causing an issue which prevents page loading. is that okay if we move jquery.mobile.js file into iphone folder since we do not use it for desktops?

If not, what would be the solution?