### PR TITLE
Don't use one-time binding for requirelogin

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -15,9 +15,9 @@
 
   <body bgcolor="#ffffff" ng-controller="IndexController">
 
-    <div ng-if="::cdash.requirelogin == 1" ng-include="'login.php'"></div>
+    <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="::cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
 
     <div ng-if="::cdash.future == 1">
       CDash cannot predict the future (yet)...
@@ -543,6 +543,6 @@
       </table>
     </div> <!-- end index content -->
 
-    <ng-include ng-if="::cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
   </body>
 </html>


### PR DESCRIPTION
This broke CDash's ability to display the login form on index.php.
Instead it would just display an empty version of the index page.