### PR TITLE
Remove characters that are not valid XML

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -155,6 +155,11 @@ function XMLStrFormat($str)
     $str = str_replace("'", '&apos;', $str);
     $str = str_replace('"', '&quot;', $str);
     $str = str_replace("\r", '', $str);
+
+    // Remove UTF-8 characters that are not valid in an XML document.
+    // https://www.w3.org/TR/REC-xml/#charsets
+    $str = preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', '', $str);
+
     return $str;
 }
 


### PR DESCRIPTION
If any of these characters were present in our user-submitted data they would prevent our XSLT-generated pages from rendering properly.