### PR TITLE
Update previous/current/next links to honor parentid

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -589,7 +589,7 @@ function createPageSpecificFilters($page_id)
     switch ($page_id) {
         case 'index.php':
         case 'project.php':
-        case 'viewChildren.php':
+        case 'indexchildren.php':
             {
                 return new IndexPhpFilters();
             }

--- a/models/build.php
+++ b/models/build.php
@@ -265,6 +265,7 @@ class build
         }
 
         $query = pdo_query("SELECT projectid,starttime,siteid,name,type,parentid FROM build WHERE id=".qnum($buildid));
+
         if (!$query) {
             add_last_sql_error("Build:FillFromId()", $this->ProjectId, $this->Id);
             return false;
@@ -340,12 +341,17 @@ class build
         //
         $subproj_table = "";
         $subproj_criteria = "";
+        $parent_criteria = "";
 
         if ($this->SubProjectId) {
             $subproj_table = ", subproject2build";
             $subproj_criteria =
                 "AND build.id=subproject2build.buildid ".
                 "AND subproject2build.subprojectid=".qnum($this->SubProjectId)." ";
+        }
+        if ($this->ParentId == -1) {
+            // Only search for other parents.
+            $parent_criteria = "AND build.parentid=-1";
         }
 
         $query = pdo_query("
@@ -355,8 +361,10 @@ class build
                 AND name='$this->Name'
                 AND projectid=".qnum($this->ProjectId)."
                 $subproj_criteria
+                $parent_criteria
                 $which_build_criteria
                 LIMIT 1");
+
         if (!$query) {
             add_last_sql_error(
                     "Build:GetRelatedBuildId", $this->ProjectId, $this->Id);

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -168,10 +168,6 @@ function echo_main_dashboard_JSON($project_instance, $date)
 
     $page_id = 'index.php';
     $response['childview'] = 0;
-    if (isset($_GET["parentid"])) {
-        $page_id = 'indexchildren.php';
-        $response['childview'] = 1;
-    }
 
     if ($CDASH_USE_LOCAL_DIRECTORY && file_exists("local/models/proProject.php")) {
         include_once("local/models/proProject.php");
@@ -195,7 +191,37 @@ function echo_main_dashboard_JSON($project_instance, $date)
     if ($project_instance->GetNumberOfSubProjects($end_UTCDate) > 0) {
         $response['menu']['subprojects'] = 1;
     }
-    if (!has_next_date($date, $currentstarttime)) {
+
+    if (isset($_GET['parentid'])) {
+        $parentid = pdo_real_escape_numeric($_GET['parentid']);
+        $page_id = 'indexchildren.php';
+        $response['childview'] = 1;
+
+        // When a parentid is specified, we should link to the next build,
+        // not the next day.
+        include_once("models/build.php");
+        $build = new Build();
+        $build->Id = $parentid;
+        $previous_buildid = $build->GetPreviousBuildId();
+        $current_buildid = $build->GetCurrentBuildId();
+        $next_buildid = $build->GetNextBuildId();
+
+        $base_url = "index.php?project=".urlencode($projectname);
+        if ($previous_buildid > 0) {
+            $response['menu']['previous'] = "$base_url&parentid=$previous_buildid";
+        } else {
+            $response['menu']['noprevious'] = "1";
+        }
+
+        $response['menu']['current'] = "$base_url&parentid=$current_buildid";
+
+        if ($next_buildid > 0) {
+            $response['menu']['next'] = "$base_url&parentid=$next_buildid";
+        } else {
+            $response['menu']['nonext'] = "1";
+        }
+    }
+    else if (!has_next_date($date, $currentstarttime)) {
         $response['menu']['nonext'] = 1;
     }
 

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -220,8 +220,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
         } else {
             $response['menu']['nonext'] = "1";
         }
-    }
-    else if (!has_next_date($date, $currentstarttime)) {
+    } elseif (!has_next_date($date, $currentstarttime)) {
         $response['menu']['nonext'] = 1;
     }
 


### PR DESCRIPTION
When viewing the children of a parent build, the link at the top of the page should take you to the previous parent build for that configuration.  Before this change, the link would simply take you to the build results for the previous day.  Similar behavior is expected for the next and current buttons.