### PR TITLE
Fix sorting by floating point values

### DIFF
--- a/cdash/common.php
+++ b/cdash/common.php
@@ -2203,7 +2203,7 @@ function cast_data_for_JSON($value)
         return $value;
     }
     if (is_numeric($value)) {
-        if (strpos('.', $value) !== false) {
+        if (strpos($value, '.') !== false) {
             return (float) $value;
         }
         return (int) $value;


### PR DESCRIPTION
A bug in our new JSON sanitization method was erroneously casting floats to int.