### PR TITLE
Link to login page when necessary

### DIFF
--- a/api/viewBuildError.php
+++ b/api/viewBuildError.php
@@ -20,7 +20,6 @@ set_include_path(__DIR__.'/..');
 include("cdash/config.php");
 require_once("cdash/pdo.php");
 include_once("cdash/common.php");
-include('login.php');
 include_once("cdash/repository.php");
 include("cdash/version.php");
 
@@ -39,7 +38,8 @@ if ($date != NULL)
 // Checks
 if(!isset($buildid) || !is_numeric($buildid))
   {
-  echo "Not a valid buildid!";
+  $response['error'] = "Not a valid buildid!";
+  echo json_encode($response);
   return;
   }
 
@@ -58,8 +58,9 @@ $build_array = pdo_fetch_array(pdo_query($build_query));
 
 if(empty($build_array))
   {
-  echo "This build does not exist. Maybe it has been deleted.";
-  exit();
+  $response['error'] = "This build does not exist. Maybe it has been deleted.";
+  echo json_encode($response);
+  return;
   }
 
 $projectid = $build_array["projectid"];
@@ -70,7 +71,12 @@ if(pdo_num_rows($project)>0)
   $projectname = $project_array["name"];
   }
 
-checkUserPolicy(@$_SESSION['cdash']['loginid'],$project_array["id"]);
+if (!checkUserPolicy(@$_SESSION['cdash']['loginid'],$project_array["id"], 1))
+  {
+  $response['requirelogin'] = '1';
+  echo json_encode($response);
+  return;
+  }
 
 $response = begin_JSON_response();
 $response['title'] = "CDash : $projectname";

--- a/viewBuildError.php
+++ b/viewBuildError.php
@@ -38,182 +38,189 @@
   <body bgcolor="#ffffff">
     <ng-include src="'header.php'"></ng-include>
     <br/>
-    <table border="0">
-      <tr>
-        <td align="left">
-          <b>Site: </b>
-          <a href="viewSite.php?siteid={{cdash.build.siteid}}">
-            {{cdash.build.site}}
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td align="left">
-          <b>Build Name: </b>
-          {{cdash.build.buildname}}
-        </td>
-      </tr>
-      <tr>
-        <td align="left">
-          <b>Build Time: </b>
-          {{cdash.build.starttime}}
-        </td>
-      </tr>
-      <tr>
-        <td align="left">
-          &#x20;
-        </td>
-      </tr>
-      <tr>
-        <td align="left">
-          Found <b>{{cdash.errors.length}}</b>&#x20;{{cdash.errortypename}}s
-        </td>
-      </tr>
-      <tr>
-        <td align="left">
-          <a href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
-            {{cdash.nonerrortypename}}s are here.
-          </a>
-        </td>
-      </tr>
-    </table>
 
-    <br/>
-    <table ng-repeat="error in cdash.errors" style="table-layout:fixed; width:100%">
-      <colgroup>
-        <col style="width: 115px"/>
-        <col/>
-      </colgroup>
+    <div ng-if="cdash.requirelogin=1">
+      Please <a href="user.php">login</a> to view this page.
+    </div>
 
-      <tr ng-if="error.sourceline" style="background-color: #b0c4de; font-weight: bold">
-        <th colspan="2" align="left">
-          <img ng-if="error.new == -1" src="images/flaggreen.gif" title="flag"/>
-          <img ng-if="error.new == 1" src="images/flag.png" title="flag"/>
-          <pre ng-if="error.new == 0" style="height: 0px;"></pre>
-        </th>
-      </tr>
+    <div ng-if="cdash.requirelogin!=1">
+      <table border="0">
+        <tr>
+          <td align="left">
+            <b>Site: </b>
+            <a href="viewSite.php?siteid={{cdash.build.siteid}}">
+              {{cdash.build.site}}
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            <b>Build Name: </b>
+            {{cdash.build.buildname}}
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            <b>Build Time: </b>
+            {{cdash.build.starttime}}
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            &#x20;
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            Found <b>{{cdash.errors.length}}</b>&#x20;{{cdash.errortypename}}s
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
+            <a href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
+              {{cdash.nonerrortypename}}s are here.
+            </a>
+          </td>
+        </tr>
+      </table>
 
-      <tr style="background-color: #b0c4de; font-weight: bold" ng-if="error.targetname">
-        <th colspan="2">
-          {{cdash.errortypename}} while building
-          <code>{{error.language}}</code> {{error.outputtype}} "
-          <code>{{error.outputfile}}</code>"
-          in target {{error.targetname}}
-        </th>
-      </tr>
+      <br/>
+      <table ng-repeat="error in cdash.errors" style="table-layout:fixed; width:100%">
+        <colgroup>
+          <col style="width: 115px"/>
+          <col/>
+        </colgroup>
 
-      <tr ng-if="cdash.cvsurl">
-        <th class="measurement">
-          <span class="nobr"> Repository </span>
-        </th>
-        <td>
-          <a href="{{cdash.cvsurl}}">
-            {{cdash.cvsurl}}
-          </a>
-        </td>
-      </tr>
+        <tr ng-if="error.sourceline" style="background-color: #b0c4de; font-weight: bold">
+          <th colspan="2" align="left">
+            <img ng-if="error.new == -1" src="images/flaggreen.gif" title="flag"/>
+            <img ng-if="error.new == 1" src="images/flag.png" title="flag"/>
+            <pre ng-if="error.new == 0" style="height: 0px;"></pre>
+          </th>
+        </tr>
 
-      <tr ng-if="error.logline">
-        <th class="measurement">
-          <span class="nobr">Build Log Line </span>
-        </th>
-        <td>
-          {{error.logline}}
-        </td>
-      </tr>
+        <tr style="background-color: #b0c4de; font-weight: bold" ng-if="error.targetname">
+          <th colspan="2">
+            {{cdash.errortypename}} while building
+            <code>{{error.language}}</code> {{error.outputtype}} "
+            <code>{{error.outputfile}}</code>"
+            in target {{error.targetname}}
+          </th>
+        </tr>
 
-      <tr ng-if="error.precontext || error.postcontext">
-        <th class="measurement">
-          <span class="nobr"> {{cdash.errortypename}} </span>
-        </th>
-        <td>
-          <pre class="compiler-output">{{error.precontext}}</pre>
-          <b>
-            <pre class="compiler-output" ng-bind-html="error.text"></pre>
-          </b>
-          <pre class="compiler-output">{{error.postcontext}}</pre>
-        </td>
-      </tr>
+        <tr ng-if="cdash.cvsurl">
+          <th class="measurement">
+            <span class="nobr"> Repository </span>
+          </th>
+          <td>
+            <a href="{{cdash.cvsurl}}">
+              {{cdash.cvsurl}}
+            </a>
+          </td>
+        </tr>
 
-      <tr ng-if="error.sourcefile && error.targetname">
-        <th class="measurement">
-          <span class="nobr">Source File</span>
-        </th>
-        <td>
-          {{error.sourcefile}}
-        </td>
-      </tr>
+        <tr ng-if="error.logline">
+          <th class="measurement">
+            <span class="nobr">Build Log Line </span>
+          </th>
+          <td>
+            {{error.logline}}
+          </td>
+        </tr>
 
-      <tr ng-if="error.labels">
-        <th class="measurement">
-          <div ng-if="error.labels.length=1">Label</div>
-          <div ng-if="error.labels.length>1">Labels</div>
-        </th>
-        <td>
-          <div ng-repeat="label in error.labels">
-          {{label}}
-          </div>
-        </td>
-      </tr>
+        <tr ng-if="error.precontext || error.postcontext">
+          <th class="measurement">
+            <span class="nobr"> {{cdash.errortypename}} </span>
+          </th>
+          <td>
+            <pre class="compiler-output">{{error.precontext}}</pre>
+            <b>
+              <pre class="compiler-output" ng-bind-html="error.text"></pre>
+            </b>
+            <pre class="compiler-output">{{error.postcontext}}</pre>
+          </td>
+        </tr>
 
-      <tr ng-if="error.argumentfirst">
-        <th class="measurement" style="width: 1%">Command</th>
-        <td>
-          <div style="margin-left: 25px; text-indent: -25px;">
-            <span id="showarguments_{{error.id}}" ng-hide="error.showArguments">
-              <span style="cursor: pointer" ng-click="error.showArguments = ! error.showArguments">
-                [+]
+        <tr ng-if="error.sourcefile && error.targetname">
+          <th class="measurement">
+            <span class="nobr">Source File</span>
+          </th>
+          <td>
+            {{error.sourcefile}}
+          </td>
+        </tr>
+
+        <tr ng-if="error.labels">
+          <th class="measurement">
+            <div ng-if="error.labels.length=1">Label</div>
+            <div ng-if="error.labels.length>1">Labels</div>
+          </th>
+          <td>
+            <div ng-repeat="label in error.labels">
+            {{label}}
+            </div>
+          </td>
+        </tr>
+
+        <tr ng-if="error.argumentfirst">
+          <th class="measurement" style="width: 1%">Command</th>
+          <td>
+            <div style="margin-left: 25px; text-indent: -25px;">
+              <span id="showarguments_{{error.id}}" ng-hide="error.showArguments">
+                <span style="cursor: pointer" ng-click="error.showArguments = ! error.showArguments">
+                  [+]
+                </span>
+                <span class="nobr">"<font class="argument">{{error.argumentfirst}}</font>"</span>
               </span>
-              <span class="nobr">"<font class="argument">{{error.argumentfirst}}</font>"</span>
-            </span>
 
-            <span id="argumentlist_{{error.id}}" ng-show="error.showArguments">
-              <span style="cursor: pointer" ng-click="error.showArguments = ! error.showArguments">
-                [-]
+              <span id="argumentlist_{{error.id}}" ng-show="error.showArguments">
+                <span style="cursor: pointer" ng-click="error.showArguments = ! error.showArguments">
+                  [-]
+                </span>
+                <span class="nobr">"<font class="argument">{{error.argumentfirst}}</font>"</span>
+                <span ng-repeat="argument in error.arguments track by $index">"<font class="argument nobr">{{argument}}</font>" </span>
               </span>
-              <span class="nobr">"<font class="argument">{{error.argumentfirst}}</font>"</span>
-              <span ng-repeat="argument in error.arguments track by $index">"<font class="argument nobr">{{argument}}</font>" </span>
-            </span>
-          </div>
-        </td>
-      </tr>
+            </div>
+          </td>
+        </tr>
 
-      <tr ng-if="error.workingdirectory">
-        <th class="measurement" style="width: 1%">
-          Directory
-        </th>
-        <td>
-          {{error.workingdirectory}}
-        </td>
-      </tr>
+        <tr ng-if="error.workingdirectory">
+          <th class="measurement" style="width: 1%">
+            Directory
+          </th>
+          <td>
+            {{error.workingdirectory}}
+          </td>
+        </tr>
 
-      <tr ng-if="error.exitcondition">
-        <th class="measurement">
-          <span class="nobr"> Exit Condition </span>
-        </th>
-        <td>
-          {{error.exitcondition}}
-        </td>
-      </tr>
+        <tr ng-if="error.exitcondition">
+          <th class="measurement">
+            <span class="nobr"> Exit Condition </span>
+          </th>
+          <td>
+            {{error.exitcondition}}
+          </td>
+        </tr>
 
-      <tr ng-if="error.stdoutput">
-        <th class="measurement">
-          <span class="nobr"> Standard Output </span>
-        </th>
-        <td>
-          <pre class="compiler-output" name="stdout">{{error.stdoutput}}</pre>
-        </td>
-      </tr>
+        <tr ng-if="error.stdoutput">
+          <th class="measurement">
+            <span class="nobr"> Standard Output </span>
+          </th>
+          <td>
+            <pre class="compiler-output" name="stdout">{{error.stdoutput}}</pre>
+          </td>
+        </tr>
 
-      <tr ng-if="error.stderror">
-        <th class="measurement">
-          <span class="nobr"> Standard Error </span>
-        </th>
-        <td>
-          <pre class="compiler-output" name="stderr">{{error.stderror}}</pre>
-        </td>
-      </tr>
-    </table>
+        <tr ng-if="error.stderror">
+          <th class="measurement">
+            <span class="nobr"> Standard Error </span>
+          </th>
+          <td>
+            <pre class="compiler-output" name="stderr">{{error.stderror}}</pre>
+          </td>
+        </tr>
+      </table>
+    </div>
 
     <!-- FOOTER -->
     <br/>

--- a/viewBuildError.php
+++ b/viewBuildError.php
@@ -39,11 +39,11 @@
     <ng-include src="'header.php'"></ng-include>
     <br/>
 
-    <div ng-if="cdash.requirelogin=1">
+    <div ng-if="cdash.requirelogin == 1">
       Please <a href="user.php">login</a> to view this page.
     </div>
 
-    <div ng-if="cdash.requirelogin!=1">
+    <div ng-if="cdash.requirelogin != 1">
       <table border="0">
         <tr>
           <td align="left">


### PR DESCRIPTION
When an anonymous user attempts to view a build error for a private project, we now provide a link to the login form instead of showing an unhelpful blank page.