### PR TITLE
Fix improper usage of add_log

### DIFF
--- a/include/createRSS.php
+++ b/include/createRSS.php
@@ -90,6 +90,6 @@ function CreateRSSFeed($projectid)
     }
 
     if (file_put_contents($filename, $feed) === false) {
-        add_log('CreateRSSFeed', 'Cannot write file ' . $filename, LOG_ERR, $projectid);
+        add_log('Cannot write file ' . $filename, 'CreateRSSFeed', LOG_ERR, $projectid);
     }
 }

--- a/models/buildgroup.php
+++ b/models/buildgroup.php
@@ -77,7 +77,7 @@ class buildgroup
         }
 
         if ($this->Id < 1) {
-            add_log('BuildGroup GetName(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetName(): Id not set', 'GetName', LOG_ERR);
             return false;
         }
 
@@ -123,7 +123,7 @@ class buildgroup
     public function GetStartTime()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetStartTime(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetStartTime(): Id not set', 'GetStartTime', LOG_ERR);
             return false;
         }
         return $this->StartTime;
@@ -138,7 +138,7 @@ class buildgroup
     public function GetEndTime()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetEndTime(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetEndTime(): Id not set', 'GetEndTime', LOG_ERR);
             return false;
         }
         return $this->EndTime;
@@ -153,7 +153,7 @@ class buildgroup
     public function GetAutoRemoveTimeFrame()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetAutoRemoveTimeFrame(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetAutoRemoveTimeFrame(): Id not set', 'GetAutoRemoveTimeFrame', LOG_ERR);
             return false;
         }
         return $this->AutoRemoveTimeFrame;
@@ -171,7 +171,7 @@ class buildgroup
     public function GetDescription()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetDescription(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetDescription(): Id not set', 'GetDescription', LOG_ERR);
             return false;
         }
         return $this->Description;
@@ -190,7 +190,7 @@ class buildgroup
     public function GetSummaryEmail()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetSummaryEmail(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetSummaryEmail(): Id not set', 'GetSummaryEmail', LOG_ERR);
             return false;
         }
         return $this->SummaryEmail;
@@ -208,7 +208,7 @@ class buildgroup
     public function GetIncludeSubProjectTotal()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetIncludeSubProjectTotal(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetIncludeSubProjectTotal(): Id not set', 'GetIncludeSubProjectTotal', LOG_ERR);
             return false;
         }
         return $this->IncludeSubProjectTotal;
@@ -227,7 +227,7 @@ class buildgroup
     public function GetEmailCommitters()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetEmailCommitters(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetEmailCommitters(): Id not set', 'GetEmailCommitters', LOG_ERR);
             return false;
         }
         return $this->EmailCommitters;
@@ -246,7 +246,7 @@ class buildgroup
     public function GetType()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetType(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetType(): Id not set', 'GetType', LOG_ERR);
             return false;
         }
         return $this->Type;
@@ -301,7 +301,7 @@ class buildgroup
     public function GetPosition()
     {
         if ($this->Id < 1) {
-            add_log('BuildGroup GetPosition(): Id not set', LOG_ERR);
+            add_log('BuildGroup GetPosition(): Id not set', 'GetPosition', LOG_ERR);
             return false;
         }
 
@@ -314,6 +314,7 @@ class buildgroup
         if (pdo_num_rows($result) < 1) {
             add_log(
                 "BuildGroup GetPosition(): no position found for buildgroup # $this->Id !",
+                'GetPosition',
                 LOG_ERR);
             return false;
         }

--- a/public/googleauth_callback.php
+++ b/public/googleauth_callback.php
@@ -33,7 +33,7 @@ function googleAuthenticate($code)
     session_start();
 
     if (!isset($_GET['state'])) {
-        add_log('no state value passed via GET', LOG_ERR);
+        add_log('no state value passed via GET', 'googleAuthenticate', LOG_ERR);
         return;
     }
 
@@ -42,7 +42,7 @@ function googleAuthenticate($code)
     $splitState = explode('_AND_STATE_IS_', $_GET['state']);
     if (sizeof($splitState) != 2) {
         add_log('Expected two values after splitting state parameter, found ' .
-            sizeof($splitState), LOG_ERR);
+                sizeof($splitState), 'googleAuthenticate', LOG_ERR);
         return;
     }
     $requestedURI = $splitState[0];
@@ -99,7 +99,7 @@ function googleAuthenticate($code)
 
     $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     if ($httpStatus != 200) {
-        add_log("Google access token request failed: $resp", LOG_ERR);
+        add_log("Google access token request failed: $resp", 'googleAuthenticate', LOG_ERR);
         return;
     }
 
@@ -120,7 +120,7 @@ function googleAuthenticate($code)
 
     $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     if ($httpStatus != 200) {
-        add_log("Get Google user email address request failed: $resp", LOG_ERR);
+        add_log("Get Google user email address request failed: $resp", 'googleAuthenticate', LOG_ERR);
         return;
     }
 

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -186,7 +186,7 @@ class GCovTarHandler
             $row = pdo_single_row_query($query);
             if (!$row || !array_key_exists('name', $row)) {
                 add_log(
-                    "No SubProject found for '$path'",
+                    "No SubProject found for '$path'", 'ParseGcovFile',
                     LOG_WARNING, $this->ProjectId, $this->Build->Id);
                 return;
             }


### PR DESCRIPTION
It seems like some log entries were always being recorded as LOG_INFO
because certain invocations of add_log thought the second argument is
the log level, when it's actually the third argument.