### PR TITLE
Don't let a build be its own parent

### DIFF
--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -208,7 +208,7 @@ class GCovTarHandler
                 $siblingBuild->Name = $this->Build->Name;
                 $siblingBuild->ProjectId = $this->ProjectId;
                 $siblingBuild->SiteId = $this->Build->SiteId;
-                $siblingBuild->ParentId = $this->Build->ParentId;
+                $siblingBuild->SetParentId($this->Build->GetParentId());
                 $siblingBuild->SetStamp($this->Build->GetStamp());
                 $siblingBuild->SetSubProject($subprojectname);
                 $siblingBuild->StartTime = $this->Build->StartTime;

--- a/xml_handlers/JavaJSONTar_handler.php
+++ b/xml_handlers/JavaJSONTar_handler.php
@@ -113,7 +113,7 @@ class JavaJSONTarHandler
          INNER JOIN subproject AS sp ON (sp.id = sp2b.subprojectid)
          INNER JOIN build AS b ON (b.id = sp2b.buildid)
          WHERE sp.name = '$subprojectName'
-         AND b.parentid=" . qnum($this->Build->ParentId);
+         AND b.parentid=" . qnum($this->Build->GetParentId());
             $buildid_result = pdo_single_row_query($query);
 
             // If we found a different buildid, create a new CoverageSummary.

--- a/xml_handlers/update_handler.php
+++ b/xml_handlers/update_handler.php
@@ -90,7 +90,7 @@ class UpdateHandler extends AbstractHandler
             // Update.xml doesn't include SubProject information.
             // Check if GetIdFromName returned a child build, and
             // if so, change our buildid to point at the parent instead.
-            $parentid = $this->Build->GetParentBuildId();
+            $parentid = $this->Build->LookupParentBuildId();
             if ($parentid > 0) {
                 $this->Build->Id = $parentid;
             }


### PR DESCRIPTION
Make $ParentId a private member and add logic to SetParentId
that prevents a build from being its own parent.