### PR TITLE
Change how temporary coverage files are named

### DIFF
--- a/tests/prepend_coverage.php.in
+++ b/tests/prepend_coverage.php.in
@@ -48,12 +48,9 @@ function finish_coverage()
   if ( extension_loaded('xdebug')) {
       $data = xdebug_get_code_coverage();
       xdebug_stop_code_coverage();
-      $file = '@CDASH_COVERAGE_DIR@'. 
-          DIRECTORY_SEPARATOR . md5($_SERVER['SCRIPT_FILENAME']);
-      file_put_contents(
-        $file . '.' . md5(uniqid(rand(), TRUE)) . '.' . $_COOKIE['PHPUNIT_SELENIUM_TEST_ID'],
-        serialize($data)
-      );
+      $file = '@CDASH_COVERAGE_DIR@' . DIRECTORY_SEPARATOR .
+          md5($_SERVER['SCRIPT_FILENAME']) . '.' . md5(uniqid(rand(), TRUE));
+      file_put_contents($file, serialize($data));
   }
 }
 


### PR DESCRIPTION
Don't rely on PHPUNIT_SELENIUM_TEST_ID, which no longer seems to be getting set.  This fixes some PHP errors that we were experiencing during coverage builds.