### PR TITLE
fix failing tests

### DIFF
--- a/cdash/config.php
+++ b/cdash/config.php
@@ -165,7 +165,7 @@ $CDASH_ENABLE_FEED = 1;
 $CDASH_SHOW_LAST_SUBMISSION = 1;
 
 // How many times to retry queries via random exponential back-off
-$CDASH_MAX_QUERY_RETRIES = 5;
+$CDASH_MAX_QUERY_RETRIES = 1;
 
 /** DO NOT EDIT AFTER THIS LINE */
 $localConfig = dirname(__FILE__).'/config.local.php';

--- a/cdash/pdocore.php
+++ b/cdash/pdocore.php
@@ -32,8 +32,11 @@ function _exponential_backoff($closure) {
   for($retry_count = 0; $retry_count < $CDASH_MAX_QUERY_RETRIES; ++$retry_count) {
     $ret = $closure();
     if ($ret === FALSE) {
-      $wait_time = (2^$retry_count)*1000 + rand(0,1000);
-      usleep($wait_time * 1000);
+      // No need to sleep the last time through the loop.
+      if ($retry_count < $CDASH_MAX_QUERY_RETRIES -1) {
+        $wait_time = (2^$retry_count)*1000 + rand(0,1000);
+        usleep($wait_time * 1000);
+      }
     } else {
       return $ret; // Success
     }


### PR DESCRIPTION
The introduction of CDASH_MAX_QUERY_RETRIES caused a handful of tests
to fail.  Apparently we expect or tolerate some queries to fail.
As far as I could tell, there is no way to configure simpletest to
wait longer for a response, so for now we redefine the default
value of CDASH_MAX_QUERY_RETRIES to 1.