### PR TITLE
Add option to instantly delete parsed submissions

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -51,7 +51,8 @@ $CDASH_TESTING_MODE = false;
 $CDASH_TESTING_RENAME_LOGS = false;
 // Should we use asynchronous submission
 $CDASH_ASYNCHRONOUS_SUBMISSION = false;
-// How long to keep finished async submissions in the DB
+// How long to keep finished async submissions in the DB.
+// Set to 0 to delete them right away.
 $CDASH_ASYNC_EXPIRATION_TIME = 691200; // 8 days.
 // Main title and subtitle for the index page
 $CDASH_MAININDEX_TITLE = 'CDash';

--- a/public/ajax/processsubmissions.php
+++ b/public/ajax/processsubmissions.php
@@ -340,23 +340,23 @@ function ProcessSubmissions($projectid)
 
         $PHP_ERROR_SUBMISSION_ID = 0;
 
-    global $CDASH_ASYNC_EXPIRATION_TIME;
-    if ($CDASH_ASYNC_EXPIRATION_TIME === 0 &&
+        global $CDASH_ASYNC_EXPIRATION_TIME;
+        if ($CDASH_ASYNC_EXPIRATION_TIME === 0 &&
             ($new_status > 1 && $new_status < 6)) {
-        // If our expiration time is set to 0 we delete finished
+            // If our expiration time is set to 0 we delete finished
         // submissions rather than marking them as done in the database.
         pdo_query(
                 "DELETE FROM submission WHERE id='$submission_id'");
-        add_last_sql_error("ProcessSubmissions-3");
-    } else {
-        // Mark it as done with $new_status and record finished time:
+            add_last_sql_error("ProcessSubmissions-3");
+        } else {
+            // Mark it as done with $new_status and record finished time:
         //
         $now_utc = gmdate(FMT_DATETIMESTD);
             pdo_query(
           "UPDATE submission SET status=$new_status, finished='$now_utc', ".
           "lastupdated='$now_utc' WHERE id='".$submission_id."'");
             add_last_sql_error("ProcessSubmissions-3");
-    }
+        }
 
     // Query for more... Continue processing while there are records to
     // process:

--- a/public/ajax/processsubmissions.php
+++ b/public/ajax/processsubmissions.php
@@ -340,13 +340,23 @@ function ProcessSubmissions($projectid)
 
         $PHP_ERROR_SUBMISSION_ID = 0;
 
-    // Mark it as done with $new_status and record finished time:
-    //
-    $now_utc = gmdate(FMT_DATETIMESTD);
+    global $CDASH_ASYNC_EXPIRATION_TIME;
+    if ($CDASH_ASYNC_EXPIRATION_TIME === 0 &&
+            ($new_status > 1 && $new_status < 6)) {
+        // If our expiration time is set to 0 we delete finished
+        // submissions rather than marking them as done in the database.
         pdo_query(
-      "UPDATE submission SET status=$new_status, finished='$now_utc', ".
-      "lastupdated='$now_utc' WHERE id='".$submission_id."'");
+                "DELETE FROM submission WHERE id='$submission_id'");
         add_last_sql_error("ProcessSubmissions-3");
+    } else {
+        // Mark it as done with $new_status and record finished time:
+        //
+        $now_utc = gmdate(FMT_DATETIMESTD);
+            pdo_query(
+          "UPDATE submission SET status=$new_status, finished='$now_utc', ".
+          "lastupdated='$now_utc' WHERE id='".$submission_id."'");
+            add_last_sql_error("ProcessSubmissions-3");
+    }
 
     // Query for more... Continue processing while there are records to
     // process:


### PR DESCRIPTION
We now delete completed submissions from the submission table
as soon as they are processed when CDASH_ASYNC_EXPIRATION_TIME
is set to 0.