### PR TITLE
Improve usability of duration filters

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -280,6 +280,40 @@ function time_difference($duration, $compact = false, $suffix = '', $displayms =
     return $diff;
 }
 
+/* Return the number of seconds represented by the specified time interval
+ * This function is the inverse of time_difference().
+ */
+function get_seconds_from_interval($input)
+{
+    if (is_numeric($input)) {
+        return $input;
+    }
+
+    // Check if strtotime understands the string.  It can handle our
+    // verbose interval strings, but not our compact ones.
+    $now = time();
+    $time_value = strtotime($input, $now);
+    if ($time_value) {
+        $duration = $time_value - $now;
+        return $duration;
+    }
+
+    // If not, convert the string from compact to verbose format
+    // and then use strtotime again.
+    $interval = preg_replace('/(\d+)h/', '$1 hours', $input);
+    $interval = preg_replace('/(\d+)m/', '$1 minutes', $interval);
+    $interval = preg_replace('/(\d+)s/', '$1 seconds', $interval);
+
+    $time_value = strtotime($interval, $now);
+    if ($time_value !== false) {
+        $duration = $time_value - $now;
+        return $duration;
+    }
+
+    add_log("Could not handle input: $input", 'get_seconds_from_interval', LOG_WARNING);
+    return null;
+}
+
 /** Microtime function */
 function microtime_float()
 {

--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -894,6 +894,21 @@ function get_filterdata_from_request($page_id = '')
             $filterdata['hasdateclause'] = 1;
         }
 
+        // Time durations can either be specified as a number of seconds,
+        // or as a string representing a time interval.
+        if (strpos($field, 'duration') !== false) {
+            $input_value = trim($sql_value, "'");
+            $sql_value = get_seconds_from_interval($input_value);
+            if ($input_value !== $sql_value &&
+                    ($field === 'buildduration' || $field === 'updateduration')) {
+                // Build duration and update duration are stored as
+                // number of minutes (not seconds) so if we just converted
+                // this value from string to seconds we should also
+                // convert it from seconds to minutes here as well.
+                $sql_value /= 60.0;
+            }
+        }
+
         if ($sql_field != '' && $sql_compare != '') {
             if ($clauses > 0) {
                 $sql .= ' ' . $sql_combine . ' ';

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ add_php_test(crosssubprojectcoverage)
 add_php_test(aggregatesubprojectcoverage)
 add_php_test(configurewarnings)
 add_php_test(filtertestlabels)
+add_php_test(seconds_from_interval)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/test_indexfilters.php
+++ b/tests/test_indexfilters.php
@@ -20,18 +20,22 @@ class IndexFiltersTestCase extends KWWebTestCase
     public function testIndexFilters()
     {
         $this->filter('buildduration', 43, 14.7, $this->win64);
+        $this->filter('buildduration', 43, '14m 47s', $this->win64);
         $this->filter('builderrors', 43, 1, $this->win32);
         $this->filter('buildwarnings', 43, 2, $this->win32);
         $this->filter('buildname', 63, 'Darwin', $this->mac);
         $this->filter('configureduration', 43, 11, $this->win32);
+        $this->filter('configureduration', 43, '11s', $this->win32);
         $this->filter('configureerrors', 43, 1, $this->win32);
         $this->filter('configurewarnings', 43, 1, $this->win32);
         $this->filter('site', 63, 'thurmite', $this->mac);
         $this->filter('testsduration', 43, 17, $this->win32);
+        $this->filter('testsduration', 43, '17s', $this->win32);
         $this->filter('testsfailed', 43, 2, $this->win32);
         $this->filter('testsnotrun', 43, 2, $this->win32);
         $this->filter('testspassed', 43, 2, $this->win32);
         $this->filter('updateduration', 43, 0.2, $this->win32);
+        $this->filter('updateduration', 43, '12s', $this->win32);
         $this->filter('updatedfiles', 43, 3, $this->win32);
     }
 

--- a/tests/test_seconds_from_interval.php
+++ b/tests/test_seconds_from_interval.php
@@ -1,0 +1,60 @@
+<?php
+//
+// After including cdash_test_case.php, subsequent require_once calls are
+// relative to the top of the CDash source tree
+//
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+require_once 'include/common.php';
+
+class SecondsFromIntervalTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testSecondsFromInterval()
+    {
+        $this->intervalTest('43s', 43);
+        $this->intervalTest('24m', 1440);
+        $this->intervalTest('24m 43s', 1483);
+        $this->intervalTest('17h', 61200);
+        $this->intervalTest('17h 43s', 61243);
+        $this->intervalTest('17h 24m', 62640);
+        $this->intervalTest('17h 24m 43s', 62683);
+        $this->intervalTest('8 days', 691200);
+        $this->intervalTest('8 days 43s', 691243);
+        $this->intervalTest('8 days 24m', 692640);
+        $this->intervalTest('8 days 24m 43s', 692683);
+        $this->intervalTest('8 days 17h', 752400);
+        $this->intervalTest('8 days 17h 43s', 752443);
+        $this->intervalTest('8 days 17h 24m', 753840);
+        $this->intervalTest('8 days 17h 24m 43s', 753883);
+        // Not testing months since they have a variable number of seconds.
+        $this->intervalTest('2 years', 63072000);
+        $this->intervalTest('2 years 43s', 63072043);
+        $this->intervalTest('2 years 24m', 63073440);
+        $this->intervalTest('2 years 24m 43s', 63073483);
+        $this->intervalTest('2 years 17h', 63133200);
+        $this->intervalTest('2 years 17h 43s', 63133243);
+        $this->intervalTest('2 years 17h 24m', 63134640);
+        $this->intervalTest('2 years 17h 24m 43s', 63134683);
+        $this->intervalTest('2 years 8 days', 63763200);
+        $this->intervalTest('2 years 8 days 43s', 63763243);
+        $this->intervalTest('2 years 8 days 24m', 63764640);
+        $this->intervalTest('2 years 8 days 24m 43s', 63764683);
+        $this->intervalTest('2 years 8 days 17h', 63824400);
+        $this->intervalTest('2 years 8 days 17h 43s', 63824443);
+        $this->intervalTest('2 years 8 days 17h 24m', 63825840);
+        $this->intervalTest('2 years 8 days 17h 24m 43s', 63825883);
+    }
+
+    public function intervalTest($input, $expected)
+    {
+        $received = get_seconds_from_interval($input);
+        if ($received !== $expected) {
+            $this->fail("Expected $expected but received $received for '$input'");
+        }
+    }
+}


### PR DESCRIPTION
Instead of having to input a number of seconds (or minutes, in some cases...) you can now input a time duration as CDash reports it, eg ``17m 48s``.