### PR TITLE
delete completed submission2ip rows

### DIFF
--- a/include/submission_functions.php
+++ b/include/submission_functions.php
@@ -301,6 +301,9 @@ function ProcessSubmissions($projectid, $mypid)
             pdo_query(
                     "DELETE FROM submission WHERE id='$submission_id'");
             add_last_sql_error("ProcessSubmissions-3");
+            pdo_query(
+                    "DELETE FROM submission2ip WHERE submissionid='$submission_id'");
+            add_last_sql_error("ProcessSubmissions-3");
         } else {
             // Mark it as done with $new_status and record finished time:
             //


### PR DESCRIPTION
When CDash is configured to not keep completed submissions,
we also need to delete the corresponding record from submission2ip
Otherwise we will eventually encounter DUPLICATE KEY errors
in the MySQL log.