### PR TITLE
restore stripped anchors upon Google login

### DIFF
--- a/javascript/cdashOauth2.js
+++ b/javascript/cdashOauth2.js
@@ -14,9 +14,8 @@ function oauth2Login() {
   // get state (anti-forgery token) from session via CDash API
   $.get('api/getState.php', function(securityToken) {
     // overload state to contain both the URL that the user is attempting to
-    // access, as well as the anti-forgery token.  slice is used here to remove
-    // the trailing "#" from the currently URL
-    var STATE = encodeURIComponent(document.URL.slice(0, -1)) + "_AND_STATE_IS_" + securityToken;
+    // access, as well as the anti-forgery token.
+    var STATE = encodeURIComponent(document.URL) + "_AND_STATE_IS_" + securityToken;
 
     // construct Google authentication URL with the query string all filled out
     var _url = OAUTHURL + 'scope=' + SCOPE + '&client_id=' + CLIENTID +

--- a/login.xsl
+++ b/login.xsl
@@ -105,7 +105,7 @@
                 <tr class="table-heading">
                   <td width="10%" class="nob"></td>
                   <td width="70%" class="nob">
-                    <a href="#" id="oauth2LoginText" onClick='oauth2Login();'>
+                    <a href="" id="oauth2LoginText" onClick='oauth2Login();'>
                       Log in with your Google account
                     </a>
                   </td>


### PR DESCRIPTION
Before this commit, if you used the "login with Google account"
link, it would strip any anchor tags off of the URL you were
attempting to access.  This commit fixes that issue.