### PR TITLE
new view for subproject builds

### DIFF
--- a/coverageRow.xsl
+++ b/coverageRow.xsl
@@ -5,23 +5,32 @@
 
 <xsl:template name="coverageRow">
    <tr class="child_row">
-      <td align="left" class="paddt"><xsl:value-of select="site"/></td>
+      <xsl:if test="/cdash/dashboard/childview=0">
+        <td align="left" class="paddt"><xsl:value-of select="site"/></td>
 
-      <td align="left" class="paddt">
-      <xsl:choose>
-        <xsl:when test="childlink">
-          <a>
-            <xsl:attribute name="href">
-              <xsl:value-of select="childlink"/>
-            </xsl:attribute>
+        <td align="left" class="paddt">
+        <xsl:choose>
+          <xsl:when test="childlink">
+            <a>
+              <xsl:attribute name="href">
+                <xsl:value-of select="childlink"/>
+              </xsl:attribute>
+              <xsl:value-of select="buildname"/>
+            </a>
+          </xsl:when>
+          <xsl:otherwise>
             <xsl:value-of select="buildname"/>
-          </a>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="buildname"/>
-        </xsl:otherwise>
-      </xsl:choose>
-      </td>
+          </xsl:otherwise>
+        </xsl:choose>
+        </td>
+      </xsl:if>
+      <xsl:if test="/cdash/dashboard/childview=1">
+        <td align="left" class="paddt">
+          <xsl:if test="count(labels/label)=0">(none)</xsl:if>
+          <xsl:if test="count(labels/label)=1"><xsl:value-of select="labels/label"/></xsl:if>
+          <xsl:if test="count(labels/label)>1">(<xsl:value-of select="count(labels/label)"/> labels)</xsl:if>
+        </td>
+      </xsl:if>
 
       <td align="center">
         <xsl:attribute name="class">
@@ -74,12 +83,14 @@
       </span>
       </td>
 
-      <xsl:if test="/cdash/dashboard/displaylabels=1">
-        <td class="nob" align="left">
-        <xsl:if test="count(labels/label)=0">(none)</xsl:if>
-        <xsl:if test="count(labels/label)=1"><xsl:value-of select="labels/label"/></xsl:if>
-        <xsl:if test="count(labels/label)>1">(<xsl:value-of select="count(labels/label)"/> labels)</xsl:if>
-        </td>
+      <xsl:if test="/cdash/dashboard/childview=0">
+        <xsl:if test="/cdash/dashboard/displaylabels=1">
+          <td class="nob" align="left">
+          <xsl:if test="count(labels/label)=0">(none)</xsl:if>
+          <xsl:if test="count(labels/label)=1"><xsl:value-of select="labels/label"/></xsl:if>
+          <xsl:if test="count(labels/label)>1">(<xsl:value-of select="count(labels/label)"/> labels)</xsl:if>
+          </td>
+        </xsl:if>
       </xsl:if>
    </tr>
 

--- a/indexchildren.xsl
+++ b/indexchildren.xsl
@@ -1,0 +1,1048 @@
+<xsl:stylesheet
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
+
+<xsl:template name="builds">
+  <xsl:param name="type"/>
+
+
+  <xsl:if test="count($type/build)=0">
+    <tr class="table-heading1 table-nobuild">
+      <td colspan="1" class="nob">
+        <h3><a href="#" class="grouptrigger">No <xsl:value-of select="name"/> Builds</a></h3>
+      </td>
+
+      <!-- quick links -->
+      <td align="right" class="nob" colspan="15">
+      <div>
+      <xsl:attribute name="id"><xsl:value-of select="linkname"/></xsl:attribute>
+      </div>
+      <div class="quicklink">
+      <xsl:for-each select="/cdash/buildgroup">
+        <xsl:if test="name!=$type/name">
+        <a>
+        <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+        <xsl:value-of select="name"/></a> |
+        </xsl:if>
+      </xsl:for-each>
+      <a href="#Coverage">Coverage</a> |
+      <a href="#DynamicAnalysis">Dynamic Analysis</a>
+      </div>
+      </td>
+    </tr>
+  </xsl:if>
+
+
+  <xsl:if test="count($type/build)>0">
+    <thead>
+    <tr class="table-heading1" >
+      <td colspan="1" class="nob">
+          <h3><a href="#" class="grouptrigger"><xsl:value-of select="$type/name"/></a></h3>
+      </td>
+      <td align="right" class="nob" colspan="15">
+   <div>
+   <xsl:attribute name="id"><xsl:value-of select="linkname"/></xsl:attribute>
+   </div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+       <xsl:if test="name!=$type/name">
+         <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+      </xsl:if>
+    </xsl:for-each>
+   <a href="#Coverage">Coverage</a> |
+   <a href="#DynamicAnalysis">Dynamic Analysis</a>
+    </div>
+    </td>
+   </tr>
+
+   <tr class="table-heading">
+
+      <th align="center" rowspan="2" width="5%">
+        <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_0</xsl:attribute>
+        SubProject
+      </th>
+
+      <td align="center" colspan="1" width="5%" class="timeheader botl">Update</td>
+      <td align="center" colspan="2" width="10%" class="timeheader botl">Configure</td>
+      <td align="center" colspan="2" width="10%" class="timeheader botl">Build</td>
+      <td align="center" colspan="3" width="15%" class="timeheader botl">Test</td>
+      <td align="center" width="20%" class="timeheader botl"></td>
+   </tr>
+
+   <tr class="table-heading">
+      <th align="center" width="3%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_1</xsl:attribute>
+      Files</th>
+      <th align="center" class="advancedviewitem" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_2</xsl:attribute>
+      Time</th>
+      <th align="center">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_3</xsl:attribute>
+      Error</th>
+      <th align="center">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_4</xsl:attribute>
+      Warn</th>
+      <th align="center" class="advancedviewitem" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_5</xsl:attribute>
+      Time</th>
+      <th align="center">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_6</xsl:attribute>
+      Error</th>
+      <th align="center">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_7</xsl:attribute>
+      Warn</th>
+      <th align="center" class="advancedviewitem" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_8</xsl:attribute>
+      Time</th>
+      <th align="center" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_9</xsl:attribute>
+      Not Run</th>
+      <th align="center" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_10</xsl:attribute>
+      Fail</th>
+      <th align="center" width="5%">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_11</xsl:attribute>
+      Pass</th>
+
+      <th align="center" width="5%" class="advancedviewitem">
+      <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_12</xsl:attribute>
+      Time</th>
+      <th align="center" width="20%">
+        <xsl:attribute name="id">sort<xsl:value-of select="id"/>sort_13</xsl:attribute>
+      Build Time</th>
+   </tr>
+   </thead>
+
+   <tbody>
+     <xsl:for-each select="$type/build">
+   <tr valign="middle">
+
+      <!-- display the label(s) as a link to the build summary -->
+      <td align="left" class="paddt">
+      <xsl:if test="count(labels/label)=0">(none)</xsl:if>
+      <xsl:if test="count(labels/label)=1">
+        <a><xsl:attribute name="href">buildSummary.php?buildid=<xsl:value-of select="buildid"/></xsl:attribute><xsl:value-of select="labels/label"/></a>
+      </xsl:if>
+      <xsl:if test="count(labels/label)>1">(<xsl:value-of select="count(labels/label)"/> labels)</xsl:if>
+
+      <!-- Icon for build errors / test failing -->
+      <xsl:if test="(compilation/error > 0 or test/fail > 0) and countchildren=0">
+      <a href="javascript:;">
+      <xsl:attribute name="onclick">javascript:buildinfo_click(<xsl:value-of select="buildid"/>)</xsl:attribute>
+      <img src="images/Info.png" alt="info" class="icon"></img>
+      </a>
+      </xsl:if>
+      <xsl:if test="string-length(buildid)>0 and countchildren=0">
+      <div>
+      <xsl:attribute name="id">buildgroup_<xsl:value-of select="buildid"/></xsl:attribute>
+      </div>
+      </xsl:if>
+
+      </td>
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="update/errors = 1">
+            error
+            </xsl:when>
+            <xsl:otherwise>
+            <xsl:choose>
+            <xsl:when test="update/warning=1">
+            warning
+            </xsl:when>
+            <xsl:otherwise>
+            <xsl:if test="update/defined=1">
+            normal
+            </xsl:if>
+            </xsl:otherwise>
+            </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+        <xsl:if test="countchildren=0">
+        <xsl:if test="userupdates>0"><img src="images/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if><a>
+        <xsl:attribute name="href">viewUpdate.php?buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="update/files"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="update/files"/>
+        </xsl:if>
+      </td>
+
+      <td align="right" class="advancedviewitem">
+        <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="update/timefull"/>#</span>
+        <xsl:value-of select="update/time"/>
+        <xsl:if test="string-length(update/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      </td>
+
+      <td align="center">
+       <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="configure/error!=0">
+            error
+            </xsl:when>
+           <xsl:when test="string-length(configure/error)>0">
+           normal
+           </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewConfigure.php?buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="configure/error"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="configure/error"/>
+        </xsl:if>
+      <xsl:if test="string-length(configure/error)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      </td>
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="configure/warning > 0">
+            warning
+            </xsl:when>
+           <xsl:when test="string-length(configure/warning)>0">
+           normal
+           </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewConfigure.php?buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="configure/warning"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="configure/warning"/>
+        </xsl:if>
+      <xsl:if test="string-length(configure/warning)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="configure/nwarningdiff > 0 and countchildren=0"><sub>+<xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
+      <xsl:if test="configure/nwarningdiff &lt; 0 and countchildren=0"><sub><xsl:value-of select="configure/nwarningdiff"/></sub></xsl:if>
+      </td>
+
+
+      <td align="center" class="advancedviewitem">
+      <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="configure/timefull"/>#</span>
+      <xsl:value-of select="configure/time"/>
+      <xsl:if test="string-length(configure/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      </td>
+
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="compilation/error > 0">
+            error
+            </xsl:when>
+           <xsl:when test="string-length(compilation/error)>0">
+           normal
+           </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+
+       <div>
+       <xsl:if test="compilation/nerrordiffp > 0 or compilation/nerrordiffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewBuildError.php?buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="compilation/error"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="compilation/error"/>
+        </xsl:if>
+      <xsl:if test="string-length(compilation/error)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="compilation/nerrordiffp > 0 and countchildren=0">
+      <a class="sup">
+        <xsl:attribute name="href">viewBuildError.php?onlydeltap&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+        +<xsl:value-of select="compilation/nerrordiffp"/>
+      </a>
+      </xsl:if>
+      <xsl:if test="compilation/nerrordiffn > 0 and countchildren=0">
+      <a>
+      <xsl:attribute name="href">viewBuildError.php?onlydeltan&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+      <span class="sub">-<xsl:value-of select="compilation/nerrordiffn"/></span>
+      </a>
+      </xsl:if>
+      </div>
+      </td>
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="compilation/warning > 0">
+            warning
+            </xsl:when>
+           <xsl:when test="string-length(compilation/warning)>0">
+           normal
+           </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+       <div>
+       <xsl:if test="compilation/nwarningdiffp > 0 or compilation/nwarningdiffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewBuildError.php?type=1&#38;buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="compilation/warning"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="compilation/warning"/>
+        </xsl:if>
+      <xsl:if test="string-length(compilation/warning)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="compilation/nwarningdiffp > 0 and countchildren=0">
+      <a class="sup">
+        <xsl:attribute name="href">viewBuildError.php?type=1&#38;onlydeltap&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+        +<xsl:value-of select="compilation/nwarningdiffp"/>
+      </a>
+      </xsl:if>
+      <xsl:if test="compilation/nwarningdiffn > 0 and countchildren=0">
+      <a>
+      <xsl:attribute name="href">viewBuildError.php?type=1&#38;onlydeltan&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+      <span class="sub">-<xsl:value-of select="compilation/nwarningdiffn"/></span>
+      </a>
+      </xsl:if>
+      </div>
+
+      </td>
+
+      <td align="center" class="advancedviewitem">
+      <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="compilation/timefull"/>#</span>
+      <xsl:value-of select="compilation/time"/>
+      <xsl:if test="string-length(compilation/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      </td>
+
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="test/notrun > 0">
+            warning
+            </xsl:when>
+            <xsl:when test="string-length(test/notrun)>0">
+            normal
+            </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+      <div>
+       <xsl:if test="test/nnotrundiffp > 0 or test/nnotrundiffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewTest.php?onlynotrun&#38;buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="test/notrun"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="test/notrun"/>
+        </xsl:if>
+      <xsl:if test="string-length(test/notrun)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="test/nnotrundiffp > 0 and countchildren=0">
+      <a class="sup">
+        <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+        +<xsl:value-of select="test/nnotrundiffp"/>
+      </a>
+      </xsl:if>
+      <xsl:if test="test/nnotrundiffn > 0 and countchildren=0">
+      <span class="sub">-<xsl:value-of select="test/nnotrundiffn"/></span>
+      </xsl:if>
+      </div>
+      </td>
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="test/fail > 0">
+            error
+            </xsl:when>
+          <xsl:when test="string-length(test/fail)>0">
+            normal
+          </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+       <div>
+       <xsl:if test="test/nfaildiffp > 0 or test/nfaildiffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+        <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewTest.php?onlyfailed&#38;buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="test/fail"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="test/fail"/>
+        </xsl:if>
+      <xsl:if test="string-length(test/fail)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="test/nfaildiffp > 0 and countchildren=0"><a class="sup">
+        <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute>
+        +<xsl:value-of select="test/nfaildiffp"/></a>
+      </xsl:if>
+      <xsl:if test="test/nfaildiffn > 0 and countchildren=0"><span class="sub">-<xsl:value-of select="test/nfaildiffn"/></span>
+      </xsl:if>
+      </div>
+      </td>
+
+      <td align="center">
+      <xsl:attribute name="class">
+        <xsl:choose>
+             <xsl:when test="string-length(test/pass)>0">
+             normal
+             </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+       <div>
+       <xsl:if test="test/npassdiffp > 0 or test/npassdiffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+       <xsl:if test="countchildren=0">
+        <a>
+        <xsl:attribute name="href">viewTest.php?onlypassed&#38;buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>
+          <xsl:value-of select="test/pass"/>
+        </a>
+        </xsl:if>
+        <xsl:if test="countchildren!=0">
+          <xsl:value-of select="test/pass"/>
+        </xsl:if>
+      <xsl:if test="string-length(test/fail)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+      <xsl:if test="test/npassdiffp > 0 and countchildren=0">
+      <a class="sup">
+        <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/>
+        </xsl:attribute>+<xsl:value-of select="test/npassdiffp"/>
+      </a>
+      </xsl:if>
+
+      <xsl:if test="test/npassdiffn > 0 and countchildren=0">
+      <span class="sub">-<xsl:value-of select="test/npassdiffn"/></span>
+      </xsl:if>
+      </div>
+      </td>
+
+      <td align="center">
+      <xsl:attribute name="class">advancedviewitem
+        <xsl:choose>
+          <xsl:when test="test/timestatus > 0">
+             error
+            </xsl:when>
+             <xsl:when test="string-length(test/timestatus)>0">
+             normal
+             </xsl:when>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:if test="string-length(test/timestatus)=0">
+         <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="test/timefull"/>#</span>
+       </xsl:if>
+      <div>
+       <xsl:if test="test/ntimediffp > 0 or test/ntimediffn > 0">
+          <xsl:attribute name="class">valuewithsub</xsl:attribute>
+       </xsl:if>
+      <xsl:choose>
+          <xsl:when test="test/timestatus > 0">
+             <a><xsl:attribute name="href">viewTest.php?onlytimestatus&#38;buildid=<xsl:value-of select="buildid"/></xsl:attribute><xsl:value-of select="test/timestatus"/></a>
+             <xsl:if test="test/ntimediffp > 0">
+             <a class="sup">
+              <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/>
+              </xsl:attribute>+<xsl:value-of select="test/ntimediffp"/>
+             </a>
+             </xsl:if>
+             <xsl:if test="test/ntimediffn > 0">
+              <span class="sub">-<xsl:value-of select="test/ntimediffn"/></span>
+             </xsl:if>
+          </xsl:when>
+           <xsl:when test="string-length(test/timestatus)>0">
+             <xsl:value-of select="test/time"/>
+             <xsl:if test="string-length(test/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+             <xsl:if test="test/ntimediffp > 0 and countchildren=0">
+             <a class="sup">
+              <xsl:attribute name="href">viewTest.php?onlydelta&#38;buildid=<xsl:value-of select="buildid"/>
+              </xsl:attribute>+<xsl:value-of select="test/ntimediffp"/>
+             </a>
+             </xsl:if>
+             <xsl:if test="test/ntimediffn > 0 and countchildren=0">
+              <span class="sub">-<xsl:value-of select="test/ntimediffn"/></span>
+              </xsl:if>
+           </xsl:when>
+             <xsl:when test="string-length(test/timestatus)=0">
+               <xsl:value-of select="test/time"/>
+               <xsl:if test="string-length(test/time)=0"><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text></xsl:if>
+             </xsl:when>
+        </xsl:choose>
+        </div>
+      </td>
+
+      <td align="center">
+        <xsl:choose>
+        <xsl:when test="string-length(builddate)=0">
+          <span class="builddateelapsed" alt="Expected build">
+           <xsl:attribute name="alt">Expected submit time: <xsl:value-of select="expectedstarttime" /></xsl:attribute>
+           Expected build
+          </span>
+        </xsl:when>
+        <xsl:otherwise>
+        <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="builddatefull"/>#</span>
+        <span class="builddateelapsed">
+           <xsl:attribute name="alt"><xsl:value-of select="builddate"/>
+           <xsl:text disable-output-escaping="yes">&lt;br&gt;</xsl:text>Update time: <xsl:value-of select="update/time"/>
+           <xsl:text disable-output-escaping="yes">&lt;br&gt;</xsl:text>Configure time: <xsl:value-of select="configure/time"/>
+           <xsl:text disable-output-escaping="yes">&lt;br&gt;</xsl:text>Compilation time: <xsl:value-of select="compilation/time"/>
+           <xsl:text disable-output-escaping="yes">&lt;br&gt;</xsl:text>Test time: <xsl:value-of select="test/time"/></xsl:attribute>
+           <xsl:value-of select="builddateelapsed"/>
+        </span>
+        </xsl:otherwise>
+        </xsl:choose>
+      </td>
+
+   </tr>
+  </xsl:for-each>
+  </tbody>
+
+  </xsl:if>
+  <!-- end "count($type/build)>0" -->
+</xsl:template>
+<!-- end template -->
+
+
+   <xsl:include href="filterdataTemplate.xsl"/>
+   <xsl:include href="header.xsl"/>
+   <xsl:include href="footer.xsl"/>
+   <xsl:include href="subprojectGroupCoverage.xsl"/>
+
+   <!-- Include local common files -->
+   <xsl:include href="local/header.xsl"/>
+   <xsl:include href="local/footer.xsl"/>
+
+   <xsl:output method="xml" indent="yes"  doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
+   doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
+
+    <xsl:template match="/">
+      <html>
+       <head>
+       <title><xsl:value-of select="cdash/title"/></title>
+        <meta name="robots" content="noindex,nofollow" />
+         <link rel="StyleSheet" type="text/css">
+         <xsl:attribute name="href"><xsl:value-of select="cdash/cssfile"/></xsl:attribute>
+         </link>
+        <link rel="stylesheet" href="css/bootstrap.min.css"/>
+
+         <!-- Include JavaScript -->
+         <script src="javascript/cdashBuildGroup.js" type="text/javascript" charset="utf-8"></script>
+         <script src="javascript/cdashFilters.js" type="text/javascript" charset="utf-8"></script>
+         <xsl:call-template name="headscripts"/>
+         <script src="javascript/cdashFeed.js" type="text/javascript" charset="utf-8"></script>
+         <script src="javascript/cdashTableCollapse.js" type="text/javascript" charset="utf-8"></script>
+
+       </head>
+       <body bgcolor="#ffffff">
+
+
+<xsl:choose>
+<xsl:when test="/cdash/uselocaldirectory=1">
+  <xsl:call-template name="header_local"/>
+</xsl:when>
+<xsl:otherwise>
+  <xsl:call-template name="header"/>
+</xsl:otherwise>
+</xsl:choose>
+
+<div id="index_content">
+<xsl:if test="cdash/dashboard/future=0">
+
+<xsl:if test="cdash/updates">
+<div id="index_top">
+  <xsl:for-each select="cdash/banner">
+  <div id="banner"><xsl:value-of select="text"/></div>
+  </xsl:for-each>
+
+  <div id="updatechanges">
+    <xsl:if test="cdash/updates/nchanges=-1">No update data</xsl:if>
+    <xsl:if test="cdash/updates/nchanges=0">No file changed</xsl:if>
+    <xsl:if test="cdash/updates/nchanges>0">
+      <a><xsl:attribute name="href"><xsl:value-of select="cdash/updates/url"/></xsl:attribute>
+         <xsl:value-of select="cdash/updates/nchanges"/> file<xsl:if test="cdash/updates/nchanges>1">s</xsl:if>
+          changed  </a>
+         by <xsl:value-of select="cdash/updates/nauthors"/> author<xsl:if test="cdash/updates/nauthors>1">s</xsl:if>
+    </xsl:if>
+         as of
+         <b><xsl:value-of select="cdash/updates/timestamp"/></b>
+  </div>
+
+<div id="settings">
+<img src="images/settings.png"/>
+<ul>
+  <li><a href="" class="advancedview">Advanced View</a></li>
+  <li><a href="" class="autorefresh">Auto-refresh</a></li>
+  <li><a id="label_colorblind" href="javascript:colorblind_toggle();">
+<xsl:if test="cdash/filterdata/colorblind = 0">Colorblind palette</xsl:if>
+<xsl:if test="cdash/filterdata/colorblind != 0">Classic palette</xsl:if>
+</a></li>
+<li>
+<a id="label_showfilters" href="javascript:filters_toggle();">
+<xsl:if test="cdash/filterdata/showfilters = 0">Show Filters</xsl:if>
+<xsl:if test="cdash/filterdata/showfilters != 0">Hide Filters</xsl:if>
+</a>
+</li>
+  <li><a href="" class="showfeed">Hide Feed</a></li>
+  <li><a href="" class="helptrigger">Help</a></li>
+</ul>
+</div>
+
+ <div id="helpmenu">
+         <div class="jqmWindow" id="help">Loading help...</div>
+         <div class="jqmWindow" id="groupsdescription">Loading group description...</div>
+</div>
+
+<!-- Filters? -->
+<xsl:if test="count(cdash/filterdata) = 1">
+  <xsl:call-template name="filterdata" select="."/>
+</xsl:if>
+</div>
+
+<div id="feed"></div>
+
+</xsl:if>
+
+<xsl:if test="cdash/testingdataurl">
+<table width="100%" cellpadding="11" cellspacing="0">
+  <tr>
+    <td height="25" align="left">
+      Testing data for this project can be found at:
+      <a><xsl:attribute name="href"><xsl:value-of select="cdash/testingdataurl"/></xsl:attribute><xsl:value-of select="cdash/testingdataurl"/></a>
+    </td>
+  </tr>
+</table>
+</xsl:if>
+
+
+<!-- Display the site & build name (common to all child builds) -->
+<br/>
+<div id="site" align="left">
+  <b>Site</b>: <a><xsl:attribute name="href">viewSite.php?siteid=<xsl:value-of select="/cdash/siteid"/>&#38;project=<xsl:value-of select="/cdash/dashboard/projectid"/>&#38;currenttime=<xsl:value-of select="/cdash/dashboard/unixtimestamp"/></xsl:attribute><xsl:value-of select="/cdash/site"/></a>
+
+  <xsl:if test="siteoutoforder=1">
+     <img border="0" src="images/flag.png" title="flag"></img>
+  </xsl:if>
+</div>
+
+<div id="buildname" align="left">
+  <b>Build Name</b>:
+  <xsl:value-of select="/cdash/buildname"/>
+  <xsl:if test="string-length(/cdash/buildplatform)>0">
+    <img class="icon" alt="platform">
+        <xsl:attribute name="src">images/platform_<xsl:value-of select="/cdash/buildplatform"/>.png</xsl:attribute>
+    </img>
+  </xsl:if>
+</div>
+<br/>
+
+
+<!-- Display the table dependencies -->
+<xsl:if test="count(cdash/subproject/dependency)>0">
+<table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb">
+<tbody>
+  <tr class="table-heading1">
+      <td colspan="2" class="nob">
+          <h3><a href="#" class="grouptrigger">SubProject Dependencies</a></h3>
+      </td>
+   <!-- quick links -->
+  <td colspan="9" align="right" class="nob">
+   <div id="Coverage">
+   </div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+     <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+    </xsl:for-each>
+    <a href="#DynamicAnalysis">Dynamic Analysis</a>
+    </div>
+    </td>
+   </tr>
+
+   <tr class="table-heading">
+     <td align="center" rowspan="2" width="20%"><b>Project</b></td>
+     <td align="center" colspan="3" width="20%"><b>Configure</b></td>
+     <td align="center" colspan="3" width="20%"><b>Build</b></td>
+     <td align="center" colspan="3" width="20%"><b>Test</b></td>
+     <td align="center" rowspan="2" width="20%" class="nob"><b>Last submission</b></td>
+  </tr>
+   <tr class="table-heading">
+     <td align="center"><b>Error</b></td>
+     <td align="center"><b>Warning</b></td>
+     <td align="center"><b>Pass</b></td>
+     <td align="center"><b>Error</b></td>
+     <td align="center"><b>Warning</b></td>
+     <td align="center"><b>Pass</b></td>
+     <td align="center"><b>Not Run</b></td>
+     <td align="center"><b>Fail</b></td>
+     <td align="center"><b>Pass</b></td>
+  </tr>
+
+  <xsl:for-each select="cdash/subproject/dependency">
+   <tr>
+      <xsl:attribute name="class"><xsl:value-of select="rowparity"/></xsl:attribute>
+      <td align="center" class="paddt"><a>
+       <xsl:attribute name="href">index.php?project=<xsl:value-of select="/cdash/dashboard/projectname_encoded"/>&amp;subproject=<xsl:value-of select="name_encoded"/>&amp;date=<xsl:value-of select="/cdash/dashboard/date"/></xsl:attribute>
+      <xsl:value-of select="name"/>
+      </a></td>
+
+    <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nconfigureerror>0">error</xsl:when>
+          <xsl:otherwise>
+          <xsl:choose>
+          <xsl:when test="nconfigureerror=0 and nconfigurewarning=0 and nconfigurepass=0"></xsl:when>
+          <xsl:otherwise>normal</xsl:otherwise>
+          </xsl:choose></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nconfigureerror!=0 or nconfigurewarning!=0 or nconfigurepass!=0">
+    <xsl:value-of select="nconfigureerror"/>
+    </xsl:if>
+    </td>
+    <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nconfigurewarning>0">warning</xsl:when>
+          <xsl:otherwise>
+          <xsl:choose>
+          <xsl:when test="nconfigureerror=0 and nconfigurewarning=0 and nconfigurepass=0"></xsl:when>
+          <xsl:otherwise>normal</xsl:otherwise>
+          </xsl:choose>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nconfigureerror!=0 or nconfigurewarning!=0 or nconfigurepass!=0">
+    <xsl:value-of select="nconfigurewarning"/>
+    </xsl:if>
+    </td>
+    <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nconfigureerror=0 and nconfigurewarning=0 and nconfigurepass=0"></xsl:when>
+          <xsl:otherwise>normal</xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nconfigureerror!=0 or nconfigurewarning!=0 or nconfigurepass!=0">
+    <xsl:value-of select="nconfigurepass"/>
+    </xsl:if>
+    </td>
+   <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nbuilderror>0">error</xsl:when>
+          <xsl:otherwise><xsl:choose>
+          <xsl:when test="nbuilderror=0 and nbuildwarning=0 and nbuildpass=0"></xsl:when>
+          <xsl:otherwise>normal</xsl:otherwise>
+          </xsl:choose></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nbuilderror!=0 or nbuildwarning!=0 or nbuildpass!=0">
+    <xsl:value-of select="nbuilderror"/>
+    </xsl:if>
+    </td>
+   <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nbuildwarning>0">warning</xsl:when>
+          <xsl:otherwise><xsl:choose>
+          <xsl:when test="nbuilderror=0 and nbuildwarning=0 and nbuildpass=0"></xsl:when>
+          <xsl:otherwise>normal</xsl:otherwise>
+          </xsl:choose></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nbuilderror!=0 or nbuildwarning!=0 or nbuildpass!=0">
+    <xsl:value-of select="nbuildwarning"/>
+    </xsl:if>
+    </td>
+   <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="nbuildpass>0">normal</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="nbuilderror!=0 or nbuildwarning!=0 or nbuildpass!=0">
+    <xsl:value-of select="nbuildpass"/>
+    </xsl:if>
+    </td>
+   <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="ntestnotrun>0">warning</xsl:when>
+          <xsl:otherwise><xsl:choose>
+          <xsl:when test="string-length(ntestnotrun)>0">normal</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+          </xsl:choose></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="ntestfail!=0 or ntestpass!=0 or ntestnotrun!=0">
+    <xsl:value-of select="ntestnotrun"/>
+    </xsl:if>
+    </td>
+  <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="ntestfail>0">error</xsl:when>
+          <xsl:otherwise><xsl:choose>
+          <xsl:when test="string-length(ntestfail)>0">normal</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+          </xsl:choose></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="ntestfail!=0 or ntestpass!=0 or ntestnotrun!=0">
+    <xsl:value-of select="ntestfail"/>
+    </xsl:if>
+    </td>
+  <td align="center">
+    <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="ntestpass>0">normal</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    <xsl:if test="ntestfail!=0 or ntestpass!=0 or ntestnotrun!=0">
+    <xsl:value-of select="ntestpass"/>
+    </xsl:if>
+    </td>
+   <td align="center"  class="nob"><xsl:value-of select="lastsubmission"/></td>
+   </tr>
+  </xsl:for-each>
+</tbody>
+</table>
+</xsl:if>
+
+<!-- Look each group -->
+<xsl:for-each select="cdash/buildgroup">
+  <table border="0" cellpadding="4" cellspacing="0" width="100%">
+  <xsl:attribute name="class">tabb childbuild <xsl:value-of select="sortlist"/></xsl:attribute>
+  <xsl:attribute name="id">project_<xsl:value-of select="/cdash/dashboard/projectid"/>_<xsl:value-of select="id"/></xsl:attribute>
+  <xsl:call-template name="builds">
+  <xsl:with-param name="type" select="."/>
+  </xsl:call-template>
+  </table>
+</xsl:for-each>
+
+<!-- COVERAGE -->
+<table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
+    <xsl:if test="count(cdash/buildgroup/coverage)=0">
+       <tr class="table-heading2 table-nobuild">
+      <td colspan="1" class="nob">
+          <h3><a href="#" class="grouptrigger">No Coverage</a></h3>
+      </td>
+   <!-- quick links -->
+  <td colspan="5" align="right" class="nob">
+   <div id="Coverage">
+   </div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+     <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+    </xsl:for-each>
+    <a href="#DynamicAnalysis">Dynamic Analysis</a>
+    </div>
+    </td>
+   </tr>
+   </xsl:if>
+
+    <xsl:if test="count(cdash/buildgroup/coverage)>0">
+<thead>
+<tr class="table-heading2">
+      <td colspan="1" class="nob">
+          <h3><a href="#" class="grouptrigger">Coverage</a></h3>
+      </td>
+   <!-- quick links -->
+  <td colspan="6" align="right" class="nob">
+   <div id="Coverage">
+   </div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+     <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+    </xsl:for-each>
+    <a href="#DynamicAnalysis">Dynamic Analysis</a>
+    </div>
+    </td>
+   </tr>
+
+   <tr class="table-heading">
+      <th align="center" id="sortcoveragesort_6" width="20%">SubProject</th>
+      <th align="center" width="10%" id="sortcoveragesort_2">Percentage</th>
+      <th align="center"  width="10%" id="sortcoveragesort_3" >LOC Tested</th>
+      <th align="center"  width="10%" id="sortcoveragesort_4">LOC Untested</th>
+      <th align="center" class="nob" width="15%" id="sortcoveragesort_5">Date</th>
+   </tr>
+</thead>
+<tbody id="coveragebody">
+
+  <xsl:choose>
+    <xsl:when test="count(cdash/subprojectgroup)>0">
+      <xsl:call-template name="subprojectGroupCoverage"/>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:for-each select="cdash/buildgroup/coverage">
+        <xsl:call-template name="coverageRow"/>
+      </xsl:for-each>
+    </xsl:otherwise>
+  </xsl:choose>
+
+</tbody>
+</xsl:if>
+</table>
+
+
+<xsl:if test="count(cdash/buildgroup/coverage)>0">
+<table width="100%" cellspacing="0" cellpadding="0">
+<tr>
+<td height="1" colspan="14" align="left" bgcolor="#888888"></td>
+</tr>
+</table>
+</xsl:if>
+
+
+<!-- Dynamic analysis -->
+<table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb child" id="dynamicanalysistable">
+    <xsl:if test="count(cdash/buildgroup/dynamicanalysis)=0">
+   <tr class="table-heading3 table-nobuild" >
+      <td colspan="1" class="nob">
+          <h3><a href="#" class="grouptrigger">No Dynamic Analysis</a></h3>
+      </td>
+   <!-- quick links -->
+  <td colspan="4" align="right" class="nob">
+   <div id="DynamicAnalysis">
+   </div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+      <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+    </xsl:for-each>
+    <a href="#Coverage">Coverage</a>
+    </div>
+    </td>
+   </tr>
+   </xsl:if>
+
+    <xsl:if test="count(cdash/buildgroup/dynamicanalysis)>0">
+  <thead>
+      <tr class="table-heading3">
+      <td colspan="1" class="nob">
+          <h3><a href="#" class="grouptrigger">Dynamic Analysis</a></h3>
+      </td>
+      <!-- quick links -->
+  <td colspan="5" align="right" class="nob">
+   <div id="DynamicAnalysis"></div>
+   <div class="quicklink">
+   <xsl:for-each select="/cdash/buildgroup">
+      <a>
+     <xsl:attribute name="href">#<xsl:value-of select="linkname"/></xsl:attribute>
+     <xsl:value-of select="name"/></a> |
+    </xsl:for-each>
+    <a href="#Coverage">Coverage</a>
+    </div>
+    </td>
+   </tr>
+   <tr class="table-heading">
+      <th align="center" width="20%" id="sortdynanalysissort_0">SubProject</th>
+      <th align="center" width="20%" id="sortdynanalysissort_1">Checker</th>
+      <th align="center" width="10%" id="sortdynanalysissort_2">Defect Count</th>
+      <th align="center" class="nob" width="15%" id="sortdynanalysissort_3">Date</th>
+   </tr>
+</thead>
+<tbody>
+  <xsl:for-each select="cdash/buildgroup/dynamicanalysis">
+
+   <tr>
+      <td align="left">
+        <xsl:if test="count(labels/label)=0">(none)</xsl:if>
+        <xsl:if test="count(labels/label)!=0"><xsl:value-of select="labels/label"/></xsl:if>
+      </td>
+      <td align="center"><xsl:value-of select="checker"/></td>
+      <td align="center">
+        <xsl:attribute name="class">
+        <xsl:choose>
+          <xsl:when test="status!='passed'">
+            error
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:choose>
+            <xsl:when test="defectcount > 0">
+             warning
+            </xsl:when>
+            <xsl:otherwise>
+              normal
+            </xsl:otherwise>
+            </xsl:choose>
+          </xsl:otherwise>
+        </xsl:choose>
+        </xsl:attribute>
+        <a><xsl:attribute name="href">viewDynamicAnalysis.php?buildid=<xsl:value-of select="buildid"/></xsl:attribute><xsl:value-of select="defectcount"/></a>
+      </td>
+      <td align="center" class="nob">
+        <span class="sorttime" style="display:none">sorttime=<xsl:value-of select="datefull"/>#</span>
+        <span class="builddateelapsed">
+          <xsl:attribute name="alt"><xsl:value-of select="date"/></xsl:attribute>
+          <xsl:value-of select="dateelapsed"/>
+        </span>
+      </td>
+   </tr>
+  </xsl:for-each>
+</tbody>
+</xsl:if>
+</table>
+
+<xsl:if test="count(cdash/buildgroup/dynamicanalysis)>0">
+  <table width="100%" cellspacing="0" cellpadding="0">
+  <tr>
+  <td height="1" colspan="14" align="left" bgcolor="#888888"></td>
+  </tr>
+  </table>
+</xsl:if>
+
+<!-- footer  -->
+<xsl:if test="/cdash/uselocaldirectory=1">
+  <xsl:call-template name="coverageheader_local"/>
+</xsl:if>
+
+</xsl:if> <!-- end dashboard is not in the future -->
+
+<xsl:if test="cdash/dashboard/future=1">
+<br/>
+CDash cannot predict the future (yet)...
+<br/>
+</xsl:if> <!-- end dashboard is in the future -->
+</div>
+<!-- FOOTER -->
+<xsl:choose>
+<xsl:when test="/cdash/uselocaldirectory=1">
+  <xsl:call-template name="footer_local"/>
+</xsl:when>
+<xsl:otherwise>
+  <xsl:call-template name="footer"/>
+</xsl:otherwise>
+</xsl:choose>
+        </body>
+      </html>
+    </xsl:template>
+</xsl:stylesheet>

--- a/javascript/cdashTableSorter.js
+++ b/javascript/cdashTableSorter.js
@@ -537,28 +537,52 @@ $(document).ready(function() {
         {
         return;
         }
-       $(this).tablesorter({
-              headers: {
-                  0: { sorter:'buildname'},     // site
-                  1: { sorter:'buildname'},     // build name
-                  2: { sorter:'numericvalue'},  // update files
-                  3: { sorter:'elapsedtime'},   // update time
-                  4: { sorter:'numericvalue'},  // config error
-                  5: { sorter:'numericvalue'},  // config warning
-                  6: { sorter:'elapsedtime'},   // configure time
-                  7: { sorter:'numericvalue'},  // build error
-                  8: { sorter:'numericvalue'},  // build warning
-                  9: { sorter:'elapsedtime'},   // build time
-                  10: { sorter:'numericvalue'}, // tests not run
-                  11: { sorter:'numericvalue'}, // test failed
-                  12: { sorter:'numericvalue'}, // test passed
-                  13: { sorter:'elapsedtime'},  // test time
-                  14: { sorter:'elapsedtime'},  // build time
-                  15: { sorter:'text'}          // labels
-              },
-            debug: false,
-            widgets: ['zebra']
-          });
+
+       if ($(this).hasClass("childbuild")) {
+         $(this).tablesorter({
+                headers: {
+                    0: { sorter:'text'},          // labels
+                    1: { sorter:'numericvalue'},  // update files
+                    2: { sorter:'elapsedtime'},   // update time
+                    3: { sorter:'numericvalue'},  // config error
+                    4: { sorter:'numericvalue'},  // config warning
+                    5: { sorter:'elapsedtime'},   // configure time
+                    6: { sorter:'numericvalue'},  // build error
+                    7: { sorter:'numericvalue'},  // build warning
+                    8: { sorter:'elapsedtime'},   // build time (advanced)
+                    9: { sorter:'numericvalue'},  // tests not run
+                    10: { sorter:'numericvalue'}, // test failed
+                    11: { sorter:'numericvalue'}, // test passed
+                    12: { sorter:'elapsedtime'},  // test time
+                    13: { sorter:'elapsedtime'},  // build time
+                },
+              debug: false,
+              widgets: ['zebra']
+            });
+       } else {
+         $(this).tablesorter({
+                headers: {
+                    0: { sorter:'buildname'},     // site
+                    1: { sorter:'buildname'},     // build name
+                    2: { sorter:'numericvalue'},  // update files
+                    3: { sorter:'elapsedtime'},   // update time
+                    4: { sorter:'numericvalue'},  // config error
+                    5: { sorter:'numericvalue'},  // config warning
+                    6: { sorter:'elapsedtime'},   // configure time
+                    7: { sorter:'numericvalue'},  // build error
+                    8: { sorter:'numericvalue'},  // build warning
+                    9: { sorter:'elapsedtime'},   // build time
+                    10: { sorter:'numericvalue'}, // tests not run
+                    11: { sorter:'numericvalue'}, // test failed
+                    12: { sorter:'numericvalue'}, // test passed
+                    13: { sorter:'elapsedtime'},  // test time
+                    14: { sorter:'elapsedtime'},  // build time
+                    15: { sorter:'text'}          // labels
+                },
+              debug: false,
+              widgets: ['zebra']
+            });
+      }
 
       // Get the cookie
       var cookiename = "cdash_table_sort_"+tableid;
@@ -598,18 +622,32 @@ $(document).ready(function() {
     // Initialize the dynamic analysis table
     $tabs = $("#dynamicanalysistable");
     $tabs.each(function(index) {
-     $(this).tablesorter({
-            headers: {
-                0: { sorter:'text'},
-                1: { sorter:'text'},
-                2: { sorter:'text'},
-                3: { sorter:'numericvalue'}, // not percent but same format
-                4: { sorter:'elapsedtime'},
-                5: { sorter:'text'}
-            },
-          debug: false,
-          widgets: ['zebra']
-        });
+
+     if ($(this).hasClass("child")) {
+       $(this).tablesorter({
+              headers: {
+                  0: { sorter:'text'},
+                  1: { sorter:'text'},
+                  2: { sorter:'numericvalue'}, // not percent but same format
+                  3: { sorter:'elapsedtime'}
+              },
+            debug: false,
+            widgets: ['zebra']
+          });
+     } else {
+       $(this).tablesorter({
+              headers: {
+                  0: { sorter:'text'},
+                  1: { sorter:'text'},
+                  2: { sorter:'text'},
+                  3: { sorter:'numericvalue'}, // not percent but same format
+                  4: { sorter:'elapsedtime'},
+                  5: { sorter:'text'}
+              },
+            debug: false,
+            widgets: ['zebra']
+          });
+     }
       });
     } // end indextable
 

--- a/subprojectGroupCoverage.xsl
+++ b/subprojectGroupCoverage.xsl
@@ -9,8 +9,10 @@
   <xsl:for-each select="cdash/subprojectgroup">
     <xsl:variable name="groupid" select="id"/>
     <tr class="parent_row">
-      <td></td>
-      <td align="left" class="paddt"></td>
+      <td class="paddt" align="left">
+        <b><xsl:value-of select="name"/></b>
+        <div class="glyphicon glyphicon-chevron-down"/>
+      </td>
 
       <td align="center">
         <xsl:attribute name="class"><xsl:choose>
@@ -32,10 +34,6 @@
       </td>
 
       <td align="center"></td>
-      <td class="nob" align="left">
-        <b><xsl:value-of select="name"/></b>
-        <div class="glyphicon glyphicon-chevron-down"/>
-      </td>
     </tr>
 
     <xsl:for-each select="/cdash/buildgroup/coverage[group=$groupid]">


### PR DESCRIPTION
Slightly different look for index.php when you are viewing the children of a single build.  No need to repeat build & site name on each row since it never changes.  Also move the name of the SubProject to the first column.