### PR TITLE
Use system temp directory when extracting coverage files

### DIFF
--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -60,19 +60,10 @@ class GCovTarHandler
     /**
      * Parse a tarball of .gcov files.
      **/
-    public function Parse($handle)
+    public function Parse($filename)
     {
-        global $CDASH_BACKUP_DIRECTORY;
-
-        // This function receives an open file handle, but we really just need
-        // the path to this file so that we can extract it.
-        $meta_data = stream_get_meta_data($handle);
-        $filename = $meta_data['uri'];
-        fclose($handle);
-
         // Create a new directory where we can extract our tarball.
-        $pathParts = pathinfo($filename);
-        $dirName = $CDASH_BACKUP_DIRECTORY . '/' . $pathParts['filename'];
+        $dirName = sys_get_temp_dir() . '/' . pathinfo($filename, PATHINFO_FILENAME);
         mkdir($dirName);
 
         // Extract the tarball.

--- a/xml_handlers/JSCoverTar_handler.php
+++ b/xml_handlers/JSCoverTar_handler.php
@@ -42,19 +42,10 @@ class JSCoverTarHandler
     /**
      * Parse a tarball of JSON files.
      **/
-    public function Parse($handle)
+    public function Parse($filename)
     {
-        global $CDASH_BACKUP_DIRECTORY;
-
-        // This function receives an open file handle, but we really just need
-        // the path to this file so that we can extract it.
-        $meta_data = stream_get_meta_data($handle);
-        $filename = $meta_data['uri'];
-        fclose($handle);
-
         // Create a new directory where we can extract our tarball.
-        $pathParts = pathinfo($filename);
-        $dirName = $CDASH_BACKUP_DIRECTORY . '/' . $pathParts['filename'];
+        $dirName = sys_get_temp_dir() . '/' . pathinfo($filename, PATHINFO_FILENAME);
         mkdir($dirName);
         // Extract the tarball.
         $phar = new PharData($filename);

--- a/xml_handlers/JavaJSONTar_handler.php
+++ b/xml_handlers/JavaJSONTar_handler.php
@@ -38,19 +38,10 @@ class JavaJSONTarHandler
     /**
      * Parse a tarball of JSON files.
      **/
-    public function Parse($handle)
+    public function Parse($filename)
     {
-        global $CDASH_BACKUP_DIRECTORY;
-
-        // This function receives an open file handle, but we really just need
-        // the path to this file so that we can extract it.
-        $meta_data = stream_get_meta_data($handle);
-        $filename = $meta_data['uri'];
-        fclose($handle);
-
         // Create a new directory where we can extract our tarball.
-        $pathParts = pathinfo($filename);
-        $dirName = $CDASH_BACKUP_DIRECTORY . '/' . $pathParts['filename'];
+        $dirName = sys_get_temp_dir() . '/' . pathinfo($filename, PATHINFO_FILENAME);
         mkdir($dirName);
 
         // Extract the tarball.
@@ -59,7 +50,6 @@ class JavaJSONTarHandler
 
         // Check if this submission included a  package_map.json file.
         // This tells us how Java packages correspond to CDash subprojects.
-        $mapFound = false;
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($dirName),
             RecursiveIteratorIterator::CHILD_FIRST);


### PR DESCRIPTION
This begins the long road to abstracting the filesystem by dealing with part that cannot be abstracted due to the way the phar extension works.