### PR TITLE
Fix failing CircleCI test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
     - ~/.composer/cache
 
   override:
-    - sudo apt-get update --quiet && sudo apt-get install --no-install-recommends --quiet --yes cmake
+    - sudo apt-get update --quiet && sudo apt-get install --no-install-recommends --quiet --yes cmake && sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
     - echo "pdo_mysql.default_socket = /var/run/mysqld/mysqld.sock" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/pdo_mysql.ini
     - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
     - cp ~/CDash/tests/circle/default /etc/apache2/sites-available


### PR DESCRIPTION
For some reason their version of gcc and gcov no longer match.  This is causing two of our tests (simple and simple_async) to fail.