### PR TITLE
Remove the middle when truncating long output

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ add_php_test(seconds_from_interval)
 add_php_test(dynamicanalysissummary)
 add_php_test(accountlockout)
 add_php_test(viewsubprojects)
+add_php_test(truncateoutput)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/data/TruncateOutput/Build.xml
+++ b/tests/data/TruncateOutput/Build.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="TruncateOutput"
+	BuildStamp="20151029-1832-Experimental"
+	Name="localhost"
+	Generator="ctest-3.4.20151019-g383ab"
+	CompilerName=""
+	CompilerVersion=""
+	OSName="Linux"
+	Hostname="localhost"
+	OSRelease="3.13.0-66-generic"
+	OSVersion="#108-Ubuntu SMP Wed Oct 7 15:20:27 UTC 2015"
+	OSPlatform="x86_64"
+	Is64Bits="1"
+	VendorString="GenuineIntel"
+	VendorID="Intel Corporation"
+	FamilyID="6"
+	ModelID="45"
+	ProcessorCacheSize="12288"
+	NumberOfLogicalCPU="12"
+	NumberOfPhysicalCPU="1"
+	TotalVirtualMemory="32690"
+	TotalPhysicalMemory="32100"
+	LogicalProcessorsPerPhysical="12"
+	ProcessorClockFrequency="1200"
+	>
+	<Build>
+		<StartDateTime>Oct 29 14:32 EDT</StartDateTime>
+		<StartBuildTime>1446143533</StartBuildTime>
+		<BuildCommand>/opt/cmake/bin/cmake --build . --config "Debug" -- -i</BuildCommand>
+		<Failure type="Error">
+			<!-- Meta-information about the build action -->
+			<Action>
+				<TargetName>foo</TargetName>
+				<Language>C++</Language>
+				<SourceFile>foo.cxx</SourceFile>
+				<OutputFile>CMakeFiles/foo.dir/foo.cxx.o</OutputFile>
+				<OutputType>object file</OutputType>
+			</Action>
+			<!-- Details of command -->
+			<Command>
+				<WorkingDirectory>/tmp/bin</WorkingDirectory>
+				<Argument>/usr/local/bin/c++</Argument>
+				<Argument>-o</Argument>
+				<Argument>CMakeFiles/foo.dir/foo.cxx.o</Argument>
+				<Argument>-c</Argument>
+				<Argument>/tmp/src/foo.cxx</Argument>
+			</Command>
+			<!-- Result of command -->
+			<Result>
+				<StdOut>The beginning survives|The middle gets truncated|This part is preserved</StdOut>
+				<StdErr>The beginning survives|The middle gets truncated|This part is preserved</StdErr>
+				<ExitCondition>1</ExitCondition>
+			</Result>
+		</Failure>
+		<Failure type="Error">
+			<!-- Meta-information about the build action -->
+			<Action>
+				<TargetName>foo</TargetName>
+				<Language>C++</Language>
+				<OutputFile>foo</OutputFile>
+				<OutputType>executable</OutputType>
+			</Action>
+			<!-- Details of command -->
+			<Command>
+				<WorkingDirectory>/tmp/bin</WorkingDirectory>
+				<Argument>/usr/local/bin/c++</Argument>
+				<Argument>CMakeFiles/foo.dir/foo.cxx.o</Argument>
+				<Argument>-o</Argument>
+				<Argument>foo</Argument>
+				<Argument>-rdynamic</Argument>
+			</Command>
+			<!-- Result of command -->
+			<Result>
+				<StdOut>The beginning survives|The middle gets truncated|This part is preserved</StdOut>
+				<StdErr>The beginning survives|The middle gets truncated|This part is preserved</StdErr>
+				<ExitCondition>4</ExitCondition>
+			</Result>
+		</Failure>
+		<Log Encoding="base64" Compression="bin/gzip"/>
+		<EndDateTime>Oct 29 14:32 EDT</EndDateTime>
+		<EndBuildTime>1446143534</EndBuildTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Build>
+</Site>

--- a/tests/test_truncateoutput.php
+++ b/tests/test_truncateoutput.php
@@ -1,0 +1,69 @@
+<?php
+//
+// After including cdash_test_case.php, subsequent require_once calls are
+// relative to the top of the CDash source tree
+//
+require_once dirname(__FILE__).'/cdash_test_case.php';
+require_once 'include/common.php';
+require_once 'include/pdo.php';
+
+class TruncateOutputTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->ConfigLine = '$CDASH_LARGE_TEXT_LIMIT = \'44\';
+';
+        $this->Expected = "The beginning survives\n...\nCDash truncated output because it exceeded 44 characters.\n...\nThis part is preserved\n";
+        $this->BuildId = 0;
+    }
+
+    public function testTruncateOutput()
+    {
+        // Set a limit so long output will be truncated.
+        $this->addLineToConfig($this->ConfigLine);
+
+        // Submit our testing data.
+        $rep  = dirname(__FILE__)."/data/TruncateOutput";
+        if (!$this->submission('InsightExample', "$rep/Build.xml")) {
+            $this->fail("failed to submit Build.xml");
+            $this->cleanup();
+            return 1;
+        }
+
+        // Query for the ID of the build that we just created.
+        $buildid_results = pdo_single_row_query(
+            "SELECT id FROM build WHERE name='TruncateOutput'");
+        $this->BuildId = $buildid_results['id'];
+
+        // Verify that the output was properly truncated.
+        $this->get($this->url . "/api/v1/viewBuildError.php?buildid=" . $this->BuildId);
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        foreach ($jsonobj['errors'] as $error) {
+            if ($error['stdoutput'] != $this->Expected) {
+                $this->fail("Expected $this->Expected, found " . $error['stdoutput']);
+                $this->cleanup();
+                return 1;
+            }
+            if ($error['stderror'] != $this->Expected) {
+                $this->fail("Expected $this->Expected, found " . $error['stderror']);
+                $this->cleanup();
+                return 1;
+            }
+        }
+
+        $this->cleanup();
+        $this->pass("Passed");
+        return 0;
+    }
+
+    public function cleanup()
+    {
+        // Restore our configuration and delete the build that we created.
+        $this->removeLineFromConfig($this->ConfigLine);
+        if ($this->BuildId > 0) {
+            remove_build($this->BuildId);
+        }
+    }
+}

--- a/xml_handlers/build_handler.php
+++ b/xml_handlers/build_handler.php
@@ -131,20 +131,25 @@ class BuildHandler extends AbstractHandler
             $threshold = $CDASH_LARGE_TEXT_LIMIT;
 
             if ($threshold > 0 && isset($this->Error->StdOutput)) {
+                $chunk_size = $threshold / 2;
                 $outlen = strlen($this->Error->StdOutput);
                 if ($outlen > $threshold) {
-                    $tmp = substr($this->Error->StdOutput, 0, $threshold);
+                    $beginning = substr($this->Error->StdOutput, 0, $chunk_size);
+                    $end = substr($this->Error->StdOutput, -$chunk_size);
                     unset($this->Error->StdOutput);
-                    $this->Error->StdOutput = $tmp .
-                        "\n...\nCDash truncated output because it exceeded $threshold characters.\n";
+                    $this->Error->StdOutput =
+                        "$beginning\n...\nCDash truncated output because it exceeded $threshold characters.\n...\n$end\n";
+                    $outlen = strlen($this->Error->StdOutput);
                 }
 
                 $errlen = strlen($this->Error->StdError);
                 if ($errlen > $threshold) {
-                    $tmp = substr($this->Error->StdError, 0, $threshold);
+                    $beginning = substr($this->Error->StdError, 0, $chunk_size);
+                    $end = substr($this->Error->StdError, -$chunk_size);
                     unset($this->Error->StdError);
-                    $this->Error->StdError = $tmp .
-                        "\n...\nCDash truncated output because it exceeded $threshold characters.\n";
+                    $this->Error->StdError =
+                        "$beginning\n...\nCDash truncated output because it exceeded $threshold characters.\n...\n$end\n";
+                    $errlen = strlen($this->Error->StdError);
                 }
             }
 


### PR DESCRIPTION
When truncating long output preserve the beginning and the end of
the message, truncating the middle.  These portions are more likely
to hold useful information for our users.