### PR TITLE
Use prepared statements instead of pg_escape_bytea

### DIFF
--- a/models/image.php
+++ b/models/image.php
@@ -66,13 +66,13 @@ class Image
     }
 
     /** Save the image */
-    public function Save()
+    public function Save($update=false)
     {
         // Get the data from the file if necessary
         $this->GetData();
+        $pdo = get_link_identifier()->getPdo();
 
         if (!$this->Exists()) {
-            $pdo = get_link_identifier()->getPdo();
             $success = true;
             if ($this->Id) {
                 $stmt = $pdo->prepare('
@@ -95,6 +95,16 @@ class Image
             }
             if (!$success) {
                 add_last_sql_error('Image::Save');
+                return false;
+            }
+        } elseif ($update) {
+            // Update the current image.
+            $stmt = $pdo->prepare('UPDATE image SET img=:img, extension=:extension, checksum=:checksum WHERE id=:id');
+            $stmt->bindParam(':img', $this->Data, PDO::PARAM_LOB);
+            $stmt->bindParam(':extension', $this->Extension);
+            $stmt->bindParam(':checksum', $this->Checksum);
+            $stmt->bindParam(':id', $this->Id);
+            if (!$stmt->execute()) {
                 return false;
             }
         }

--- a/public/createProject.php
+++ b/public/createProject.php
@@ -246,7 +246,7 @@ if ($session_OK) {
                 $handle = fopen($_FILES['logo']['tmp_name'], 'r');
                 $contents = 0;
                 if ($handle) {
-                    $contents = addslashes(fread($handle, $_FILES['logo']['size']));
+                    $contents = fread($handle, $_FILES['logo']['size']);
                     $filetype = $_FILES['logo']['type'];
                     fclose($handle);
                     unset($handle);
@@ -356,7 +356,7 @@ if ($session_OK) {
             $handle = fopen($_FILES['logo']['tmp_name'], 'r');
             $contents = 0;
             if ($handle) {
-                $contents = addslashes(fread($handle, $_FILES['logo']['size']));
+                $contents = fread($handle, $_FILES['logo']['size']);
                 $filetype = $_FILES['logo']['type'];
                 fclose($handle);
                 unset($handle);

--- a/public/displayImage.php
+++ b/public/displayImage.php
@@ -50,15 +50,9 @@ switch ($img_array['extension']) {
         echo $img_array['extension'];
         return;
 }
-
 if ($CDASH_DB_TYPE == 'pgsql') {
-    $buf = '';
-    while (!feof($img_array['img'])) {
-        $buf .= fread($img_array['img'], 2048);
-    }
-    $buf = stripslashes($buf);
+    $buf = stream_get_contents($img_array['img']);
 } else {
     $buf = $img_array['img'];
 }
 echo $buf;
-return;

--- a/tests/test_image.php
+++ b/tests/test_image.php
@@ -37,7 +37,8 @@ class ImageTestCase extends KWWebTestCase
         }
 
         $pathToImage = dirname(__FILE__) . '/data/smile.gif';
-
+        $image->Filename = $pathToImage;
+        $image->Extension = 'image/gif';
         //dummy checksum so we don't break the test on pgSQL
         $image->Checksum = 100;
 


### PR DESCRIPTION
``pg_escape_bytea()`` is the only function that we use from the PHP pgsql module (as opposed to PDO_PGSQL).
CircleCI doesn't provide pgsql.so, so by eliminating our use of this function we will be able to start automatically testing CDash with PostgreSQL on CircleCI.