### PR TITLE
Don't use the bullseye metric for line coverage

### DIFF
--- a/public/ajax/getviewcoverage.php
+++ b/public/ajax/getviewcoverage.php
@@ -167,8 +167,13 @@ while ($coveragefile_array = pdo_fetch_array($coveragefile)) {
     $covfile['locuntested'] = $coveragefile_array['locuntested'];
     $covfile['loctested'] = $coveragefile_array['loctested'];
     $covfile['covered'] = 1;
-    // Compute the coverage metric for bullseye
-    if ($coveragefile_array['branchstested'] > 0 || $coveragefile_array['branchsuntested'] > 0 || $coveragefile_array['functionstested'] > 0 || $coveragefile_array['functionsuntested'] > 0) {
+    // Compute the coverage metric for bullseye (branch coverage without line coverage)
+    if (($coveragefile_array['loctested'] == 0 &&
+                $coveragefile_array['locuntested'] == 0) &&
+            $coveragefile_array['branchstested'] > 0 ||
+            $coveragefile_array['branchsuntested'] > 0 ||
+            $coveragefile_array['functionstested'] > 0 ||
+            $coveragefile_array['functionsuntested'] > 0) {
         // Metric coverage
         $metric = 0;
         if ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested'] > 0) {

--- a/public/viewCoverage.php
+++ b/public/viewCoverage.php
@@ -244,8 +244,11 @@ $covfile_array = array();
 while ($coveragefile_array = pdo_fetch_array($coveragefile)) {
     $covfile['covered'] = 1;
 
-    // Compute the coverage metric for bullseye
-    if ($coveragefile_array['branchstested'] > 0 || $coveragefile_array['branchsuntested'] > 0 || $coveragefile_array['functionstested'] > 0 || $coveragefile_array['functionsuntested'] > 0) {
+    // Compute the coverage metric for bullseye.  (branch coverage without line coverage)
+    if (
+            ($coveragefile_array['loctested'] == 0 && $coveragefile_array['locuntested'] == 0) &&
+            $coveragefile_array['branchstested'] > 0 || $coveragefile_array['branchsuntested'] > 0 ||
+            $coveragefile_array['functionstested'] > 0 || $coveragefile_array['functionsuntested'] > 0) {
         // Metric coverage
         $metric = 0;
         if ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested'] > 0) {


### PR DESCRIPTION
We have two different methods for computing how well a file is
covered.  The gcov metric looks at how many lines were covered,
and the bullseye metric is based on how many branches and functions
were covered.

When these were first introduced in CDash we had no way of
handling branch coverage from gcov.  Now we do.  Thus we need
to update our criteria for determining which metric to use.

Now we only use the bullseye metric when no line coverage is
present, but we have some information about branch and/or function
level coverage.