### PR TITLE
Prevent user discovery

### DIFF
--- a/public/api/v1/getuserid.php
+++ b/public/api/v1/getuserid.php
@@ -16,15 +16,17 @@
 
 =========================================================================*/
 
-$noforcelogin = 1;
 require_once(dirname(dirname(dirname(__DIR__)))."/config/config.php");
 require_once("include/common.php");
 require_once("include/pdo.php");
+
+// Don't display the login form.
+$noforcelogin = 1;
 include('public/login.php');
 
 // Check for authenticated user.
-@$userid = $_SESSION['cdash']['loginid'];
-if (!isset($userid) || !is_numeric($userid)) {
+if (!isset($_SESSION['cdash']) || !isset($_SESSION['cdash']['loginid']) ||
+        !is_numeric($_SESSION['cdash']['loginid'])) {
     return;
 }
 

--- a/public/api/v1/getuserid.php
+++ b/public/api/v1/getuserid.php
@@ -16,9 +16,17 @@
 
 =========================================================================*/
 
+$noforcelogin = 1;
 require_once(dirname(dirname(dirname(__DIR__)))."/config/config.php");
 require_once("include/common.php");
 require_once("include/pdo.php");
+include('public/login.php');
+
+// Check for authenticated user.
+@$userid = $_SESSION['cdash']['loginid'];
+if (!isset($userid) || !is_numeric($userid)) {
+    return;
+}
 
 echo '<?xml version="1.0" encoding="UTF-8"?>';
 echo "<userid>";

--- a/public/recoverPassword.php
+++ b/public/recoverPassword.php
@@ -37,7 +37,8 @@ if ($recover) {
     add_last_sql_error("recoverPassword");
 
     if (pdo_num_rows($emailResult) == 0) {
-        $xml .= "<warning>This email is not registered.</warning>";
+        // Don't reveal whether or not this is a valid account.
+        $xml .= "<message>A confirmation message has been sent to your inbox.</message>";
     } else {
         // Create a new password
         $keychars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&";

--- a/tests/test_api.php
+++ b/tests/test_api.php
@@ -59,6 +59,7 @@ class APITestCase extends KWWebTestCase
             return 1;
         }
 
+        $this->login();
         $userid = $this->get($this->url."/api/v1/getuserid.php?author=simpleuser@localhost");
         if (!preg_match("/..xml version..1.0. encoding..UTF-8....userid.\d+..userid./", $userid)) {
             $this->fail("Output does not match expected pattern when querying API for userid (test1): $userid");
@@ -104,6 +105,13 @@ class APITestCase extends KWWebTestCase
         $userid = $this->get($this->url."/api/v1/getuserid.php?author=blahblahblahblahblah&project=PublicDashboard");
         if ($userid !== '<?xml version="1.0" encoding="UTF-8"?><userid>not found<no-such-user/></userid>') {
             $this->fail("Expected valid output not found when querying API for userid (test8): $userid");
+            return 1;
+        }
+
+        $this->logout();
+        $empty_content = $this->get($this->url."/api/v1/getuserid.php?author=simpleuser@localhost");
+        if ($empty_content !== '') {
+            $this->fail("Expected valid output not found when querying API for userid while unauthenticated: $empty_content");
             return 1;
         }
 


### PR DESCRIPTION
Fix a couple locations that made it possible to determine whether or not an email address was a valid CDash account.