### PR TITLE
Allow SSL CA to be set independently of key and certificate

### DIFF
--- a/include/CDash/Database.php
+++ b/include/CDash/Database.php
@@ -101,10 +101,12 @@ class Database
         $this->username = $username;
         $this->password = $password;
         $this->retries = $retries;
-        if (!is_null($ssl_ca) && !is_null($ssl_cert) && !is_null($ssl_key)) {
-            $this->attributes[\PDO::MYSQL_ATTR_SSL_KEY] = $ssl_key;
-            $this->attributes[\PDO::MYSQL_ATTR_SSL_CERT] = $ssl_cert;
+        if (!is_null($ssl_ca)) {
             $this->attributes[\PDO::MYSQL_ATTR_SSL_CA] = $ssl_ca;
+            if (!is_null($ssl_cert) && !is_null($ssl_key)) {
+                $this->attributes[\PDO::MYSQL_ATTR_SSL_KEY] = $ssl_key;
+                $this->attributes[\PDO::MYSQL_ATTR_SSL_CERT] = $ssl_cert;
+            }
         }
     }
 


### PR DESCRIPTION
Needed for Amazon RDS.