### PR TITLE
Fix behavior of Build Duration filter

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -133,11 +133,7 @@ class IndexPhpFilters extends DefaultFilters
         $sql_field = '';
         switch (strtolower($field)) {
             case 'buildduration': {
-                if ($CDASH_DB_TYPE === 'pgsql') {
-                    $sql_field = 'ROUND(EXTRACT(EPOCH FROM (b.endtime - b.starttime))::numeric / 60, 1)';
-                } else {
-                    $sql_field = 'ROUND(TIMESTAMPDIFF(SECOND,b.starttime,b.endtime)/60.0,1)';
-                }
+                $sql_field = 'b.buildduration';
             }
                 break;
 
@@ -904,12 +900,10 @@ function get_filterdata_from_request($page_id = '')
         if (strpos($field, 'duration') !== false) {
             $input_value = trim($sql_value, "'");
             $sql_value = get_seconds_from_interval($input_value);
-            if ($input_value !== $sql_value &&
-                    ($field === 'buildduration' || $field === 'updateduration')) {
-                // Build duration and update duration are stored as
-                // number of minutes (not seconds) so if we just converted
-                // this value from string to seconds we should also
-                // convert it from seconds to minutes here as well.
+            if ($input_value !== $sql_value && $field === 'updateduration') {
+                // Update duration is stored as number of minutes (not seconds)
+                // so if we just converted this value from string to seconds
+                // we should also convert it from seconds to minutes here as well.
                 $sql_value /= 60.0;
             }
         }

--- a/tests/test_excludesubprojects.php
+++ b/tests/test_excludesubprojects.php
@@ -232,7 +232,7 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
             array(
                 'filter' => 'buildduration',
                 'compare' => 41,
-                'value' => 23.1,
+                'value' => '10m 46s',
                 'exclude' => 'Teuchos'
             ),
             array(

--- a/tests/test_indexfilters.php
+++ b/tests/test_indexfilters.php
@@ -18,8 +18,8 @@ class IndexFiltersTestCase extends KWWebTestCase
 
     public function testIndexFilters()
     {
-        $this->filter('buildduration', 43, 14.7, 'Win64');
-        $this->filter('buildduration', 43, '14m 47s', 'Win64');
+        $this->filter('buildduration', 43, 293, 'Win32');
+        $this->filter('buildduration', 43, '4m 53s', 'Win32');
         $this->filter('builderrors', 43, 1, 'Win32');
         $this->filter('buildwarnings', 43, 2, 'Win32');
         $this->filter('buildname', 63, 'Darwin', 'Darwin');


### PR DESCRIPTION
We recently redefined Build Time to be just the time spent during
the build step, rather than how long the entire build took
(including update/configure/test/etc).

Because of this change, we also need to modify the Build Duration filter
so that it finds builds based on their build step duration rather than
their total duration.