### PR TITLE
Improve behavior of Latest buildgroups

### DIFF
--- a/include/index_functions.php
+++ b/include/index_functions.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-function get_dynamic_builds($projectid)
+function get_dynamic_builds($projectid, $end_UTCDate)
 {
     $builds = array();
 
@@ -53,6 +53,7 @@ function get_dynamic_builds($projectid)
             }
             if (!empty($whereClauses)) {
                 $where = 'WHERE ' . implode($whereClauses, ' AND ');
+                $where .= " AND b.starttime<'$end_UTCDate'";
             }
 
             // We only want the most recent build.

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -496,7 +496,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
     }
     $dynamic_builds = array();
     if (empty($filter_sql)) {
-        $dynamic_builds = get_dynamic_builds($projectid);
+        $dynamic_builds = get_dynamic_builds($projectid, $end_UTCDate);
         $build_data = array_merge($build_data, $dynamic_builds);
     }
 

--- a/public/mobile/old_index.php
+++ b/public/mobile/old_index.php
@@ -698,7 +698,7 @@ function generate_main_dashboard_XML($project_instance, $date)
 
     $dynamic_builds = array();
     if (empty($filter_sql)) {
-        $dynamic_builds = get_dynamic_builds($projectid);
+        $dynamic_builds = get_dynamic_builds($projectid, $end_UTCDate);
         $build_data = array_merge($build_data, $dynamic_builds);
     }
 


### PR DESCRIPTION
These groups now show you the most recent build that occurred on
or before the day that you're currently viewing.  Previously they
showed you the newest build no matter what date you specified.
Thus it was impossible to see any result but the most recent.