### PR TITLE
Use get_seconds_from_interval for SubProject filters

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -82,6 +82,39 @@ class DefaultFilters implements PageSpecificFilters
 
 class IndexPhpFilters extends DefaultFilters
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Check if the SubProject filter was specified.
+        // If so, we won't add SQL clauses for some other filters.
+        // Instead we handle them in PHP code via build_survives_filter().
+        $this->HasSubProjectsFilter = false;
+        $filtercount = pdo_real_escape_numeric(@$_REQUEST['filtercount']);
+        for ($i = 1; $i <= $filtercount; ++$i) {
+            if (empty($_REQUEST['field' . $i])) {
+                continue;
+            }
+            $field = htmlspecialchars(pdo_real_escape_string($_REQUEST['field' . $i]));
+            if ($field === 'subprojects') {
+                $this->HasSubProjectsFilter = true;
+                break;
+            }
+        }
+        $this->FiltersAffectedBySubProjects = array(
+                'buildduration',
+                'builderrors',
+                'buildwarnings',
+                'configureduration',
+                'configureerrors',
+                'configurewarnings',
+                'testsduration',
+                'testsfailed',
+                'testsnotrun',
+                'testspassed',
+                'testtimestatus');
+    }
+
     public function getDefaultFilter()
     {
         return array(
@@ -129,6 +162,15 @@ class IndexPhpFilters extends DefaultFilters
 
     public function getSqlField($field)
     {
+        // Some filters can return inaccurate results when we are also
+        // filtering by SubProjects.  In these cases we do not modify
+        // the SQL query and instead handle the filtration in PHP code as a
+        // subsequent step.
+        if ($this->HasSubProjectsFilter &&
+                in_array($field, $this->FiltersAffectedBySubProjects)) {
+            return '';
+        }
+
         global $CDASH_DB_TYPE;
         $sql_field = '';
         switch (strtolower($field)) {

--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -1063,11 +1063,15 @@ function build_survives_filter($build_response, $filterdata)
 {
     $filters = $filterdata['filters'];
     foreach ($filters as $filter) {
+        // Get the filter's value for comparison.
+        $filter_value = $filter['value'];
+
         // Get the build value that's relevant to this filter.
         // (number of configure warnings, number of test failures, etc.)
         $build_value = false;
         switch ($filter['field']) {
             case 'buildduration':
+                $filter_value = get_seconds_from_interval($filter_value);
                 if ($build_response['hascompilation']) {
                     $build_value = $build_response['compilation']['timefull'];
                 }
@@ -1086,6 +1090,7 @@ function build_survives_filter($build_response, $filterdata)
                 break;
 
             case 'configureduration':
+                $filter_value = get_seconds_from_interval($filter_value);
                 if ($build_response['hasconfigure']) {
                     $build_value = $build_response['configure']['timefull'];
                 }
@@ -1104,6 +1109,7 @@ function build_survives_filter($build_response, $filterdata)
                 break;
 
             case 'testsduration':
+                $filter_value = get_seconds_from_interval($filter_value);
                 if ($build_response['hastest']) {
                     $build_value = $build_response['test']['timefull'];
                 }
@@ -1137,9 +1143,6 @@ function build_survives_filter($build_response, $filterdata)
                 continue;
                 break;
         }
-
-        // Get the filter's value for comparison.
-        $filter_value = $filter['value'];
 
         // Compare the build & filter's values, returning false if
         // they don't match the filter's expectation.

--- a/tests/test_excludesubprojects.php
+++ b/tests/test_excludesubprojects.php
@@ -231,8 +231,8 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
         $test_cases = array(
             array(
                 'filter' => 'buildduration',
-                'compare' => 41,
-                'value' => '10m 46s',
+                'compare' => 43,
+                'value' => '10m%2045s',
                 'exclude' => 'Teuchos'
             ),
             array(


### PR DESCRIPTION
`build_survives_filter` is used to reevaluate our filters (build duration, test failures, etc) when we are including or excluding SubProject(s).

Within this function we need to convert interval strings ('10m 45s') to a number of seconds (645).  This number of seconds is then used to check whether or not a build should be filtered out.

As part of this commit we also strengthen the ExcludeSubProjects test to verify that this bug stays fixed.