### PR TITLE
Trust HTML for build errors in subproject view

### DIFF
--- a/models/builderror.php
+++ b/models/builderror.php
@@ -124,7 +124,7 @@ class BuildError
 
         if (isset($data['subprojectid'])) {
             $marshaled['subprojectid'] = $data['subprojectid'];
-            $marshaled['subprojectname'] = $data['name'];
+            $marshaled['subprojectname'] = $data['subprojectname'];
         }
 
         return $marshaled;

--- a/public/js/controllers/viewBuildError.js
+++ b/public/js/controllers/viewBuildError.js
@@ -6,11 +6,25 @@ CDash.controller('BuildErrorController',
       method: 'GET',
       params: $rootScope.queryString
     }).success(function(cdash) {
-      for (var i in cdash.errors) {
-        // Handle the fact that we add HTML links to compiler output.
-        cdash.errors[i].precontext = $sce.trustAsHtml(cdash.errors[i].precontext);
-        cdash.errors[i].postcontext = $sce.trustAsHtml(cdash.errors[i].postcontext);
-        cdash.errors[i].text = $sce.trustAsHtml(cdash.errors[i].text);
+      // Handle the fact that we add HTML links to compiler output.
+      var trustErrorHtml = function (error) {
+          error.precontext = $sce.trustAsHtml(error.precontext);
+          error.postcontext = $sce.trustAsHtml(error.postcontext);
+          error.text = $sce.trustAsHtml(error.text);
+          return error;
+      };
+
+      // Errors are either cdash.errors, or all values in cdash.errors.*
+      if (Array.isArray(cdash.errors)) {
+          for (var i in cdash.errors) {
+              cdash.errors[i] = trustErrorHtml(cdash.errors[i]);
+          }
+      } else {
+          for (var subproject in cdash.errors) {
+              for (var error in cdash.errors[subproject]) {
+                  cdash.errors[subproject][error] = trustErrorHtml(cdash.errors[subproject][error]);
+              }
+          }
       }
       renderTimer.initialRender($scope, cdash);
 

--- a/tests/js/e2e_tests/viewBuildError.js
+++ b/tests/js/e2e_tests/viewBuildError.js
@@ -19,4 +19,15 @@ describe("viewBuildError", function() {
     browser.get('viewBuildError.php?buildid=6&type=1');
     expect(browser.getPageSource()).toContain("10</b> Warnings");
   });
+
+  it("displays build errors inline", function() {
+    browser.get('viewBuildError.php?buildid=67&type=0');
+    expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
+  });
+
+  it("displays build errors inline on parent builds", function() {
+    browser.get('viewBuildError.php?buildid=66&type=0');
+    expect(browser.getPageSource()).toContain("some-test-subproject");
+    expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
+  });
 });


### PR DESCRIPTION
@jcfr fixes #332

The API was returning the correct data for both views, however Angular only marked the embedded html as "trusted" for the individual build errors (not the subproject build errors).