### PR TITLE
Make logging optional from pdo_error

### DIFF
--- a/include/pdocore.php
+++ b/include/pdocore.php
@@ -82,12 +82,14 @@ function pdo_select_db($database, $link_identifier = null)
  * @param CDash\Database|null $link_identifier
  * @return string containing error message (or not in the case of production)
  */
-function pdo_error($link_identifier = null)
+function pdo_error($link_identifier = null, $log_error = true)
 {
     global $CDASH_PRODUCTION_MODE;
     $error_info = get_link_identifier($link_identifier)->getPdo()->errorInfo();
     if (isset($error_info[2]) && $error_info[0] !== '00000') {
-        add_log($error_info[2], 'pdo_error', LOG_ERR);
+        if ($log_error) {
+            add_log($error_info[2], 'pdo_error', LOG_ERR);
+        }
         if ($CDASH_PRODUCTION_MODE) {
             return 'SQL error encountered, query hidden.';
         }

--- a/models/build.php
+++ b/models/build.php
@@ -657,7 +657,7 @@ class Build
                  '$this->Uuid')";
 
             if (!pdo_query($query)) {
-                $error = pdo_error();
+                $error = pdo_error(null, false);
                 // This error might be due to a unique constraint violation
                 // for this UUID.  Query for such a previously existing build.
                 $existing_id_result = pdo_single_row_query(


### PR DESCRIPTION
Update pdo_error() to make logging of the error optional.

During parallel submission processing we sometimes anticipate
an SQL error (due to a race condition) and handle it internally.
In these cases we should not write the error to the CDash log.