### PR TITLE
Simplify how labels are handled by index.php

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -825,7 +825,8 @@ function echo_main_dashboard_JSON($project_instance, $date)
         }
 
         // Handle whether or not this build has labels.
-        if ($build_array['numlabels'] == 0) {
+        if (!array_key_exists('numlabels', $build_array) ||
+                $build_array['numlabels'] == 0) {
             $build_label = "(none)";
         } elseif ($build_array['numlabels'] == 1) {
             // If exactly one label for this build, look it up here.

--- a/tests/test_subprojectnextprevious.php
+++ b/tests/test_subprojectnextprevious.php
@@ -265,6 +265,29 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
             $success = false;
         }
 
+        // Make sure that a build is not displayed when all of its
+        // SubProjects have been blacklisted away.
+        $this->get($this->url . "/api/v1/index.php?project=Trilinos&date=2011-07-23&filtercount=1&showfilters=1&field1=subprojects&compare1=92&value1=Didasko");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $num_buildgroups = count($jsonobj['buildgroups']);
+        if ($num_buildgroups !== 0) {
+            $error_msg = "Expected 0 BuildGroups while blacklisting, found $num_buildgroups";
+            $success = false;
+        }
+
+        // Make sure that the reported number of labels does not
+        // change when an irrelevant blacklist criterion is added.
+        $this->get($this->url . "/api/v1/index.php?project=Trilinos&date=2011-07-23&filtercount=1&showfilters=1&field1=subprojects&compare1=92&value1=Teuchos");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $label = $buildgroup['builds'][0]['label'];
+        if ($label !== 'Didasko') {
+            $error_msg = "Expected label 'Didasko', found $label";
+            $success = false;
+        }
+
         // Delete the builds that we created during this test.
         remove_build($second_parentid);
         remove_build($third_parentid);


### PR DESCRIPTION
Most of the time we only display how many labels a build has, not what
they actually are.