### PR TITLE
Always use SimplePHPPageBuilder for SimpleTest

### DIFF
--- a/tests/kwtest/simpletest/browser.php
+++ b/tests/kwtest/simpletest/browser.php
@@ -19,8 +19,7 @@ require_once(dirname(__FILE__) . '/selector.php');
 require_once(dirname(__FILE__) . '/frames.php');
 require_once(dirname(__FILE__) . '/user_agent.php');
 if (! SimpleTest::getParsers()) {
-    SimpleTest::setParsers(array(new SimpleTidyPageBuilder(), new SimplePHPPageBuilder()));
-    //SimpleTest::setParsers(array(new SimplePHPPageBuilder()));
+    SimpleTest::setParsers(array(new SimplePHPPageBuilder()));
 }
 /**#@-*/
 


### PR DESCRIPTION
CircleCI was using SimpleTidyPageBuilder instead, which caused
compressedtest to fail there.