### PR TITLE
Speedup test history

### DIFF
--- a/api/v1/viewTest.php
+++ b/api/v1/viewTest.php
@@ -567,9 +567,16 @@ function get_test_history($testname, $previous_buildids)
 {
     $retval = array();
 
+    // STRAIGHT_JOIN is a MySQL specific enhancement.
+    $join_type = "INNER JOIN";
+    global $CDASH_DB_TYPE;
+    if ($CDASH_DB_TYPE === 'mysql') {
+        $join_type = "STRAIGHT_JOIN";
+    }
+
     $history_query = "
         SELECT DISTINCT status FROM build2test AS b2t
-        STRAIGHT_JOIN test AS t ON (t.id = b2t.testid)
+        $join_type test AS t ON (t.id = b2t.testid)
         WHERE b2t.buildid IN ($previous_buildids) AND t.name = '$testname'";
     $history_results = pdo_query($history_query);
 
@@ -608,11 +615,18 @@ function get_test_summary($testname, $projectid, $groupid, $begin, $end)
 {
     $retval = array();
 
+    // STRAIGHT_JOIN is a MySQL specific enhancement.
+    $join_type = "INNER JOIN";
+    global $CDASH_DB_TYPE;
+    if ($CDASH_DB_TYPE === 'mysql') {
+        $join_type = "STRAIGHT_JOIN";
+    }
+
     $summary_query = "
         SELECT DISTINCT b2t.status FROM build AS b
-        STRAIGHT_JOIN build2group AS b2g ON (b.id = b2g.buildid)
-        STRAIGHT_JOIN build2test AS b2t ON (b.id = b2t.buildid)
-        STRAIGHT_JOIN test AS t ON (b2t.testid = t.id)
+        $join_type build2group AS b2g ON (b.id = b2g.buildid)
+        $join_type build2test AS b2t ON (b.id = b2t.buildid)
+        $join_type test AS t ON (b2t.testid = t.id)
         WHERE b2g.groupid = $groupid
         AND b.projectid = $projectid
         AND b.starttime>='$begin'

--- a/api/v1/viewTest.php
+++ b/api/v1/viewTest.php
@@ -569,7 +569,7 @@ function get_test_history($testname, $previous_buildids)
 
     $history_query = "
         SELECT DISTINCT status FROM build2test AS b2t
-        INNER JOIN test AS t ON (t.id = b2t.testid)
+        STRAIGHT_JOIN test AS t ON (t.id = b2t.testid)
         WHERE b2t.buildid IN ($previous_buildids) AND t.name = '$testname'";
     $history_results = pdo_query($history_query);
 

--- a/api/v1/viewTest.php
+++ b/api/v1/viewTest.php
@@ -35,9 +35,9 @@ if ($date != null) {
 }
 
 if (isset($_GET['tests'])) {
-  // AJAX call to load history & summary data for currently visible tests.
+    // AJAX call to load history & summary data for currently visible tests.
   load_test_details();
-  exit(0);
+    exit(0);
 }
 
 $response = begin_JSON_response();
@@ -645,64 +645,64 @@ function get_test_summary($testname, $projectid, $begin, $end)
 
 function load_test_details()
 {
-  // Parse input arguments.
+    // Parse input arguments.
   $tests = array();
-  foreach ($_GET['tests'] as $test) {
-    $tests[] = pdo_real_escape_string($test);
-  }
-  if (empty($tests)) {
-    return;
-  }
-
-  $previous_builds = "";
-  if (array_key_exists('previous_builds', $_GET)) {
-    $previous_builds = pdo_real_escape_string($_GET['previous_builds']);
-  }
-  $time_begin = "";
-  if (array_key_exists('time_begin', $_GET)) {
-    $time_begin = pdo_real_escape_string($_GET['time_begin']);
-  }
-  $time_end = "";
-  if (array_key_exists('time_end', $_GET)) {
-    $time_end = pdo_real_escape_string($_GET['time_end']);
-  }
-  $projectid = pdo_real_escape_numeric($_GET['projectid']);
-
-  $response = array();
-  $tests_response = array();
-
-  foreach ($tests as $test) {
-    $test_response = array();
-    $test_response['name'] = $test;
-    $data_found = false;
-
-    if ($time_begin && $time_end) {
-      $summary_response = get_test_summary($test, $projectid, $time_begin, $time_end);
-      if (!empty($summary_response)) {
-        $test_response = array_merge($test_response, $summary_response);
-        $response['displaysummary'] = true;
-        $data_found = true;
-      }
+    foreach ($_GET['tests'] as $test) {
+        $tests[] = pdo_real_escape_string($test);
+    }
+    if (empty($tests)) {
+        return;
     }
 
-    if ($previous_builds) {
-      $history_response = get_test_history($test, $previous_builds);
-      if (!empty($history_response)) {
-        $test_response = array_merge($test_response, $history_response);
-        $response['displayhistory'] = true;
-        $data_found = true;
-      }
+    $previous_builds = "";
+    if (array_key_exists('previous_builds', $_GET)) {
+        $previous_builds = pdo_real_escape_string($_GET['previous_builds']);
+    }
+    $time_begin = "";
+    if (array_key_exists('time_begin', $_GET)) {
+        $time_begin = pdo_real_escape_string($_GET['time_begin']);
+    }
+    $time_end = "";
+    if (array_key_exists('time_end', $_GET)) {
+        $time_end = pdo_real_escape_string($_GET['time_end']);
+    }
+    $projectid = pdo_real_escape_numeric($_GET['projectid']);
+
+    $response = array();
+    $tests_response = array();
+
+    foreach ($tests as $test) {
+        $test_response = array();
+        $test_response['name'] = $test;
+        $data_found = false;
+
+        if ($time_begin && $time_end) {
+            $summary_response = get_test_summary($test, $projectid, $time_begin, $time_end);
+            if (!empty($summary_response)) {
+                $test_response = array_merge($test_response, $summary_response);
+                $response['displaysummary'] = true;
+                $data_found = true;
+            }
+        }
+
+        if ($previous_builds) {
+            $history_response = get_test_history($test, $previous_builds);
+            if (!empty($history_response)) {
+                $test_response = array_merge($test_response, $history_response);
+                $response['displayhistory'] = true;
+                $data_found = true;
+            }
+        }
+
+
+        if ($data_found) {
+            $tests_response[] = $test_response;
+        }
     }
 
-
-    if ($data_found) {
-      $tests_response[] = $test_response;
+    if (!empty($tests_response)) {
+        $response['tests'] = $tests_response;
     }
-  }
 
-  if (!empty($tests_response)) {
-    $response['tests'] = $tests_response;
-  }
-
-  echo json_encode($response);
+    echo json_encode($response);
 }

--- a/api/v1/viewTest.php
+++ b/api/v1/viewTest.php
@@ -55,8 +55,10 @@ $db = pdo_connect("$CDASH_DB_HOST", "$CDASH_DB_LOGIN", "$CDASH_DB_PASS");
 pdo_select_db("$CDASH_DB_NAME", $db);
 
 $build_array = pdo_fetch_array(pdo_query(
-    "SELECT projectid, siteid, type, name, starttime, endtime
-     FROM build WHERE id='$buildid'"));
+    "SELECT projectid, siteid, type, name, starttime, endtime, groupid
+     FROM build AS b
+     LEFT JOIN build2group AS b2g ON (b.id = b2g.buildid)
+     WHERE id='$buildid'"));
 $projectid = $build_array["projectid"];
 if (!isset($projectid) || $projectid==0) {
     $response['error'] = "This build doesn't exist. Maybe it has been deleted.";
@@ -84,6 +86,7 @@ $buildtype = $build_array['type'];
 $buildname = $build_array['name'];
 $starttime = $build_array['starttime'];
 $endtime = $build_array['endtime'];
+$groupid = $build_array['groupid'];
 
 $date = get_dashboard_date_from_build_starttime($starttime, $project_array["nightlytime"]);
 get_dashboard_JSON_by_name($projectname, $date, $response);

--- a/javascript/controllers/viewTest.js
+++ b/javascript/controllers/viewTest.js
@@ -51,7 +51,8 @@ CDash.controller('ViewTestController',
             'previous_builds': $scope.cdash.previous_builds,
             'time_begin': $scope.cdash.time_begin,
             'time_end': $scope.cdash.time_end,
-            'projectid': $scope.cdash.projectid
+            'projectid': $scope.cdash.projectid,
+            'groupid': $scope.cdash.groupid
           }
         }).success(function(response) {
           $scope.cdash.displayhistory = $scope.cdash.displayhistory || response.displayhistory;

--- a/javascript/controllers/viewTest.js
+++ b/javascript/controllers/viewTest.js
@@ -33,6 +33,61 @@ CDash.controller('ViewTestController',
       var begin = ((pageNo - 1) * $scope.pagination.numPerPage)
       , end = begin + $scope.pagination.numPerPage;
       $scope.pagination.filteredTests = $scope.cdash.tests.slice(begin, end);
+
+      // Load history & summary data for these newly revealed tests (if necessary).
+      var tests_to_load = [];
+      for (var i = 0, len = $scope.pagination.filteredTests.length; i < len; i++) {
+        if ( !('detailsloaded' in $scope.pagination.filteredTests[i]) ) {
+          tests_to_load.push($scope.pagination.filteredTests[i]['name']);
+        }
+      }
+
+      if (tests_to_load.length > 0) {
+        $http({
+          url: 'api/v1/viewTest.php',
+          method: 'GET',
+          params: {
+            'tests[]': tests_to_load,
+            'previous_builds': $scope.cdash.previous_builds,
+            'time_begin': $scope.cdash.time_begin,
+            'time_end': $scope.cdash.time_end,
+            'projectid': $scope.cdash.projectid
+          }
+        }).success(function(response) {
+          $scope.cdash.displayhistory = $scope.cdash.displayhistory || response.displayhistory;
+          $scope.cdash.displaysummary = $scope.cdash.displaysummary || response.displaysummary;
+
+          function copy_test_details(test, response) {
+            if ('history' in response) {
+              test['history'] = response['history'];
+              test['historyclass'] = response['historyclass'];
+            }
+            if ('summary' in response) {
+              test['summary'] = response['summary'];
+              test['summaryclass'] = response['summaryclass'];
+            }
+            test['detailsloaded'] = true;
+          }
+
+          // Update our currently displayed filtered results with this new data.
+          for (var i = 0, len1 = response.tests.length; i < len1; i++) {
+            for (var j = 0, len2 = $scope.pagination.filteredTests.length; j < len2; j++) {
+              if (response.tests[i].name === $scope.pagination.filteredTests[j].name) {
+                copy_test_details($scope.pagination.filteredTests[j], response.tests[i]);
+              }
+            }
+          }
+
+          // Also copy this newfound data into the 'master list' of tests.
+          for (var i = 0, len1 = response.tests.length; i < len1; i++) {
+            for (var j = 0, len2 = $scope.cdash.tests.length; j < len2; j++) {
+              if (response.tests[i].name === $scope.cdash.tests[j].name) {
+                copy_test_details($scope.cdash.tests[j], response.tests[i]);
+              }
+            }
+          }
+        });
+      }
     };
 
     $scope.pageChanged = function() {

--- a/views/viewTest.html
+++ b/views/viewTest.html
@@ -193,7 +193,7 @@
                 ng-click="updateOrderByFields('history', $event)"
                 tooltip-popup-delay='1500'
                 tooltip-append-to-body="true"
-                uib-tooltip='Test status over the past four days'>
+                uib-tooltip='Test status for this build over the past four runs'>
                 History
                 <span class="glyphicon" ng-class="orderByFields.indexOf('-history') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('history') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
@@ -202,7 +202,7 @@
                 ng-click="updateOrderByFields('summary', $event)"
                 tooltip-popup-delay='1500'
                 tooltip-append-to-body="true"
-                uib-tooltip='Test status across the BuildGroup'>
+                uib-tooltip='Current test status across the BuildGroup'>
                 Summary
                 <span class="glyphicon" ng-class="orderByFields.indexOf('-summary') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('summary') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>


### PR DESCRIPTION
The 'History' and 'Summary' columns on viewTest.php can be expensive to compute.  When a build has more than 25 tests, we now use AJAX calls to compute this info as tests are revealed to the user.