### PR TITLE
Pass subproject filters along to the child view

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -1368,7 +1368,7 @@ function get_child_builds_hyperlink($parentid, $filterdata)
         // at the child level.
         if ($num_includes > 1) {
             $existing_filter_params .= '&filtercombine=or';
-        } else if (array_key_exists('filtercombine', $filterdata)) {
+        } elseif (array_key_exists('filtercombine', $filterdata)) {
             $existing_filter_params .=
                 '&filtercombine=' . $filterdata['filtercombine'];
         }


### PR DESCRIPTION
We recently added a new filter called 'subprojects' to index.php.
This allows you to blacklist or whitelist what subprojects will
be included in the tally of build errors & such on this page.

This commit causes these filters to be preserved when you delve
down into the child build view.  So if you excluded a subproject
at the parent view, it also will not appear after you click
on a child build.