### PR TITLE
Bug fix: don't set start time to build stamp

### DIFF
--- a/tests/test_sequenceindependence.php
+++ b/tests/test_sequenceindependence.php
@@ -223,8 +223,8 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
         // Verify the result from the build table.
         $build_row = pdo_fetch_array($build_result);
-        if ($build_row['starttime'] != '2009-02-23 07:10:00') {
-            $this->fail("Expected starttime to be '2009-02-23 07:10:00', found " . $build_row['starttime']);
+        if ($build_row['starttime'] != '2009-02-23 07:10:37') {
+            $this->fail("Expected starttime to be '2009-02-23 07:10:37', found " . $build_row['starttime']);
             return false;
         }
         if ($build_row['endtime'] != '2009-02-23 12:32:00') {


### PR DESCRIPTION
This commit fixes a bug where the Upload Handler would set the
build's start time equal to the build stamp.  For nightly builds,
this is the nightly start time set for this project.

The result was builds that looked as if they started at 1am in
the morning, no matter when they actually began.