### PR TITLE
Fix Google authentication

### DIFF
--- a/public/googleauth_callback.php
+++ b/public/googleauth_callback.php
@@ -1,6 +1,6 @@
 <?php
-include_once("include/common.php");
 include(dirname(__DIR__)."/config/config.php");
+include_once("include/common.php");
 require_once("include/pdo.php");
 
   /** Google authentication */


### PR DESCRIPTION
We need to include config.php before any other files because it
sets up our include path.