### PR TITLE
Add viewing multiple test measurement graphs in one page

### DIFF
--- a/ajax/showtestmeasurementdatagraphviewerphp.php
+++ b/ajax/showtestmeasurementdatagraphviewerphp.php
@@ -1,0 +1,165 @@
+<?php
+/*=========================================================================
+
+  Program:   CDash - Cross-Platform Dashboard System
+  Module:    $Id: showtestmeasurementdatagraphviewerphp.php 3363 2013-09-08 17:44:41Z jjomier $
+  Language:  PHP
+  Date:      $Date: 2013-09-08 19:44:41 +0200 (Sun, 08 Sep 2013) $
+  Version:   $Revision: 3363 $
+
+  Copyright (c) 2002 Kitware, Inc.  All rights reserved.
+  See Copyright.txt or http://www.cmake.org/HTML/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+  Copyright (c) 2014 Volkan Gezer <volkangezer@gmail.com>
+=========================================================================*/
+$cdashpath = str_replace('\\', '/', dirname(dirname(__FILE__)));
+set_include_path($cdashpath . PATH_SEPARATOR . get_include_path());
+
+require_once("cdash/config.php");
+require_once("cdash/pdo.php");
+require_once("cdash/common.php");
+
+$testname = pdo_real_escape_numeric($_GET["test"]);
+$sitename = pdo_real_escape_numeric($_GET["site"]);
+$graph_nr = pdo_real_escape_numeric($_GET["graph"]);
+$starttime = pdo_real_escape_numeric($_GET["starttime"]);
+$endtime = pdo_real_escape_numeric($_GET["endtime"]);
+@$zoomout = $_GET["zoomout"];
+$measurementname = htmlspecialchars(pdo_real_escape_string($_GET["measurement"]));
+
+
+if(!isset($sitename))
+  {
+  echo "Not a valid build!";
+  return;
+  }
+if(!isset($testname))
+  {
+  echo "Not a valid test!";
+  return;
+  }
+if(!isset($measurementname) || !is_string($measurementname))
+  {
+  echo "Not a valid measurementname!";
+  return;
+  }
+
+$db = pdo_connect("$CDASH_DB_HOST", "$CDASH_DB_LOGIN","$CDASH_DB_PASS");
+pdo_select_db("$CDASH_DB_NAME",$db);
+
+// Find the other builds
+$previousbuilds = "SELECT test.id, testmeasurement.name AS mname,
+            test.name AS tname, site.name AS site, build2test.buildid,
+            testmeasurement.value, build.starttime, build.endtime
+            FROM (test, site, build)
+            JOIN testmeasurement ON (testmeasurement.testid = test.id)
+            JOIN build2test ON (build2test.buildid = build.id AND test.id = build2test.testid)
+            WHERE site.id = build.siteid AND testmeasurement.type LIKE '%numeric%'
+            AND test.name='$testname' AND testmeasurement.name='$measurementname' AND site.name='$sitename'
+            ";
+
+if($starttime !== '')
+  {
+  $previousbuilds .= " AND build.starttime >= '$starttime'";
+  }
+if($endtime !== '')
+  {
+  $previousbuilds .= " AND build.endtime <= '$endtime'";
+  }
+
+$previousbuilds=pdo_query($previousbuilds);
+
+    $tarray = array();
+    while($build_array = pdo_fetch_array($previousbuilds))
+      {
+      $t['x'] = strtotime($build_array["starttime"])*1000;
+      $time[] = date("Y-m-d H:i:s",strtotime($build_array["starttime"]));
+      $t['y'] = $build_array["value"];
+      $t['builid'] = $build_array["buildid"];
+      $t['testid'] = $build_array["id"];
+
+      $tarray[]=$t;
+      }
+
+    if(@$_GET['export']=="csv") // If user wants to export as CSV file
+  {
+  header("Cache-Control: public");
+  header("Content-Description: File Transfer");
+  header("Content-Disposition: attachment; filename=".$testname."_".$measurementname.".csv"); // Prepare some headers to download
+  header("Content-Type: application/octet-stream;"); 
+  header("Content-Transfer-Encoding: binary");
+  $filecontent = "Date;$measurementname\n"; // Standard columns
+  for($c=0;$c<count($tarray);$c++) $filecontent .= "{$time[$c]};{$tarray[$c]['y']}\n";
+  echo ($filecontent); // Start file download
+  die; // to suppress unwanted output
+  
+  }
+?>
+&nbsp;
+<script language="javascript" type="text/javascript">
+$(function () {
+    var d1 = [];
+    var buildids = [];
+    var testids = [];
+    <?php
+    $tarray = array_reverse($tarray);
+    foreach($tarray as $axis)
+  {
+  ?>
+      buildids[<?php echo $axis['x']; ?>]=<?php echo $axis['builid']; ?>;
+      testids[<?php echo $axis['x']; ?>]=<?php echo $axis['testid']; ?>;
+      d1.push([<?php echo $axis['x']; ?>,<?php echo $axis['y']; ?>]);
+    <?php
+      $t = $axis['x'];
+      } ?>
+
+  var options = {
+    //bars: { show: true,  barWidth: 35000000, lineWidth:0.9  },
+    lines: { show: true },
+    points: { show: true },
+    xaxis: { mode: "time"},
+    grid: {backgroundColor: "#fffaff",
+      clickable: true,
+      hoverable: true,
+      hoverFill: '#444',
+      hoverRadius: 4
+    },
+    selection: { mode: "xy" },
+    colors: ["#0000FF", "#dba255", "#919733"]
+  };
+
+    var divname = '#graph_holder_<?php echo($graph_nr)?>';
+
+    $(divname).bind("selected", function (event, area) {
+    plot = $.plot($(divname), [{label: <?php echo("\"$measurementname <a href='ajax/showtestmeasurementdatagraphviewerphp.php?test=$testname&site=$sitename&measurement=$measurementname&graph=$graph_nr&export=csv'>Export as CSV</a>\""); ?>, data: d1}],
+           $.extend(true, {}, options, {xaxis: { min: area.x1, max: area.x2 }, yaxis: { min: 0}}));
+
+    });
+
+    $(divname).bind("plotclick", function (e, pos, item) {
+        if (item) {
+            plot.highlight(item.series, item.datapoint);
+            buildid = buildids[item.datapoint[0]];
+            testid = testids[item.datapoint[0]];
+            window.location = "testDetails.php?test="+testid+"&build="+buildid;
+            }
+     });
+
+<?php if(isset($zoomout))
+{
+?>
+    plot = $.plot($(divname),
+                  [{label: <?php echo("\"$measurementname\""); ?> ,data: d1}], options,{xaxis: { min: <?php echo $t-2000000000?>, max: <?php echo $t+50000000; ?>}, yaxis: { min: 0}});
+
+<?php } else { ?>
+    plot = $.plot($(divname),
+                  [{label: <?php echo("\"$measurementname\""); ?> ,data: d1}],
+                  $.extend(true,{}, options, {xaxis: { min: <?php echo $t-2000000000?>, max: <?php echo $t+50000000; ?>}, yaxis: { min: 0}})
+                 );
+<?php }
+?>
+});

--- a/filterdataFunctions.php
+++ b/filterdataFunctions.php
@@ -566,6 +566,60 @@ class ViewTestPhpFilters extends DefaultFilters
   }
 }
 
+class graphViewerphpFilters extends DefaultFilters
+{
+  public function getDefaultFilter()
+  {
+    return array(
+      'field' => 'testname',
+      'fieldtype' => 'string',
+      'compare' => 63,
+      'value' => '',
+    );
+  }
+
+  public function getFilterDefinitionsXML()
+  {
+    $xml = '';
+    $xml .= getFilterDefinitionXML('testname', 'Test Name', 'string', '', '');
+    $xml .= getFilterDefinitionXML('measurement', 'Measurement', 'string', '', '');
+    $xml .= getFilterDefinitionXML('site', 'Site', 'string', '', '');
+
+    return $xml;
+  }
+
+  public function getSqlField($field)
+  {
+  $sql_field = '';
+  switch (strtolower($field))
+  {
+
+    case 'testname':
+    {
+      $sql_field = "test.name";
+    }
+    break;
+
+    case 'site':
+    {
+      $sql_field = "site.name";
+    }
+    break;
+
+    case 'measurement':
+    {
+      $sql_field = "testmeasurement.name";
+    }
+    break;
+
+    default:
+      trigger_error('unknown $field value: ' . $field, E_USER_WARNING);
+    break;
+  }
+  return $sql_field;
+  }
+}
+
 
 // Factory method to create page specific filters:
 //
@@ -596,6 +650,13 @@ function createPageSpecificFilters($page_id)
     case 'viewTest.php':
     {
       return new ViewTestPhpFilters();
+    }
+    break;
+
+    case 'graphViewer.php':
+    case 'showtestmeasurementdatagraphviewerphp.php':
+    {
+      return new graphViewerphpFilters();
     }
     break;
 
@@ -915,7 +976,7 @@ function get_filterdata_from_request($page_id = '')
     @$add = $_REQUEST['add'.$i];
     @$remove = $_REQUEST['remove'.$i];
 
-    $fieldinfo = split('/', $fieldinfo, 2);
+    $fieldinfo = explode('/', $fieldinfo, 2);
     $field = $fieldinfo[0];
     $fieldtype = $fieldinfo[1];
 

--- a/filterdataTemplate.xsl
+++ b/filterdataTemplate.xsl
@@ -160,16 +160,31 @@ Filter Definitions:<br/>
   </td>
   </xsl:if>
   <xsl:if test="cdash/filterdata/showlimit = 1">
-  <td>
-      Limit results to
-      <input type="text" size="3" onblur="filters_onblur(this)" onchange="filters_onchange(this)"
-             id="id_limit" name="limit" align="center">
-        <xsl:attribute name="value"><xsl:value-of select="cdash/filterdata/limit"/></xsl:attribute>
-      </input>
-      rows (0 for unlimited)
-  </td>
+    <xsl:if test="cdash/filterdata/pageId != 'graphViewer.php'">
+    <td>
+        Limit results to
+        <input type="text" size="3" onblur="filters_onblur(this)" onchange="filters_onchange(this)"
+              id="id_limit" name="limit" align="center">
+          <xsl:attribute name="value"><xsl:value-of select="cdash/filterdata/limit"/></xsl:attribute>
+        </input>
+        rows (0 for unlimited)
+    </td>
+    </xsl:if>
   </xsl:if>
   </tr>
+
+  <xsl:if test="cdash/filterdata/pageId = 'graphViewer.php'">
+    <tr>
+    <td>
+      Between (yyyy-mm-dd): <input type='text' id='starttime' name='starttime'>
+                    <xsl:attribute name="value"><xsl:value-of select="cdash/starttime" /></xsl:attribute>
+                  </input>
+      and <input type='text' id='endtime' name='endtime'>
+                    <xsl:attribute name="value"><xsl:value-of select="cdash/endtime" /></xsl:attribute>
+                </input> (leave any field blank to remove limit in that direction).
+    </td>
+    </tr>
+  </xsl:if>
 
   <tr>
     <xsl:attribute name="class">

--- a/graphViewer.php
+++ b/graphViewer.php
@@ -1,0 +1,188 @@
+<?php
+error_reporting(E_ALL ^E_NOTICE);
+/*=========================================================================
+
+  Program:   CDash - Cross-Platform Dashboard System
+  Module:    $Id: graphViewer.php $
+  Language:  PHP
+  Date:      $Date: 2013-07-17 23:38:13 +0200 (Wed, 17 Jul 2013) $
+
+  Copyright (c) 2002 Kitware, Inc.  All rights reserved.
+  See Copyright.txt or http://www.cmake.org/HTML/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+  Copyright (c) 2014 Volkan Gezer <volkangezer@gmail.com>
+=========================================================================*/
+include("cdash/config.php");
+require_once("cdash/pdo.php");
+include('login.php');
+include_once("cdash/common.php");
+include_once("models/project.php");
+require_once("filterdataFunctions.php");
+
+if ($session_OK)
+{
+$projectid = pdo_real_escape_numeric($_REQUEST["projectid"]);
+checkUserPolicy(@$_SESSION['cdash']['loginid'],$projectid);
+
+// Checks
+if(!isset($projectid) || !is_numeric($projectid))
+  {
+  echo "Not a valid projectid!";
+  return;
+  }
+
+if(isset($_REQUEST["value1"]) && strlen($_REQUEST["value1"])>0)
+  {
+  $filtercount = $_REQUEST["filtercount"];
+  }
+else
+  {
+  $filtercount = 0;
+  }
+
+$project = pdo_query("SELECT * FROM project WHERE id='$projectid'");
+if(pdo_num_rows($project)>0)
+  {
+  $project_array = pdo_fetch_array($project);
+  $projectname = $project_array["name"];
+  $nightlytime = $project_array["nightlytime"];
+  }
+
+$starttime=$_POST['starttime'];
+$endtime=$_POST['endtime'];
+
+
+$xml = begin_XML_for_XSLT();
+$xml .= "<backurl>user.php</backurl>";
+$xml .= "<title>CDash - ".$projectname." Graph Viewer</title>";
+$xml .= "<menutitle>".$projectname."</menutitle>";
+$xml .= "<menusubtitle>Graph Viewer</menusubtitle>";
+$xml .= "<date>".date("Y-m-d")."</date>";
+
+$xml .= "<dashboard>";
+$xml .= "<date>".date("Y-m-d")."</date>";
+$xml .= "<projectname>".$projectname."</projectname>";
+$xml .= "<projectname_encoded>".urlencode($projectname)."</projectname_encoded>";
+$xml .= "<projectid>".$projectid."</projectid>";
+$xml .= "</dashboard>";
+
+if($projectid>0)
+  {
+  $Project = new Project;
+  $Project->Id = $projectid;
+  $xml .= "<project>";
+  $xml .= add_XML_value("id",$projectid);
+  $xml .= add_XML_value("name",$Project->GetName());
+  $xml .= add_XML_value("name_encoded",urlencode($Project->GetName()));
+
+  $xml .= "</project>";
+  }
+
+// Menu
+$xml .= "<menu>";
+
+$nightlytime = get_project_property($projectname,"nightlytime");
+$xml .= add_XML_value("back","index.php?project=".urlencode($projectname)."&date=".get_dashboard_date_from_build_starttime($build_array["starttime"],$nightlytime));
+
+  $xml .= add_XML_value("noprevious","1");
+  $xml .= add_XML_value("nonext","1");
+  $xml .= "</menu>";
+  $xml .= add_XML_value("filtercount",$filtercount);
+  if($filtercount>0)
+  {
+  $xml .= add_XML_value("showfilters",1);
+  }
+   {
+   $xml .= "<user>";
+   $userid = $_SESSION['cdash']['loginid'];
+   $user = pdo_query("SELECT admin FROM ".qid("user")." WHERE id='$userid'");
+   $user_array = pdo_fetch_array($user);
+   $xml .= add_XML_value("id",$userid);
+   $xml .= add_XML_value("admin",$user_array["admin"]);
+   $xml .= "</user>";
+   }
+
+// Filters:
+//
+$filterdata = get_filterdata_from_request();
+$filter_sql = $filterdata['sql'];
+$limit_sql = '';
+if ($filterdata['limit']>0)
+{
+  $limit_sql = ' LIMIT '.$filterdata['limit'];
+}
+$xml .= $filterdata['xml'];
+
+if($filter_sql)
+{
+
+  $query = "SELECT test.id, testmeasurement.name AS mname, test.name AS tname, site.name AS site, build2test.buildid,
+            testmeasurement.value, build.starttime, build.endtime
+            FROM (test, site, build)
+            JOIN testmeasurement ON (testmeasurement.testid = test.id)
+            JOIN build2test ON (build2test.buildid = build.id AND test.id = build2test.testid)
+            WHERE site.id = build.siteid AND testmeasurement.type LIKE '%numeric%'";
+  if($starttime !== '')
+    {
+    $query .= " AND build.starttime >= '$starttime'";
+    }
+  if($endtime !== '')
+    {
+    $query .= " AND build.endtime <= '$endtime'";
+    }
+  $query .= "$filter_sql $limit_sql";
+  $result = pdo_query($query);
+
+  $test_list = array();
+  $measurement_list = array();
+  $site_list = array();
+  $graph_array = array();
+  while($row = pdo_fetch_array($result))
+    {
+    if(!in_array($row['mname'],$measurement_list)) $measurement_list[] = $row['mname'];
+    if(!in_array($row['tname'],$test_list)) $test_list[] = $row['tname'];
+    if(!in_array($row['site'],$site_list)) $site_list[] = $row['site'];
+
+    $graph_array[$row['mname']][$row['tname']][$row['site']][]=$row['value'];
+    }
+  $xml .= add_XML_value("starttime", $starttime);
+  $xml .= add_XML_value("endtime", $endtime);
+  if(pdo_num_rows($result) == 0)
+    {
+    $xml .= "<test>";
+    $xml .= add_XML_value("name", "Filters returned no results!");
+    $xml .= "</test>";
+    }
+  foreach($graph_array as $measurement => $tests)
+    {
+    foreach($tests as $test => $computers)
+      {
+      $xml .= "<test>";
+      $xml .= add_XML_value("name", $test);
+      $xml .= add_XML_value("mname", $measurement);
+      foreach($computers as $sitename => $values)
+        {
+        $xml .= "<site>";
+        $xml .= add_XML_value("tname", $test);
+        $xml .= add_XML_value("mname", $measurement);
+        $xml .= add_XML_value("name", $sitename);
+        foreach($values as $index => $value)
+          {
+          $xml .= add_XML_value("value", $value);
+          }
+        $xml .= "</site>";
+        }
+        $xml .= "</test>";
+      }
+    }
+
+}
+$xml .= "</cdash>";
+
+// Now doing the xslt transition
+generate_XSLT($xml,"graphViewer");
+} // end if session
+?>

--- a/graphViewer.xsl
+++ b/graphViewer.xsl
@@ -1,0 +1,144 @@
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
+
+   <xsl:include href="header.xsl"/>
+   <xsl:include href="footer.xsl"/>
+<!--    <xsl:include href="headscripts.xsl"/> -->
+<!--    <xsl:include href="headeradminproject.xsl"/> -->
+
+    <!-- Local includes -->
+   <xsl:include href="local/header.xsl"/>
+   <xsl:include href="local/footer.xsl"/>
+<!--    <xsl:include href="local/headscripts.xsl"/> -->
+<!--    <xsl:include href="local/headeradminproject.xsl"/> -->
+   <xsl:include href="filterdataTemplate.xsl"/>
+<xsl:output method="xml" indent="yes"  doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+   doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
+
+<xsl:template match="/">
+<html>
+<head>
+  <title><xsl:value-of select="cdash/title"/></title>
+  <meta name="robots" content="noindex,nofollow" />
+  <link rel="StyleSheet" type="text/css">
+    <xsl:attribute name="href">
+      <xsl:value-of select="cdash/cssfile"/>
+    </xsl:attribute>
+  </link>
+  <xsl:call-template name="headscripts"/>
+  <script src="javascript/je_compare-1.0.0.min.js" type="text/javascript" charset="utf-8"></script>
+  <script src="javascript/cdashFilters.js" type="text/javascript" charset="utf-8"></script>
+  <script src="javascript/cdashTestGraph.js" type="text/javascript" charset="utf-8"></script>
+</head>
+<script type="text/javascript" language='javascript'>
+function showAllGraphs(zoomout)
+  {
+  <xsl:for-each select="/cdash/test">
+     <xsl:for-each select="site">
+              displaygraph_viewerphp('<xsl:value-of select="mname"/>',
+                                     '<xsl:value-of select="tname"/>',
+                                     '<xsl:value-of select="name"/>',
+                                     '<xsl:value-of select="mname"/><xsl:value-of select="tname"/><xsl:value-of select="name"/>',
+                                     '<xsl:value-of select="/cdash/starttime"/>',
+                                     '<xsl:value-of select="/cdash/endtime"/>',
+                                     zoomout);
+     </xsl:for-each>
+  </xsl:for-each>
+  }
+
+ $(function() {
+    $( "#starttime" ).datepicker({
+      defaultDate: "+0d",
+      changeMonth: true,
+      numberOfMonths: 1,
+      dateFormat: "yy-mm-dd",
+      onClose: function( selectedDate ) {
+        $( "#endtime" ).datepicker( "option", "minDate", selectedDate );
+      }
+    });
+    $( "#endtime" ).datepicker({
+      defaultDate: "+0d",
+      changeMonth: true,
+      numberOfMonths: 1,
+      dateFormat: "yy-mm-dd",
+      onClose: function( selectedDate ) {
+        $( "#starttime" ).datepicker( "option", "maxDate", selectedDate );
+      }
+    });
+  });
+
+ 
+</script>
+<body bgcolor="#ffffff">
+
+<xsl:choose>
+<xsl:when test="/cdash/uselocaldirectory=1">
+  <xsl:call-template name="header_local"/>
+</xsl:when>
+<xsl:otherwise>
+  <xsl:call-template name="header"/>
+</xsl:otherwise>
+</xsl:choose>
+Please set filters to display all graphs based on the search results:
+<a id="label_showfilters" href="javascript:filters_toggle();">
+<xsl:if test="cdash/filterdata/showfilters = 0">Set Filters <xsl:if test="cdash/filtercount > 0"> (<xsl:value-of select="cdash/filtercount"/>)</xsl:if></xsl:if>
+<xsl:if test="cdash/filterdata/showfilters != 0">Hide Filters</xsl:if>
+</a>
+
+<!-- Filters? -->
+<xsl:if test="count(cdash/filterdata) = 1">
+  <xsl:call-template name="filterdata" select="."/>
+</xsl:if>
+
+  <br/>
+  <xsl:if test="/cdash/filtercount > 0">
+    <center>
+      <a href="javascript:showAllGraphs(false)">Display All Graphs</a> -
+      <a href="javascript:showAllGraphs(true)">Zoom Out All Graphs (This may take a while!)</a>
+    </center>
+  </xsl:if>
+<table width="800px" align='center' border='1'>
+  <xsl:for-each select="/cdash/test">
+     <tr><xsl:attribute name="class"><xsl:if test="position() mod 2 = 0">treven</xsl:if><xsl:if test="position() mod 2 = 1">trodd</xsl:if></xsl:attribute>
+     <td>
+           <b><xsl:value-of select="name" /> - <xsl:value-of select="mname" /></b>
+     </td></tr>
+     <xsl:for-each select="site">
+      <tr><xsl:attribute name="class"><xsl:if test="position() mod 2 = 0">treven</xsl:if><xsl:if test="position() mod 2 = 1">trodd</xsl:if></xsl:attribute><td>
+            <i><xsl:value-of select="name" /></i> -
+            <a>
+            <xsl:attribute name="href">
+              javascript:displaygraph_viewerphp('<xsl:value-of select="mname"/>','<xsl:value-of select="tname"/>','<xsl:value-of select="name"/>','<xsl:value-of select="mname"/><xsl:value-of select="tname"/><xsl:value-of select="name"/>','<xsl:value-of select="/cdash/starttime"/>','<xsl:value-of select="/cdash/endtime"/>',false)
+            </xsl:attribute>
+            Show Graph </a><br />
+            <!-- Graph holder -->
+            <div id="graph"></div>
+            <div>
+              <xsl:attribute name="id">graph_options_<xsl:value-of select="mname"/><xsl:value-of select="tname"/><xsl:value-of select="name"/></xsl:attribute>
+            </div>
+            <div>
+              <xsl:attribute name="id">graph_<xsl:value-of select="mname"/><xsl:value-of select="tname"/><xsl:value-of select="name"/></xsl:attribute>
+            </div>
+            <div>
+              <xsl:attribute name="id">graph_holder_<xsl:value-of select="mname"/><xsl:value-of select="tname"/><xsl:value-of select="name"/></xsl:attribute>
+            </div>
+      </td></tr>
+     </xsl:for-each>
+  </xsl:for-each>
+</table>
+
+<!-- FOOTER -->
+<br/>
+
+<xsl:choose>
+<xsl:when test="/cdash/uselocaldirectory=1">
+  <xsl:call-template name="footer_local"/>
+</xsl:when>
+<xsl:otherwise>
+  <xsl:call-template name="footer"/>
+</xsl:otherwise>
+</xsl:choose>
+</body>
+</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/header.xsl
+++ b/header.xsl
@@ -161,6 +161,7 @@
         <li><a><xsl:attribute name="href"><xsl:value-of select="cdash/dashboard/home"/> </xsl:attribute>Home</a></li>
         <li><a><xsl:attribute name="href"><xsl:value-of select="cdash/dashboard/documentation"/> </xsl:attribute>Documentation</a></li>
         <li><a><xsl:attribute name="href"><xsl:value-of select="cdash/dashboard/svn"/> </xsl:attribute>Repository</a></li>
+        <li><a><xsl:attribute name="href">graphViewer.php?projectid=<xsl:value-of select="cdash/dashboard/projectid"/> </xsl:attribute>Graph</a></li>
 
         <li>
           <xsl:if test="string-length(cdash/user/projectrole)>0">

--- a/javascript/cdashTestGraph.js
+++ b/javascript/cdashTestGraph.js
@@ -106,4 +106,23 @@ function displaygraph_selected(buildid,testid,zoomout)
       });
     }
 }
+function displaygraph_viewerphp(measurementname,testname,sitename,graph,starttime,endtime,zoomout)
+{
 
+      $("#graph_holder_"+graph).attr("style","width:800px;height:400px;");
+      if(zoomout)
+        {
+        $("#graph_"+graph).load("ajax/showtestmeasurementdatagraphviewerphp.php?test="+testname+"&site="+sitename+"&measurement="+measurementname+"&graph="+graph+"&starttime="+starttime+"&endtime="+endtime+"&zoomout=1");
+        return;
+        }
+
+        $("#graph_"+graph).fadeIn('slow');
+        $("#graph_"+graph).html("fetching...<img src=images/loading.gif></img>");
+        $("#graph_options_"+graph).html("<a href=javascript:displaygraph_viewerphp('"+measurementname+"','"+testname+"','"+sitename+"','"+graph+"','"+starttime+"','"+endtime+"',true)>Zoom out</a> \n\
+                                  <br/> <a href='ajax/showtestmeasurementdatagraphviewerphp.php?test="+testname+"&site="+sitename+"&measurement="+measurementname+"&graph="+graph+"&starttime="+starttime+"&endtime="+endtime+"&export=csv'>Export as CSV File</a>");
+        $("#graph_"+graph).load("ajax/showtestmeasurementdatagraphviewerphp.php?test="+testname+"&site="+sitename+"&measurement="+measurementname+"&graph="+graph+"&starttime="+starttime+"&endtime="+endtime,{},function(){
+          $("#graph_holder_"+graph).fadeIn('slow');
+          $("#graph_options_"+graph).show();
+          });
+
+}


### PR DESCRIPTION
This patch includes all corrections from the email:
http://public.kitware.com/pipermail/cdash/2014-August/001492.html

What does it do?
- Users can create rules depending on test, site or measurement.
  This makes use of the existing filtering feature which enables
  "contain, start with, etc..." filtering
- Graphs can be limited using a time range
- All graphs can be shown and zoomed out with one click
