### PR TITLE
Don't copy CoverageSummaryDiff

### DIFF
--- a/include/copy_build_data.php
+++ b/include/copy_build_data.php
@@ -28,11 +28,17 @@ function copy_build_data($old_buildid, $new_buildid, $type)
 function copy_coverage_data($old_buildid, $new_buildid)
 {
     $tables_to_copy = array(
-        'coverage', 'coveragefilelog', 'coveragesummary', 'coveragesummarydiff');
+        'coverage', 'coveragefilelog', 'coveragesummary');
 
     foreach ($tables_to_copy as $table) {
         copy_build_table($old_buildid, $new_buildid, $table);
     }
+
+    // Compute difference in coverage from previous build.
+    require_once('models/coveragesummary.php');
+    $summary = new CoverageSummary();
+    $summary->BuildId = $new_buildid;
+    $summary->ComputeDifference();
 }
 
 /**


### PR DESCRIPTION
CDash checks for duplicates before asking the client to upload
a tarball of coverage data.  When a duplicate is detected it
skips the upload and copies the existing coverage info into this
new build.

As part of this process, we were also copying the difference in
coverage from the previous build.  This was wrong.  We now call
CoverageSummary::ComputeDifference() after the copy is done.