### PR TITLE
Support connecting via unix_socket in PDO

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -38,6 +38,8 @@ $CDASH_DB_PASS = '';
 $CDASH_DB_NAME = 'cdash';
 // Database type
 $CDASH_DB_TYPE = 'mysql';
+// Must be one of host, unix_socket
+$CDASH_DB_CONNECTION_TYPE = 'host';
 
 // Support for SSL database connections.
 $CDASH_SSL_KEY = null;

--- a/include/CDash/Database.php
+++ b/include/CDash/Database.php
@@ -85,11 +85,14 @@ namespace CDash {
         public function __construct($database_type, $hostname, $username, $password,
                                     $database_port = null, $database_name = null,
                                     $use_persistent_connections = false, $retries = 1,
-                                    $ssl_key = null, $ssl_cert = null, $ssl_ca = null)
+                                    $ssl_key = null, $ssl_cert = null, $ssl_ca = null, $connection_type = 'host')
         {
-            $dsn = $database_type . ':host=' . $hostname;
+            $dsn = $database_type . ':' . $connection_type . '=' . $hostname;
             $this->attributes = array(\PDO::ATTR_PERSISTENT => $use_persistent_connections);
-            if (!is_null($database_port) and $database_port !== '') {
+
+            // The unix_socket connection type can't be used with a port
+            // http://php.net/manual/en/ref.pdo-mysql.connection.php
+            if (!is_null($database_port) and $database_port !== '' and $connection_type != 'unix_socket') {
                 $dsn = $dsn . ';port=' . strval($database_port);
             }
             if (!is_null($database_name) and $database_name != '') {

--- a/include/pdocore.php
+++ b/include/pdocore.php
@@ -32,13 +32,13 @@ function pdo_connect($server = null, $username = null, $password = null, $databa
 {
     global $CDASH_DB_PORT, $CDASH_DB_TYPE, $CDASH_MAX_QUERY_RETRIES,
            $CDASH_USE_PERSISTENT_MYSQL_CONNECTION, $CDASH_DB_NAME,
-           $CDASH_SSL_KEY, $CDASH_SSL_CERT, $CDASH_SSL_CA;
+           $CDASH_SSL_KEY, $CDASH_SSL_CERT, $CDASH_SSL_CA, $CDASH_DB_CONNECTION_TYPE;
     $db_name = is_null($database) ? $CDASH_DB_NAME : $database;
     return new CDash\Database(
         $CDASH_DB_TYPE, $server, $username, $password, $CDASH_DB_PORT,
         $db_name, $CDASH_USE_PERSISTENT_MYSQL_CONNECTION,
         $CDASH_MAX_QUERY_RETRIES, $CDASH_SSL_KEY, $CDASH_SSL_CERT,
-        $CDASH_SSL_CA
+        $CDASH_SSL_CA, $CDASH_DB_CONNECTION_TYPE
     );
 }
 


### PR DESCRIPTION
This is the recommended method of operation when connecting to a Cloud SQL database from a GAE application.