### PR TITLE
Update recoverPassword.php to use a secure random number generator.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php": ">=5.3.3",
     "ext-curl": "*",
     "ext-xsl": "*",
-    "ext-pdo": "*"
+    "ext-pdo": "*",
+    "paragonie/random_compat": "~1.0.10"
   },
   "require-dev": {
     "ext-gd": "*",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "https://github.com/Kitware/CDash",
   "license": "Apache-2.0",
   "dependencies": {
-    "protractor": "^2.0.0"
+    "protractor": "^2.0.0",
+    "paragonie/random_compat": "^1.0.10"
   },
   "devDependencies": {
     "eslint": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "repository": "https://github.com/Kitware/CDash",
   "license": "Apache-2.0",
   "dependencies": {
-    "protractor": "^2.0.0",
-    "paragonie/random_compat": "^1.0.10"
+    "protractor": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^1.5.1",

--- a/recoverPassword.php
+++ b/recoverPassword.php
@@ -40,21 +40,15 @@ if ($recover) {
         $xml .= "<warning>This email is not registered.</warning>";
     } else {
         // Create a new password
-    $keychars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&";
+        $keychars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&";
         $length = 10;
-
-    // seed with microseconds
-    function make_seed_recoverpass()
-    {
-        list($usec, $sec) = explode(' ', microtime());
-        return (float) $sec + ((float) $usec * 100000);
-    }
-        srand(make_seed_recoverpass());
 
         $password = "";
         $max=strlen($keychars)-1;
         for ($i=0;$i<=$length;$i++) {
-            $password .= substr($keychars, rand(0, $max), 1);
+            // random_int is available in PHP 7 and the random_compat PHP 5.x
+            // polyfill included in the Composer package.json dependencies.
+            $password .= substr($keychars, random_int(0, $max), 1);
         }
 
         $currentURI = get_server_URI();


### PR DESCRIPTION
The original implementation of recoverPassword.php uses a timestamp for
seeding the random number generator (via srand). If two people reset
their passwords at the exact same time, their passwords will be
identical. An attacker who resets their password and another users at
almost the same time can determine the approx. int value used as the
seed and then generate a list of possible passwords, iterating through
the seed values. This creates a password list that can be used to
brute-force a victims password.

This attack was tested against CDash and was found to be effective.

If you're happy with this approach, we can replace other uses of
insecure random number generators in the codebase in a similar way.

References:
http://www.openwall.com/php_mt_seed/
https://paragonie.com/blog/2015/07/how-safely-generate-random-strings-and-integers-in-php