### PR TITLE
Add back styling that was removed in aggregate view branch

### DIFF
--- a/public/views/partials/buildError.html
+++ b/public/views/partials/buildError.html
@@ -1,4 +1,4 @@
-<table>
+<table style="table-layout:fixed; width:100%">
   <colgroup>
     <col style="width: 115px"/>
     <col/>


### PR DESCRIPTION
When introducing 635e4268c08831031c47a617ce9b895b00d99854, I moved buildError html into a partial and lost the style attribute that was on the table tag - this resulted in funky scroll output noticed here: https://open.cdash.org/viewBuildError.php?buildid=4332313.


Thanks @mathstuf for noticing.