### PR TITLE
Remember Items Per Page setting

### DIFF
--- a/public/js/controllers/queryTests.js
+++ b/public/js/controllers/queryTests.js
@@ -6,8 +6,15 @@ CDash.controller('QueryTestsController',
     $scope.pagination = [];
     $scope.pagination.filteredBuilds = [];
     $scope.pagination.currentPage = 1;
-    $scope.pagination.numPerPage = 25;
     $scope.pagination.maxSize = 5;
+
+    // Check if we have a cookie for number of tests to display.
+    var num_per_page_cookie = $.cookie('queryTests_num_per_page');
+    if(num_per_page_cookie) {
+      $scope.pagination.numPerPage = parseInt(num_per_page_cookie);
+    } else {
+      $scope.pagination.numPerPage = 25;
+    }
 
     // Hide filters by default.
     $scope.showfilters = false;
@@ -68,5 +75,10 @@ CDash.controller('QueryTestsController',
       $scope.cdash.builds = $filter('orderBy')($scope.cdash.builds, $scope.orderByFields);
       $scope.pageChanged();
       $.cookie('cdash_query_tests_sort', $scope.orderByFields);
+    };
+
+    $scope.numTestsPerPageChanged = function() {
+      $.cookie("queryTests_num_per_page", $scope.pagination.numPerPage, { expires: 365 });
+      $scope.pageChanged();
     };
 });

--- a/public/js/controllers/viewTest.js
+++ b/public/js/controllers/viewTest.js
@@ -6,8 +6,15 @@ CDash.controller('ViewTestController',
     $scope.pagination = [];
     $scope.pagination.filteredTests = [];
     $scope.pagination.currentPage = 1;
-    $scope.pagination.numPerPage = 25;
     $scope.pagination.maxSize = 5;
+
+    // Check if we have a cookie for number of tests to display.
+    var num_per_page_cookie = $.cookie('viewTest_num_per_page');
+      if(num_per_page_cookie) {
+        $scope.pagination.numPerPage = parseInt(num_per_page_cookie);
+      } else {
+        $scope.pagination.numPerPage = 25;
+      }
 
     // Hide filters by default.
     $scope.showfilters = false;
@@ -126,5 +133,10 @@ CDash.controller('ViewTestController',
       $scope.cdash.tests = $filter('orderBy')($scope.cdash.tests, $scope.orderByFields);
       $scope.pageChanged();
       $.cookie('cdash_view_test_sort', $scope.orderByFields);
+    };
+
+    $scope.numTestsPerPageChanged = function() {
+      $.cookie("viewTest_num_per_page", $scope.pagination.numPerPage, { expires: 365 });
+      $scope.pageChanged();
     };
 });

--- a/public/views/queryTests.html
+++ b/public/views/queryTests.html
@@ -137,7 +137,7 @@
 
     <div>
       <label>Items per page</label>
-      <select ng-model="pagination.numPerPage" convert-to-number ng-change="pageChanged()">
+      <select ng-model="pagination.numPerPage" convert-to-number ng-change="numTestsPerPageChanged()">
         <option value="25">25</option>
         <option value="50">50</option>
         <option value="100">100</option>

--- a/public/views/viewTest.html
+++ b/public/views/viewTest.html
@@ -256,7 +256,7 @@
 
           <div>
             <label>Items per page</label>
-            <select ng-model="pagination.numPerPage" convert-to-number ng-change="pageChanged()">
+            <select ng-model="pagination.numPerPage" convert-to-number ng-change="numTestsPerPageChanged()">
               <option value="25">25</option>
               <option value="50">50</option>
               <option value="100">100</option>


### PR DESCRIPTION
Remember what value the user specified for Items Per Page
on viewTest.php and queryTests.php.  Previously this would
default back to 25 whenever the page was revisited.