### PR TITLE
Pin important Ansible galaxy roles

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure(2) do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
     config.cache.enable :apt
+    config.cache.enable :npm
   end
 
   config.vm.network "forwarded_port", guest: 80, host: 8000

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,8 @@
 - src: geerlingguy.mysql
+  version: 2.2.1
 - src: geerlingguy.apache
+  version: 1.7.2
 - src: geerlingguy.php
+  version: 2.0.3
 - src: geerlingguy.composer
 - src: leonidas.nvm


### PR DESCRIPTION
I ran into an issue with the PHP role changed and the provisioned instance no longer passed the test suite.

I pinned the major roles to versions, and setup a nightly build on my machine to ensure that tests pass on a vagrant machine (trusty64) provisioned with Ansible.