### PR TITLE
Add htmlentities to API usage of filterstring

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -384,7 +384,8 @@ function echo_main_dashboard_JSON($project_instance, $date)
     }
     unset($filterdata['xml']);
     $response['filterdata'] = $filterdata;
-    $response['filterurl'] = @$_GET['filterstring'];
+    // htmlentities used here to prevent XSS injection from filterstring content
+    $response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
 
     // Check if we should be excluding some SubProjects from our
     // build results.

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -385,7 +385,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
     unset($filterdata['xml']);
     $response['filterdata'] = $filterdata;
     // htmlentities used here to prevent XSS injection from filterstring content
-    $response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
+    $response['filterurl'] = htmlentities(@$_GET['filterstring'], ENT_QUOTES | ENT_HTML5);
 
     // Check if we should be excluding some SubProjects from our
     // build results.

--- a/public/api/v1/queryTests.php
+++ b/public/api/v1/queryTests.php
@@ -71,7 +71,8 @@ $limit_sql = '';
 if ($filterdata['limit']>0) {
     $limit_sql = ' LIMIT '.$filterdata['limit'];
 }
-$response['filterurl'] = @$_GET["filterstring"];
+// htmlentities used here to prevent XSS injection from filterstring content
+$response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
 
 // Menu
 $menu = array();

--- a/public/api/v1/queryTests.php
+++ b/public/api/v1/queryTests.php
@@ -72,7 +72,7 @@ if ($filterdata['limit']>0) {
     $limit_sql = ' LIMIT '.$filterdata['limit'];
 }
 // htmlentities used here to prevent XSS injection from filterstring content
-$response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
+$response['filterurl'] = htmlentities(@$_GET['filterstring'], ENT_QUOTES | ENT_HTML5);
 
 // Menu
 $menu = array();

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -252,7 +252,8 @@ $limit_sql = '';
 if ($filterdata['limit']>0) {
     $limit_sql = ' LIMIT '.$filterdata['limit'];
 }
-$response['filterurl'] = @$_GET["filterstring"];
+// htmlentities used here to prevent XSS injection from filterstring content
+$response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
 
 $limitnew = "";
 $onlydelta_extra = "";

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -253,7 +253,7 @@ if ($filterdata['limit']>0) {
     $limit_sql = ' LIMIT '.$filterdata['limit'];
 }
 // htmlentities used here to prevent XSS injection from filterstring content
-$response['filterurl'] = htmlentities(@$_GET['filterstring'],ENT_QUOTES | ENT_HTML5);
+$response['filterurl'] = htmlentities(@$_GET['filterstring'], ENT_QUOTES | ENT_HTML5);
 
 $limitnew = "";
 $onlydelta_extra = "";


### PR DESCRIPTION
Add a call to the htmlentities function in the API where
'filterstring' is pulled from the webpage to prevent XSS.