### PR TITLE
Rename Build Time column to Start Time

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -252,7 +252,7 @@
               </th>
 
               <th align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'builddatefull', $event)">
-                Build Time
+                Start Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-builddatefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('builddatefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 

--- a/tests/js/e2e_tests/sort_index.js
+++ b/tests/js/e2e_tests/sort_index.js
@@ -81,8 +81,8 @@ describe("sort_index", function() {
     sort_test('Pass', 9, '3', '1');
   });
 
-  it("sort by Build Time", function() {
-    sort_test('Build Time', 10, 'Jul 07, 2010 - 08:26 EDT', 'Jul 07, 2010 - 08:22 EDT');
+  it("sort by Start Time", function() {
+    sort_test('Start Time', 10, 'Jul 07, 2010 - 08:26 EDT', 'Jul 07, 2010 - 08:22 EDT');
   });
 
   it("sort by multiple columns", function() {
@@ -94,7 +94,7 @@ describe("sort_index", function() {
 
     // Click on the Build Time header.
     var buildtime_header = element.all(by.className('table-heading')).all(by.tagName('th')).filter(function(elem) { return elem.isDisplayed(); }).get(10);
-    expect(buildtime_header.getText()).toBe('Build Time');
+    expect(buildtime_header.getText()).toBe('Start Time');
     buildtime_header.click();
     expect(buildtime_header.element(by.tagName('span')).getAttribute('class')).toContain("glyphicon-chevron-down");
 


### PR DESCRIPTION
Distinguish the column on the far right of index.php (which shows
when the build started) from the advanced 'Time' column under the
'Build' heading (which shows how long the build took to complete).