### PR TITLE
Add option to instantly delete parsed XML files

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -98,7 +98,8 @@ $CDASH_LOG_FILE_MAXSIZE_MB = 50;
 $CDASH_LOG_LEVEL = LOG_WARNING;
 // Using external authentication
 $CDASH_EXTERNAL_AUTH = '0';
-// Backup timeframe
+// Backup timeframe.
+// Set to '0' if you do not wish to backup parsed .xml files.
 $CDASH_BACKUP_TIMEFRAME = '48'; // 48 hours
 // Request full email address to add new users
 // instead of displaying a list

--- a/include/ctestparser.php
+++ b/include/ctestparser.php
@@ -368,6 +368,13 @@ function ctest_parse($filehandler, $projectid, $expected_md5='', $do_checksum=tr
         $parsingerror = $localParser->EndParsingFile();
     }
 
+    // Delete this file as soon as its been parsed if
+    // CDASH_BACKUP_TIMEFRAME is set to '0'.
+    global $CDASH_BACKUP_TIMEFRAME;
+    if ($CDASH_BACKUP_TIMEFRAME === '0') {
+        unlink($filename);
+    }
+
     displayReturnStatus($statusarray);
     return $handler;
 }


### PR DESCRIPTION
We now delete XML files as soon as they are parsed if
CDASH_BACKUP_TIMEFRAME is set to '0'.