### PR TITLE
Enable local overrides for header & footer on AngularJS pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ trim_trailing_whitespace = true
 [*.json]
 indent_size = 2
 
+[*.html]
+indent_size = 2
+
 [*.markdown]
 trim_trailing_whitespace = false
 

--- a/api/v1/viewSubProjects.php
+++ b/api/v1/viewSubProjects.php
@@ -90,9 +90,8 @@ function echo_subprojects_dashboard_JSON($project_instance, $date)
     $googletracker = htmlentities($Project->GoogleTracker);
     $docurl = make_cdash_url(htmlentities($Project->DocumentationUrl));
 
-  // Main dashboard section
-  $projectname_encoded = urlencode($Project->Name);
-    $response = array();
+    // Main dashboard section
+    $projectname_encoded = urlencode($Project->Name);
     $response['datetime'] = date("l, F d Y H:i:s T", time());
     $response['date'] = $date;
     $response['unixtimestamp'] = $currentstarttime;

--- a/cdash/common.php
+++ b/cdash/common.php
@@ -477,7 +477,7 @@ function get_projects($onlyactive=true)
             $dayssincelastsubmission = (time()-strtotime($project['last_build']))/86400;
         }
         $project['dayssincelastsubmission'] = $dayssincelastsubmission;
-            
+
         if ($project['last_build'] != 'NA' && $project['dayssincelastsubmission']<=$CDASH_ACTIVE_PROJECT_DAYS) {
             // Get the number of builds in the past 7 days
       $submittime_UTCDate = gmdate(FMT_DATETIME, time()-604800);
@@ -486,7 +486,7 @@ function get_projects($onlyactive=true)
             $buildquery_array = pdo_fetch_array($buildquery);
             $project['nbuilds'] = $buildquery_array[0];
         }
-    
+
     /** Not showing the upload size for now for performance reasons */
     //$Project = new Project;
     //$Project->Id = $project['id'];
@@ -575,7 +575,7 @@ function get_server_URI($localhost=false)
     if (!$CDASH_CURL_REQUEST_LOCALHOST && $CDASH_BASE_URL != '') {
         return $CDASH_BASE_URL;
     }
-      
+
     $currentPort="";
     $httpprefix="http://";
     if ($_SERVER['SERVER_PORT']!=80 && $_SERVER['SERVER_PORT']!=443) {
@@ -2061,7 +2061,7 @@ function __json_encode($data)
 
 function begin_JSON_response()
 {
-    global $CDASH_VERSION;
+    global $CDASH_VERSION, $CDASH_USE_LOCAL_DIRECTORY;
 
     $response = array();
     $response['version'] = $CDASH_VERSION;
@@ -2071,6 +2071,19 @@ function begin_JSON_response()
         $userid = $_SESSION['cdash']['loginid'];
     }
     $response['userid'] = $userid;
+
+    // Check for local overrides of common view partials.
+    $files_to_check = array("header", "footer");
+    $base_dir = str_replace('\\', '/', dirname(dirname(__FILE__)));
+    foreach ($files_to_check as $file_to_check) {
+        $local_file = "local/views/$file_to_check.html";
+        if ($CDASH_USE_LOCAL_DIRECTORY == '1' &&
+                file_exists("$base_dir/$local_file")) {
+            $response[$file_to_check] = $local_file;
+        } else {
+            $response[$file_to_check] = "views/partials/$file_to_check.html";
+        }
+    }
 
     return $response;
 }

--- a/views/index.html
+++ b/views/index.html
@@ -31,8 +31,7 @@
 
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <!-- TODO: use local header if it exists. -->
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
 
     <div ng-if="cdash.future == 1">
       CDash cannot predict the future (yet)...
@@ -371,7 +370,7 @@
 
             <td ng-if="buildgroup.hasupdatedata" align="center" ng-class="{'error': build.update.errors == 1, 'warning': build.update.warning == 1, 'normal': build.update.defined == 1}">
               <div ng-if="build.numchildren == 0">
-                <img ng-if="build.userupdates > 0" src="images/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/> 
+                <img ng-if="build.userupdates > 0" src="images/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/>
                 <a ng-href="viewUpdate.php?buildid={{build.id}}">
                   {{build.update.files}}
                 </a>
@@ -756,7 +755,6 @@
       </table>
     </div> <!-- end index content -->
 
-    <!-- FOOTER TODO: local override -->
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/manageBuildGroup.html
+++ b/views/manageBuildGroup.html
@@ -32,7 +32,7 @@
   </head>
   <body bgcolor="#ffffff" ng-controller="ManageBuildGroupController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
     <br/>
 
     <div class="container" ng-if="cdash.requirelogin != 1 && !loading">
@@ -381,6 +381,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/manageSubProject.html
+++ b/views/manageSubProject.html
@@ -28,7 +28,7 @@
 
   <body bgcolor="#ffffff" ng-controller="ManageSubProjectController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
     <br/>
 
     <div class="container" ng-if="!loading && cdash.requirelogin != 1">
@@ -240,6 +240,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/viewBuildError.html
+++ b/views/viewBuildError.html
@@ -40,7 +40,7 @@
   <body bgcolor="#ffffff" ng-controller="BuildErrorController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading">
@@ -224,6 +224,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/viewNotes.html
+++ b/views/viewNotes.html
@@ -26,56 +26,61 @@
   </head>
 
   <body bgcolor="#ffffff" ng-controller="ViewNotesController">
-    <ng-include src="'views/partials/header.html'"></ng-include>
-    <br/>
+    <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <table border="0">
-      <tr>
-        <td align="left">
-          <b>Site: </b>
-          <a href="viewSite.php?siteid={{cdash.build.siteid}}">{{cdash.build.site}}</a>
-        </td>
-      <tr>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
 
-      <tr>
-        <td align="left">
-          <b>Build Name: </b>
-          <a href="buildSummary.php?buildid={{cdash.build.buildid}}">{{cdash.build.buildname}}</a>
-        </td>
-      </tr>
-
-      <tr>
-        <td align="left">
-          <b>Stamp: </b>
-          {{cdash.build.stamp}}
-        </td>
-      <tr>
-    </table>
-
-    <br/>
-    <a href="" ng-repeat="note in cdash.notes" ng-click="gotoNote($index)">
-      <img src="images/document.png" alt="Notes" border="0" align="top"/>
-      {{note.time}} -- {{note.name}}
+    <div ng-if="cdash.requirelogin != 1">
       <br/>
-    </a>
 
-    <br/>
-    <br/>
-    <br/>
+      <table border="0">
+        <tr>
+          <td align="left">
+            <b>Site: </b>
+            <a href="viewSite.php?siteid={{cdash.build.siteid}}">{{cdash.build.site}}</a>
+          </td>
+        <tr>
 
-    <div ng-repeat="note in cdash.notes">
-      <div class="title-divider"  id="note{{$index}}">
-        <b>{{note.time}} -- {{note.name}}</b>
+        <tr>
+          <td align="left">
+            <b>Build Name: </b>
+            <a href="buildSummary.php?buildid={{cdash.build.buildid}}">{{cdash.build.buildname}}</a>
+          </td>
+        </tr>
+
+        <tr>
+          <td align="left">
+            <b>Stamp: </b>
+            {{cdash.build.stamp}}
+          </td>
+        <tr>
+      </table>
+
+      <br/>
+      <a href="" ng-repeat="note in cdash.notes" ng-click="gotoNote($index)">
+        <img src="images/document.png" alt="Notes" border="0" align="top"/>
+        {{note.time}} -- {{note.name}}
+        <br/>
+      </a>
+
+      <br/>
+      <br/>
+      <br/>
+
+      <div ng-repeat="note in cdash.notes">
+        <div class="title-divider"  id="note{{$index}}">
+          <b>{{note.time}} -- {{note.name}}</b>
+        </div>
+        <br/>
+        <pre>
+          {{note.text}}
+        </pre>
+        <br/>
       </div>
-      <br/>
-      <pre>
-        {{note.text}}
-      </pre>
       <br/>
     </div>
 
     <!-- FOOTER -->
-    <br/>
-    <ng-include src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/viewSubProjects.html
+++ b/views/viewSubProjects.html
@@ -19,11 +19,8 @@
   </head>
 
   <body ng-controller="ViewSubProjectsController">
-    <ng-include src="'views/partials/header.html'"></ng-include>
-
-    <div ng-if="cdash.requirelogin == 1">
-      Please <a href="user.php">login</a> to view this page.
-    </div>
+    <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
 
     <div id="content" ng-if="!loading && cdash.requirelogin != 1">
       <table ng-show="cdash.banners.length > 0" border="0" width="100%">
@@ -160,8 +157,8 @@
     </div>
 
     <br/>
-<!-- FOOTER -->
+    <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>

--- a/views/viewTest.html
+++ b/views/viewTest.html
@@ -26,10 +26,11 @@
   </head>
 
   <body bgcolor="#ffffff" ng-controller="ViewTestController">
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/header.html'"></ng-include>
-    <br/>
 
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
+
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header"></ng-include>
+    <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading">
       <h3>Testing started on {{cdash.build.testtime}}</h3>
@@ -238,6 +239,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
   </body>
 </html>


### PR DESCRIPTION
If you create a header.html or footer.html in local/views that version will be used instead of the default one that ships with CDash.