### PR TITLE
Rename 'Build Time' filter to 'Build Start Time'

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -101,7 +101,7 @@ class IndexPhpFilters extends DefaultFilters
         $xml .= getFilterDefinitionXML('buildwarnings', 'Build Warnings', 'number', '', '0');
         $xml .= getFilterDefinitionXML('buildname', 'Build Name', 'string', '', '');
         $xml .= getFilterDefinitionXML('buildstamp', 'Build Stamp', 'string', '', '');
-        $xml .= getFilterDefinitionXML('buildstarttime', 'Build Time', 'date', '', '');
+        $xml .= getFilterDefinitionXML('buildstarttime', 'Build Start Time', 'date', '', '');
         $xml .= getFilterDefinitionXML('buildtype', 'Build Type', 'string', '', 'Nightly');
         $xml .= getFilterDefinitionXML('configureduration', 'Configure Duration', 'number', '', '0');
         $xml .= getFilterDefinitionXML('configureerrors', 'Configure Errors', 'number', '', '0');
@@ -329,7 +329,7 @@ class QueryTestsPhpFilters extends DefaultFilters
         $xml = '';
 
         $xml .= getFilterDefinitionXML('buildname', 'Build Name', 'string', '', '');
-        $xml .= getFilterDefinitionXML('buildstarttime', 'Build Time', 'date', '', '');
+        $xml .= getFilterDefinitionXML('buildstarttime', 'Build Start Time', 'date', '', '');
         $xml .= getFilterDefinitionXML('buildtype', 'Build Type', 'string', '', 'Nightly');
         $xml .= getFilterDefinitionXML('details', 'Details', 'string', '', '');
         $xml .= getFilterDefinitionXML('label', 'Label', 'string', '', '');

--- a/public/js/controllers/filters.js
+++ b/public/js/controllers/filters.js
@@ -32,7 +32,7 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
       "defaultvalue": ""
     },
     "buildstarttime": {
-      "text": "Build Time",
+      "text": "Build Start Time",
       "type": "date",
       "defaultvalue": ""
     },


### PR DESCRIPTION
The term 'Build Time' was ambiguous.  Did it refer to when the
build occurred, or how long it took?

We opt for 'Build Start Time' rather than the less verbose 'Start Time'
because this filter is available on both index.php (which displays builds)
and queryTests.php (which displays tests).