### PR TITLE
Workaround for older PHP versions without SplFileInfo::getExtension.

### DIFF
--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -86,7 +86,7 @@ class GCovTarHandler
     $iterator->rewind();
     foreach ($iterator as $fileinfo)
       {
-      if ($fileinfo->getExtension() == "gcov")
+      if (pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION) == "gcov")
         {
         $this->ParseGcovFile($fileinfo);
         }


### PR DESCRIPTION
SplFileInfo::getExtension() requires PHP >= 5.3.6.