### PR TITLE
More carefully split coverage by directory

### DIFF
--- a/public/ajax/getviewcoverage.php
+++ b/public/ajax/getviewcoverage.php
@@ -129,7 +129,7 @@ if ($filterdata['limit'] > 0) {
 }
 
 if (isset($_GET['dir']) && $_GET['dir'] != '') {
-    $SQLsearchTerm .= " AND cf.fullpath LIKE '%" . htmlspecialchars(pdo_real_escape_string($_GET['dir'])) . "%'";
+    $SQLsearchTerm .= " AND cf.fullpath LIKE '%" . htmlspecialchars(pdo_real_escape_string($_GET['dir'])) . "/%'";
 }
 
 // Coverage files


### PR DESCRIPTION
This commit fixes a bug that occurred when coverage was split
across two or more similarly named directories.

Suppose you have coverage for the following files:
  app/foo.cxx
  apptest/bar.cxx

While viewing the results from the app/ directory, you would also
see a file named "est/bar.cxx".

We now search for a trailing / to make sure we are only grabbing
files from the specified directory.