### PR TITLE
Fewer watchers

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -1076,6 +1076,30 @@ function echo_main_dashboard_JSON($project_instance, $date)
         }
         $build_response['submitdate'] = date(FMT_DATETIMEDISPLAY, $submittimestamp);
 
+        // Generate a string summarizing this build's timing.
+        $timesummary = $build_response['builddate'];
+        if ($build_response['hasupdate'] &&
+                array_key_exists('time', $build_response['update'])) {
+            $timesummary .= ', Update time: ' .
+                $build_response['update']['time'];
+        }
+        if ($build_response['hasconfigure'] &&
+                array_key_exists('time', $build_response['configure'])) {
+            $timesummary .= ', Configure time: ' .
+                $build_response['configure']['time'];
+        }
+        if ($build_response['hascompilation'] &&
+                array_key_exists('time', $build_response['compilation'])) {
+            $timesummary .= ', Compilation time: ' .
+                $build_response['compilation']['time'];
+        }
+        if ($build_response['hastest'] &&
+                array_key_exists('time', $build_response['test'])) {
+            $timesummary .= ', Test time: ' .
+                $build_response['test']['time'];
+        }
+        $build_response['timesummary'] = $timesummary;
+
         if ($build_array['name'] != 'Aggregate Coverage') {
             $buildgroups_response[$i]['builds'][] = $build_response;
         }
@@ -1426,6 +1450,7 @@ function add_expected_builds($groupid, $currentstarttime, $received_builds)
             $build_response['site'] = $site;
             $build_response['siteoutoforder'] = $siteoutoforder;
             $build_response['siteid'] = $siteid;
+            $build_response['id'] = false;
             $build_response['buildname'] = $buildname;
             $build_response['buildtype'] = $buildtype;
             $build_response['buildgroupid'] = $groupid;

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -847,8 +847,9 @@ function echo_main_dashboard_JSON($project_instance, $date)
         $update_response['files'] = $countupdatefiles;
         $buildgroups_response[$i]['numupdatedfiles'] += $countupdatefiles;
 
+        $build_response['hasupdate'] = false;
         if (!empty($build_array['updatestarttime'])) {
-            $update_response['defined'] = 1;
+            $build_response['hasupdate'] = true;
 
             if ($build_array['countupdateerrors'] > 0) {
                 $update_response['errors'] = 1;
@@ -895,25 +896,18 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $compilation_response['time'] = time_difference($duration * 60.0, true);
             $compilation_response['timefull'] = $duration;
 
-            $diff = $build_array['countbuilderrordiffp'];
-            if ($diff != 0) {
-                $compilation_response['nerrordiffp'] = $diff;
-            }
-            $diff = $build_array['countbuilderrordiffn'];
-            if ($diff != 0) {
-                $compilation_response['nerrordiffn'] = $diff;
-            }
-
-            $diff = $build_array['countbuildwarningdiffp'];
-            if ($diff != 0) {
-                $compilation_response['nwarningdiffp'] = $diff;
-            }
-            $diff = $build_array['countbuildwarningdiffn'];
-            if ($diff != 0) {
-                $compilation_response['nwarningdiffn'] = $diff;
-            }
+            $compilation_response['nerrordiffp'] =
+                $build_array['countbuilderrordiffp'];
+            $compilation_response['nerrordiffn'] =
+                $build_array['countbuilderrordiffn'];
+            $compilation_response['nwarningdiffp'] =
+                $build_array['countbuildwarningdiffp'];
+            $compilation_response['nwarningdiffn'] =
+                $build_array['countbuildwarningdiffn'];
         }
+        $build_response['hascompilation'] = false;
         if (!empty($compilation_response)) {
+            $build_response['hascompilation'] = true;
             $build_response['compilation'] = $compilation_response;
             $buildgroups_response[$i]['hascompilationdata'] = true;
         }
@@ -938,10 +932,8 @@ function echo_main_dashboard_JSON($project_instance, $date)
         $configure_response['warning'] = $nconfigurewarnings;
         $buildgroups_response[$i]['numconfigurewarning'] += $nconfigurewarnings;
 
-        $diff = $build_array['countconfigurewarningdiff'];
-        if ($diff != 0) {
-            $configure_response['warningdiff'] = $diff;
-        }
+        $configure_response['warningdiff'] =
+            $build_array['countconfigurewarningdiff'];
 
         if (array_key_exists('configureduration', $build_array) &&
             $build_array['configureduration'] != 0
@@ -952,12 +944,16 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $buildgroups_response[$i]['configureduration'] += $duration;
             $hasconfiguredata = true;
         }
+        $build_response['hasconfigure'] = false;
         if ($hasconfiguredata) {
             $build_response['configure'] = $configure_response;
+            $build_response['hasconfigure'] = true;
             $buildgroups_response[$i]['hasconfiguredata'] = true;
         }
 
+        $build_response['hastest'] = false;
         if ($build_array['hastest'] != 0) {
+            $build_response['hastest'] = true;
             $buildgroups_response[$i]['hastestdata'] = true;
             $test_response = array();
 
@@ -968,12 +964,10 @@ function echo_main_dashboard_JSON($project_instance, $date)
                     $selected_tests_not_run;
             }
 
-            if ($build_array['counttestsnotrundiffp'] != 0) {
-                $test_response['nnotrundiffp'] = $build_array['counttestsnotrundiffp'];
-            }
-            if ($build_array['counttestsnotrundiffn'] != 0) {
-                $test_response['nnotrundiffn'] = $build_array['counttestsnotrundiffn'];
-            }
+            $test_response['nnotrundiffp'] =
+                $build_array['counttestsnotrundiffp'];
+            $test_response['nnotrundiffn'] =
+                $build_array['counttestsnotrundiffn'];
 
             if ($include_subprojects) {
                 $nfail = $selected_tests_failed;
@@ -982,12 +976,10 @@ function echo_main_dashboard_JSON($project_instance, $date)
                     $selected_tests_failed;
             }
 
-            if ($build_array['counttestsfaileddiffp'] != 0) {
-                $test_response['nfaildiffp'] = $build_array['counttestsfaileddiffp'];
-            }
-            if ($build_array['counttestsfaileddiffn'] != 0) {
-                $test_response['nfaildiffn'] = $build_array['counttestsfaileddiffn'];
-            }
+            $test_response['nfaildiffp'] =
+                $build_array['counttestsfaileddiffp'];
+            $test_response['nfaildiffn'] =
+                $build_array['counttestsfaileddiffn'];
 
             if ($include_subprojects) {
                 $npass = $selected_tests_passed;
@@ -996,22 +988,17 @@ function echo_main_dashboard_JSON($project_instance, $date)
                     $selected_tests_passed;
             }
 
-            if ($build_array['counttestspasseddiffp'] != 0) {
-                $test_response['npassdiffp'] = $build_array['counttestspasseddiffp'];
-            }
-            if ($build_array['counttestspasseddiffn'] != 0) {
-                $test_response['npassdiffn'] = $build_array['counttestspasseddiffn'];
-            }
+            $test_response['npassdiffp'] =
+                $build_array['counttestspasseddiffp'];
+            $test_response['npassdiffn'] =
+                $build_array['counttestspasseddiffn'];
 
             if ($project_array['showtesttime'] == 1) {
                 $test_response['timestatus'] = $build_array['countteststimestatusfailed'];
-
-                if ($build_array['countteststimestatusfaileddiffp'] != 0) {
-                    $test_response['ntimediffp'] = $build_array['countteststimestatusfaileddiffp'];
-                }
-                if ($build_array['countteststimestatusfaileddiffn'] != 0) {
-                    $test_response['ntimediffn'] = $build_array['countteststimestatusfaileddiffn'];
-                }
+                $test_response['ntimediffp'] =
+                    $build_array['countteststimestatusfaileddiffp'];
+                $test_response['ntimediffn'] =
+                    $build_array['countteststimestatusfaileddiffn'];
             }
 
             if ($share_label_filters) {
@@ -1443,6 +1430,10 @@ function add_expected_builds($groupid, $currentstarttime, $received_builds)
             $build_response['buildtype'] = $buildtype;
             $build_response['buildgroupid'] = $groupid;
             $build_response['expectedandmissing'] = 1;
+            $build_response['hasupdate'] = false;
+            $build_response['hasconfigure'] = false;
+            $build_response['hascompilation'] = false;
+            $build_response['hastest'] = false;
 
             // Compute historical average to get approximate expected time.
             // PostgreSQL doesn't have the necessary functions for this.

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -213,6 +213,7 @@ CDash.filter("showEmptyBuildsLast", function () {
     }
 
     // Check for label filters
+    cdash.extrafilterurl = '';
     if (cdash.sharelabelfilters) {
       cdash.extrafilterurl = filters.getLabelString(cdash.filterdata);
     }
@@ -275,6 +276,7 @@ CDash.filter("showEmptyBuildsLast", function () {
       $scope.cdash.advancedview = 1;
     }
     $.cookie('cdash_'+$scope.cdash.projectname+'_advancedview', $scope.cdash.advancedview);
+    window.location.reload(true);
   };
 
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -10,31 +10,31 @@
     <link rel="stylesheet" type="text/css" href="css/jqModal.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
-    <title ng-bind="title">CDash</title>
+    <title ng-bind="::title">CDash</title>
   </head>
 
   <body bgcolor="#ffffff" ng-controller="IndexController">
 
-    <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
+    <div ng-if="::cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="::cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
 
-    <div ng-if="cdash.future == 1">
+    <div ng-if="::cdash.future == 1">
       CDash cannot predict the future (yet)...
     </div>
 
     <div id="index_content" ng-if="!loading && cdash.requirelogin != 1 && cdash.future != 1 && !cdash.error">
-      <div id="index_top" ng-if="cdash.updates">
-        <div name="banner" ng-repeat="banner in cdash.banners">
-          {{banner.text}}
+      <div id="index_top" ng-if="::cdash.updates">
+        <div name="banner" ng-repeat="banner in ::cdash.banners">
+          {{::banner.text}}
         </div>
 
         <div id="updatechanges">
           <span>
-            <span ng-if="cdash.updates.nchanges == -1">No update data</span>
-            <span ng-if="cdash.updates.nchanges == 0">No file changed</span>
-            <span ng-if="cdash.updates.nchanges > 0">
-              <a ng-href="{{cdash.updates.url}}">
+            <span ng-if="::cdash.updates.nchanges == -1">No update data</span>
+            <span ng-if="::cdash.updates.nchanges == 0">No file changed</span>
+            <span ng-if="::cdash.updates.nchanges > 0">
+              <a ng-href="{{::cdash.updates.url}}">
                 <ng-pluralize count="cdash.updates.nchanges"
                               when="{'1':     '{} file',
                                      'other': '{} files'}">
@@ -46,7 +46,7 @@
                 </ng-pluralize>
               </a>
             </span>
-            as of <b>{{cdash.updates.timestamp}}</b>
+            as of <b>{{::cdash.updates.timestamp}}</b>
           </span>
         </div>
 
@@ -56,14 +56,14 @@
           <ul ng-show="showsettings">
             <li>
               <a id="label_advancedview" ng-click="toggleAdvancedView()">
-                <span ng-show="cdash.advancedview == 0">Advanced View</span>
-                <span ng-show="cdash.advancedview != 0">Simple View</span>
+                <span ng-if="::cdash.advancedview == 0">Advanced View</span>
+                <span ng-if="::cdash.advancedview != 0">Simple View</span>
               </a>
             </li>
             <li>
               <a class="autorefresh" ng-click="toggleAutoRefresh()">
-                <span ng-show="!autoRefresh">Auto-refresh</span>
-                <span ng-show="autoRefresh">Stop auto-refresh</span>
+                <span ng-if="::!autoRefresh">Auto-refresh</span>
+                <span ng-if="::autoRefresh">Stop auto-refresh</span>
               </a>
             </li>
             <li>
@@ -99,137 +99,145 @@
         <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
       </div> <!-- End index-top -->
 
-      <div ng-show="showFeed" id="feed" ng-include="'ajax/getfeed.php?projectid='+ cdash.projectid"></div>
+      <div ng-show="showFeed" id="feed" ng-include="::'ajax/getfeed.php?projectid='+ cdash.projectid"></div>
 
-      <table ng-if="cdash.testingdataurl" width="100%" cellpadding="11" cellspacing="0">
+      <table ng-if="::cdash.testingdataurl" width="100%" cellpadding="11" cellspacing="0">
         <tr>
           <td height="25" align="left">
             Testing data for this project can be found at:
-            <a ng-href="{{cdash.testingdataurl}}">{{cdash.testingdataurl}}</a>
+            <a ng-href="{{::cdash.testingdataurl}}">{{::cdash.testingdataurl}}</a>
           </td>
         </tr>
       </table>
 
       <!-- Display the site & build name common to all child builds. -->
-      <div ng-if="cdash.childview == 1">
+      <div ng-if="::cdash.childview == 1">
         <br/>
         <div id="site" align="left">
           <b>Site</b>:
-          <a ng-href="viewSite.php?siteid={{cdash.siteid}}&project={{cdash.projectid}}&currenttime={{cdash.unixtimestamp}}">
-            {{cdash.site}}
+          <a ng-href="viewSite.php?siteid={{::cdash.siteid}}&project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+            {{::cdash.site}}
           </a>
-          <img ng-if="cdash.siteoutoforder == 1" src="img/flag.png" title="flag"/>
+          <img ng-if="::cdash.siteoutoforder == 1" src="img/flag.png" title="flag"/>
         </div>
 
         <div id="buildname" align="left">
-          <b>Build Name</b>: {{cdash.buildname}}
-          <img ng-if="cdash.buildplatform" class="icon" alt="platform" ng-src="img/platform_{{cdash.buildplatform}}.png"/>
+          <b>Build Name</b>: {{::cdash.buildname}}
+          <img ng-if="::cdash.buildplatform" class="icon" alt="platform" ng-src="img/platform_{{::cdash.buildplatform}}.png"/>
         </div>
 
         <div id="numbuilds" align="left">
-          <b>Number of SubProjects Built</b>: {{cdash.buildgroups[0].builds.length}}
+          <b>Number of SubProjects Built</b>: {{::cdash.buildgroups[0].builds.length}}
         </div>
         <br/>
       </div>
 
       <!-- Display subproject dependencies -->
-      <ng-include ng-if="cdash.subproject.dependencies.length > 0" ng-init="cdash.tableName = 'SubProject Dependencies'; cdash.subprojects = cdash.subproject.dependencies" src="'views/partials/subProjectTable.html'"></ng-include>
+      <ng-include ng-if="::cdash.subproject.dependencies.length > 0" ng-init="cdash.tableName = 'SubProject Dependencies'; cdash.subprojects = cdash.subproject.dependencies" src="'views/partials/subProjectTable.html'"></ng-include>
 
       <!-- BuildGroups -->
-      <div ng-repeat="buildgroup in cdash.buildgroups | orderBy:'position'">
-        <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="project_{{cdash.projectid}}_{{buildgroup.id}}">
+      <div ng-repeat="buildgroup in ::cdash.buildgroups | orderBy:'position'">
+        <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="project_{{::cdash.projectid}}_{{::buildgroup.id}}">
           <thead>
             <tr class="table-heading1" >
               <td colspan="1" class="nob">
-                <h3 id="{{buildgroup.linkname}}"><a href="#" class="grouptrigger">{{buildgroup.name}}</a></h3>
+                <h3 id="{{::buildgroup.linkname}}"><a href="#" class="grouptrigger">{{::buildgroup.name}}</a></h3>
               </td>
-              <td align="right" class="nob" colspan="{{cdash.displaylabels == 1 ? 15 : 14}}">
+              <td align="right" class="nob" colspan="{{::cdash.displaylabels == 1 ? 15 : 14}}">
               </td>
             </tr>
 
             <tr class="table-heading">
 
-              <th ng-if="cdash.childview == 1" align="center" rowspan="2" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'label', $event)">
+              <th ng-if="::cdash.childview == 1" align="center" rowspan="2" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'label', $event)">
                 SubProject
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-label') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('label') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="cdash.childview != 1" align="center" rowspan="2" width="20%" style="cursor: pointer"
+              <th ng-if="::cdash.childview != 1" align="center" rowspan="2" width="20%" style="cursor: pointer"
                   ng-click="updateOrderByFields(buildgroup, 'site', $event)">
                 Site
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-site') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('site') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="cdash.childview != 1" align="center" rowspan="2" width="25%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'buildname', $event)">
+              <th ng-if="::cdash.childview != 1" align="center" rowspan="2" width="25%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'buildname', $event)">
                 Build Name
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-buildname') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('buildname') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <td ng-if="buildgroup.hasupdatedata" align="center" colspan="{{1 + cdash.advancedview}}" width="5%" class="timeheader botl">Update</td>
-              <td ng-if="buildgroup.hasconfiguredata" align="center" colspan="{{2 + cdash.advancedview}}" width="10%" class="timeheader botl">Configure</td>
-              <td ng-if="buildgroup.hascompilationdata" align="center" colspan="{{2 + cdash.advancedview}}" width="10%" class="timeheader botl">Build</td>
-              <td ng-if="buildgroup.hastestdata" align="center" colspan="{{3 +  + cdash.advancedview}}" width="15%" class="timeheader botl">Test</td>
+              <td ng-if="::buildgroup.hasupdatedata" align="center" colspan="{{::1 + cdash.advancedview}}" width="5%" class="timeheader botl">Update</td>
+              <td ng-if="::buildgroup.hasconfiguredata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Configure</td>
+              <td ng-if="::buildgroup.hascompilationdata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Build</td>
+              <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 +  + cdash.advancedview}}" width="15%" class="timeheader botl">Test</td>
               <td align="center" width="20%" class="timeheader botl"></td>
-              <td ng-if="cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
+              <td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
             </tr>
 
             <tr class="table-heading">
-              <th ng-if="buildgroup.hasupdatedata" align="center" width="3%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'update.files', $event)">
+              <th ng-if="::buildgroup.hasupdatedata" align="center" width="3%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'update.files', $event)">
                 Files
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-update.files') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('update.files') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hasupdatedata" ng-show="cdash.advancedview != 0" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'update.timefull', $event)">
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0"
+                  ng-click="updateOrderByFields(buildgroup, 'update.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-update.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('update.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hasconfiguredata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'configure.error', $event)">
+              <th ng-if="::buildgroup.hasconfiguredata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'configure.error', $event)">
                 Error
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-configure.error') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('configure.error') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hasconfiguredata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'configure.warning', $event)">
+              <th ng-if="::buildgroup.hasconfiguredata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'configure.warning', $event)">
                 Warn
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-configure.warning') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('configure.warning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hasconfiguredata" ng-show="cdash.advancedview != 0" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'configure.timefull', $event)">
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0"
+                  ng-click="updateOrderByFields(buildgroup, 'configure.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-configure.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('configure.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hascompilationdata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'compilation.error', $event)">
+              <th ng-if="::buildgroup.hascompilationdata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'compilation.error', $event)">
                 Error
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-compilation.error') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('compilation.error') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hascompilationdata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'compilation.warning', $event)">
+              <th ng-if="::buildgroup.hascompilationdata" align="center" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'compilation.warning', $event)">
                 Warn
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-compilation.warning') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('compilation.warning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hascompilationdata" ng-show="cdash.advancedview != 0" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'compilation.timefull', $event)">
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0"
+                  ng-click="updateOrderByFields(buildgroup, 'compilation.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-compilation.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('compilation.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.notrun', $event)">
+              <th ng-if="::buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.notrun', $event)">
                 Not Run
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.notrun') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.notrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.fail', $event)">
+              <th ng-if="::buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.fail', $event)">
                 Fail
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.fail') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.fail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.pass', $event)">
+              <th ng-if="::buildgroup.hastestdata" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.pass', $event)">
                 Pass
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.pass') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.pass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-if="buildgroup.hastestdata" ng-show="cdash.advancedview != 0" align="center" width="5%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'test.timefull', $event)">
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::buildgroup.hastestdata && cdash.advancedview != 0"
+                  ng-click="updateOrderByFields(buildgroup, 'test.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
@@ -239,14 +247,14 @@
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-builddatefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('builddatefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th ng-show="cdash.childview != 1 && cdash.displaylabels == 1" align="center" rowspan="2" width="5%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'label', $event)">
+              <th ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" rowspan="2" width="5%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'label', $event)">
                 Labels
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-label') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('label') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
            </tr>
           </thead>
 
-          <tbody ng-if="buildgroup.hasnormalbuilds">
+          <tbody ng-if="::buildgroup.hasnormalbuilds">
             <tr ng-repeat="build in buildgroup.pagination.filteredBuilds | filter:normalBuild"
                 ng-class-odd="'odd'" ng-class-even="'even'"
                 normal-build
@@ -254,7 +262,7 @@
             </tr>
           </tbody>
 
-          <tbody ng-if="buildgroup.hasparentbuilds">
+          <tbody ng-if="::buildgroup.hasparentbuilds">
             <tr ng-repeat="build in buildgroup.pagination.filteredBuilds | filter:parentBuild"
                 ng-class-odd="'odd'" ng-class-even="'even'"
                 parent-build
@@ -275,7 +283,7 @@
           </uib-pagination>
         </div>
 
-        <div ng-if="buildgroup.builds.length > 10">
+        <div ng-if="::buildgroup.builds.length > 10">
           <label>Items per page</label>
           <select ng-model="buildgroup.pagination.numPerPage" convert-to-number ng-change="numBuildsPerPageChanged(buildgroup)">
             <option value="10">10</option>
@@ -292,12 +300,12 @@
 
       <!-- Coverage -->
       <a name="Coverage"></a>
-      <table ng-if="cdash.coverages.length > 0 || cdash.coveragegroups.length > 0" border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
+      <table ng-if="::cdash.coverages.length > 0 || cdash.coveragegroups.length > 0" border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
         <thead>
           <tr class="table-heading2">
             <td colspan="1" class="nob">
               <h3><a href="#" class="grouptrigger">Coverage</a>
-              <a ng-if="cdash.comparecoverage == 1" href="compareCoverage.php?project={{cdash.projectname}}&date={{cdash.date}}">Compare Coverage</a></h3>
+              <a ng-if="::cdash.comparecoverage == 1" href="compareCoverage.php?project={{::cdash.projectname}}&date={{::cdash.date}}">Compare Coverage</a></h3>
             </td>
             <td colspan="6" align="right" class="nob">
             </td>
@@ -305,18 +313,18 @@
 
           <tr class="table-heading">
             <!-- Site & Build Name for non-grouped coverage -->
-            <th ng-if="cdash.childview != 1" align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'site', $event, 'coverage')">
+            <th ng-if="::cdash.childview != 1" align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'site', $event, 'coverage')">
               Site
               <span class="glyphicon" ng-class="sortCoverage.orderByFields.indexOf('-site') != -1 ? 'glyphicon-chevron-down' : (sortCoverage.orderByFields.indexOf('site') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
-            <th ng-if="cdash.childview != 1" align="center" width="25%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'buildname', $event, 'coverage')">
+            <th ng-if="::cdash.childview != 1" align="center" width="25%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'buildname', $event, 'coverage')">
               Build Name
               <span class="glyphicon" ng-class="sortCoverage.orderByFields.indexOf('-buildname') != -1 ? 'glyphicon-chevron-down' : (sortCoverage.orderByFields.indexOf('buildname') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
             <!-- SubProject name for grouped coverage -->
-            <th ng-if="cdash.childview == 1" align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage,'label', $event, 'coverage')">
+            <th ng-if="::cdash.childview == 1" align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage,'label', $event, 'coverage')">
               SubProject
               <span class="glyphicon" ng-class="sortCoverage.orderByFields.indexOf('-label') != -1 ? 'glyphicon-chevron-down' : (sortCoverage.orderByFields.indexOf('label') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
@@ -337,131 +345,131 @@
               <span class="glyphicon" ng-class="sortCoverage.orderByFields.indexOf('-locuntested') != -1 ? 'glyphicon-chevron-down' : (sortCoverage.orderByFields.indexOf('locuntested') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
-            <th align="center" width="15%" ng-class="{'nob': cdash.displaylabels == 0 && cdash.coveragegroups.length == 0}" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'datefull', $event, 'coverage')">
+            <th align="center" width="15%" ng-class="::{'nob': cdash.displaylabels == 0 && cdash.coveragegroups.length == 0}" style="cursor: pointer" ng-click="updateOrderByFields(sortCoverage, 'datefull', $event, 'coverage')">
               Date
               <span class="glyphicon" ng-class="sortCoverage.orderByFields.indexOf('-datefull') != -1 ? 'glyphicon-chevron-down' : (sortCoverage.orderByFields.indexOf('datefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
             <!-- Conditionally display the labels -->
-            <th ng-if = "cdash.displaylabels == 1 && !cdash.coveragegroups" align="center" class="nob" width="10%">Labels</th>
+            <th ng-if = "::cdash.displaylabels == 1 && !cdash.coveragegroups" align="center" class="nob" width="10%">Labels</th>
 
           </tr>
         </thead>
 
         <!-- Coverage groups -->
-        <tbody ng-repeat="group in cdash.coveragegroups |orderBy:'position'" id="coveragebody">
+        <tbody ng-repeat="group in ::cdash.coveragegroups |orderBy:'position'" id="coveragebody">
           <tr class="parent_row">
             <td class="paddt" align="left">
-              <b>{{group.label}}</b>
+              <b>{{::group.label}}</b>
               <div class="glyphicon"  ng-click="group.hidden = ! group.hidden" ng-class="{'glyphicon-chevron-down': !group.hidden, 'glyphicon-chevron-right': group.hidden}"></div>
             </td>
 
-            <td align="center" ng-class="{'normal': group.percentage >= group.thresholdgreen, 'warning': group.percentage < group.thresholdgreen && group.percentage >= group.thresholdyellow, 'error': group.percentage < group.thresholdyellow}">
-              {{group.percentage}}%
+            <td align="center" ng-class="::{'normal': group.percentage >= group.thresholdgreen, 'warning': group.percentage < group.thresholdgreen && group.percentage >= group.thresholdyellow, 'error': group.percentage < group.thresholdyellow}">
+              {{::group.percentage}}%
             </td>
 
             <td align="center" >
-              {{group.loctested}}
+              {{::group.loctested}}
             </td>
             <td align="center" >
-              {{group.locuntested}}
+              {{::group.locuntested}}
             </td>
 
             <td align="center"></td>
           </tr>
 
-          <tr class="child_row" ng-show="!group.hidden" ng-repeat="coverage in group.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
+          <tr class="child_row" ng-show="!group.hidden" ng-repeat="coverage in ::group.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
             <td align="left" class="paddt">
-              {{coverage.label}}
+              {{::coverage.label}}
             </td>
 
-            <td align="center" ng-class="{'normal': coverage.percentage >= group.thresholdgreen, 'warning': coverage.percentage < group.thresholdgreen && coverage.percentage >= group.thresholdyellow, 'error': coverage.percentage < group.thresholdyellow}">
-              <a ng-href="viewCoverage.php?buildid={{coverage.buildid}}">
-                {{coverage.percentage}}%
+            <td align="center" ng-class="::{'normal': coverage.percentage >= group.thresholdgreen, 'warning': coverage.percentage < group.thresholdgreen && coverage.percentage >= group.thresholdyellow, 'error': coverage.percentage < group.thresholdyellow}">
+              <a ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
+                {{::coverage.percentage}}%
               </a>
-              <sub ng-if="coverage.percentagediff > 0">+{{coverage.percentagediff}}%</sub>
-              <sub ng-if="coverage.percentagediff < 0">{{coverage.percentagediff}}%</sub>
+              <sub ng-if="::coverage.percentagediff > 0">+{{::coverage.percentagediff}}%</sub>
+              <sub ng-if="::coverage.percentagediff < 0">{{::coverage.percentagediff}}%</sub>
             </td>
 
             <td align="center">
-              {{coverage.loctested}}
-              <sub ng-if="coverage.loctesteddiff > 0">+{{coverage.loctesteddiff}}</sub>
-              <sub ng-if="coverage.loctesteddiff < 0">{{coverage.loctesteddiff}}</sub>
+              {{::coverage.loctested}}
+              <sub ng-if="::coverage.loctesteddiff > 0">+{{::coverage.loctesteddiff}}</sub>
+              <sub ng-if="::coverage.loctesteddiff < 0">{{::coverage.loctesteddiff}}</sub>
             </td>
 
             <td align="center">
-              {{coverage.locuntested}}
-              <sub ng-if="coverage.locuntesteddiff > 0">+{{coverage.locuntesteddiff}}</sub>
-              <sub ng-if="coverage.locuntesteddiff < 0">{{coverage.locuntesteddiff}}</sub>
+              {{::coverage.locuntested}}
+              <sub ng-if="::coverage.locuntesteddiff > 0">+{{::coverage.locuntesteddiff}}</sub>
+              <sub ng-if="::coverage.locuntesteddiff < 0">{{::coverage.locuntesteddiff}}</sub>
             </td>
 
-            <td align="center" ng-class="{'nob': cdash.displaylabels == 0}">
-              <span class="builddateelapsed" alt="{{coverage.date}}">
-                {{coverage.dateelapsed}}
+            <td align="center" ng-class="::{'nob': cdash.displaylabels == 0}">
+              <span class="builddateelapsed" alt="{{::coverage.date}}">
+                {{::coverage.dateelapsed}}
               </span>
             </td>
           </tr>
         </tbody>
 
         <!-- Ungrouped coverage -->
-        <tbody ng-if="!cdash.coveragegroups || cdash.coveragegroups.length == 0" id="coveragebody">
-          <tr class="child_row" ng-repeat="coverage in cdash.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
-            <td ng-if="cdash.childview != 1" align="left" class="paddt">
-              {{coverage.site}}
+        <tbody ng-if="::!cdash.coveragegroups || cdash.coveragegroups.length == 0" id="coveragebody">
+          <tr class="child_row" ng-repeat="coverage in ::cdash.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
+            <td ng-if="::cdash.childview != 1" align="left" class="paddt">
+              {{::coverage.site}}
             </td>
 
-            <td ng-if="cdash.childview != 1" align="left" class="paddt">
-              {{coverage.buildname}}
+            <td ng-if="::cdash.childview != 1" align="left" class="paddt">
+              {{::coverage.buildname}}
             </td>
 
-            <td ng-if="cdash.childview == 1" align="left" class="paddt">
-              {{coverage.label}}
+            <td ng-if="::cdash.childview == 1" align="left" class="paddt">
+              {{::coverage.label}}
             </td>
 
-            <td align="center" ng-class="{'normal': coverage.percentage >= cdash.thresholdgreen, 'warning': coverage.percentage < cdash.thresholdgreen && coverage.percentage >= cdash.thresholdyellow, 'error': coverage.percentage < cdash.thresholdyellow}">
-              <a ng-if="coverage.childlink" ng-href="{{coverage.childlink}}">
-                {{coverage.percentage}}%
+            <td align="center" ng-class="::{'normal': coverage.percentage >= cdash.thresholdgreen, 'warning': coverage.percentage < cdash.thresholdgreen && coverage.percentage >= cdash.thresholdyellow, 'error': coverage.percentage < cdash.thresholdyellow}">
+              <a ng-if="::coverage.childlink" ng-href="{{::coverage.childlink}}">
+                {{::coverage.percentage}}%
               </a>
-              <a ng-if="!coverage.childlink" ng-href="viewCoverage.php?buildid={{coverage.buildid}}">
-                {{coverage.percentage}}%
+              <a ng-if="::!coverage.childlink" ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
+                {{::coverage.percentage}}%
               </a>
-              <sub ng-if="coverage.percentagediff > 0">+{{coverage.percentagediff}}%</sub>
-              <sub ng-if="coverage.percentagediff < 0">{{coverage.percentagediff}}%</sub>
+              <sub ng-if="::coverage.percentagediff > 0">+{{::coverage.percentagediff}}%</sub>
+              <sub ng-if="::coverage.percentagediff < 0">{{::coverage.percentagediff}}%</sub>
             </td>
 
             <td align="center">
-              {{coverage.loctested}}
-              <sub ng-if="coverage.loctesteddiff > 0">+{{coverage.loctesteddiff}}</sub>
-              <sub ng-if="coverage.loctesteddiff < 0">{{coverage.loctesteddiff}}</sub>
+              {{::coverage.loctested}}
+              <sub ng-if="::coverage.loctesteddiff > 0">+{{::coverage.loctesteddiff}}</sub>
+              <sub ng-if="::coverage.loctesteddiff < 0">{{::coverage.loctesteddiff}}</sub>
             </td>
 
             <td align="center">
-              {{coverage.locuntested}}
-              <sub ng-if="coverage.locuntesteddiff > 0">+{{coverage.locuntesteddiff}}</sub>
-              <sub ng-if="coverage.locuntesteddiff < 0">{{coverage.locuntesteddiff}}</sub>
+              {{::coverage.locuntested}}
+              <sub ng-if="::coverage.locuntesteddiff > 0">+{{::coverage.locuntesteddiff}}</sub>
+              <sub ng-if="::coverage.locuntesteddiff < 0">{{::coverage.locuntesteddiff}}</sub>
             </td>
 
-            <td align="center" ng-class="{'nob': cdash.displaylabels == 0}">
-              <span class="builddateelapsed" alt="{{coverage.date}}">
-                {{coverage.dateelapsed}}
+            <td align="center" ng-class="::{'nob': cdash.displaylabels == 0}">
+              <span class="builddateelapsed" alt="{{::coverage.date}}">
+                {{::coverage.dateelapsed}}
               </span>
             </td>
 
-            <td ng-if="cdash.displaylabels == 1" class="nob" align="left">
-              {{coverage.label}}
+            <td ng-if="::cdash.displaylabels == 1" class="nob" align="left">
+              {{::coverage.label}}
             </td>
           </tr>
         </tbody>
       </table>
 
-      <table ng-if="cdash.coverages.length > 0 || cdash.coveragegroups.length > 0" width="100%" cellspacing="0" cellpadding="0">
+      <table ng-if="::cdash.coverages.length > 0 || cdash.coveragegroups.length > 0" width="100%" cellspacing="0" cellpadding="0">
         <tr>
           <td height="1" colspan="14" align="left" bgcolor="#888888"></td>
         </tr>
       </table>
 
       <!-- Dynamic analysis -->
-      <table ng-if="cdash.dynamicanalyses.length > 0" border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="dynamicanalysistable">
+      <table ng-if="::cdash.dynamicanalyses.length > 0" border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="dynamicanalysistable">
         <thead>
           <tr class="table-heading3">
             <td colspan="1" class="nob">
@@ -472,19 +480,19 @@
           </tr>
 
           <tr class="table-heading">
-            <th ng-if="cdash.childview == 1" align="center" width="20%"
+            <th ng-if="::cdash.childview == 1" align="center" width="20%"
                 ng-click="updateOrderByFields(sortDA, 'label', $event, 'DA')">
               SubProject
               <span class="glyphicon" ng-class="sortDA.orderByFields.indexOf('-label') != -1 ? 'glyphicon-chevron-down' : (sortDA.orderByFields.indexOf('label') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
-            <th ng-if="cdash.childview != 1" align="center" width="20%"
+            <th ng-if="::cdash.childview != 1" align="center" width="20%"
                 ng-click="updateOrderByFields(sortDA, 'site', $event, 'DA')">
               Site
               <span class="glyphicon" ng-class="sortDA.orderByFields.indexOf('-site') != -1 ? 'glyphicon-chevron-down' : (sortDA.orderByFields.indexOf('site') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
-            <th ng-if="cdash.childview != 1" align="center" width="25%"
+            <th ng-if="::cdash.childview != 1" align="center" width="25%"
                 ng-click="updateOrderByFields(sortDA, 'buildname', $event, 'DA')">
               Build Name
               <span class="glyphicon" ng-class="sortDA.orderByFields.indexOf('-buildname') != -1 ? 'glyphicon-chevron-down' : (sortDA.orderByFields.indexOf('buildname') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -511,39 +519,39 @@
         </thead>
 
         <tbody>
-          <tr ng-repeat="da in cdash.dynamicanalyses |orderBy:sortDA.orderByFields"
+          <tr ng-repeat="da in ::cdash.dynamicanalyses |orderBy:sortDA.orderByFields"
               ng-class-odd="'odd'" ng-class-even="'even'">
-            <td ng-if="cdash.childview == 1" align="left">
-              {{da.label}}
+            <td ng-if="::cdash.childview == 1" align="left">
+              {{::da.label}}
             </td>
 
-            <td ng-if="cdash.childview != 1" align="left">
-              {{da.site}}
+            <td ng-if="::cdash.childview != 1" align="left">
+              {{::da.site}}
             </td>
 
-            <td ng-if="cdash.childview != 1" align="left">
-              {{da.buildname}}
+            <td ng-if="::cdash.childview != 1" align="left">
+              {{::da.buildname}}
             </td>
 
-            <td align="center">{{da.checker}}</td>
+            <td align="center">{{::da.checker}}</td>
 
-            <td align="center" ng-class="{'error': da.status != 'passed', 'warning': da.defectcount > 0, 'normal': da.defectcount < 1}">
-              <a ng-href="viewDynamicAnalysis.php?buildid={{da.buildid}}">{{da.defectcount}}</a>
+            <td align="center" ng-class="::{'error': da.status != 'passed', 'warning': da.defectcount > 0, 'normal': da.defectcount < 1}">
+              <a ng-href="viewDynamicAnalysis.php?buildid={{::da.buildid}}">{{::da.defectcount}}</a>
             </td>
-            <td align="center" ng-class="{'nob': cdash.displaylabels == 0}">
-              <span class="builddateelapsed" alt="{{da.date}}">{{da.dateelapsed}}</span>
+            <td align="center" ng-class="::{'nob': cdash.displaylabels == 0}">
+              <span class="builddateelapsed" alt="{{::da.date}}">{{::da.dateelapsed}}</span>
             </td>
           </tr>
         </tbody>
       </table>
 
-      <table ng-if="cdash.dynamicanalysis.length > 0" width="100%" cellspacing="0" cellpadding="0">
+      <table ng-if="::cdash.dynamicanalysis.length > 0" width="100%" cellspacing="0" cellpadding="0">
         <tr>
           <td height="1" colspan="14" align="left" bgcolor="#888888"></td>
         </tr>
       </table>
     </div> <!-- end index content -->
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="::cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
   </body>
 </html>

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -1,30 +1,30 @@
 <!-- For child view, display the label(s) as a link to the build summary -->
-<td ng-if="cdash.childview == 1" align="left" class="paddt">
-  <a ng-href="buildSummary.php?buildid={{build.id}}">
-    {{build.label}}
+<td ng-if="::cdash.childview == 1" align="left" class="paddt">
+  <a ng-href="buildSummary.php?buildid={{::build.id}}">
+    {{::build.label}}
   </a>
   <!-- Icon for build errors / test failing -->
-  <a ng-if="build.compilation.error > 0 || build.test.fail > 0" href="javascript:;"
+  <a ng-if="::build.compilation.error > 0 || build.test.fail > 0" href="javascript:;"
      ng-click="toggleBuildProblems(build)">
     <img src="img/Info.png" alt="info" class="icon"></img>
   </a>
-  <div ng-if="build.id" id="buildgroup_{{build.id}}"></div>
+  <div ng-if="::build.id" id="buildgroup_{{::build.id}}"></div>
 </td>
 
 <!-- Otherwise, show build name & site on the row. -->
-<td ng-if="cdash.childview != 1" align="left" class="paddt">
-  <a ng-href="viewSite.php?siteid={{build.siteid}}&project={{cdash.projectid}}&currenttime={{cdash.unixtimestamp}}">{{build.site}}</a>
-  <img ng-if="build.siteoutoforder == 1" border="0" src="img/flag.png" title="flag"></img>
+<td ng-if="::cdash.childview != 1" align="left" class="paddt">
+  <a ng-href="viewSite.php?siteid={{::build.siteid}}&project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">{{::build.site}}</a>
+  <img ng-if="::build.siteoutoforder == 1" border="0" src="img/flag.png" title="flag"></img>
 </td>
 
-<td ng-if="cdash.childview != 1" align="left">
-  <div ng-if="build.id && build.buildplatform.length > 0" style="float:left;">
-    <img class="icon" alt="platform" ng-src="img/platform_{{build.buildplatform}}.png"/>
+<td ng-if="::cdash.childview != 1" align="left">
+  <div ng-if="::build.id && build.buildplatform.length > 0" style="float:left;">
+    <img class="icon" alt="platform" ng-src="img/platform_{{::build.buildplatform}}.png"/>
   </div>
 
-  <div ng-if="build.id" style="float: left; margin: 0px 4px;">
-    <a class="buildinfo" alt="generator" ng-href="buildSummary.php?buildid={{build.id}}">
-      {{build.buildname}}
+  <div ng-if="::build.id" style="float: left; margin: 0px 4px;">
+    <a class="buildinfo" alt="generator" ng-href="buildSummary.php?buildid={{::build.id}}">
+      {{::build.buildname}}
     </a>
   </div>
 
@@ -32,156 +32,176 @@
   <build-name-elements></build-name-elements>
 </td>
 
-<td ng-if="buildgroup.hasupdatedata" align="center" ng-class="{'error': build.update.errors == 1, 'warning': build.update.warning == 1, 'normal': build.update.defined == 1}">
-  <div>
-    <img ng-if="build.userupdates > 0" src="img/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/>
-    <a ng-href="viewUpdate.php?buildid={{build.id}}">
-      {{build.update.files}}
-    </a>
-  </div>
-
-</td>
-
-<td ng-if="buildgroup.hasupdatedata" align="right" ng-show="cdash.advancedview != 0" ng-show="cdash.advancedview != 0">
-  {{build.update.time}}
-</td>
-
-<td ng-if="buildgroup.hasconfiguredata" align="center" ng-class="{'error': build.configure.error > 0, 'normal': build.configure.error == 0}">
-  <a ng-href="viewConfigure.php?buildid={{build.id}}">
-    {{build.configure.error}}
-  </a>
-</td>
-
-<td ng-if="buildgroup.hasconfiguredata" align="center" ng-class="{'warning': build.configure.warning > 0, 'normal': build.configure.warning == 0}">
-  <a ng-href="viewConfigure.php?buildid={{build.id}}">
-    {{build.configure.warning}}
-  </a>
-  <sub ng-if="build.configure.nwarningdiff > 0">+{{build.configure.nwarningdiff}}</sub>
-  <sub ng-if="build.configure.nwarningdiff < 0">{{build.configure.nwarningdiff}}</sub>
-</td>
-
-<td ng-if="buildgroup.hasconfiguredata" align="center" ng-show="cdash.advancedview != 0">
-  {{build.configure.time}}
-</td>
-
-<td ng-if="buildgroup.hascompilationdata" align="center" ng-class="{'error': build.compilation.error > 0, 'normal': build.compilation.error == 0}">
-  <div ng-class="{'valuewithsub': build.compilation.nerrordiffp > 0 || build.compilation.nerrordiffn > 0}">
-    <a ng-href="viewBuildError.php?buildid={{build.id}}">
-      {{build.compilation.error}}
-    </a>
-    <a ng-if="build.compilation.nerrordiffp > 0" class="sup" ng-href="viewBuildError.php?onlydeltap&buildid={{build.id}}">
-      +{{build.compilation.nerrordiffp}}
-    </a>
-
-    <a ng-if="build.compilation.nerrordiffn > 0" ng-href="viewBuildError.php?onlydeltan&buildid={{build.id}}">
-      <span class="sub">-{{build.compilation.nerrordiffn}}</span>
+<td ng-if="::buildgroup.hasupdatedata" align="center"
+    ng-class="::!build.hasupdate ? '' : (
+                build.update.errors == 1 ? 'error': (
+                build.update.warning == 1 ? 'warning' : 'normal'))">
+  <div ng-if="::build.hasupdate">
+    <img ng-if="::build.userupdates > 0" src="img/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/>
+    <a ng-href="viewUpdate.php?buildid={{::build.id}}">
+      {{::build.update.files}}
     </a>
   </div>
 </td>
 
-<td ng-if="buildgroup.hascompilationdata" align="center" ng-class="{'warning': build.compilation.warning > 0, 'normal': build.compilation.warning == 0}">
-  <div ng-class="{'valuewithsub': build.compilation.nwarningdiffp > 0 || build.compilation.nwarningdiffn > 0}">
-    <a ng-href="viewBuildError.php?type=1&buildid={{build.id}}">
-      {{build.compilation.warning}}
-    </a>
+<td ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0" align="right">
+  <div ng-if="::build.hasupdate">
+    {{::build.update.time}}
+  </div>
+</td>
 
-    <a ng-if="build.compilation.nwarningdiffp > 0" class="sup" ng-href="viewBuildError.php?type=1&onlydeltap&buildid={{build.id}}">
-      +{{build.compilation.nwarningdiffp}}
-    </a>
-    <a ng-if="build.compilation.nwarningdiffn > 0" ng-href="viewBuildError.php?type=1&onlydeltan&buildid={{build.id}}">
-      <span class="sub">-{{build.compilation.nwarningdiffn}}</span>
+<td ng-if="::buildgroup.hasconfiguredata" align="center" ng-class="::{'error': build.configure.error > 0, 'normal': build.configure.error == 0}">
+  <div ng-if="::build.hasconfigure">
+    <a ng-href="viewConfigure.php?buildid={{::build.id}}">
+      {{::build.configure.error}}
     </a>
   </div>
 </td>
 
-<td ng-if="buildgroup.hascompilationdata" align="center" ng-show="cdash.advancedview != 0">
-  {{build.compilation.time}}
-</td>
-
-<td ng-if="buildgroup.hastestdata" align="center" ng-class="{'warning': build.test.notrun > 0, 'normal': build.test.notrun == 0}">
-  <div ng-class="{'valuewithsub': build.test.nnotrundiffp > 0 || build.test.nnotrundiffn > 0}">
-    <a ng-href="viewTest.php?onlynotrun&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      {{build.test.notrun}}
+<td ng-if="::buildgroup.hasconfiguredata" align="center" ng-class="::{'warning': build.configure.warning > 0, 'normal': build.configure.warning == 0}">
+  <div ng-if="::build.hasconfigure">
+    <a ng-href="viewConfigure.php?buildid={{::build.id}}">
+      {{::build.configure.warning}}
     </a>
-    <a ng-if="build.test.nnotrundiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      +{{build.test.nnotrundiffp}}
-    </a>
-    <span ng-if="build.test.nnotrundiffn > 0" class="sub">-{{build.test.nnotrundiffn}}</span>
+    <sub ng-if="::build.configure.nwarningdiff > 0">+{{::build.configure.nwarningdiff}}</sub>
+    <sub ng-if="::build.configure.nwarningdiff < 0">{{::build.configure.nwarningdiff}}</sub>
   </div>
 </td>
 
-<td ng-if="buildgroup.hastestdata" align="center" ng-class="{'error': build.test.fail > 0, 'normal': build.test.fail < 1}">
-  <div ng-class="{'valuewithsub': build.test.nfaildiffp > 0 || build.test.nfaildiffn > 0}">
-    <a ng-href="viewTest.php?onlyfailed&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      {{build.test.fail}}
+<td ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0" align="center">
+  <div ng-if="::build.hasconfigure">
+    {{::build.configure.time}}
+  </div>
+</td>
+
+<td ng-if="::buildgroup.hascompilationdata" align="center" ng-class="::{'error': build.compilation.error > 0, 'normal': build.compilation.error == 0}">
+  <div ng-if="::build.hascompilation"
+       ng-class="::{'valuewithsub': build.compilation.nerrordiffp > 0 || build.compilation.nerrordiffn > 0}">
+    <a ng-href="viewBuildError.php?buildid={{::build.id}}">
+      {{::build.compilation.error}}
     </a>
-    <a ng-if="build.test.nfaildiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      +{{build.test.nfaildiffp}}
+    <a ng-if="::build.compilation.nerrordiffp > 0" class="sup" ng-href="viewBuildError.php?onlydeltap&buildid={{::build.id}}">
+      +{{::build.compilation.nerrordiffp}}
     </a>
-    <span ng-if="build.test.nfaildiffn > 0" class="sub">
-      -{{build.test.nfaildiffn}}
+
+    <a ng-if="::build.compilation.nerrordiffn > 0" ng-href="viewBuildError.php?onlydeltan&buildid={{::build.id}}">
+      <span class="sub">-{{::build.compilation.nerrordiffn}}</span>
+    </a>
+  </div>
+</td>
+
+<td ng-if="::buildgroup.hascompilationdata" align="center" ng-class="::{'warning': build.compilation.warning > 0, 'normal': build.compilation.warning == 0}">
+  <div ng-if="::build.hascompilation"
+       ng-class="::{'valuewithsub': build.compilation.nwarningdiffp > 0 || build.compilation.nwarningdiffn > 0}">
+    <a ng-href="viewBuildError.php?type=1&buildid={{::build.id}}">
+      {{::build.compilation.warning}}
+    </a>
+
+    <a ng-if="::build.compilation.nwarningdiffp > 0" class="sup" ng-href="viewBuildError.php?type=1&onlydeltap&buildid={{::build.id}}">
+      +{{::build.compilation.nwarningdiffp}}
+    </a>
+    <a ng-if="::build.compilation.nwarningdiffn > 0" ng-href="viewBuildError.php?type=1&onlydeltan&buildid={{::build.id}}">
+      <span class="sub">-{{::build.compilation.nwarningdiffn}}</span>
+    </a>
+  </div>
+</td>
+
+<td ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0" align="center">
+  <div ng-if="::build.hascompilation">
+    {{::build.compilation.time}}
+  </div>
+</td>
+
+<td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'warning': build.test.notrun > 0, 'normal': build.test.notrun == 0}">
+  <div ng-if="::build.hastest"
+       ng-class="::{'valuewithsub': build.test.nnotrundiffp > 0 || build.test.nnotrundiffn > 0}">
+    <a ng-href="viewTest.php?onlynotrun&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      {{::build.test.notrun}}
+    </a>
+    <a ng-if="::build.test.nnotrundiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      +{{::build.test.nnotrundiffp}}
+    </a>
+    <span ng-if="::build.test.nnotrundiffn > 0" class="sub">-{{::build.test.nnotrundiffn}}</span>
+  </div>
+</td>
+
+<td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'error': build.test.fail > 0, 'normal': build.test.fail < 1}">
+  <div ng-if="::build.hastest"
+       ng-class="::{'valuewithsub': build.test.nfaildiffp > 0 || build.test.nfaildiffn > 0}">
+    <a ng-href="viewTest.php?onlyfailed&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      {{::build.test.fail}}
+    </a>
+    <a ng-if="::build.test.nfaildiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      +{{::build.test.nfaildiffp}}
+    </a>
+    <span ng-if="::build.test.nfaildiffn > 0" class="sub">
+      -{{::build.test.nfaildiffn}}
     </span>
   </div>
 </td>
 
-<td ng-if="buildgroup.hastestdata" align="center" ng-class="{'normal': build.test.pass > -1}">
-  <div ng-class="{'valuewithsub': build.test.npassdiffp > 0 || build.test.npassdiffn > 0}">
-    <a ng-href="viewTest.php?onlypassed&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      {{build.test.pass}}
+<td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'normal': build.test.pass > -1}">
+  <div ng-if="::build.hastest"
+       ng-class="::{'valuewithsub': build.test.npassdiffp > 0 || build.test.npassdiffn > 0}">
+    <a ng-href="viewTest.php?onlypassed&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      {{::build.test.pass}}
     </a>
-    <a ng-if="build.test.npassdiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{build.id}}{{cdash.extrafilterurl}}">
-      +{{build.test.npassdiffp}}
+    <a ng-if="::build.test.npassdiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+      +{{::build.test.npassdiffp}}
     </a>
 
-    <span ng-if="build.test.npassdiffn > 0" class="sub">
-      -{{build.test.npassdiffn}}
+    <span ng-if="::build.test.npassdiffn > 0" class="sub">
+      -{{::build.test.npassdiffn}}
     </span>
   </div>
 </td>
 
-<td ng-if="buildgroup.hastestdata" align="center" ng-show="cdash.advancedview != 0" ng-class="{'error': build.test.timestatus > 0, 'normal': build.test.timestatus}">
-  <div ng-class="{'valuewithsub': build.build.test.ntimediffp > 0 || build.test.ntimediffn > 0}">
-    <div ng-if="build.test.timestatus > 0">
-      <a ng-href="viewTest.php?onlytimestatus&buildid={{build.id}}{{cdash.extrafilterurl}}">
-        {{build.test.timestatus}}
+<td align="center"
+    ng-if="::buildgroup.hastestdata && cdash.advancedview != 0"
+    ng-class="::{'error': build.test.timestatus > 0, 'normal': build.test.timestatus == 0}">
+  <div ng-if="::build.hastest"
+       ng-class="::{'valuewithsub': build.build.test.ntimediffp > 0 || build.test.ntimediffn > 0}">
+    <div ng-if="::build.test.timestatus > 0">
+      <a ng-href="viewTest.php?onlytimestatus&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+        {{::build.test.timestatus}}
       </a>
-      <a ng-if="build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{build.id}}{{cdash.extrafilterurl}}">
-        +{{build.test.ntimediffp}}
+      <a ng-if="::build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.extrafilterurl}}">
+        +{{::build.test.ntimediffp}}
       </a>
-      <span ng-if="build.test.ntimediffn > 0" class="sub">
-        -{{build.test.ntimediffn}}
+      <span ng-if="::build.test.ntimediffn > 0" class="sub">
+        -{{::build.test.ntimediffn}}
       </span>
     </div>
 
-    <span ng-if="build.test.timestatus">
-      {{build.test.time}}
-      <a ng-if="build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{buildid}}{{cdash.extrafilterurl}}">
-        +{{build.test.ntimediffp}}
+    <span ng-if="::build.test.timestatus">
+      {{::build.test.time}}
+      <a ng-if="::build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.extrafilterurl}}">
+        +{{::build.test.ntimediffp}}
       </a>
-      <span ng-if="build.test.ntimediffn > 0" class="sub">
-        -{{build.test.ntimediffn}}
+      <span ng-if="::build.test.ntimediffn > 0" class="sub">
+        -{{::build.test.ntimediffn}}
       </span>
     </span>
 
-    <span ng-if="!build.test.timestatus">
-      {{build.test.time}}
+    <span ng-if="::!build.test.timestatus">
+      {{::build.test.time}}
     </span>
   </div>
 </td>
 
 <td align="center">
-  <span ng-if="!build.builddate" class="builddateelapsed" alt="Expected submit time: {{build.expectedstarttime}}">
+  <span ng-if="::!build.builddate" class="builddateelapsed" alt="Expected submit time: {{::build.expectedstarttime}}">
     Expected build
   </span>
 
-  <div ng-if="build.builddate">
-    <span class="builddateelapsed" title="{{build.builddate}}, Update time: {{build.update.time}}, Configure time: {{build.configure.time}}, Compilation time: {{build.compilation.time}}, Test time: {{build.test.time}}">
-      {{build.builddateelapsed}}
+  <div ng-if="::build.builddate">
+    <span class="builddateelapsed" title="{{::build.builddate}}, Update time: {{::build.update.time}}, Configure time: {{::build.configure.time}}, Compilation time: {{::build.compilation.time}}, Test time: {{::build.test.time}}">
+      {{::build.builddateelapsed}}
     </span>
   </div>
 </td>
 
 <!-- display the labels -->
-<td ng-if="cdash.childview != 1 && cdash.displaylabels == 1" class="nob" align="left">
-  {{build.label}}
+<td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" class="nob" align="left">
+  {{::build.label}}
 </td>

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -195,7 +195,7 @@
   </span>
 
   <div ng-if="::build.builddate">
-    <span class="builddateelapsed" title="{{::build.builddate}}, Update time: {{::build.update.time}}, Configure time: {{::build.configure.time}}, Compilation time: {{::build.compilation.time}}, Test time: {{::build.test.time}}">
+    <span class="builddateelapsed" title="{{::build.timesummary}}">
       {{::build.builddateelapsed}}
     </span>
   </div>

--- a/public/views/partials/buildNameElements.html
+++ b/public/views/partials/buildNameElements.html
@@ -1,42 +1,41 @@
-<div ng-if="!build.id" style="float: left; margin: 0px 4px;">{{build.buildname}}</div>
+<div ng-if="::!build.id" style="float: left; margin: 0px 4px;">{{::build.buildname}}</div>
 
 <div style="float:left;">
   <a title="View notes"
-     ng-if="build.notes > 0"
-     ng-show="cdash.advancedview != 0"
-     ng-href="viewNotes.php?buildid={{build.id}}">
+     ng-if="::build.notes > 0 && cdash.advancedview != 0"
+     ng-href="viewNotes.php?buildid={{::build.id}}">
     <img src="img/document.png" alt="Notes" class="icon"/>
   </a>
 
   <a href="javascript:;" style="float: left;"
-     ng-if="build.uploadfilecount > 0"
-     ng-href="viewFiles.php?buildid={{build.id}}"
-     title="{{build.uploadfilecount}} files uploaded with this build">
+     ng-if="::build.uploadfilecount > 0"
+     ng-href="viewFiles.php?buildid={{::build.id}}"
+     title="{{::build.uploadfilecount}} files uploaded with this build">
     <img src="img/package.png" alt="Files" class="icon"/>
   </a>
 
   <!-- If the build has errors or test failing -->
   <a href="javascript:;" style="float: left;"
-     ng-if="build.compilation.error > 0 || build.test.fail > 0"
+     ng-if="::build.compilation.error > 0 || build.test.fail > 0"
      ng-click="toggleBuildProblems(build)">
     <img src="img/Info.png" alt="info" class="icon"></img>
   </a>
 
   <!-- If the build is expected and missing -->
   <a href="javascript:;" style="float: left;"
-     ng-if="build.expectedandmissing == 1"
+     ng-if="::build.expectedandmissing == 1"
      ng-click="toggleExpectedInfo(build)">
     <img src="img/Info.png" alt="info" class="icon"></img>
   </a>
 
   <!-- Display the note icon -->
-  <a name="Build Notes" class="jTip" id="buildnote_{{build.id}}"
-     ng-if="build.buildnotes > 0"
-     ng-href="ajax/buildnote.php?buildid={{build.id}}&width=350&link=buildSummary.php%3Fbuildid%3D{{build.id}}">
+  <a name="Build Notes" class="jTip" id="buildnote_{{::build.id}}"
+     ng-if="::build.buildnotes > 0"
+     ng-href="ajax/buildnote.php?buildid={{::build.id}}&width=350&link=buildSummary.php%3Fbuildid%3D{{::build.id}}">
     <img src="img/note.png" alt="note" class="icon"></img>
   </a>
 
-  <div style="float: left;" ng-if="cdash.user.id > 0">
+  <div style="float: left;" ng-if="::cdash.user.id > 0">
     <!-- Display folder icon for logged in users -->
     <a href="javascript:;" ng-click="toggleAdminOptions(build)">
       <img src="img/folder.png" class="icon"/>
@@ -46,110 +45,116 @@
 </div>
 
 <!-- Problematic build history table -->
-<table width="100%" border="0" ng-show="build.showProblems" class="animate-show">
-  <tbody>
-    <tr ng-if="build.hasErrors">
-      <td bgcolor="#DDDDDD" id="nob">
-        <font size="2">
-          Build has been failing since
-          <b>
-            <a ng-href="index.php?project={{cdash.projectname}}&date={{build.failingDate}}">
-              {{build.failingSince}}
-            </a>
-            (<ng-pluralize count="build.daysWithErrors"
-                          when="{'0':     'today',
-                                 '1':     '{} day',
-                                 'other': '{} days'}">
-            </ng-pluralize>)
-          </b>
-        </font>
-      </td>
-    </tr>
-    <tr ng-if="build.hasFailingTests">
-      <td bgcolor="#DDDDDD" id="nob">
-        <font size="2">
-          Tests have been failing since
-          <b>
-            <a ng-href="index.php?project={{cdash.projectname}}&date={{build.testsFailingDate}}">
-              {{build.testsFailingSince}}
-            </a>
-            (<ng-pluralize count="build.daysWithFailingTests"
-                          when="{'0':     'today',
-                                 '1':     '{} day',
-                                 'other': '{} days'}">
-            </ng-pluralize>)
-          </b>
-        </font>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div ng-if="::build.compilation.error > 0 || build.test.fail > 0">
+  <table width="100%" border="0" ng-if="build.showProblems" class="animate-show">
+    <tbody>
+      <tr ng-if="::build.hasErrors">
+        <td bgcolor="#DDDDDD" id="nob">
+          <font size="2">
+            Build has been failing since
+            <b>
+              <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.failingDate}}">
+                {{::build.failingSince}}
+              </a>
+              (<ng-pluralize count="::build.daysWithErrors"
+                            when="{'0':     'today',
+                                   '1':     '{} day',
+                                   'other': '{} days'}">
+              </ng-pluralize>)
+            </b>
+          </font>
+        </td>
+      </tr>
+      <tr ng-if="::build.hasFailingTests">
+        <td bgcolor="#DDDDDD" id="nob">
+          <font size="2">
+            Tests have been failing since
+            <b>
+              <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.testsFailingDate}}">
+                {{::build.testsFailingSince}}
+              </a>
+              (<ng-pluralize count="::build.daysWithFailingTests"
+                            when="{'0':     'today',
+                                   '1':     '{} day',
+                                   'other': '{} days'}">
+              </ng-pluralize>)
+            </b>
+          </font>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <!-- expected info table -->
-<table width="100%" border="0" ng-show="build.showExpectedInfo" class="animate-show">
-  <tbody>
-    <tr>
-      <td bgcolor="#DDDDDD" id="nob">
-        <font size="2">
-          <span ng-if="build.lastSubmission == -1">
-            This build has never submitted.
-          </span>
-          <span ng-if="build.lastSubmission != -1">
-            This build has not submitted since
-              <b>
-                <a ng-href="index.php?project={{cdash.projectname}}&date={{build.lastSubmissionDate}}">
-                  {{build.lastSubmission}}
-                </a>
-            (<ng-pluralize count="build.daysSinceLastBuild"
-                          when="{'1':     '{} day',
-                                 'other': '{} days'}">
-            </ng-pluralize>)
-          </span>
-        </font>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div ng-if="::build.expectedandmissing == 1">
+  <table width="100%" border="0" ng-if="build.showExpectedInfo" class="animate-show">
+    <tbody>
+      <tr>
+        <td bgcolor="#DDDDDD" id="nob">
+          <font size="2">
+            <span ng-if="::build.lastSubmission == -1">
+              This build has never submitted.
+            </span>
+            <span ng-if="::build.lastSubmission != -1">
+              This build has not submitted since
+                <b>
+                  <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.lastSubmissionDate}}">
+                    {{::build.lastSubmission}}
+                  </a>
+              (<ng-pluralize count="::build.daysSinceLastBuild"
+                            when="{'1':     '{} day',
+                                   'other': '{} days'}">
+              </ng-pluralize>)
+            </span>
+          </font>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <!-- admin options table -->
-<table width="100%" border="0" class="animate-show"
-       ng-show="build.showAdminOptions == 1 && cdash.user.admin == 1">
-  <!-- If user is admin of the project propose to group this build -->
-  <tr ng-repeat="group in cdash.all_buildgroups">
-    <td width="35%">
-      <b>{{group.name}}</b>:
-    </td>
-    <td ng-if="group.name == buildgroup.name" colspan="2">
-      <a ng-show="build.expected == 0" href="javascript:;" ng-click="toggleExpected(build, group.id)">
-        [mark as expected]
-      </a>
-      <a ng-show="build.expected == 1" href="javascript:;" ng-click="toggleExpected(build, group.id)">
-        [mark as non expected]
-      </a>
-    </td>
-    <td ng-if="group.name != buildgroup.name" colspan="2">
-      <input type="checkbox" ng-model="build.expected" ng-true-value="'1'" ng-false-value="'0'"> expected</input>
-    </td>
-    <td ng-if="group.name != buildgroup.name" class="nob">
-      <a href="javascript:;" ng-click="moveToGroup(build, group.id)"> [move to group] </a>
-    </td>
-  </tr>
-  <tr>
-    <td colspan="3" class="nob">
-      <a href="javascript:;" ng-click="removeBuild(build)"> [remove this build] </a>
-    </td>
-  </tr>
-</table>
+<div ng-if="::cdash.user.admin == 1">
+  <div ng-if="build.showAdminOptions == 1">
+    <table width="100%" border="0" class="animate-show">
+      <!-- If user is admin of the project propose to group this build -->
+      <tr ng-repeat="group in ::cdash.all_buildgroups">
+        <td width="35%">
+          <b>{{::group.name}}</b>:
+        </td>
+        <td ng-if="::group.name == buildgroup.name" colspan="2">
+          <a ng-show="build.expected == 0" href="javascript:;" ng-click="toggleExpected(build, group.id)">
+            [mark as expected]
+          </a>
+          <a ng-show="build.expected == 1" href="javascript:;" ng-click="toggleExpected(build, group.id)">
+            [mark as non expected]
+          </a>
+        </td>
+        <td ng-if="::group.name != buildgroup.name" colspan="2">
+          <input type="checkbox" ng-model="build.expected" ng-true-value="'1'" ng-false-value="'0'"> expected</input>
+        </td>
+        <td ng-if="::group.name != buildgroup.name" class="nob">
+          <a href="javascript:;" ng-click="moveToGroup(build, group.id)"> [move to group] </a>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3" class="nob">
+          <a href="javascript:;" ng-click="removeBuild(build)"> [remove this build] </a>
+        </td>
+      </tr>
+    </table>
 
-<div ng-show="build.showAdminOptions == 1"
-     tooltip-popup-delay="1500"
-     tooltip-append-to-body="true"
-     uib-tooltip="Done builds will be overwritten if a new one is submitted with the same site, build name, and timestamp."
->
-  <a ng-show="build.done == 0" href="javascript:;" ng-click="toggleDone(build)">
-    [mark as done]
-  </a>
-  <a ng-show="build.done == 1" href="javascript:;" ng-click="toggleDone(build)">
-    [mark as not done]
-  </a>
+    <div tooltip-popup-delay="1500"
+         tooltip-append-to-body="true"
+         uib-tooltip="Done builds will be overwritten if a new one is submitted with the same site, build name, and timestamp."
+    >
+      <a ng-show="build.done == 0" href="javascript:;" ng-click="toggleDone(build)">
+        [mark as done]
+      </a>
+      <a ng-show="build.done == 1" href="javascript:;" ng-click="toggleDone(build)">
+        [mark as not done]
+      </a>
+    </div>
+  </div>
 </div>

--- a/public/views/partials/footer.html
+++ b/public/views/partials/footer.html
@@ -5,11 +5,11 @@
   <div id="footerlogo">
     <a href="http://www.cdash.org"><img src="img/logo2.gif" border="0" height="40" alt="CDash logo"/></a>
     <span id="footertext">
-      CDash {{cdash.version}}
+      CDash {{::cdash.version}}
       © <a href="http://www.kitware.com">Kitware</a> |
       <a href="http://www.cdash.org/Bug" target="blank">Report problems</a>
-      <span ng-if="cdash.generationtime">
-        | {{cdash.generationtime}}s
+      <span ng-if="::cdash.generationtime">
+        | {{::cdash.generationtime}}s
       </span>
     </span>
   </div>

--- a/tests/js/e2e_tests/done_build.js
+++ b/tests/js/e2e_tests/done_build.js
@@ -37,7 +37,7 @@ describe("done_build", function() {
   it("toggle done for normal build", function() {
     var loginPage = new LoginPage();
     loginPage.login();
-    toggle_done('index.php?project=InsightExample', 2);
+    toggle_done('index.php?project=InsightExample', 1);
   });
 
   it("toggle done for parent build", function() {

--- a/tests/js/e2e_tests/expected_build.js
+++ b/tests/js/e2e_tests/expected_build.js
@@ -6,7 +6,7 @@ describe("expected_build", function() {
     browser.get('index.php?project=InsightExample');
 
     // Locate the folder icon
-    var folderIcon = element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(2);
+    var folderIcon = element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(1);
 
     // Make sure that we located the right img.
     expect(folderIcon.getAttribute('src')).toContain('img/folder.png');
@@ -21,7 +21,7 @@ describe("expected_build", function() {
 
     // Refresh the page to make sure this build is now expected.
     browser.get('index.php?project=InsightExample');
-    element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(2).click();
+    element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(1).click();
     expect(element(by.partialLinkText('mark as non expected')).isPresent()).toBe(true);
 
     // Make it non expected again.
@@ -31,7 +31,7 @@ describe("expected_build", function() {
 
     // Refresh & verify.
     browser.get('index.php?project=InsightExample');
-    element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(2).click();
+    element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(0)).all(by.tagName('img')).get(1).click();
     expect(element(by.partialLinkText('mark as expected')).isPresent()).toBe(true);
   });
 });

--- a/tests/js/e2e_tests/filterLabels.js
+++ b/tests/js/e2e_tests/filterLabels.js
@@ -29,10 +29,10 @@ describe("filterLabels", function() {
 
     // Next, click on a specific test
     var build_failures = element.all(by.binding('build.test.fail'));
-    expect(build_failures.count()).toBe(5);
-    var test3 = build_failures.get(3);
-    expect(test3.getText()).toBe('10');
-    test3.click();
+    expect(build_failures.count()).toBe(2);
+    var test = build_failures.get(0);
+    expect(test.getText()).toBe('10');
+    test.click();
     browser.waitForAngular();
 
     // Make sure the expected number of tests are displayed

--- a/tests/js/e2e_tests/remove_build.js
+++ b/tests/js/e2e_tests/remove_build.js
@@ -6,7 +6,7 @@ describe("remove_build", function() {
     browser.get('index.php?project=InsightExample');
 
     // Locate the folder icon for the 2nd build.
-    var folderIcon = element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(1)).all(by.tagName('img')).get(2);
+    var folderIcon = element(by.repeater('build in buildgroup.pagination.filteredBuilds').row(1)).all(by.tagName('img')).get(1);
 
     // Make sure that we located the right img.
     expect(folderIcon.getAttribute('src')).toContain('img/folder.png');

--- a/tests/js/e2e_tests/subprojectGroupOrder.js
+++ b/tests/js/e2e_tests/subprojectGroupOrder.js
@@ -34,6 +34,6 @@ describe("subProjectGroupOrder", function() {
     element(by.linkText('subproject_coverage_example')).click();
 
     // Make sure that Production is the first group listed.
-    expect(element(by.repeater('group in cdash.coveragegroups').row(0)).getInnerHtml()).toContain("Production");
+    expect(element(by.repeater('group in ::cdash.coveragegroups').row(0)).getInnerHtml()).toContain("Production");
   });
 });


### PR DESCRIPTION
Improve render speed of index.php by reducing the number of watchers that Angular generates.  This is done through the use of one-time binding.