### PR TITLE
restore SubProject filtering

### DIFF
--- a/javascript/cdash_angular.js
+++ b/javascript/cdash_angular.js
@@ -7,10 +7,19 @@ var CDash = angular
 
 // Keep subprojects with missing fields at the bottom of the list.
 // Shared between index.html & viewSubProjects.html
-CDash.filter("showEmptyLast", function () {
+CDash.filter("showEmptySubProjectsLast", function () {
   return function (subprojects, sortField) {
     if (!angular.isArray(subprojects)) return;
     if (!sortField) return subprojects;
+    if (angular.isArray(sortField)) {
+      if (sortField.length < 1) {
+        return subprojects;
+      }
+      sortField = sortField[0];
+    }
+    if (sortField.charAt(0) == '-') {
+      sortField = sortField.substring(1);
+    }
 
     // First weed out the subprojects that are completely empty.
     // These will stay at the bottom of the table.

--- a/views/partials/subProjectTable.html
+++ b/views/partials/subProjectTable.html
@@ -70,7 +70,7 @@
   </thead>
 
   <tbody>
-    <tr ng-repeat="subproject in cdash.subprojects |orderBy:orderByFields|showEmptyLast:orderByField" ng-class-odd="'odd'" ng-class-even="'even'">
+    <tr ng-repeat="subproject in cdash.subprojects |orderBy:orderByFields|showEmptySubProjectsLast:orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
       <td align="center" >
         <a ng-href="index.php?subproject={{subproject.name_encoded}}&{{cdash.linkparams}}">
           {{subproject.name}}


### PR DESCRIPTION
Move any SubProjects that are missing data to the bottom
of the table.  This behavior was inadvertently lost when
we enabled sorting by multiple columns.