### PR TITLE
Delete subproject dependencies

### DIFF
--- a/manageSubproject.php
+++ b/manageSubproject.php
@@ -177,6 +177,10 @@ if($projectid>=0)
       
       foreach($dependencies as $dependency)
         {
+        if (!in_array($dependency, $subprojs))
+          {
+          continue;
+          }
         $Dependency = $subprojs[$dependency];
         $xml .= "<dependency>";
         $xml .= add_XML_value("id",$dependency);

--- a/manageSubproject.php
+++ b/manageSubproject.php
@@ -177,7 +177,7 @@ if($projectid>=0)
       
       foreach($dependencies as $dependency)
         {
-        if (!in_array($dependency, $subprojs))
+        if (!array_key_exists($dependency, $subprojs))
           {
           continue;
           }

--- a/models/subproject.php
+++ b/models/subproject.php
@@ -61,11 +61,14 @@ class SubProject
       $keephistory = false;
       }
 
+    // Regardless of whether or not we're performing a "soft delete",
+    // we should remove any dependencies on this subproject.
+    pdo_query(
+      "DELETE FROM subproject2subproject WHERE dependsonid=".qnum($this->Id));
     if(!$keephistory)
       {
       pdo_query("DELETE FROM subproject2build WHERE subprojectid=".qnum($this->Id));
       pdo_query("DELETE FROM subproject2subproject WHERE subprojectid=".qnum($this->Id));
-      pdo_query("DELETE FROM subproject2subproject WHERE dependsonid=".qnum($this->Id));
       pdo_query("DELETE FROM subproject WHERE id=".qnum($this->Id));
       }
     else


### PR DESCRIPTION
When a subproject is removed, we should also remove any dependencies on it.  This fixes a bug that could cause manageSubproject.php to not render.