### PR TITLE
fix sorting of BuildGroups on manage page

### DIFF
--- a/javascript/controllers/manageBuildGroup.js
+++ b/javascript/controllers/manageBuildGroup.js
@@ -45,7 +45,7 @@ CDash.filter('filter_builds', function() {
     // Sort BuildGroups by position.
     if ($scope.cdash.buildgroups) {
       $scope.cdash.buildgroups.sort(function (a, b) {
-        return Number(a.position) > Number(b.position);
+        return Number(a.position) - Number(b.position);
       });
 
       // Update positions when the user stops dragging.


### PR DESCRIPTION
Now they will actually be shown in position order.