### PR TITLE
Make parallel submissions more robust

### DIFF
--- a/models/build.php
+++ b/models/build.php
@@ -1976,8 +1976,6 @@ class Build
             return;
         }
 
-        pdo_begin_transaction();
-
         // Update build step duration for this build.
         pdo_query(
                 "UPDATE build SET buildduration=buildduration + $duration
@@ -1996,8 +1994,6 @@ class Build
             add_last_sql_error('Build:UpdateBuildDuration',
                 $this->ProjectId, $this->ParentId);
         }
-
-        pdo_commit();
     }
 
     // Return the dashboard date (in Y-m-d format) for this build.


### PR DESCRIPTION
The test of this feature was failing periodically.  I tracked
this down to database deadlocks occurring within UpdateBuildDuration().
Removing the transaction from this function seems to have fixed
the problem.  This transaction was unnecessary since the UPDATEs
performed here are atomic.