### PR TITLE
Fix a couple minor bugs with Previous/Next/Current links

### DIFF
--- a/public/api/v1/viewBuildError.php
+++ b/public/api/v1/viewBuildError.php
@@ -96,6 +96,12 @@ $buildname = $build_array['name'];
 $starttime = $build_array['starttime'];
 $revision = $build_array['revision'];
 
+if (isset($_GET['type'])) {
+    $type = pdo_real_escape_numeric($_GET['type']);
+} else {
+    $type = 0;
+}
+
 $date = get_dashboard_date_from_build_starttime($build_array['starttime'], $project_array['nightlytime']);
 get_dashboard_JSON_by_name($projectname, $date, $response);
 
@@ -109,15 +115,15 @@ $current_buildid = $build->GetCurrentBuildId();
 $next_buildid = $build->GetNextBuildId();
 
 if ($previous_buildid > 0) {
-    $menu['previous'] = "viewBuildError.php?buildid=$previous_buildid";
+    $menu['previous'] = "viewBuildError.php?type=$type&buildid=$previous_buildid";
 } else {
     $menu['noprevious'] = 1;
 }
 
-$menu['current'] = "viewBuildError.php?buildid=$current_buildid";
+$menu['current'] = "viewBuildError.php?type=$type&buildid=$current_buildid";
 
 if ($next_buildid > 0) {
-    $menu['next'] = "viewBuildError.php?buildid=$next_buildid";
+    $menu['next'] = "viewBuildError.php?type=$type&buildid=$next_buildid";
 } else {
     $menu['nonext'] = 1;
 }
@@ -134,14 +140,6 @@ $build_response['starttime'] =
     date(FMT_DATETIMETZ, strtotime($build_array['starttime'] . 'UTC'));
 $build_response['buildid'] = $build_array['id'];
 $response['build'] = $build_response;
-
-@$type = $_GET['type'];
-if ($type != null) {
-    $type = pdo_real_escape_numeric($type);
-}
-if (!isset($type)) {
-    $type = 0;
-}
 
 // Set the error
 if ($type == 0) {

--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -105,7 +105,7 @@
           <a ng-if="cdash.menu.next" href="{{cdash.menu.next}}{{cdash.filterurl}}">
             Next
           </a>
-          <a ng-if="!cdash.menu.next" href="index.php?project={{cdash.projectname_encoded}}&date={{cdash.nextdate}}{{cdash.filterurl}}">
+          <a ng-if="!cdash.menu.next" href="index.php?project={{cdash.projectname_encoded}}&date={{cdash.nextdate}}{{cdash.extraurl}}{{cdash.filterurl}}">
             Next
           </a>
         </li>

--- a/tests/test_subprojectnextprevious.php
+++ b/tests/test_subprojectnextprevious.php
@@ -309,6 +309,24 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
             $success = false;
         }
 
+        // Make sure the 'type' parameter is preserved across Previous/Next/Current
+        // on viewBuildError.php.
+        $this->get($this->url . "/api/v1/viewBuildError.php?type=1&buildid=$second_buildid");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        if (strpos($jsonobj['menu']['next'], "type=1") === false) {
+            $error_msg = "type=1 not found in Next link of viewBuildError.php";
+            $success = false;
+        }
+        if (strpos($jsonobj['menu']['previous'], "type=1") === false) {
+            $error_msg = "type=1 not found in Previous link of viewBuildError.php";
+            $success = false;
+        }
+        if (strpos($jsonobj['menu']['current'], "type=1") === false) {
+            $error_msg = "type=1 not found in Current link of viewBuildError.php";
+            $success = false;
+        }
+
         // Delete the builds that we created during this test.
         remove_build($second_parentid);
         remove_build($third_parentid);


### PR DESCRIPTION
While performing manual testing I found a couple scenarios where these links would discard parameters from the query string.