### PR TITLE
only show relevant results when whitelisting

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -864,6 +864,19 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $build_response['label'] = "(none)";
         } else {
             if ($include_subprojects) {
+                // Skip this build entirely if it doesn't contain
+                // any of the whitelisted SubProjects.
+                $skip_this_build = true;
+                foreach ($included_subprojects as $included_subproject) {
+                    if (in_array($included_subproject, $labels_array)) {
+                        $skip_this_build = false;
+                        break;
+                    }
+                }
+                if ($skip_this_build) {
+                    continue;
+                }
+
                 $num_labels = $num_selected_subprojects;
             } else {
                 $num_labels = count($labels_array) - $num_selected_subprojects;

--- a/tests/test_subprojectnextprevious.php
+++ b/tests/test_subprojectnextprevious.php
@@ -254,6 +254,17 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
             $success = false;
         }
 
+        // Make sure that a build is not displayed when it does not
+        // contain any of the whitelisted SubProjects.
+        $this->get($this->url . "/api/v1/index.php?project=Trilinos&date=2011-07-23&filtercount=1&showfilters=1&field1=subprojects&compare1=93&value1=Teuchos");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $num_buildgroups = count($jsonobj['buildgroups']);
+        if ($num_buildgroups !== 0) {
+            $error_msg = "Expected 0 BuildGroups while whitelisting, found $num_buildgroups";
+            $success = false;
+        }
+
         // Delete the builds that we created during this test.
         remove_build($second_parentid);
         remove_build($third_parentid);


### PR DESCRIPTION
We recently added a new filter to index.php called
"SubProjects include".  This allows users to view just the
results for one or more SubProjects that they are interested in.

This commit fixes a bug with the new filter.  After applying the
filter, index.php would continue to display parent builds that
did not build any of the whitelisted SubProjects.  This behavior
is now fixed.  When using the "SubProjects include" filter,
parent builds that do not include any of the whitelisted
SubProjects will no longer be listed on index.php.