### PR TITLE
New table: build2configure

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -946,7 +946,6 @@ function remove_build($buildid)
     pdo_query('DELETE FROM buildinformation WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM builderrordiff WHERE buildid IN ' . $buildids);
 
-    pdo_query('DELETE FROM configureerror WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM configureerrordiff WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM coveragesummarydiff WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM testdiff WHERE buildid IN ' . $buildids);
@@ -1012,6 +1011,7 @@ function remove_build($buildid)
     $configureids .= ')';
     if (strlen($configureids) > 2) {
         pdo_query("DELETE FROM configure WHERE id IN $configureids");
+        pdo_query("DELETE FROM configureerror WHERE id IN $configureids");
     }
     pdo_query("DELETE FROM build2configure WHERE buildid IN $buildids");
 

--- a/include/common.php
+++ b/include/common.php
@@ -946,7 +946,6 @@ function remove_build($buildid)
     pdo_query('DELETE FROM buildinformation WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM builderrordiff WHERE buildid IN ' . $buildids);
 
-    pdo_query('DELETE FROM configure WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM configureerror WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM configureerrordiff WHERE buildid IN ' . $buildids);
     pdo_query('DELETE FROM coveragesummarydiff WHERE buildid IN ' . $buildids);
@@ -992,6 +991,29 @@ function remove_build($buildid)
 
     // Remove the buildfailure.
     pdo_query('DELETE FROM buildfailure WHERE buildid IN ' . $buildids);
+
+    // Delete the configure if not shared.
+    $configureids = '(';
+    $build2configure = pdo_query(
+            "SELECT a.configureid, COUNT(b.configureid) AS c
+            FROM build2configure AS a
+            LEFT JOIN build2configure AS b
+            ON (a.configureid=b.configureid AND b.buildid NOT IN $buildids)
+            WHERE a.buildid IN $buildids
+            GROUP BY a.configureid HAVING count(b.configureid)=0");
+    while ($build2configure_array = pdo_fetch_array($build2configure)) {
+        // It is safe to delete this configure because it is only used
+        // by builds that are being deleted.
+        if ($configureids != '(') {
+            $configureids .= ',';
+        }
+        $configureids .= $build2configure_array['configureid'];
+    }
+    $configureids .= ')';
+    if (strlen($configureids) > 2) {
+        pdo_query("DELETE FROM configure WHERE id IN $configureids");
+    }
+    pdo_query("DELETE FROM build2configure WHERE buildid IN $buildids");
 
     // coverage file are kept unless they are shared
     $coveragefile = pdo_query('SELECT a.fileid,count(b.fileid) AS c

--- a/include/sendemail.php
+++ b/include/sendemail.php
@@ -360,7 +360,10 @@ function get_email_summary($buildid, $errors, $errorkey, $maxitems, $maxchars, $
 
         $information = "\n\n*Configure*\n";
 
-        $configure = pdo_query('SELECT status,log FROM configure WHERE buildid=' . qnum($buildid));
+        $configure = pdo_query(
+            'SELECT status, log FROM configure AS c
+            INNER JOIN build2configure AS b2c ON (c.id=b2c.configureid)
+            WHERE b2c.buildid=' . qnum($buildid));
         $configure_array = pdo_fetch_array($configure);
 
         $information .= 'Status: ' . $configure_array['status'] . ' (' . $serverURI . '/viewConfigure.php?buildid=' . $buildid . ")\n";

--- a/include/upgrade_functions.php
+++ b/include/upgrade_functions.php
@@ -924,3 +924,47 @@ function PopulateBuild2Configure($configure_table, $b2c_table)
             VALUES ($configureid, $buildid, '$starttime', '$endtime')");
     }
 }
+
+/** Track configure errors by configureid, not buildid.
+ *  This function is parameterized to make it easier to test.
+ **/
+function UpgradeConfigureErrorTable($table = 'configureerror',
+        $b2c_table='build2configure')
+{
+    // Add the configureid field.
+    AddTableField($table, 'configureid', 'bigint(20)', 'BIGINT', '0');
+    AddTableIndex($table, 'configureid');
+
+    // Assign configureid to existing rows in this table.
+    pdo_query(
+        "UPDATE $table AS t
+        SET configureid=
+        (SELECT configureid FROM $b2c_table WHERE buildid=t.buildid)");
+
+    // Remove duplicates.
+    $query = "SELECT type, text, configureid, COUNT(*) FROM $table
+        GROUP BY type, text, configureid HAVING COUNT(*) > 1";
+    $result = pdo_query($query);
+    while ($row = pdo_fetch_array($result)) {
+        $type = $row['type'];
+        $text = $row['text'];
+        $configureid = $row['configureid'];
+        $dupe_query =
+            "SELECT buildid FROM $table
+            WHERE type=$type AND text='$text' AND configureid=$configureid";
+        $dupe_result = pdo_query($dupe_query);
+        $first = true;
+        while ($dupe_row = pdo_fetch_array($dupe_result)) {
+            $buildid = $dupe_row['buildid'];
+            // The first row survives, the rest of the duplicates get deleted.
+            if ($first) {
+                $first = false;
+            } else {
+                pdo_query("DELETE FROM $table WHERE buildid=$buildid AND type=$type AND text='$text' AND configureid=$configureid");
+            }
+        }
+    }
+
+    // Remove the buildid field.
+    RemoveTableField($table, 'buildid');
+}

--- a/include/upgrade_functions.php
+++ b/include/upgrade_functions.php
@@ -558,9 +558,9 @@ function UpgradeConfigureDuration()
 {
     // Do non-parent builds first.
     $query = '
-        SELECT b.id, c.starttime, c.endtime
+        SELECT b.id, b2c.starttime, b2c.endtime
         FROM build AS b
-        LEFT JOIN configure AS c ON b.id=c.buildid
+        LEFT JOIN build2configure AS b2c ON b.id=b2c.buildid
         WHERE b.configureduration = 0 AND b.parentid != -1';
     $result = pdo_query($query);
 
@@ -858,5 +858,69 @@ function PopulateDynamicAnalysisSummaryTable()
             $summary->BuildId = $parentid;
             $summary->Insert(true);
         }
+    }
+}
+
+/** Move data from the configure table to the new build2configure table.
+ *  This function is parameterized to make it easier to test.
+ **/
+function PopulateBuild2Configure($configure_table, $b2c_table)
+{
+    // Set crc32 for configure rows.
+    $query =
+        "SELECT id, command, log, status FROM $configure_table";
+    $result = pdo_query($query);
+    while ($row = pdo_fetch_array($result)) {
+        $configureid = $row['id'];
+        $crc32 = crc32($row['command'] . $row['log'] . $row['status']);
+        pdo_query(
+            "UPDATE $configure_table SET crc32 = $crc32 WHERE id=$configureid");
+    }
+
+    // Find all configure rows that have duplicate crc32 values.
+    $query = "SELECT crc32, COUNT(*) FROM $configure_table
+        GROUP BY crc32 HAVING COUNT(*) > 1";
+    $result = pdo_query($query);
+    while ($row = pdo_fetch_array($result)) {
+        $crc32 = $row['crc32'];
+        $dupe_query =
+            "SELECT id, buildid, starttime, endtime FROM $configure_table
+            WHERE crc32 = $crc32";
+        $dupe_result = pdo_query($dupe_query);
+        $first = true;
+        $keeper_id = null;
+        while ($dupe_row = pdo_fetch_array($dupe_result)) {
+            $configureid = $dupe_row['id'];
+            $buildid = $dupe_row['buildid'];
+            $starttime = $dupe_row['starttime'];
+            $endtime = $dupe_row['endtime'];
+            // The first row survives, the rest of the duplicates get deleted.
+            if ($first) {
+                $keeper_id = $configureid;
+                $first = false;
+            } else {
+                pdo_query("DELETE FROM $configure_table WHERE id=$configureid");
+            }
+            pdo_query(
+                "INSERT INTO $b2c_table
+                (configureid, buildid, starttime, endtime)
+                VALUES ($keeper_id, $buildid, '$starttime', '$endtime')");
+        }
+    }
+
+    // Populate build2configure rows for non-duplicated configure rows.
+    $query =
+        "SELECT id, buildid, starttime, endtime FROM $configure_table
+        WHERE buildid NOT IN (SELECT buildid FROM $b2c_table)";
+    $result = pdo_query($query);
+    while ($row = pdo_fetch_array($result)) {
+        $configureid = $row['id'];
+        $buildid = $row['buildid'];
+        $starttime = $row['starttime'];
+        $endtime = $row['endtime'];
+        pdo_query(
+            "INSERT INTO $b2c_table
+            (configureid, buildid, starttime, endtime)
+            VALUES ($configureid, $buildid, '$starttime', '$endtime')");
     }
 }

--- a/models/build.php
+++ b/models/build.php
@@ -519,19 +519,22 @@ class Build
 
     public function GetConfigures($status=false)
     {
+        $where = ($status !== false) ? "AND c.status = $status" : "";
         if ($this->IsParentBuild()) {
-            $where = ($status !== false) ? "AND c.status = $status" : "";
             return pdo_query("SELECT sp.name subprojectname, sp.id subprojectid, c.*, b.configureerrors,
                               b.configurewarnings
                               FROM configure c
-                              JOIN subproject2build sp2b ON sp2b.buildid = c.buildid
+                              JOIN build2configure b2c ON b2c.configureid=c.id
+                              JOIN subproject2build sp2b ON sp2b.buildid = b2c.buildid
                               JOIN subproject sp ON sp.id = sp2b.subprojectid
-                              JOIN build b ON b.id = c.buildid
+                              JOIN build b ON b.id = b2c.buildid
                               WHERE b.parentid = " . $this->Id . "
                               $where");
         } else {
-            $where = ($status !== false) ? "AND status = $status" : "";
-            return pdo_query("SELECT * FROM configure WHERE buildid = " . $this->Id . " $where");
+            return pdo_query(
+                    "SELECT * FROM configure c
+                    JOIN build2configure b2c ON b2c.configureid=c.id
+                    WHERE b2c.buildid = $this->Id $where");
         }
     }
 

--- a/models/buildconfigure.php
+++ b/models/buildconfigure.php
@@ -20,6 +20,7 @@ include_once 'models/buildconfigureerrordiff.php';
 /** BuildConfigure class */
 class BuildConfigure
 {
+    public $Id;
     public $StartTime;
     public $EndTime;
     public $Command;
@@ -65,7 +66,7 @@ class BuildConfigure
             return false;
         }
 
-        $query = pdo_query('SELECT COUNT(*) FROM configure WHERE buildid=' . qnum($this->BuildId));
+        $query = pdo_query('SELECT COUNT(*) FROM build2configure WHERE buildid=' . qnum($this->BuildId));
         if (!$query) {
             add_last_sql_error('BuildConfigure Exists()', 0, $this->BuildId);
             return false;
@@ -86,7 +87,17 @@ class BuildConfigure
             return false;
         }
 
-        $query = pdo_query('DELETE FROM configure WHERE buildid=' . qnum($this->BuildId));
+        // Delete the configure row if it is not shared with any other build.
+        $count_row = pdo_single_row_query(
+            'SELECT configureid, COUNT(*) AS c FROM build2configure
+            WHERE buildid=' . qnum($this->BuildId) . ' GROUP BY configureid');
+        if ($count_row['c'] > 1) {
+            pdo_query(
+                'DELETE FROM configure WHERE id = ' . qnum($count_row['configureid']));
+        }
+
+        // Delete the build2configure row for this build.
+        $query = pdo_query('DELETE FROM build2configure WHERE buildid=' . qnum($this->BuildId));
         if (!$query) {
             add_last_sql_error('BuildConfigure Delete()', 0, $this->BuildId);
             return false;
@@ -112,7 +123,8 @@ class BuildConfigure
         }
     }
 
-    // Save in the database
+    // Save in the database.  Returns true is a new configure row was created,
+    // false otherwise.
     public function Insert()
     {
         if (!$this->BuildId) {
@@ -129,15 +141,36 @@ class BuildConfigure
         $log = pdo_real_escape_string($this->Log);
         $status = pdo_real_escape_string($this->Status);
 
-        $query = 'INSERT INTO configure (buildid,starttime,endtime,command,log,status)
-            VALUES (' . qnum($this->BuildId) . ",'$this->StartTime','$this->EndTime','$command','$log','$status')";
+        $new_configure_inserted = false;
+        $exists_row = pdo_single_row_query(
+            "SELECT id FROM configure
+            WHERE command='$command' AND log='$log' AND status=$status");
+        if (!$exists_row || !array_key_exists('id', $exists_row)) {
+            // No such configure exists yet, insert a new row.
+            $query =
+                "INSERT INTO configure (command, log, status)
+                VALUES ('$command','$log','$status')";
+            if (!pdo_query($query)) {
+                add_last_sql_error('BuildConfigure Insert', 0, $this->BuildId);
+                return false;
+            }
+            $new_configure_inserted = true;
+            $this->Id = pdo_insert_id('configure');
+        } else {
+            $this->Id = $exists_row['id'];
+        }
+
+        // Insert a new build2configure row for this build.
+        $query =
+            "INSERT INTO build2configure (buildid, configureid, starttime, endtime)
+            VALUES ($this->BuildId, $this->Id, '$this->StartTime', '$this->EndTime')";
         if (!pdo_query($query)) {
-            add_last_sql_error('BuildConfigure Insert', 0, $this->BuildId);
+            add_last_sql_error('Build2Configure Insert', 0, $this->BuildId);
             return false;
         }
 
         $this->InsertLabelAssociations();
-        return true;
+        return $new_configure_inserted;
     }
 
     /** Return true if the specified line contains a configure warning,
@@ -189,7 +222,7 @@ class BuildConfigure
 
         pdo_query(
             'UPDATE configure SET warnings=' . qnum($this->NumberOfWarnings) . '
-                WHERE buildid=' . qnum($this->BuildId));
+                WHERE id=' . qnum($this->Id));
         add_last_sql_error('BuildConfigure ComputeWarnings', 0, $this->BuildId);
     }
 
@@ -202,7 +235,10 @@ class BuildConfigure
         }
 
         $this->NumberOfErrors = 0;
-        $configure = pdo_query('SELECT status FROM configure WHERE buildid=' . qnum($this->BuildId));
+        $configure = pdo_query(
+            'SELECT status FROM configure c
+            JOIN build2configure b2c ON (b2c.configureid=c.id)
+            WHERE buildid=' . qnum($this->BuildId));
         if (!$configure) {
             add_last_sql_error('BuildConfigure ComputeErrors', 0, $this->BuildId);
             return false;

--- a/models/buildconfigure.php
+++ b/models/buildconfigure.php
@@ -144,13 +144,15 @@ class BuildConfigure
         $pdo->beginTransaction();
 
         $exists_stmt = $pdo->prepare(
-                'SELECT id FROM configure WHERE crc32=?');
+                'SELECT * FROM configure WHERE crc32=?');
         $exists_stmt->execute(array($this->Crc32));
         $exists_row = $exists_stmt->fetch(PDO::FETCH_ASSOC);
         $new_configure_inserted = false;
 
         if (is_array($exists_row)) {
             $this->Id = $exists_row['id'];
+            $this->NumberOfWarnings = $exists_row['warnings'];
+            $this->NumberOfErrors = $exists_row['status'];
         } else {
             // No such configure exists yet, insert a new row.
             $stmt = $pdo->prepare('
@@ -238,8 +240,8 @@ class BuildConfigure
                 // Add the warnings in the configureerror table
                 $warning = pdo_real_escape_string($precontext . $log_lines[$l] . "\n" . $postcontext);
 
-                pdo_query("INSERT INTO configureerror (buildid,type,text)
-                        VALUES ('$this->BuildId','1','$warning')");
+                pdo_query("INSERT INTO configureerror (configureid,type,text)
+                        VALUES ('$this->Id','1','$warning')");
                 add_last_sql_error('BuildConfigure ComputeWarnings', 0, $this->BuildId);
                 $this->NumberOfWarnings++;
             }

--- a/models/buildconfigure.php
+++ b/models/buildconfigure.php
@@ -30,6 +30,7 @@ class BuildConfigure
     public $Labels;
     public $NumberOfWarnings;
     public $NumberOfErrors;
+    private $Crc32;
 
     public function AddError($error)
     {
@@ -140,16 +141,16 @@ class BuildConfigure
         $command = pdo_real_escape_string($this->Command);
         $log = pdo_real_escape_string($this->Log);
         $status = pdo_real_escape_string($this->Status);
-
+        $this->Crc32 = crc32($command . $log . $status);
         $new_configure_inserted = false;
+
         $exists_row = pdo_single_row_query(
-            "SELECT id FROM configure
-            WHERE command='$command' AND log='$log' AND status=$status");
+            "SELECT id FROM configure WHERE crc32=$this->Crc32");
         if (!$exists_row || !array_key_exists('id', $exists_row)) {
             // No such configure exists yet, insert a new row.
             $query =
-                "INSERT INTO configure (command, log, status)
-                VALUES ('$command','$log','$status')";
+                "INSERT INTO configure (command, log, status, crc32)
+                VALUES ('$command','$log','$status', $this->Crc32)";
             if (!pdo_query($query)) {
                 add_last_sql_error('BuildConfigure Insert', 0, $this->BuildId);
                 return false;

--- a/models/buildconfigureerror.php
+++ b/models/buildconfigureerror.php
@@ -19,13 +19,13 @@ class BuildConfigureError
 {
     public $Type;
     public $Text;
-    public $BuildId;
+    public $ConfigureId;
 
     /** Return if exists */
     public function Exists()
     {
-        if (!$this->BuildId || !is_numeric($this->BuildId)) {
-            echo 'BuildConfigureError::Save(): BuildId not set';
+        if (!$this->ConfigureId || !is_numeric($this->ConfigureId)) {
+            echo 'BuildConfigureError::Save(): ConfigureId not set';
             return false;
         }
 
@@ -34,9 +34,9 @@ class BuildConfigureError
             return false;
         }
 
-        $query = pdo_query("SELECT count(*) AS c FROM configureerror WHERE buildid='" . $this->BuildId . "'
+        $query = pdo_query("SELECT count(*) AS c FROM configureerror WHERE configureid='" . $this->ConfigureId . "'
                          AND type='" . $this->Type . "' AND text='" . $this->Text . "'");
-        add_last_sql_error('BuildConfigureError:Exists', 0, $this->BuildId);
+        add_last_sql_error('BuildConfigureError:Exists', 0, $this->ConfigureId);
         $query_array = pdo_fetch_array($query);
         if ($query_array['c'] > 0) {
             return true;
@@ -47,8 +47,8 @@ class BuildConfigureError
     /** Save in the database */
     public function Save()
     {
-        if (!$this->BuildId || !is_numeric($this->BuildId)) {
-            echo 'BuildConfigureError::Save(): BuildId not set';
+        if (!$this->ConfigureId || !is_numeric($this->ConfigureId)) {
+            echo 'BuildConfigureError::Save(): ConfigureId not set';
             return false;
         }
 
@@ -59,10 +59,10 @@ class BuildConfigureError
 
         if (!$this->Exists()) {
             $text = pdo_real_escape_string($this->Text);
-            $query = 'INSERT INTO configureerror (buildid,type,text)
-                VALUES (' . qnum($this->BuildId) . ',' . qnum($this->Type) . ",'$text')";
+            $query = 'INSERT INTO configureerror (configureid,type,text)
+                VALUES (' . qnum($this->ConfigureId) . ',' . qnum($this->Type) . ",'$text')";
             if (!pdo_query($query)) {
-                add_last_sql_error('BuildConfigureError:Save', 0, $this->BuildId);
+                add_last_sql_error('BuildConfigureError:Save', 0, $this->ConfigureId);
                 return false;
             }
         }

--- a/models/project.php
+++ b/models/project.php
@@ -808,7 +808,25 @@ class Project
         return $nbuilds / $nb_days;
     }
 
-    /** Get the number of warning builds given a date range */
+    /** Encapsulate common portion of the query used in GetNumberOf*Builds */
+    private function CommonBuildQuery($startUTCdate, $endUTCdate,
+                                           $childrenOnly = false)
+    {
+        $query =
+            'SELECT count(*) FROM build
+            JOIN build2group ON (build2group.buildid=build.id)
+            JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+            WHERE build.projectid=' . qnum($this->Id) . "
+            AND build.starttime>'$startUTCdate'
+            AND build.starttime<='$endUTCdate'
+            AND buildgroup.includesubprojectotal=1";
+        if ($childrenOnly) {
+            $query .= ' AND build.parentid > 0';
+        }
+        return $query;
+    }
+
+    /** Get the number of builds with warning for a given date range */
     public function GetNumberOfWarningBuilds($startUTCdate, $endUTCdate,
                                              $childrenOnly = false)
     {
@@ -817,17 +835,9 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,build2group,buildgroup
-              WHERE build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.buildwarnings>0";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
-
+        $query = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= ' AND build.buildwarnings>0';
         $project = pdo_query($query);
         if (!$project) {
             add_last_sql_error('Project GetNumberOfWarningBuilds', $this->Id);
@@ -838,7 +848,7 @@ class Project
         return $count;
     }
 
-    /** Get the number of error builds given a date range */
+    /** Get the number of builds with errors for a given date range */
     public function GetNumberOfErrorBuilds($startUTCdate, $endUTCdate,
                                            $childrenOnly = false)
     {
@@ -848,17 +858,9 @@ class Project
         }
 
         // build failures
-        $query =
-            'SELECT count(*) FROM build,build2group,buildgroup
-       WHERE build.projectid=' . qnum($this->Id) . "
-       AND build.starttime>'$startUTCdate'
-       AND build.starttime<='$endUTCdate'
-       AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-       AND buildgroup.includesubprojectotal=1
-       AND build.builderrors>0";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= ' AND build.builderrors>0';
 
         $project = pdo_query($query);
         if (!$project) {
@@ -870,7 +872,7 @@ class Project
         return $count;
     }
 
-    /** Get the number of failing builds given a date range */
+    /** Get the number of passing builds for a given date range */
     public function GetNumberOfPassingBuilds($startUTCdate, $endUTCdate,
                                              $childrenOnly = false)
     {
@@ -879,17 +881,9 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,build2group,buildgroup
-              WHERE build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.builderrors=0
-              AND build.buildwarnings=0";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= ' AND build.builderrors=0 AND build.buildwarnings=0';
 
         $project = pdo_query($query);
         if (!$project) {
@@ -900,7 +894,27 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of failing configure given a date range */
+    /** Encapsulate common portion of the query used in GetNumberOf*Configures */
+    private function CommonConfigureQuery($startUTCdate, $endUTCdate,
+                                          $childrenOnly = false)
+    {
+        $query =
+            'SELECT count(*) FROM build
+            JOIN build2configure ON (build2configure.buildid=build.id)
+            JOIN configure ON (configure.id=build2configure.configureid)
+            JOIN build2group ON (build2group.buildid=build.id)
+            JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+            WHERE build.projectid=' . qnum($this->Id) . "
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'
+              AND buildgroup.includesubprojectotal=1";
+        if ($childrenOnly) {
+            $query .= ' AND build.parentid > 0';
+        }
+        return $query;
+    }
+
+    /** Get the number of builds with configure warnings for a given date range */
     public function GetNumberOfWarningConfigures($startUTCdate, $endUTCdate,
                                                  $childrenOnly = false)
     {
@@ -909,16 +923,9 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,configure,build2group,buildgroup
-              WHERE  configure.buildid=build.id  AND build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND  configure.warnings>0";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= ' AND configure.warnings>0';
 
         $project = pdo_query($query);
         if (!$project) {
@@ -929,7 +936,7 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of failing configure given a date range */
+    /** Get the number of builds with configure failures for a given date range */
     public function GetNumberOfErrorConfigures($startUTCdate, $endUTCdate,
                                                $childrenOnly = false)
     {
@@ -938,16 +945,9 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,configure,buildgroup,build2group
-              WHERE  configure.buildid=build.id  AND build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND configure.status='1'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= " AND configure.status='1'";
 
         $project = pdo_query($query);
         if (!$project) {
@@ -958,7 +958,7 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of failing configure given a date range */
+    /** Get the number of builds with passing configures for a given date range */
     public function GetNumberOfPassingConfigures($startUTCdate, $endUTCdate,
                                                  $childrenOnly = false)
     {
@@ -967,14 +967,9 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM configure,build,build2group,buildgroup WHERE build.projectid=' . qnum($this->Id) . "
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND configure.buildid=build.id AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate' AND configure.status='0'";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                $childrenOnly);
+        $query .= " AND configure.status='0'";
 
         $project = pdo_query($query);
         if (!$project) {
@@ -985,7 +980,25 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of tests given a date range */
+    /** Encapsulate common portion of the query used in GetNumberOf*Tests */
+    private function CommonTestsQuery($field, $startUTCdate, $endUTCdate,
+                                      $childrenOnly = false)
+    {
+        $query = "SELECT SUM(build.$field) FROM build
+            JOIN build2group ON (build2group.buildid=build.id)
+            JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+            WHERE build.projectid=" . qnum($this->Id) . "
+              AND build.$field>=0
+              AND buildgroup.includesubprojectotal=1
+              AND build.starttime>'$startUTCdate'
+              AND build.starttime<='$endUTCdate'";
+        if ($childrenOnly) {
+            $query .= ' AND build.parentid > 0';
+        }
+        return $query;
+    }
+
+    /** Get the number of passing tests for a given date range */
     public function GetNumberOfPassingTests($startUTCdate, $endUTCdate,
                                             $childrenOnly = false)
     {
@@ -994,17 +1007,8 @@ class Project
             return false;
         }
 
-        $query = 'SELECT SUM(build.testpassed) FROM build,build2group,buildgroup WHERE build.projectid=' . qnum($this->Id) . "
-              AND build2group.buildid=build.id
-              AND build.testpassed>=0
-              AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
-
+        $query = $this->CommonTestsQuery('testpassed', $startUTCdate,
+                $endUTCdate, $childrenOnly);
         $project = pdo_query($query);
         if (!$project) {
             add_last_sql_error('Project GetNumberOfPassingTests', $this->Id);
@@ -1014,7 +1018,7 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of tests given a date range */
+    /** Get the number of failing tests for a given date range */
     public function GetNumberOfFailingTests($startUTCdate, $endUTCdate,
                                             $childrenOnly = false)
     {
@@ -1023,16 +1027,8 @@ class Project
             return false;
         }
 
-        $query = 'SELECT SUM(build.testfailed) FROM build,build2group,buildgroup WHERE build.projectid=' . qnum($this->Id) . "
-              AND build2group.buildid=build.id
-              AND build.testfailed>=0
-              AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
+        $query = $this->CommonTestsQuery('testfailed', $startUTCdate,
+                $endUTCdate, $childrenOnly);
 
         $project = pdo_query($query);
         if (!$project) {
@@ -1043,7 +1039,7 @@ class Project
         return intval($project_array[0]);
     }
 
-    /** Get the number of tests given a date range */
+    /** Get the number of not run tests for a given date range */
     public function GetNumberOfNotRunTests($startUTCdate, $endUTCdate,
                                            $childrenOnly = false)
     {
@@ -1052,17 +1048,8 @@ class Project
             return false;
         }
 
-        $query = 'SELECT SUM(build.testnotrun) FROM build,build2group,buildgroup WHERE build.projectid=' . qnum($this->Id) . "
-              AND build2group.buildid=build.id
-              AND build.testnotrun>=0
-              AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'";
-        if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
-        }
-
+        $query = $this->CommonTestsQuery('testnotrun', $startUTCdate,
+                $endUTCdate, $childrenOnly);
         $project = pdo_query($query);
         if (!$project) {
             add_last_sql_error('Project GetNumberOfNotRunTests', $this->Id);

--- a/models/subproject.php
+++ b/models/subproject.php
@@ -362,6 +362,32 @@ class SubProject
         return date(FMT_DATETIMESTD, strtotime($project_array['submittime'] . 'UTC'));
     }
 
+    /** Encapsulate common portion of the query used in GetNumberOf*Builds */
+    private function CommonBuildQuery($startUTCdate, $endUTCdate,
+                                      $search_term, $allSubProjects = false)
+    {
+        $query = 'SELECT ';
+        if ($allSubProjects) {
+            $query .= 'subprojectid, ';
+        }
+        $query .= 'count(*) FROM build
+        JOIN subproject2build ON (subproject2build.buildid=build.id)
+        JOIN build2group ON (build2group.buildid=build.id)
+        JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+        WHERE ';
+        if (!$allSubProjects) {
+            $query .= 'subprojectid=' . qnum($this->Id) . 'AND ';
+        }
+        $query .=
+            "buildgroup.includesubprojectotal=1 AND
+            build.starttime>'$startUTCdate' AND
+            build.starttime<='$endUTCdate' AND $search_term";
+        if ($allSubProjects) {
+            $query .= ' GROUP BY subprojectid';
+        }
+        return $query;
+    }
+
     /** Get the number of warning builds given a date range */
     public function GetNumberOfWarningBuilds($startUTCdate, $endUTCdate, $allSubProjects = false)
     {
@@ -369,23 +395,10 @@ class SubProject
             echo 'SubProject GetNumberOfWarningBuilds(): Id not set';
             return false;
         }
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(build.id) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.buildwarnings>0 ";
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
-        $project = pdo_query($queryStr);
 
+        $queryStr = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                'build.buildwarnings>0', $allSubProjects);
+        $project = pdo_query($queryStr);
         if (!$project) {
             add_last_sql_error('SubProject GetNumberOfWarningBuilds');
             return false;
@@ -412,25 +425,9 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(build.id) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.builderrors>0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                'build.builderrors>0', $allSubProjects);
         $project = pdo_query($queryStr);
-
         if (!$project) {
             add_last_sql_error('SubProject GetNumberOfErrorBuilds');
             return false;
@@ -456,23 +453,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(build.id) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.builderrors=0 AND build.buildwarnings=0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonBuildQuery($startUTCdate, $endUTCdate,
+                'build.builderrors=0 AND build.buildwarnings=0', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -492,6 +474,34 @@ class SubProject
         }
     }
 
+    /** Encapsulate common portion of the query used in GetNumberOf*Configures */
+    private function CommonConfigureQuery($startUTCdate, $endUTCdate,
+                                          $search_term, $allSubProjects = false)
+    {
+        $query = 'SELECT ';
+        if ($allSubProjects) {
+            $query .= 'subprojectid, ';
+        }
+        $query .= 'count(*) FROM build
+        JOIN build2configure ON (build2configure.buildid=build.id)
+        JOIN configure ON (configure.id=build2configure.configureid)
+        JOIN subproject2build ON (subproject2build.buildid=build.id)
+        JOIN build2group ON (build2group.buildid=build.id)
+        JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+        WHERE ';
+        if (!$allSubProjects) {
+            $query .= 'subprojectid=' . qnum($this->Id) . 'AND ';
+        }
+        $query .=
+            "buildgroup.includesubprojectotal=1 AND
+            build.starttime>'$startUTCdate' AND
+            build.starttime<='$endUTCdate' AND $search_term";
+        if ($allSubProjects) {
+            $query .= ' GROUP BY subprojectid';
+        }
+        return $query;
+    }
+
     /** Get the number of failing configure given a date range */
     public function GetNumberOfWarningConfigures($startUTCdate, $endUTCdate, $allSubProjects = false)
     {
@@ -500,24 +510,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(*) FROM configure,build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND configure.buildid=build.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND configure.warnings>0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                'configure.warnings>0', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -545,24 +539,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(*) FROM configure,build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND configure.buildid=build.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND configure.status=1 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                'configure.status=1', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -590,24 +568,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'count(*) FROM configure,build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND configure.buildid=build.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND configure.status=0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonConfigureQuery($startUTCdate, $endUTCdate,
+                'configure.status=0', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -627,6 +589,32 @@ class SubProject
         }
     }
 
+    /** Encapsulate common portion of the query used in GetNumberOf*Tests */
+    private function CommonTestQuery($startUTCdate, $endUTCdate,
+                                     $field, $allSubProjects = false)
+    {
+        $query = 'SELECT ';
+        if ($allSubProjects) {
+            $query .= 'subprojectid, ';
+        }
+        $query .= "SUM($field) FROM build
+        JOIN subproject2build ON (subproject2build.buildid=build.id)
+        JOIN build2group ON (build2group.buildid=build.id)
+        JOIN buildgroup ON (buildgroup.id=build2group.groupid)
+        WHERE ";
+        if (!$allSubProjects) {
+            $query .= 'subprojectid=' . qnum($this->Id) . 'AND ';
+        }
+        $query .=
+            "buildgroup.includesubprojectotal=1 AND
+            build.starttime>'$startUTCdate' AND
+            build.starttime<='$endUTCdate' AND $field >= 0";
+        if ($allSubProjects) {
+            $query .= ' GROUP BY subprojectid';
+        }
+        return $query;
+    }
+
     /** Get the number of tests given a date range */
     public function GetNumberOfPassingTests($startUTCdate, $endUTCdate, $allSubProjects = false)
     {
@@ -635,23 +623,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'SUM(build.testpassed) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.testpassed>=0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonTestQuery($startUTCdate, $endUTCdate,
+                'build.testpassed', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -679,23 +652,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'SUM(build.testfailed) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.testfailed>=0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonTestQuery($startUTCdate, $endUTCdate,
+                'build.testfailed', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {
@@ -723,23 +681,8 @@ class SubProject
             return false;
         }
 
-        $queryStr = 'SELECT ';
-        if ($allSubProjects) {
-            $queryStr .= 'subprojectid, ';
-        }
-        $queryStr .= 'SUM(build.testnotrun) FROM build,subproject2build,build2group,buildgroup WHERE ';
-        if (!$allSubProjects) {
-            $queryStr .= 'subprojectid=' . qnum($this->Id) . 'AND ';
-        }
-
-        $queryStr .= "build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-                  AND buildgroup.includesubprojectotal=1
-                  AND subproject2build.buildid=build.id AND build.starttime>'$startUTCdate'
-                  AND build.starttime<='$endUTCdate' AND build.testnotrun>=0 ";
-
-        if ($allSubProjects) {
-            $queryStr .= 'GROUP BY subprojectid';
-        }
+        $queryStr = $this->CommonTestQuery($startUTCdate, $endUTCdate,
+                'build.testnotrun', $allSubProjects);
         $project = pdo_query($queryStr);
 
         if (!$project) {

--- a/public/ajax/showbuildhistory.php
+++ b/public/ajax/showbuildhistory.php
@@ -49,7 +49,8 @@ $previousbuilds = pdo_query("SELECT build.id,build.starttime,build.endtime,build
                              FROM build
                              JOIN build2update ON (build2update.buildid=build.id)
                              JOIN buildupdate ON (build2update.updateid=buildupdate.id)
-                             JOIN configure ON (configure.buildid=build.id)
+                             JOIN build2configure ON (build2configure.buildid=build.id)
+                             JOIN configure ON (configure.id=build2configure.configureid)
                              WHERE build.siteid='$siteid' AND build.type='$buildtype' AND build.name='$buildname'
                              AND build.projectid='$projectid' AND build.starttime<='$starttime'
                              ORDER BY build.starttime DESC LIMIT 50");

--- a/public/api/v1/api_build.php
+++ b/public/api/v1/api_build.php
@@ -135,11 +135,17 @@ class BuildAPI extends CDashAPI
             }
 
             // Finds the configuration errors
-            $configquery = pdo_query("SELECT count(*) AS c FROM configureerror WHERE buildid='" . $build['id'] . "' AND type='0'");
+            $configquery = pdo_query(
+                "SELECT count(*) AS c FROM configureerror AS ce
+                JOIN build2configure AS b2c ON (b2c.configureid=ce.configureid)
+                WHERE b2c.buildid='" . $build['id'] . "' AND type='0'");
             $query_configarray = pdo_fetch_array($configquery);
             $build['configureerrors'] = $query_configarray['c'];
 
-            $configquery = pdo_query("SELECT count(*) AS c FROM configureerror WHERE buildid='" . $build['id'] . "' AND type='1'");
+            $configquery = pdo_query(
+                "SELECT count(*) AS c FROM configureerror AS ce
+                JOIN build2configure AS b2c ON (b2c.configureid=ce.configureid)
+                WHERE b2c.buildid='" . $build['id'] . "' AND type='1'");
             $query_configarray = pdo_fetch_array($configquery);
             $build['configurewarnings'] = $query_configarray['c'];
 

--- a/public/api/v1/viewProjects.php
+++ b/public/api/v1/viewProjects.php
@@ -34,7 +34,7 @@ $response['hostname'] = $_SERVER['SERVER_NAME'];
 $response['date'] = date('r');
 
 // Check if the database is up to date
-$query = 'SELECT configureduration FROM build LIMIT 1';
+$query = 'SELECT id FROM configure LIMIT 1';
 $dbTest = pdo_query($query);
 if ($dbTest === false) {
     $response['upgradewarning'] = 1;

--- a/public/buildSummary.php
+++ b/public/buildSummary.php
@@ -318,7 +318,10 @@ if (pdo_num_rows($buildupdate) > 0) {
 
 // Configure
 $xml .= '<configure>';
-$configure = pdo_query("SELECT * FROM configure WHERE buildid='$buildid'");
+$configure = pdo_query(
+        "SELECT * FROM configure c
+        JOIN build2configure b2c ON b2c.configureid=c.id
+        WHERE b2c.buildid='$buildid'");
 $configure_array = pdo_fetch_array($configure);
 
 $nerrors = 0;
@@ -405,7 +408,10 @@ if ($previous_buildid > 0) {
     $xml .= add_XML_value('nupdateerrors', $nupdateerrors);
     $xml .= add_XML_value('nupdatewarnings', $nupdatewarnings);
 
-    $configure = pdo_query("SELECT * FROM configure WHERE buildid='$previous_buildid'");
+    $configure = pdo_query(
+            "SELECT * FROM configure c
+            JOIN build2configure b2c ON b2c.configureid=c.id
+            WHERE b2c.buildid='$previous_buildid'");
     $configure_array = pdo_fetch_array($configure);
 
     $nconfigureerrors = 0;

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -709,6 +709,9 @@ if (isset($_GET['upgrade-2-4'])) {
         RemoveTableField('configure', 'buildid');
         RemoveTableField('configure', 'starttime');
         RemoveTableField('configure', 'endtime');
+
+        // Change configureerror to use configureid instead of buildid.
+        UpgradeConfigureErrorTable('configureerror', 'build2configure');
     }
 
     // Better caching of build & test time, particularly for parent builds.
@@ -871,6 +874,7 @@ if ($Cleanup) {
     delete_unused_rows('user2project', 'projectid', 'project');
     delete_unused_rows('userstatistics', 'projectid', 'project');
 
+    delete_unused_rows('build2configure', 'buildid', 'build');
     delete_unused_rows('build2note', 'buildid', 'build');
     delete_unused_rows('build2test', 'buildid', 'build');
     delete_unused_rows('buildemail', 'buildid', 'build');
@@ -880,8 +884,8 @@ if ($Cleanup) {
     delete_unused_rows('buildinformation', 'buildid', 'build');
     delete_unused_rows('buildnote', 'buildid', 'build');
     delete_unused_rows('buildtesttime', 'buildid', 'build');
-    delete_unused_rows('configure', 'buildid', 'build');
-    delete_unused_rows('configureerror', 'buildid', 'build');
+    delete_unused_rows('configure', 'id', 'build2configure', 'configureid');
+    delete_unused_rows('configureerror', 'configureid', 'configure');
     delete_unused_rows('configureerrordiff', 'buildid', 'build');
     delete_unused_rows('coverage', 'buildid', 'build');
     delete_unused_rows('coveragefilelog', 'buildid', 'build');

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -677,6 +677,40 @@ if (isset($_GET['upgrade-2-4'])) {
     // This speeds up viewTest API for builds with lots of tests & labels.
     AddTableIndex('label2test', 'testid');
 
+    // Restructure configure table.
+    // This reduces the footprint of this table and allows multiple builds
+    // to share a configure.
+    if (!pdo_query('SELECT id FROM configure LIMIT 1')) {
+        // Add id column to configure table.
+        if ($CDASH_DB_TYPE != 'pgsql') {
+            pdo_query(
+                'ALTER TABLE configure ADD id int(11) NOT NULL AUTO_INCREMENT,
+                ADD PRIMARY KEY(id)');
+        } else {
+            pdo_query(
+                'ALTER TABLE configure ADD id SERIAL NOT NULL,
+                ADD PRIMARY KEY (id)');
+        }
+
+        // Add crc32 column to configure table.
+        AddTableField('configure', 'crc32', 'bigint(20)', 'BIGINT', '0');
+
+        // Populate build2configure table.
+        PopulateBuild2Configure('configure', 'build2configure');
+
+        // Add unique constraint to crc32 column.
+        if ($db_type === 'pgsql') {
+            pdo_query('ALTER TABLE configure ADD UNIQUE (crc32)');
+        } else {
+            pdo_query('ALTER TABLE configure ADD UNIQUE KEY (crc32)');
+        }
+
+        // Remove columns from configure that have been moved to build2configure.
+        RemoveTableField('configure', 'buildid');
+        RemoveTableField('configure', 'starttime');
+        RemoveTableField('configure', 'endtime');
+    }
+
     // Better caching of build & test time, particularly for parent builds.
     $query = 'SELECT configureduration FROM build LIMIT 1';
     $dbTest = pdo_query($query);

--- a/public/user.php
+++ b/public/user.php
@@ -233,7 +233,10 @@ if ($session_OK) {
             $xml .= add_XML_value('datelink', 'index.php?project=' . urlencode($projectname) . '&date=' . $date);
 
             // Configure
-            $configure = pdo_query("SELECT status FROM configure WHERE buildid='$buildid'");
+            $configure = pdo_query(
+                    "SELECT status FROM configure c
+                    JOIN build2configure b2c ON b2c.configureid=c.id
+                    WHERE buildid='$buildid'");
             if (pdo_num_rows($configure) > 0) {
                 $configure_array = pdo_fetch_array($configure);
                 $xml .= add_XML_value('configure', $configure_array['status']);

--- a/sql/mysql/cdash-upgrade-2.0-2.4.sql
+++ b/sql/mysql/cdash-upgrade-2.0-2.4.sql
@@ -70,3 +70,12 @@ CREATE TABLE IF NOT EXISTS `lockout` (
   `unlocktime` timestamp NOT NULL DEFAULT '1980-01-01 00:00:00',
   PRIMARY KEY  (`userid`)
 );
+
+CREATE TABLE IF NOT EXISTS `build2configure` (
+  `configureid` int(11) NOT NULL default '0',
+  `buildid` int(11) NOT NULL default '0',
+  `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
+  `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
+  PRIMARY KEY  (`buildid`),
+  KEY `configureid` (`configureid`)
+);

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -208,12 +208,14 @@ CREATE TABLE IF NOT EXISTS `build2update` (
 --
 
 CREATE TABLE `configure` (
-  `id` int(11) NOT NULL auto_increment,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `command` text NOT NULL,
   `log` MEDIUMTEXT NOT NULL,
-  `status` tinyint(4) NOT NULL default '0',
+  `status` tinyint(4) NOT NULL DEFAULT '0',
   `warnings` smallint(6) DEFAULT '-1',
-  PRIMARY KEY (`id`)
+  `crc32` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `crc32` (`crc32`)
 );
 
 -- --------------------------------------------------------

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -782,10 +782,10 @@ CREATE TABLE `summaryemail` (
 
 
 CREATE TABLE `configureerror` (
-  `buildid` bigint(20) NOT NULL,
+  `configureid` int(11) NOT NULL,
   `type` tinyint(4) NOT NULL,
   `text` text NOT NULL,
-  KEY `buildid` (`buildid`),
+  KEY `configureid` (`configureid`),
   KEY `type` (`type`)
 );
 

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -96,6 +96,22 @@ CREATE TABLE `buildgroupposition` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `build2configure`
+--
+
+CREATE TABLE `build2configure` (
+  `configureid` int(11) NOT NULL default '0',
+  `buildid` int(11) NOT NULL default '0',
+  `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
+  `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
+  PRIMARY KEY  (`buildid`),
+  KEY `configureid` (`configureid`)
+);
+
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `build2group`
 --
 
@@ -192,14 +208,12 @@ CREATE TABLE IF NOT EXISTS `build2update` (
 --
 
 CREATE TABLE `configure` (
-  `buildid` int(11) NOT NULL default '0',
-  `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
-  `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
+  `id` int(11) NOT NULL auto_increment,
   `command` text NOT NULL,
   `log` MEDIUMTEXT NOT NULL,
   `status` tinyint(4) NOT NULL default '0',
   `warnings` smallint(6) DEFAULT '-1',
-  KEY `buildid` (`buildid`)
+  PRIMARY KEY (`id`)
 );
 
 -- --------------------------------------------------------

--- a/sql/pgsql/cdash-upgrade-2.0-2.4.sql
+++ b/sql/pgsql/cdash-upgrade-2.0-2.4.sql
@@ -71,3 +71,12 @@ CREATE TABLE "lockout" (
   "unlocktime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
   PRIMARY KEY ("userid")
 );
+
+CREATE TABLE "build2configure" (
+  "configureid" integer DEFAULT '0' NOT NULL,
+  "buildid" integer DEFAULT '0' NOT NULL,
+  "starttime" timestamp(0) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "endtime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
+  PRIMARY KEY ("buildid")
+);
+CREATE INDEX "configureid" on "build2configure" ("configureid");

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -689,11 +689,11 @@ CREATE INDEX "groupid3" on "summaryemail" ("groupid");
 -- Table: configureerror
 --
 CREATE TABLE "configureerror" (
-  "buildid" bigint NOT NULL,
+  "configureid" integer NOT NULL,
   "type" smallint NOT NULL,
   "text" text NOT NULL
 );
-CREATE INDEX "buildid15" on "configureerror" ("buildid");
+CREATE INDEX "configureid2" on "configureerror" ("configureid");
 CREATE INDEX "type3" on "configureerror" ("type");
 
 --

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -177,8 +177,10 @@ CREATE TABLE "configure" (
   "log" text NOT NULL,
   "status" smallint DEFAULT '0' NOT NULL,
   "warnings" smallint DEFAULT '-1',
+  "crc32" bigint DEFAULT NULL,
    PRIMARY KEY ("id")
 );
+CREATE UNIQUE INDEX "configure_crc32" on "configure" ("crc32");
 
 --
 -- Table: coverage

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -77,6 +77,17 @@ CREATE INDEX "endtime2" on "buildgroupposition" ("endtime");
 CREATE INDEX "starttime3" on "buildgroupposition" ("starttime");
 CREATE INDEX "position" on "buildgroupposition" ("position");
 
+-- Table: build2configure
+--
+CREATE TABLE "build2configure" (
+  "configureid" integer DEFAULT '0' NOT NULL,
+  "buildid" integer DEFAULT '0' NOT NULL,
+  "starttime" timestamp(0) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "endtime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
+  PRIMARY KEY ("buildid")
+);
+CREATE INDEX "configureid" on "build2configure" ("configureid");
+
 --
 -- Table: build2group
 --
@@ -161,15 +172,13 @@ CREATE INDEX "build2update_updateid" on "build2update" ("updateid");
 -- Table: configure
 --
 CREATE TABLE "configure" (
-  "buildid" bigint DEFAULT '0' NOT NULL,
-  "starttime" timestamp(0) DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  "endtime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
+  "id" SERIAL NOT NULL,
   "command" text NOT NULL,
   "log" text NOT NULL,
   "status" smallint DEFAULT '0' NOT NULL,
-  "warnings" smallint DEFAULT '-1'
+  "warnings" smallint DEFAULT '-1',
+   PRIMARY KEY ("id")
 );
-CREATE INDEX "buildid3" on "configure" ("buildid");
 
 --
 -- Table: coverage

--- a/tests/test_buildconfigure.php
+++ b/tests/test_buildconfigure.php
@@ -36,7 +36,7 @@ class BuildConfigureTestCase extends KWWebTestCase
 
         $configure->BuildId = 1;
         $error = new BuildConfigureError();
-        $error->BuildId = 1;
+        $error->ConfigureId = 1;
         $error->Type = 1;
         $configure->AddError($error);
 

--- a/tests/test_upgrade.php
+++ b/tests/test_upgrade.php
@@ -572,4 +572,127 @@ class UpgradeTestCase extends KWWebTestCase
         }
         return $retval;
     }
+
+    public function testBuild2ConfigureUpgrade()
+    {
+        require_once dirname(__FILE__) . '/cdash_test_case.php';
+        require_once 'include/common.php';
+        require_once 'include/pdo.php';
+
+        $retval = 0;
+        $configure_table_name = 'testconfigure';
+        $b2c_table_name = 'testbuild2configure';
+
+        global $CDASH_DB_TYPE;
+        if ($CDASH_DB_TYPE == 'pgsql') {
+            $create_query_1 = '
+                CREATE TABLE "' . $configure_table_name . '" (
+                "id" serial NOT NULL,
+                "buildid" integer DEFAULT \'0\' NOT NULL,
+                "command" text NOT NULL,
+                "log" text NOT NULL,
+                "status" smallint DEFAULT \'0\' NOT NULL,
+                "warnings" smallint DEFAULT \'-1\',
+                "starttime" timestamp(0) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                "endtime" timestamp(0) DEFAULT \'1980-01-01 00:00:00\' NOT NULL,
+                "crc32" bigint DEFAULT NULL,
+                PRIMARY KEY ("id"))';
+            $create_query_2 = '
+                CREATE TABLE "' . $b2c_table_name . '" (
+                "configureid" integer DEFAULT \'0\' NOT NULL,
+                "buildid" integer DEFAULT \'0\' NOT NULL,
+                "starttime" timestamp(0) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                "endtime" timestamp(0) DEFAULT \'1980-01-01 00:00:00\' NOT NULL,
+                PRIMARY KEY ("buildid"))';
+        } else {
+            // MySQL
+            $create_query_1 = "
+                CREATE TABLE `$configure_table_name` (
+                `id` int(11) NOT NULL auto_increment,
+                `buildid` bigint(11) NOT NULL,
+                `command` text NOT NULL,
+                `log` MEDIUMTEXT NOT NULL,
+                `status` tinyint(4) NOT NULL DEFAULT '0',
+                `warnings` smallint(6) DEFAULT '-1',
+                `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
+                `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
+                `crc32` bigint(20) NOT NULL,
+                PRIMARY KEY  (`id`))";
+            $create_query_2 = "
+                CREATE TABLE `$b2c_table_name` (
+                `configureid` int(11) NOT NULL default '0',
+                `buildid` int(11) NOT NULL default '0',
+                `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
+                `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
+                PRIMARY KEY  (`buildid`))";
+        }
+
+        // Create testing tables.
+        if (!pdo_query($create_query_1)) {
+            $this->fail('pdo_query returned false');
+            $retval = 1;
+        }
+        if (!pdo_query($create_query_2)) {
+            $this->fail('pdo_query returned false');
+            $retval = 1;
+        }
+
+        // Insert testing data in configure table.
+        // Two rows that duplicate each other
+        $dupe_buildids = array(1, 2);
+        foreach ($dupe_buildids as $buildid) {
+            pdo_query(
+                "INSERT INTO $configure_table_name
+                (buildid, command, log, status, crc32)
+                VALUES ($buildid, 'dupe command', 'dupe log', 0, 0)");
+        }
+
+        // ...and one that does not.
+        pdo_query(
+            "INSERT INTO $configure_table_name
+            (buildid, command, log, status, crc32)
+            VALUES (3, 'unique command', 'unique log', 0, 0)");
+
+        // Verify that the right number of testing rows made it into the database.
+        $count_query = "
+            SELECT COUNT(id) AS numrows FROM $configure_table_name";
+        $count_results = pdo_single_row_query($count_query);
+        if ($count_results['numrows'] != 3) {
+            $this->fail(
+                'Expected 3 configure rows, found ' . $count_results['numrows']);
+            $retval = 1;
+        }
+
+        // Run the upgrade function.
+        PopulateBuild2Configure($configure_table_name, $b2c_table_name);
+
+        // Verify that we now have only two configure rows.
+        $count_query = "
+            SELECT COUNT(id) AS numrows FROM $configure_table_name";
+        $count_results = pdo_single_row_query($count_query);
+        if ($count_results['numrows'] != 2) {
+            $this->fail(
+                'Expected 2 configure rows, found ' . $count_results['numrows']);
+            $retval = 1;
+        }
+
+        // Verify that we have three build2configure rows.
+        $count_query = "
+            SELECT COUNT(buildid) AS numrows FROM $b2c_table_name";
+        $count_results = pdo_single_row_query($count_query);
+        if ($count_results['numrows'] != 3) {
+            $this->fail(
+                'Expected three b2c rows, found ' . $count_results['numrows']);
+            $retval = 1;
+        }
+
+        // Drop testing tables.
+        pdo_query("DROP TABLE $configure_table_name");
+        pdo_query("DROP TABLE $b2c_table_name");
+
+        if ($retval == 0) {
+            $this->pass('Passed');
+        }
+        return $retval;
+    }
 }

--- a/xml_handlers/configure_handler.php
+++ b/xml_handlers/configure_handler.php
@@ -111,11 +111,11 @@ class ConfigureHandler extends AbstractHandler
             if ($this->Configure->Exists()) {
                 $this->Configure->Delete();
             }
-            $this->Configure->Insert();
-
-            // Insert errors from the log file
-            $this->Configure->ComputeWarnings();
-            $this->Configure->ComputeErrors();
+            if ($this->Configure->Insert()) {
+                // Insert errors from the log file
+                $this->Configure->ComputeWarnings();
+                $this->Configure->ComputeErrors();
+            }
 
             $this->Build->ComputeConfigureDifferences();
 


### PR DESCRIPTION
Up until now, CDash has enforced a one-to-one relationship between builds and configures.  This will no longer do in light of our new, single-step subproject builds (#376).

This PR makes it possible for multiple builds to share a single configure row in the database.  Previously each build would store its own configure output.  As a result of this PR, this data is now shared between builds when possible.
