### PR TITLE
More robustly report number of child builds

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -1310,6 +1310,19 @@ function echo_main_dashboard_JSON($project_instance, $date)
         $response['coverages'] = array_values($response['coverages']);
     }
 
+    if ($response['childview'] == 1) {
+        // Report number of children.
+        if (!empty($buildgroups_response)) {
+            $numchildren = count($buildgroups_response[0]['builds']);
+        } else {
+            $row = pdo_single_row_query(
+                    'SELECT count(id) AS numchildren
+                    FROM build WHERE parentid=' . qnum($parentid));
+            $numchildren = $row['numchildren'];
+        }
+        $response['numchildren'] = $numchildren;
+    }
+
     // Generate coverage by group here.
     if (!empty($coverage_groups)) {
         $response['coveragegroups'] = array();

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -127,7 +127,7 @@
         </div>
 
         <div id="numbuilds" align="left">
-          <b>Number of SubProjects Built</b>: {{::cdash.buildgroups[0].builds.length}}
+          <b>Number of SubProjects</b>: {{::cdash.numchildren}}
         </div>
         <br/>
       </div>

--- a/tests/js/e2e_tests/filterLabels.js
+++ b/tests/js/e2e_tests/filterLabels.js
@@ -5,7 +5,7 @@ describe("filterLabels", function() {
     element(by.linkText('Windows_NT-MSVC10-SERIAL_DEBUG_DEV')).click();
 
     // First, verify the expected number of builds
-    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects Built: 36');
+    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects: 36');
     // Note: A maximum of 10 builds are displayed at a time
     expect(element.all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(10);
 
@@ -24,7 +24,7 @@ describe("filterLabels", function() {
     browser.waitForAngular();
 
     // Make sure the expected number of builds are displayed
-    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects Built: 5');
+    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects: 5');
     expect(element.all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(5);
 
     // Next, click on a specific test
@@ -45,7 +45,7 @@ describe("filterLabels", function() {
     element(by.linkText('Windows_NT-MSVC10-SERIAL_DEBUG_DEV')).click();
 
     // First, verify the expected number of builds
-    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects Built: 36');
+    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects: 36');
     // Note: A maximum of 10 builds are displayed at a time
     expect(element.all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(10);
 
@@ -64,7 +64,7 @@ describe("filterLabels", function() {
     browser.waitForAngular();
 
     // Make sure the expected number of builds are displayed
-    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects Built: 5');
+    expect(element(by.id('numbuilds')).getText()).toBe('Number of SubProjects: 5');
     expect(element.all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(5);
 
     // Next, hover on 'Dashboard' and click on 'Tests Query'


### PR DESCRIPTION
This new approach handles the case of parent builds that only
contain coverage info (no configure/build/test data).