### PR TITLE
Introduce gulp incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 /log/
 /nbproject/private/
 /node_modules
+/public/js/1stparty.min.js
+/public/js/1stparty.min.js.map
+/public/js/3rdparty.min.js
+/public/js/3rdparty.min.js.map
 /public/js/CDash_*.min.js*
 /tests/config.test.local.php
 /upload/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,14 @@
 (function () {
 
   var gulp = require('gulp'),
-      eslint = require('gulp-eslint'),
       del = require('del'),
-      sourcemaps = require('gulp-sourcemaps'),
       concat = require('gulp-concat'),
-      uglify = require('gulp-uglify'),
-      rename = require("gulp-rename"),
+      eslint = require('gulp-eslint'),
+      newer = require('gulp-newer'),
       replace = require('gulp-replace'),
+      rename = require("gulp-rename"),
+      sourcemaps = require('gulp-sourcemaps'),
+      uglify = require('gulp-uglify'),
       release = false, // Change to true when cutting a release.
       version;
 
@@ -37,8 +38,28 @@
   });
 
 
- gulp.task('uglify', function() {
-   gulp.src(['public/js/jquery-1.10.2.js',
+ gulp.task('uglify-1stparty', function() {
+   return gulp.src(['public/js/cdashmenu.js',
+             'public/js/cdashIndexTable.js',
+             'public/js/cdashSortable.js',
+             'public/js/tabNavigation.js',
+             'public/js/linechart.js',
+             'public/js/bulletchart.js',
+             'public/js/cdash_angular.js',
+             'public/js/controllers/**.js'])
+       .pipe(sourcemaps.init())
+       .pipe(newer('public/js/1stparty.min.js'))
+       .pipe(uglify({mangle: false})).on('error', function(e) {
+           console.log(e);
+        })
+       .pipe(concat('1stparty.min.js'))
+       .pipe(sourcemaps.write('./'))
+       .pipe(gulp.dest('public/js'));
+ });
+
+
+ gulp.task('uglify-3rdparty', function() {
+   return gulp.src(['public/js/jquery-1.10.2.js',
              'public/js/jquery-ui-1.10.4.min.js',
              'public/js/jquery.cookie.js',
              'public/js/jquery.flot.min.js',
@@ -49,28 +70,31 @@
              'public/js/jqModal.js',
              'public/js/bootstrap.min.js',
              'public/js/tooltip.js',
-             'public/js/cdashmenu.js',
-             'public/js/cdashIndexTable.js',
-             'public/js/cdashSortable.js',
-             'public/js/tabNavigation.js',
              'public/js/je_compare.js',
              'public/js/d3.min.js',
              'public/js/nv.d3.min.js',
-             'public/js/linechart.js',
-             'public/js/bulletchart.js',
              'node_modules/as-jqplot/dist/jquery.jqplot.js',
              'node_modules/as-jqplot/dist/plugins/jqplot.dateAxisRenderer.js',
              'node_modules/as-jqplot/dist/plugins/jqplot.highlighter.js',
              'public/js/angular-1.4.7.min.js',
              'public/js/angular-animate.min.js',
              'public/js/angular-ui-sortable.min.js',
-             'public/js/ui-bootstrap-tpls-0.14.2.min.js',
-             'public/js/cdash_angular.js',
-             'public/js/controllers/**.js'])
+             'public/js/ui-bootstrap-tpls-0.14.2.min.js'])
        .pipe(sourcemaps.init())
+       .pipe(newer('public/js/3rdparty.min.js'))
        .pipe(uglify({mangle: false})).on('error', function(e) {
            console.log(e);
         })
+       .pipe(concat('3rdparty.min.js'))
+       .pipe(sourcemaps.write('./'))
+       .pipe(gulp.dest('public/js'));
+ });
+
+
+ gulp.task('uglify', ['uglify-3rdparty', 'uglify-1stparty'], function() {
+   gulp.src(['public/js/3rdparty.min.js',
+             'public/js/1stparty.min.js'])
+       .pipe(sourcemaps.init({loadMaps: true}))
        .pipe(concat('CDash.concat.js'))
        .pipe(rename('CDash_' + version + '.min.js'))
        .pipe(sourcemaps.write('./'))
@@ -89,5 +113,5 @@
   });
 
 
-  gulp.task('default', ['quality', 'clean', 'uglify', 'replace']);
+  gulp.task('default', ['quality', 'uglify', 'clean', 'replace']);
 }());

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^1.0.0",
+    "gulp-newer": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
This commit splits our Javascript files into two categories:
1st party and 3rd party.  Each bundle is only rebuilt if something
changed within them.

This speeds up our gulp execution time in the case where no 3rd
party code has been modified.  Previously running gulp after changing
a CDash Javascript file took ~90 seconds.  With this change, it now
takes ~3 seconds.