### PR TITLE
Remove escaping of remember me checkbox input

### DIFF
--- a/include/login_functions.php
+++ b/include/login_functions.php
@@ -285,11 +285,7 @@ function auth($SessionCachePolicy = 'private_no_expire')
             $passwd = htmlspecialchars(pdo_real_escape_string($passwd));
         }
 
-        @$rememberme = $_POST['rememberme'];
-        if ($rememberme != null) {
-            $rememberme = pdo_real_escape_numeric($rememberme);
-        }
-        return authenticate($login, $passwd, $SessionCachePolicy, $rememberme);
+        return authenticate($login, $passwd, $SessionCachePolicy, isset($_POST['rememberme']));
     } else {                                         // arrive from session var
         $cookiename = str_replace('.', '_', 'CDash-' . $_SERVER['SERVER_NAME']); // php doesn't like dot in cookie names
         if (isset($_COOKIE[$cookiename])) {


### PR DESCRIPTION
'rememberme' is a checkbox, so the test for whether or not it's checked
should be a simple isset. We were running pdo_real_escape_numeric on the
value (which was "on") so $rememberme was always set to 0. It's only
ever used as a boolean so it was always evaluating to false.

This can be tested by logging into a CDash instance (checking the remember me box) and seeing if a CDash-servername cookie exists.