### PR TITLE
Make PostgreSQL install more robust

### DIFF
--- a/install.php
+++ b/install.php
@@ -111,7 +111,11 @@ if (true === @pdo_select_db("$CDASH_DB_NAME", $db)
 // If we should create the tables
 @$Submit = $_POST["Submit"];
     if ($Submit) {
-        pdo_select_db("");
+        if ($db_type=='mysql') {
+            pdo_select_db("");
+        } else {
+            pdo_select_db("$CDASH_DB_NAME");
+        }
         $admin_email = htmlspecialchars(pdo_real_escape_string($_POST["admin_email"]));
         $admin_password = htmlspecialchars(pdo_real_escape_string($_POST["admin_password"]));
 


### PR DESCRIPTION
We previously had an implicit assumption that a database would
exist that shares its name with our db user.  Instead, attempt to
connect to the CDash PostgreSQL database, since it is not created
for you during the install step anyway.