### PR TITLE
Check for current revision for version-only diff

### DIFF
--- a/include/repository.php
+++ b/include/repository.php
@@ -837,6 +837,9 @@ function perform_version_only_diff($update, $projectid)
         return;
     }
     $previous_revision = $row['revision'];
+    if (empty($previous_revision)) {
+        return;
+    }
 
     // Record the previous revision in the buildupdate table.
     $stmt = $pdo->prepare(

--- a/include/repository.php
+++ b/include/repository.php
@@ -794,6 +794,11 @@ function post_github_pull_request_comment($projectid, $pull_request, $comment, $
 /** Find changes for a "version only" update. */
 function perform_version_only_diff($update, $projectid)
 {
+    // Return early if we don't have a current revision.
+    if (empty($update->Revision)) {
+        return;
+    }
+
     // Return early if this project doesn't have a remote repository viewer.
     require_once 'models/buildupdate.php';
     require_once 'models/project.php';


### PR DESCRIPTION
Don't attempt to calculate the difference between two revisions without a current revision.