### PR TITLE
Speedup coverage aggregation for GcovTar_handler

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -2117,3 +2117,20 @@ function cast_data_for_JSON($value)
     }
     return $value;
 }
+
+/* Get the site ID for 'CDash Server'.
+ * This is the site associated with Aggregate Coverage builds.
+ */
+function get_server_siteid()
+{
+    require_once 'models/site.php';
+    $server = new Site();
+    $server->Name = 'CDash Server';
+    if (!$server->Exists()) {
+        // Create it if it doesn't exist.
+        $server_ip = $_SERVER['SERVER_ADDR'];
+        $server->Ip = $server_ip;
+        $server->Insert();
+    }
+    return $server->Id;
+}

--- a/tests/test_buildgetdate.php
+++ b/tests/test_buildgetdate.php
@@ -31,7 +31,7 @@ class BuildGetDateTestCase extends KWWebTestCase
 
         $expected_date = '2009-02-23';
         $date = $build->GetDate();
-        if ($build->GetDate() !== $expected_date) {
+        if ($date !== $expected_date) {
             $this->fail("Evening case: expected $expected_date, found $date");
             $retval = 1;
         }
@@ -39,8 +39,9 @@ class BuildGetDateTestCase extends KWWebTestCase
         $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 20:00:00'));
 
         $expected_date = '2009-02-24';
+        $build->NightlyStartTime = false;
         $date = $build->GetDate();
-        if ($build->GetDate() !== $expected_date) {
+        if ($date !== $expected_date) {
             $this->fail("Evening case: expected $expected_date, found $date");
             $retval = 1;
         }
@@ -49,16 +50,18 @@ class BuildGetDateTestCase extends KWWebTestCase
         pdo_query("UPDATE project SET nightlytime = '09:00:00' WHERE id=1");
         $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 08:59:59'));
         $expected_date = '2009-02-22';
+        $build->NightlyStartTime = false;
         $date = $build->GetDate();
-        if ($build->GetDate() !== $expected_date) {
+        if ($date !== $expected_date) {
             $this->fail("Morning case: expected $expected_date, found $date");
             $retval = 1;
         }
 
         $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 09:00:00'));
         $expected_date = '2009-02-23';
+        $build->NightlyStartTime= false;
         $date = $build->GetDate();
-        if ($build->GetDate() !== $expected_date) {
+        if ($date !== $expected_date) {
             $this->fail("Morning case: expected $expected_date, found $date");
             $retval = 1;
         }


### PR DESCRIPTION
To assign aggregate coverage to the correct build we need to know
the beginning and end of the current testing day, as well as
the siteid of 'CDash Server'.

These values are not specific to the covered source file.
So rather than looking them up in CoverageFileLog::UpdateAggregate(),
we now find them in GcovTar_Handler instead.  This means that we are
only finding this data once per tarball instead of finding it for each
.gcov file.