### PR TITLE
Fixed 'Subproject Dependencies' multicolumn sorting

### DIFF
--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -58,7 +58,7 @@ CDash.filter("showEmptyBuildsLast", function () {
 
   $scope.sortCoverage = { orderByFields: [] };
   $scope.sortDA = { orderByFields: [] };
-  $scope.sortSubProjectDependencies = { orderByFields: [] };
+  $scope.sortSubProjects = { orderByFields: [] };
 
   // Show/hide feed based on cookie settings.
   var feed_cookie = $.cookie('cdash_hidefeed');

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -58,6 +58,7 @@ CDash.filter("showEmptyBuildsLast", function () {
 
   $scope.sortCoverage = { orderByFields: [] };
   $scope.sortDA = { orderByFields: [] };
+  $scope.sortSubProjectDependencies = { orderByFields: [] };
 
   // Show/hide feed based on cookie settings.
   var feed_cookie = $.cookie('cdash_hidefeed');

--- a/public/js/controllers/viewSubProjects.js
+++ b/public/js/controllers/viewSubProjects.js
@@ -5,7 +5,7 @@ CDash.controller('ViewSubProjectsController',
     // Hide filters by default.
     $scope.showfilters = false;
 
-    $scope.orderByFields = [];
+    $scope.sortSubProjectDependencies = { orderByFields: [] };
 
     $http({
       url: 'api/v1/viewSubProjects.php',
@@ -17,7 +17,7 @@ CDash.controller('ViewSubProjectsController',
       $scope.loading = false;
     });
 
-    $scope.updateOrderByFields = function(field, $event) {
-      multisort.updateOrderByFields($scope, field, $event);
+    $scope.updateOrderByFields = function(obj, field, $event) {
+      multisort.updateOrderByFields(obj, field, $event);
     };
 });

--- a/public/js/controllers/viewSubProjects.js
+++ b/public/js/controllers/viewSubProjects.js
@@ -5,7 +5,7 @@ CDash.controller('ViewSubProjectsController',
     // Hide filters by default.
     $scope.showfilters = false;
 
-    $scope.sortSubProjectDependencies = { orderByFields: [] };
+    $scope.sortSubProjects = { orderByFields: [] };
 
     $http({
       url: 'api/v1/viewSubProjects.php',

--- a/public/views/partials/subProjectTable.html
+++ b/public/views/partials/subProjectTable.html
@@ -5,72 +5,72 @@
     </tr>
     <tr class="table-heading">
 
-      <th align="center" rowspan="2" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'name', $event)">
+      <th align="center" rowspan="2" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'name', $event)">
         <b>SubProject</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-name') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('name') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-name') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('name') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
       <td align="center" colspan="3" width="20%"><b>Configure</b></td>
       <td align="center" colspan="3" width="20%"><b>Build</b></td>
       <td align="center" colspan="3" width="20%"><b>Test</b></td>
 
-      <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'lastsubmission', $event)">
+      <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'lastsubmission', $event)">
         <b>Last submission</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
     </tr>
     <tr class="table-heading">
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigureerror', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigureerror', $event)">
         <b>Error</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigureerror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigureerror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigureerror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigureerror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigurewarning', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurewarning', $event)">
         <b>Warning</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigurewarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigurewarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigurewarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigurewarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigurepass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurepass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigurepass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigurepass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigurepass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigurepass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuilderror', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuilderror', $event)">
         <b>Error</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuilderror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuilderror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuilderror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuilderror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuildwarning', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuildwarning', $event)">
         <b>Warning</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuildwarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuildwarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuildwarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuildwarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuildpass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuildpass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuildpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuildpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuildpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuildpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestnotrun', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestnotrun', $event)">
         <b>Not Run</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestnotrun') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestnotrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestnotrun') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestnotrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestfail', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestfail', $event)">
         <b>Fail</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestfail') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestfail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestfail') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestfail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestpass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestpass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
     </tr>
   </thead>
 
   <tbody>
-    <tr ng-repeat="subproject in cdash.subprojects |orderBy:sortSubProjectDependencies.orderByFields|showEmptySubProjectsLast:sortSubProjectDependencies.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
+    <tr ng-repeat="subproject in cdash.subprojects |orderBy:sortSubProjects.orderByFields|showEmptySubProjectsLast:sortSubProjects.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
       <td align="center" >
         <a ng-href="index.php?subproject={{subproject.name_encoded}}&{{cdash.linkparams}}">
           {{subproject.name}}

--- a/public/views/partials/subProjectTable.html
+++ b/public/views/partials/subProjectTable.html
@@ -16,7 +16,7 @@
 
       <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'lastsubmission', $event)">
         <b>Last submission</b>
-        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
     </tr>

--- a/public/views/partials/subProjectTable.html
+++ b/public/views/partials/subProjectTable.html
@@ -5,72 +5,72 @@
     </tr>
     <tr class="table-heading">
 
-      <th align="center" rowspan="2" width="20%" style="cursor: pointer" ng-click="updateOrderByFields('name', $event)">
+      <th align="center" rowspan="2" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'name', $event)">
         <b>SubProject</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-name') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('name') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-name') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('name') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
       <td align="center" colspan="3" width="20%"><b>Configure</b></td>
       <td align="center" colspan="3" width="20%"><b>Build</b></td>
       <td align="center" colspan="3" width="20%"><b>Test</b></td>
 
-      <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields('lastsubmission', $event)">
+      <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'lastsubmission', $event)">
         <b>Last submission</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
     </tr>
     <tr class="table-heading">
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nconfigureerror', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigureerror', $event)">
         <b>Error</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nconfigureerror') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nconfigureerror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigureerror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigureerror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nconfigurewarning', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigurewarning', $event)">
         <b>Warning</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nconfigurewarning') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nconfigurewarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigurewarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigurewarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nconfigurepass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nconfigurepass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nconfigurepass') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nconfigurepass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nconfigurepass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nconfigurepass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nbuilderror', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuilderror', $event)">
         <b>Error</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nbuilderror') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nbuilderror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuilderror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuilderror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nbuildwarning', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuildwarning', $event)">
         <b>Warning</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nbuildwarning') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nbuildwarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuildwarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuildwarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('nbuildpass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'nbuildpass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-nbuildpass') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('nbuildpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-nbuildpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('nbuildpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('ntestnotrun', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestnotrun', $event)">
         <b>Not Run</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-ntestnotrun') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('ntestnotrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestnotrun') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestnotrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('ntestfail', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestfail', $event)">
         <b>Fail</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-ntestfail') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('ntestfail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestfail') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestfail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields('ntestpass', $event)">
+      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjectDependencies, 'ntestpass', $event)">
         <b>Pass</b>
-        <span class="glyphicon" ng-class="orderByFields.indexOf ('-ntestpass') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf ('ntestpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+        <span class="glyphicon" ng-class="sortSubProjectDependencies.orderByFields.indexOf ('-ntestpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjectDependencies.orderByFields.indexOf ('ntestpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
     </tr>
   </thead>
 
   <tbody>
-    <tr ng-repeat="subproject in cdash.subprojects |orderBy:orderByFields|showEmptySubProjectsLast:orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
+    <tr ng-repeat="subproject in cdash.subprojects |orderBy:sortSubProjectDependencies.orderByFields|showEmptySubProjectsLast:sortSubProjectDependencies.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
       <td align="center" >
         <a ng-href="index.php?subproject={{subproject.name_encoded}}&{{cdash.linkparams}}">
           {{subproject.name}}


### PR DESCRIPTION
Previously, the sorting on the 'Subproject Dependencies' table
(e.g. index.php?subproject...) was broken.

PTAL @zackgalbreath