### PR TITLE
Add php5-memcache as a system dependency for Ansible

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -25,6 +25,7 @@
         - php5-json
         - php5-xsl
         - php5-gd
+        - php5-memcache
         - php5-mysql
         - php5-xdebug
         - libapache2-mod-php5


### PR DESCRIPTION
This gets the nightly builds for the Vagrant setup running again (missed a night).