### PR TITLE
Fix some bugs with our coverage summary reporting

### DIFF
--- a/include/index_functions.php
+++ b/include/index_functions.php
@@ -95,6 +95,9 @@ function get_dynamic_builds($projectid, $end_UTCDate)
               b.testfailed AS counttestsfailed,
               b.testpassed AS counttestspassed,
               b.testtimestatusfailed AS countteststimestatusfailed,
+              cs.loctested, cs.locuntested,
+              csd.loctested AS loctesteddiff, csd.locuntested AS locuntesteddiff,
+              das.checker, das.numdefects,
               sp.id AS subprojectid,
               sp.groupid AS subprojectgroup,
               (SELECT count(buildid) FROM build2uploadfile WHERE buildid=b.id) AS builduploadfiles
@@ -106,6 +109,9 @@ function get_dynamic_builds($projectid, $end_UTCDate)
               LEFT JOIN buildupdate AS bu ON (b2u.updateid=bu.id)
               LEFT JOIN configure AS c ON (c.buildid=b.id)
               LEFT JOIN buildinformation AS i ON (i.buildid=b.id)
+              LEFT JOIN coveragesummary AS cs ON (cs.buildid=b.id)
+              LEFT JOIN coveragesummarydiff AS csd ON (csd.buildid=b.id)
+              LEFT JOIN dynamicanalysissummary AS das ON (das.buildid=b.id)
               LEFT JOIN builderrordiff AS be_diff ON (be_diff.buildid=b.id AND be_diff.type=0)
               LEFT JOIN builderrordiff AS bw_diff ON (bw_diff.buildid=b.id AND bw_diff.type=1)
               LEFT JOIN configureerrordiff AS ce_diff ON (ce_diff.buildid=b.id AND ce_diff.type=1)

--- a/models/coveragefilelog.php
+++ b/models/coveragefilelog.php
@@ -308,5 +308,12 @@ class CoverageFileLog
         // Insert/Update the aggregate summary.
         $aggregateSummary->Insert(true);
         $aggregateSummary->ComputeDifference($this->PreviousAggregateParentId);
+
+        if ($this->Build->SubProjectId && $this->AggregateBuildId) {
+            // Compute diff for the aggregate parent too.
+            $aggregateParentSummary = new CoverageSummary();
+            $aggregateParentSummary->BuildId = $this->AggregateBuildId;
+            $aggregateParentSummary->ComputeDifference();
+        }
     }
 }

--- a/models/coveragesummary.php
+++ b/models/coveragesummary.php
@@ -340,13 +340,14 @@ class CoverageSummary
             $previousloctested = $previouscoverage_array['loctested'];
             $previouslocuntested = $previouscoverage_array['locuntested'];
 
-            // Don't log if no diff
+            $summaryDiff = new CoverageSummaryDiff();
+            $summaryDiff->BuildId = $this->BuildId;
             $loctesteddiff = $loctested - $previousloctested;
             $locuntesteddiff = $locuntested - $previouslocuntested;
 
-            if ($loctesteddiff != 0 && $locuntesteddiff != 0) {
-                $summaryDiff = new CoverageSummaryDiff();
-                $summaryDiff->BuildId = $this->BuildId;
+            // Don't log if no diff unless an entry already exists
+            // for this build.
+            if ($summaryDiff->Exists() || $loctesteddiff != 0 || $locuntesteddiff != 0) {
                 $summaryDiff->LocTested = $loctesteddiff;
                 $summaryDiff->LocUntested = $locuntesteddiff;
                 $summaryDiff->Insert();

--- a/models/coveragesummarydiff.php
+++ b/models/coveragesummarydiff.php
@@ -41,4 +41,24 @@ class CoverageSummaryDiff
         }
         add_last_sql_error('CoverageSummary:ComputeDifference');
     }
+
+    /** Return whether or not a CoverageSummaryDiff exists for this build. */
+    public function Exists()
+    {
+        if (!$this->BuildId) {
+            return false;
+        }
+
+        $exists_result = pdo_single_row_query(
+            'SELECT COUNT(1) AS numrows FROM coveragesummarydiff
+                WHERE buildid=' . qnum($this->BuildId));
+
+        if ($exists_result && array_key_exists('numrows', $exists_result)) {
+            $numrows = $exists_result['numrows'];
+            if ($numrows > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -1158,9 +1158,9 @@ function echo_main_dashboard_JSON($project_instance, $date)
 
         $coverageIsGrouped = false;
 
-        if (!empty($build_array['loctested'])) {
-            $loctested = $build_array['loctested'];
-            $locuntested = $build_array['locuntested'];
+        $loctested = $build_array['loctested'];
+        $locuntested = $build_array['locuntested'];
+        if ($loctested + $locuntested > 0) {
             $coverage_response = array();
             $coverage_response['buildid'] = $build_array['id'];
             if ($linkToChildCoverage) {

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -455,6 +455,9 @@ class GCovTarHandler
     public function ParseUncoveredSourceFile($fileinfo, $path)
     {
         $coverageFileLog = new CoverageFileLog();
+        $coverageFileLog->AggregateBuildId = $this->AggregateBuildId;
+        $coverageFileLog->PreviousAggregateParentId =
+            $this->PreviousAggregateParentId;
         $coverageFile = new CoverageFile();
         $coverageFile->FullPath = trim($path);
         $coverage = new Coverage();


### PR DESCRIPTION
1) We were failing to display coverage for builds that reported 0 covered lines of code.
2) The difference in coverage from one build to the next could be inaccurately reported by the GcovTar handler.
3) The difference in aggregate coverage from one day to the next was not being calculated for SubProject builds.