### PR TITLE
Add support for ext-memcached and make optional

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -22,12 +22,12 @@
       php_packages:
         - php5
         - php5-curl
-        - php5-json
-        - php5-xsl
         - php5-gd
-        - php5-memcache
+        - php5-json
+        - php5-memcached
         - php5-mysql
         - php5-xdebug
+        - php5-xsl
         - libapache2-mod-php5
       php_memory_limit: "512M"
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,6 @@ dependencies:
     - chmod a+rwx backup log public/rss public/upload
     - sudo composer self-update --no-interaction
     - test -n "${CIRCLE_PR_REPONAME}" || composer config --global --no-interaction github-oauth.github.com $GITHUB_OAUTH_TOKEN
-    - yes | pecl install -f memcache
     - composer install --no-interaction --no-progress --prefer-dist
     - npm install
     - node_modules/.bin/webdriver-manager update

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "ext-memcache": "*",
     "ext-pdo": "*",
     "ext-xsl": "*",
     "bernard/bernard": "dev-master#f30c0186f0fb391eb6c7ab28f515bb30d34f402d",
@@ -39,6 +38,8 @@
     "sensiolabs/security-checker": "~3.0"
   },
   "suggest": {
+    "ext-memcache": "*",
+    "ext-memcached": "*",
     "ext-pdo_mysql": "",
     "ext-pdo_pgsql": "",
     "ext-phar": ""

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,7 @@
     "sensiolabs/security-checker": "~3.0"
   },
   "suggest": {
-    "ext-memcache": "*",
-    "ext-memcached": "*",
+    "ext-memcached": "",
     "ext-pdo_mysql": "",
     "ext-pdo_pgsql": "",
     "ext-phar": ""

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "00c98a5b7160ecfdb3882fd0bcf017b9",
-    "content-hash": "0504515f0d9d21beadbec5e072ba9b1c",
+    "hash": "daf1d6cedb05df38d02507f4f103eed6",
+    "content-hash": "97d19cf1c2786edaaaa932c9b31f700b",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -329,16 +329,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "31382fef2889136415751badebbd1cb022a4ed72"
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/31382fef2889136415751badebbd1cb022a4ed72",
-                "reference": "31382fef2889136415751badebbd1cb022a4ed72",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -383,7 +383,7 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-04-13 19:56:01"
+            "time": "2016-06-24 23:00:38"
         },
         {
             "name": "monolog/monolog",
@@ -2756,7 +2756,6 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "ext-memcache": "*",
         "ext-pdo": "*",
         "ext-xsl": "*"
     },

--- a/config/config.php
+++ b/config/config.php
@@ -247,7 +247,6 @@ $CDASH_LOCKOUT_ATTEMPTS = 0;
 // How long to lock an account for? (in minutes)
 $CDASH_LOCKOUT_LENGTH = 0;
 
-
 // Whether or not to use Memcache for certain pages
 $CDASH_MEMCACHE_ENABLED = false;
 
@@ -258,6 +257,8 @@ $CDASH_MEMCACHE_SERVER = array('localhost', 11211);
 // Note: Memcache limits key size to 250 characters
 $CDASH_MEMCACHE_PREFIX = 'cdash';
 
+// Whether to use the AWS ElastiCache Auto Discovery feature
+$CDASH_USE_ELASTICACHE_AUTO_DISCOVERY = false;
 
 /* DO NOT EDIT AFTER THIS LINE */
 $localConfig = dirname(__FILE__) . '/config.local.php';

--- a/include/memcache_functions.php
+++ b/include/memcache_functions.php
@@ -23,3 +23,43 @@ function cdash_memcache_key($page_name)
                               $page_name,
                               md5(serialize($_REQUEST))));
 }
+
+function cdash_memcache_connect($server, $port)
+{
+    if (class_exists('Memcached')) {
+        $memcache = new Memcached();
+        $memcache->setOption(Memcached::OPT_COMPRESSION, true);
+        global $CDASH_USE_ELASTICACHE_AUTO_DISCOVERY;
+        if ($CDASH_USE_ELASTICACHE_AUTO_DISCOVERY) {
+            $memcache->setOption(Memcached::OPT_CLIENT_MODE, Memcached::DYNAMIC_CLIENT_MODE);
+        }
+        if ($memcache->addServer($server, $port) !== false) {
+            return $memcache;
+        }
+    } elseif (class_exists('Memcache')) {
+        $memcache = new Memcache();
+        if ($memcache->connect($server, $port) !== false) {
+            return $memcache;
+        }
+    }
+    return false;
+}
+
+function cdash_memcache_get($memcache, $key)
+{
+    if ($memcache === false) {
+        return false;
+    }
+    return $memcache->get($key);
+}
+
+function cdash_memcache_set($memcache, $key, $var, $expire)
+{
+    if ($memcache instanceof Memcached) {
+        return $memcache->set($key, $var, $expire);
+    }
+    if ($memcache instanceof Memcache) {
+        return $memcache->set($key, $var, MEMCACHE_COMPRESSED, $expire);
+    }
+    return false;
+}

--- a/include/memcache_functions.php
+++ b/include/memcache_functions.php
@@ -27,39 +27,31 @@ function cdash_memcache_key($page_name)
 function cdash_memcache_connect($server, $port)
 {
     if (class_exists('Memcached')) {
-        $memcache = new Memcached();
-        $memcache->setOption(Memcached::OPT_COMPRESSION, true);
+        $memcached = new Memcached();
+        $memcached->setOption(Memcached::OPT_COMPRESSION, true);
         global $CDASH_USE_ELASTICACHE_AUTO_DISCOVERY;
         if ($CDASH_USE_ELASTICACHE_AUTO_DISCOVERY) {
-            $memcache->setOption(Memcached::OPT_CLIENT_MODE, Memcached::DYNAMIC_CLIENT_MODE);
+            $memcached->setOption(Memcached::OPT_CLIENT_MODE, Memcached::DYNAMIC_CLIENT_MODE);
         }
-        if ($memcache->addServer($server, $port) !== false) {
-            return $memcache;
-        }
-    } elseif (class_exists('Memcache')) {
-        $memcache = new Memcache();
-        if ($memcache->connect($server, $port) !== false) {
-            return $memcache;
+        if ($memcached->addServer($server, $port) !== false) {
+            return $memcached;
         }
     }
     return false;
 }
 
-function cdash_memcache_get($memcache, $key)
+function cdash_memcache_get($memcached, $key)
 {
-    if ($memcache === false) {
+    if ($memcached === false) {
         return false;
     }
-    return $memcache->get($key);
+    return $memcached->get($key);
 }
 
-function cdash_memcache_set($memcache, $key, $var, $expire)
+function cdash_memcache_set($memcached, $key, $var, $expire)
 {
-    if ($memcache instanceof Memcached) {
-        return $memcache->set($key, $var, $expire);
+    if ($memcached === false) {
+        return false;
     }
-    if ($memcache instanceof Memcache) {
-        return $memcache->set($key, $var, MEMCACHE_COMPRESSED, $expire);
-    }
-    return false;
+    return $memcached->set($key, $var, $expire);
 }

--- a/public/api/v1/overview.php
+++ b/public/api/v1/overview.php
@@ -43,10 +43,10 @@ if (!pdo_select_db("$CDASH_DB_NAME", $db)) {
 // Connect to memcache
 if ($CDASH_MEMCACHE_ENABLED) {
     list($server, $port) = $CDASH_MEMCACHE_SERVER;
-    $memcache = new Memcache;
+    $memcache = cdash_memcache_connect($server, $port);
 
     // Disable memcache for this request if it fails to connect
-    if ($memcache->connect($server, $port) === false) {
+    if ($memcache === false) {
         $CDASH_MEMCACHE_ENABLED = false;
     }
 }
@@ -85,7 +85,7 @@ $date_range = 14;
 // (This is a good method of ensuring the cache for this page stays up)
 if ($CDASH_MEMCACHE_ENABLED &&
     !(isset($_GET['use_cache']) && $_GET['use_cache'] == 0) &&
-    ($cachedResponse = $memcache->get(cdash_memcache_key('overview'))) !== false) {
+    ($cachedResponse = cdash_memcache_get($memcache, cdash_memcache_key('overview'))) !== false) {
     echo $cachedResponse;
     return;
 }
@@ -633,7 +633,7 @@ $response = json_encode(cast_data_for_JSON($response));
 
 // Cache the overview page for 6 hours
 if ($CDASH_MEMCACHE_ENABLED) {
-    $memcache->set(cdash_memcache_key('overview'), $response, MEMCACHE_COMPRESSED, 60 * 60 * 6);
+    cdash_memcache_set($memcache, cdash_memcache_key('overview'), $response, 60 * 60 * 6);
 }
 
 echo $response;

--- a/public/googleauth_callback.php
+++ b/public/googleauth_callback.php
@@ -90,7 +90,15 @@ function googleAuthenticate($code)
     }
 
     try {
-        $client = new Google_Client();
+        $config = new Google_Config();
+        if ($CDASH_MEMCACHE_ENABLED) {
+            $config->setCacheClass('Google_Cache_Memcache');
+            list($server, $port) = $CDASH_MEMCACHE_SERVER;
+            $config->setClassConfig('Google_Cache_Memcache', 'host', $server);
+            $config->setClassConfig('Google_Cache_Memcache', 'port', $port);
+        }
+
+        $client = new Google_Client($config);
         $client->setClientId($GOOGLE_CLIENT_ID);
         $client->setClientSecret($GOOGLE_CLIENT_SECRET);
         $client->setRedirectUri($redirectURI);


### PR DESCRIPTION
Unfortunately, it turns out that [AWS ElastiCache Node Auto Discovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) only works with the [memcached](http://php.net/manual/en/book.memcached.php) extension. ~~Now, either of the two memcache(d) extensions may be used and are optional.~~ Now, the memcached extension is used instead of the memcache extension and is optional.

PTAL @danlamanna.