### PR TITLE
Speed up GcovTar parsing

### DIFF
--- a/models/coveragefilelog.php
+++ b/models/coveragefilelog.php
@@ -23,12 +23,16 @@ class CoverageFileLog
     public $FileId;
     public $Lines;
     public $Branches;
+    // The following members are used by GcovTar_handler & friends to
+    // speed up parsing for coverage across SubProjects.
     public $AggregateBuildId;
+    public $PreviousAggregateParentId;
 
     public function __construct()
     {
         $this->Lines = array();
         $this->Branches = array();
+        $this->PreviousAggregateParentId = null;
     }
 
     public function AddLine($number, $code)
@@ -306,6 +310,6 @@ class CoverageFileLog
 
         // Insert/Update the aggregate summary.
         $aggregateSummary->Insert(true);
-        $aggregateSummary->ComputeDifference();
+        $aggregateSummary->ComputeDifference($this->PreviousAggregateParentId);
     }
 }

--- a/models/coveragesummary.php
+++ b/models/coveragesummary.php
@@ -315,11 +315,11 @@ class CoverageSummary
     }   // Insert()
 
     /** Compute the coverage summary diff */
-    public function ComputeDifference()
+    public function ComputeDifference($previous_parentid=null)
     {
         $build = new Build();
         $build->Id = $this->BuildId;
-        $previousBuildId = $build->GetPreviousBuildId();
+        $previousBuildId = $build->GetPreviousBuildId($previous_parentid);
         if ($previousBuildId < 1) {
             return;
         }

--- a/tests/data/CoverageAcrossSubProjects/MyExperimentalFeature/Build.xml
+++ b/tests/data/CoverageAcrossSubProjects/MyExperimentalFeature/Build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Site BuildName="subproject_coverage_example"
-	BuildStamp="20160209-1908-Experimental"
+	BuildStamp="20160209-1908-Nightly"
 	Name="localhost"
 	Generator="ctest-3.4.20160121-g750ae8-dirty"
 	CompilerName=""

--- a/tests/data/CoverageAcrossSubProjects/MyProductionCode/Build.xml
+++ b/tests/data/CoverageAcrossSubProjects/MyProductionCode/Build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Site BuildName="subproject_coverage_example"
-	BuildStamp="20160209-1908-Experimental"
+	BuildStamp="20160209-1908-Nightly"
 	Name="localhost"
 	Generator="ctest-3.4.20160121-g750ae8-dirty"
 	CompilerName=""

--- a/tests/data/CoverageAcrossSubProjects/MyThirdPartyDependency/Build.xml
+++ b/tests/data/CoverageAcrossSubProjects/MyThirdPartyDependency/Build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Site BuildName="subproject_coverage_example"
-	BuildStamp="20160209-1908-Experimental"
+	BuildStamp="20160209-1908-Nightly"
 	Name="localhost"
 	Generator="ctest-3.4.20160121-g750ae8-dirty"
 	CompilerName=""

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -29,7 +29,7 @@ class GCovTarHandler
     private $Labels;
     private $SubProjectPath;
     private $SubProjectSummaries;
-    private $ServerSiteId;
+    private $AggregateBuildId;
 
     public function __construct($buildid)
     {
@@ -105,8 +105,14 @@ class GCovTarHandler
         }
 
         // Lookup some data used during coverage aggregation.
-        $this->ServerSiteId = get_server_siteid();
         $this->Build->ComputeTestingDayBounds();
+        $aggregateBuild = get_aggregate_build($this->Build);
+        $aggregateParentId = $aggregateBuild->GetParentId();
+        if ($aggregateParentId > 0) {
+            $this->AggregateBuildId = $aggregateParentId;
+        } else {
+            $this->AggregateBuildId = $aggregateBuild->Id;
+        }
 
         // Recursively search for .gcov files and parse them.
         $iterator->rewind();
@@ -151,7 +157,7 @@ class GCovTarHandler
     public function ParseGcovFile($fileinfo)
     {
         $coverageFileLog = new CoverageFileLog();
-        $coverageFileLog->ServerSiteId = $this->ServerSiteId;
+        $coverageFileLog->AggregateBuildId = $this->AggregateBuildId;
         $coverageFile = new CoverageFile();
         $coverage = new Coverage();
         $coverage->CoverageFile = $coverageFile;

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -30,6 +30,7 @@ class GCovTarHandler
     private $SubProjectPath;
     private $SubProjectSummaries;
     private $AggregateBuildId;
+    private $PreviousAggregateParentId;
 
     public function __construct($buildid)
     {
@@ -56,6 +57,7 @@ class GCovTarHandler
             }
         }
         $this->SubProjectSummaries = array();
+        $this->PreviousAggregateParentId = null;
     }
 
     /**
@@ -110,6 +112,9 @@ class GCovTarHandler
         $aggregateParentId = $aggregateBuild->GetParentId();
         if ($aggregateParentId > 0) {
             $this->AggregateBuildId = $aggregateParentId;
+            $aggregateParent = new Build();
+            $aggregateParent->Id = $aggregateParentId;
+            $this->PreviousAggregateParentId = $aggregateParent->GetPreviousBuildId();
         } else {
             $this->AggregateBuildId = $aggregateBuild->Id;
         }
@@ -158,6 +163,8 @@ class GCovTarHandler
     {
         $coverageFileLog = new CoverageFileLog();
         $coverageFileLog->AggregateBuildId = $this->AggregateBuildId;
+        $coverageFileLog->PreviousAggregateParentId =
+            $this->PreviousAggregateParentId;
         $coverageFile = new CoverageFile();
         $coverage = new Coverage();
         $coverage->CoverageFile = $coverageFile;


### PR DESCRIPTION
Our recent additions of cross-subproject & aggregate coverage have slowed this parser down when lots of .gcov files are submitted.  This PR speeds things back up considerably.