### PR TITLE
Always honor BuildGroup order as specified by project admins

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.js]
+indent_size = 2
+
 [*.json]
 indent_size = 2
 

--- a/api/v1/build.php
+++ b/api/v1/build.php
@@ -157,7 +157,7 @@ function rest_post()
     // Insert it into the new group.
     pdo_query(
       "INSERT INTO build2group(groupid,buildid)
-       VALUES ('$groupid','$buildid')");
+       VALUES ('$newgroupid','$buildid')");
 
     // Mark any previous buildgroup rule as finished as of this time.
     $now = gmdate(FMT_DATETIME);
@@ -172,7 +172,7 @@ function rest_post()
     pdo_query(
       "INSERT INTO build2grouprule(groupid, buildtype, buildname, siteid,
                                    expected, starttime, endtime)
-       VALUES ('$groupid','$buildtype','$buildname','$siteid','$expected',
+       VALUES ('$newgroupid','$buildtype','$buildname','$siteid','$expected',
                '$now','1980-01-01 00:00:00')");
   }
 }

--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -1117,6 +1117,11 @@ function echo_main_dashboard_JSON($project_instance, $date)
     $buildgroups_response =
         array_filter($buildgroups_response, "is_buildgroup_nonempty");
 
+    // Report buildgroups as a list, not an associative array.
+    // Otherwise any missing buildgroups will cause our view to
+    // not honor the order specified by the project admins.
+    $buildgroups_response = array_values($buildgroups_response);
+
     // Generate coverage by group here.
     if (!empty($coverage_groups)) {
         $response['coveragegroups'] = array();

--- a/javascript/controllers/index.js
+++ b/javascript/controllers/index.js
@@ -266,7 +266,10 @@ CDash.filter("showExpectedLast", function () {
       newgroupid: groupid,
       expected: build.expected
     };
-    $http.post('api/v1/build.php', parameters);
+    $http.post('api/v1/build.php', parameters)
+    .success(function(data) {
+      window.location.reload();
+    });
   };
 
   $scope.colorblind_toggle = function() {


### PR DESCRIPTION
This branch fixes a bug where BuildGroups would sometimes not appear in the correct order.  This occurred when one or more of the BuildGroups were pruned for not containing any builds.