### PR TITLE
Improve coverage aggregate

### DIFF
--- a/tests/test_branchcoverage.php
+++ b/tests/test_branchcoverage.php
@@ -66,7 +66,6 @@ class BranchCoverageTestCase extends KWWebTestCase
             $this->fail('\"<td align="right">Foo</td>\" not found when expected');
             return 1;
         }
-
         // Look up the ID of one of the coverage files that we just submitted.
         $fileid_result = $this->db->query("
       SELECT c.fileid FROM coverage AS c
@@ -77,8 +76,8 @@ class BranchCoverageTestCase extends KWWebTestCase
 
         // Make sure branch coverage is being displayed properly.
         $content = $this->get($this->url . "/viewCoverageFile.php?buildid=$buildid&fileid=$fileid");
-        if (strpos($content, '<span class="error">  1/2</span><span class="normal">    7 | if (x &lt;= 0)</span>') === false) {
-            $this->fail('\"<span class="error">  1/2</span><span class="normal">    7 | if (x &lt;= 0)</span>\" not found when expected');
+        if (strpos($content, '<span class="error">  1/2</span><span class="normal">    7 |   if (x &lt;= 0)</span>') === false) {
+            $this->fail('\"<span class="error">  1/2</span><span class="normal">    7 |   if (x &lt;= 0)</span>\" not found when expected');
             return 1;
         }
         return 0;

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -245,8 +245,7 @@ class GCovTarHandler
                 // Separate out delimited values from this line.
                 $timesHit = trim($fields[0]);
                 $lineNumber = trim($fields[1]);
-
-                $sourceLine = trim($fields[2]);
+                $sourceLine = rtrim($fields[2]);
 
                 if ($lineNumber > 0) {
                     $coverageFile->File .= $sourceLine;

--- a/xml_handlers/JSCoverTar_handler.php
+++ b/xml_handlers/JSCoverTar_handler.php
@@ -180,7 +180,7 @@ class JSCoverTarHandler
                     // Record this line of code if this is the first time that
                     // this file has been encountered.
                     $sourceLine = $coverageEntry['source'][$i - 1];
-                    $coverageFile->File .= $sourceLine;
+                    $coverageFile->File .= rtrim($sourceLine);
                     $coverageFile->File .= '<br>';
                 }
 

--- a/xml_handlers/JavaJSONTar_handler.php
+++ b/xml_handlers/JavaJSONTar_handler.php
@@ -180,7 +180,7 @@ class JavaJSONTarHandler
 
         foreach ($coverageLines as $coverageLine) {
             $sourceLine = $coverageLine['source'];
-            $coverageFile->File .= $sourceLine;
+            $coverageFile->File .= rtrim($sourceLine);
             $coverageFile->File .= '<br>';
 
             $timesHit = $coverageLine['covered'];

--- a/xml_handlers/coverage_log_handler.php
+++ b/xml_handlers/coverage_log_handler.php
@@ -34,6 +34,7 @@ class CoverageLogHandler extends AbstractHandler
         $this->Site = new Site();
         $this->UpdateEndTime = false;
         $this->CoverageFiles = array();
+        $this->CurrentLine = "";
     }
 
     /** Start element */
@@ -61,6 +62,7 @@ class CoverageLogHandler extends AbstractHandler
             if ($attributes['COUNT'] >= 0) {
                 $this->CurrentCoverageFileLog->AddLine($attributes['NUMBER'], $attributes['COUNT']);
             }
+            $this->CurrentLine = "";
         }
     }
 
@@ -98,6 +100,7 @@ class CoverageLogHandler extends AbstractHandler
                 $coverageFileLog->Insert();
             }
         } elseif ($name == 'LINE') {
+            $this->CurrentCoverageFile->File .= rtrim($this->CurrentLine);
             // Cannot be <br/> for backward compatibility.
             $this->CurrentCoverageFile->File .= '<br>';
         } elseif ($name == 'FILE') {
@@ -121,7 +124,7 @@ class CoverageLogHandler extends AbstractHandler
         $element = $this->getElement();
         switch ($element) {
             case 'LINE':
-                $this->CurrentCoverageFile->File .= $data;
+                $this->CurrentLine .= $data;
                 break;
             case 'STARTDATETIME':
                 $this->StartTimeStamp =


### PR DESCRIPTION
Fix some issues as we move towards a real world deployment of aggregate coverage:
* Make sure we end up with the exact same source file no matter how it was submitted.
* More carefully handle the difference between a line of code that's uncoverable vs one that's merely uncovered.