### PR TITLE
Allow daily updates to be disabled for submissions

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -52,6 +52,11 @@ $CDASH_PRODUCTION_MODE = false;
 $CDASH_TESTING_MODE = false;
 $CDASH_TESTING_RENAME_LOGS = false;
 
+// Whether or not CDash submissions should trigger daily updates.
+// Disable this if you want more fine grained control over when/how
+// daily updates are triggered (e.g. cron).
+$CDASH_DAILY_UPDATES = true;
+
 /**
   * If a Bernard Driver is available then CDASH_BERNARD_SUBMISSION can be enabled
   * to allow processing of submissions to take place in the background on other

--- a/include/do_submit.php
+++ b/include/do_submit.php
@@ -117,7 +117,7 @@ function do_submit($fileHandleOrSubmissionId, $projectid, $expected_md5 = '', $d
     $baseUrl = get_server_URI(false);
     $request = $baseUrl . '/ajax/dailyupdatescurl.php?projectid=' . $projectid;
 
-    if (curl_request($request) === false) {
+    if ($CDASH_DAILY_UPDATES && curl_request($request) === false) {
         return false;
     }
 
@@ -238,7 +238,7 @@ function do_submit_asynchronous($filehandle, $projectid, $expected_md5 = '')
     $currentURI = get_server_URI(true);
     $request = $currentURI . '/ajax/dailyupdatescurl.php?projectid=' . $projectid;
 
-    if (curl_request($request) === false) {
+    if ($CDASH_DAILY_UPDATES && curl_request($request) === false) {
         return;
     }
 


### PR DESCRIPTION
@zackgalbreath I've set this up so we can manage the triggering of dailyupdates via a cron job, and skip the processing on each submission.