### PR TITLE
Fix various issues with how coverage data is displayed

### DIFF
--- a/cdash/common.php
+++ b/cdash/common.php
@@ -2377,17 +2377,35 @@ function get_dashboard_JSON_by_name($projectname, $date, &$response)
 }
 
 function get_labels_JSON_from_query_results($qry, &$response)
+{
+$rows = pdo_all_rows_query($qry);
+if (count($rows)>0)
   {
-  $rows = pdo_all_rows_query($qry);
-  if (count($rows)>0)
+  $labels = array();
+  foreach($rows as $row)
     {
-    $labels = array();
-    foreach($rows as $row)
-      {
-      $labels[] = $row['text'];
-      }
-    $response['labels'] = $labels;
+    $labels[] = $row['text'];
     }
+  $response['labels'] = $labels;
   }
+}
+
+function compute_percentcoverage($loctested, $locuntested)
+{
+  $loc = $loctested + $locuntested;
+
+  if($loc>0)
+    {
+    $percentcoverage = round($loctested/$loc*100, 2);
+    }
+  else
+    {
+    $percentcoverage = 100;
+    }
+
+  return $percentcoverage;
+}
+
+
 
 ?>

--- a/coverageRow.xsl
+++ b/coverageRow.xsl
@@ -37,10 +37,13 @@
           <xsl:choose>
             <xsl:when test="percentage >= percentagegreen">
               normal
-              </xsl:when>
-            <xsl:otherwise>
+            </xsl:when>
+            <xsl:when test="percentage >= percentageyellow">
               warning
-             </xsl:otherwise>
+            </xsl:when>
+            <xsl:otherwise>
+              error
+            </xsl:otherwise>
           </xsl:choose>
         </xsl:attribute>
         <a>

--- a/index.php
+++ b/index.php
@@ -1419,7 +1419,9 @@ function generate_main_dashboard_XML($project_instance, $date)
         $xml .= add_XML_value("childlink", "$child_builds_hyperlink#Coverage");
         }
 
-      @$percent = round($coverage_array["loctested"]/($coverage_array["loctested"]+$coverage_array["locuntested"])*100,2);
+      $percent = round(
+        compute_percentcoverage($coverage_array["loctested"],
+                                $coverage_array["locuntested"]), 2);
 
       $coverageThreshold = $project_array["coveragethreshold"];
       if ($build_array["subprojectgroup"])
@@ -1436,6 +1438,7 @@ function generate_main_dashboard_XML($project_instance, $date)
 
       $xml .= "  <percentage>".$percent."</percentage>";
       $xml .= "  <percentagegreen>".$coverageThreshold."</percentagegreen>";
+      $xml .= "  <percentageyellow>".$coverageThreshold * 0.7."</percentageyellow>";
       $xml .= "  <fail>".$coverage_array["locuntested"]."</fail>";
       $xml .= "  <pass>".$coverage_array["loctested"]."</pass>";
 
@@ -1583,7 +1586,8 @@ function generate_main_dashboard_XML($project_instance, $date)
       $xml .= "<subprojectgroup>";
       $xml .= add_XML_value("name", $group->GetName());
       $xml .= add_XML_value("id", $group->GetId());
-      $xml .= add_XML_value("threshold", $group->GetCoverageThreshold());
+      $xml .= add_XML_value("thresholdgreen", $group->GetCoverageThreshold());
+      $xml .= add_XML_value("thresholdyellow", $group->GetCoverageThreshold() * 0.7);
       $xml .= add_XML_value("coverage", $coverage);
       $xml .= add_XML_value("tested", $tested);
       $xml .= add_XML_value("untested", $untested);

--- a/indexchildren.xsl
+++ b/indexchildren.xsl
@@ -843,7 +843,7 @@
 </xsl:for-each>
 
 <!-- COVERAGE -->
-<table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
+<table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb childbuild" id="coveragetable">
     <xsl:if test="count(cdash/buildgroup/coverage)=0">
        <tr class="table-heading2 table-nobuild">
       <td colspan="1" class="nob">

--- a/javascript/cdashTableSorter.js
+++ b/javascript/cdashTableSorter.js
@@ -164,6 +164,7 @@ $(document).ready(function() {
             return false;
         },
         format: function(s) {
+            s = s.trim();
             // format your data for normalization
             var i = s.indexOf("<a");
             if(i == -1)
@@ -498,20 +499,34 @@ $(document).ready(function() {
     // Initialize the coverage table
     $tabs = $("#coveragetable");
     $tabs.each(function(index) {
-     $(this).tablesorter({
-            headers: {
-                0: { sorter:'text'},
-                1: { sorter:'text'},
-                2: { sorter:'percentage'},
-                3: { sorter:'numericvalue'},
-                4: { sorter:'numericvalue'},
-                5: { sorter:'elapsedtime'},
-                6: { sorter:'text'}
-            },
+      if ($(this).hasClass("childbuild")) {
+        $(this).tablesorter({
+          headers: {
+            0: { sorter:'text'},         // subproject
+            1: { sorter:'percentage'}, // coverage %
+            2: { sorter:'numericvalue'}, // LOC tested
+            3: { sorter:'numericvalue'}, // LOC untested
+            4: { sorter:'elapsedtime'}   // date
+          },
           debug: false,
           widgets: ['zebra']
         });
-      });
+      } else {
+        $(this).tablesorter({
+          headers: {
+            0: { sorter:'text'},
+            1: { sorter:'text'},
+            2: { sorter:'numericvalue'},
+            3: { sorter:'numericvalue'},
+            4: { sorter:'numericvalue'},
+            5: { sorter:'elapsedtime'},
+            6: { sorter:'text'}
+          },
+          debug: false,
+          widgets: ['zebra']
+        });
+      }
+    });
 
     // Initialize the dynamic analysis table
     $tabs = $("#dynamicanalysistable");

--- a/subprojectGroupCoverage.xsl
+++ b/subprojectGroupCoverage.xsl
@@ -7,6 +7,7 @@
 <xsl:template name="subprojectGroupCoverage">
 
   <xsl:for-each select="cdash/subprojectgroup">
+    <xsl:sort select="name"/>
     <xsl:variable name="groupid" select="id"/>
     <tr class="parent_row">
       <td class="paddt" align="left">
@@ -40,6 +41,7 @@
     </tr>
 
     <xsl:for-each select="/cdash/buildgroup/coverage[group=$groupid]">
+      <xsl:sort select="percentage" data-type="number"/>
       <xsl:call-template name="coverageRow"/>
     </xsl:for-each>
 

--- a/subprojectGroupCoverage.xsl
+++ b/subprojectGroupCoverage.xsl
@@ -16,11 +16,14 @@
 
       <td align="center">
         <xsl:attribute name="class"><xsl:choose>
-          <xsl:when test="coverage >= threshold">
+          <xsl:when test="coverage >= thresholdgreen">
             normal
           </xsl:when>
-          <xsl:otherwise>
+          <xsl:when test="coverage >= thresholdyellow">
             warning
+          </xsl:when>
+          <xsl:otherwise>
+            error
           </xsl:otherwise>
         </xsl:choose></xsl:attribute>
         <xsl:value-of select="coverage"/>%

--- a/viewCoverage.php
+++ b/viewCoverage.php
@@ -88,24 +88,6 @@ if(pdo_num_rows($project) == 0)
   exit();
   }
 
-
-function compute_percentcoverage($loctested, $locuntested)
-{
-  $loc = $loctested + $locuntested;
-
-  if($loc>0)
-    {
-    $percentcoverage = round($loctested/$loc*100, 2);
-    }
-  else
-    {
-    $percentcoverage = 0;
-    }
-
-  return $percentcoverage;
-}
-
-
 $role=0;
 $user2project = pdo_query("SELECT role FROM user2project WHERE userid='$userid' AND projectid='$projectid'");
 if(pdo_num_rows($user2project)>0)


### PR DESCRIPTION
* For a build with 0 total LOC, report coverage as 100% rather than 0%.
* Use all three colors (red/yellow/green) for coverage summaries.  Previously red was not used.
* Fix sorting coverage by percentage for subproject builds.  This was previously using lexographical (rather than numerical) sort.
* Sort grouped coverage from lowest to highest percentage by default.