### PR TITLE
Split build graph into 4 separate graphs

### DIFF
--- a/public/buildSummary.xsl
+++ b/public/buildSummary.xsl
@@ -378,15 +378,37 @@ Add a Note to this Build</a>
 <div id="addnote"></div>
 <br/>
 
-<!-- Graph -->
-<div class="title-divider">Graph</div>
-<img src="img/graph.png" title="graph"/><a><xsl:attribute name="href">javascript:showgraph_click(<xsl:value-of select="cdash/build/id"/>)</xsl:attribute>
-Show Build Graphs</a>
-<div id="graphoptions"></div>
-<div id="graph"></div>
+<!-- Graphs -->
+<div class="title-divider">Graphs</div>
+<img src="img/graph.png" title="graph"/><a><xsl:attribute name="href">javascript:showbuildgraph_click(<xsl:value-of select="cdash/build/id"/>, "time")</xsl:attribute>
+Show Build Time Graph</a>
+<div id="buildtimegraphoptions"></div>
+<div id="buildtimegraph"></div>
 <center>
-<div id="grapholder"></div>
+<div id="buildtimegrapholder"></div>
 </center>
+<img src="img/graph.png" title="graph"/><a><xsl:attribute name="href">javascript:showbuildgraph_click(<xsl:value-of select="cdash/build/id"/>, "errors")</xsl:attribute>
+Show Build Errors Graph</a>
+<div id="builderrorsgraphoptions"></div>
+<div id="builderrorsgraph"></div>
+<center>
+<div id="builderrorsgrapholder"></div>
+</center>
+<img src="img/graph.png" title="graph"/><a><xsl:attribute name="href">javascript:showbuildgraph_click(<xsl:value-of select="cdash/build/id"/>, "warnings")</xsl:attribute>
+Show Build Warnings Graph</a>
+<div id="buildwarningsgraphoptions"></div>
+<div id="buildwarningsgraph"></div>
+<center>
+<div id="buildwarningsgrapholder"></div>
+</center>
+<img src="img/graph.png" title="graph"/><a><xsl:attribute name="href">javascript:showbuildgraph_click(<xsl:value-of select="cdash/build/id"/>, "testsfailed")</xsl:attribute>
+Show Build Tests Failed Graph</a>
+<div id="buildtestsfailedgraphoptions"></div>
+<div id="buildtestsfailedgraph"></div>
+<center>
+<div id="buildtestsfailedgrapholder"></div>
+</center>
+
 <br/>
 
 <!-- Update -->

--- a/public/js/cdashBuildGraph.js
+++ b/public/js/cdashBuildGraph.js
@@ -1,25 +1,26 @@
-function showgraph_click(buildid,zoomout)
+function showbuildgraph_click(buildid,type,zoomout)
 {
   if(zoomout)
     {
-    $("#graph").load("ajax/showbuildtimegraph.php?buildid="+buildid);
+    $("#build"+type+"graph").load("ajax/showbuildgraph.php?buildid="+buildid+"&graphtype="+type);
     return;
     }
 
-  if($("#graph").html() != "" && $("#grapholder").is(":visible"))
+  if($("#build"+type+"graph").html() != "" && $("#build"+type+"grapholder").is(":visible"))
     {
-    $("#grapholder").hide(); //fadeOut('medium');
-    $("#graphoptions").html("");
+    $("#build"+type+"grapholder").hide(); //fadeOut('medium');
+    $("#build"+type+"graphoptions").html("");
     return;
     }
 
-  $("#graph").fadeIn('slow');
-  $("#graph").html("fetching...<img src=img/loading.gif></img>");
-  $("#grapholder").attr("style","width:800px;height:400px;");
-  $("#graphoptions").html("<a href=javascript:showgraph_click("+buildid+",true)>Zoom out</a>");
+  $("#build"+type+"graph").fadeIn('slow');
+  $("#build"+type+"graph").html("fetching...<img src=img/loading.gif></img>");
+  $("#build"+type+"grapholder").attr("style","width:800px;height:400px;");
+  $("#build"+type+"graphoptions").html("<a href=javascript:showbuildgraph_click("+buildid+",'"+type+"',true)>Zoom out</a>");
 
-  $("#graph").load("ajax/showbuildtimegraph.php?buildid="+buildid,{},function(){$("#grapholder").fadeIn('slow');
-$("#graphoptions").show();
+  $("#build"+type+"graph").load("ajax/showbuildgraph.php?buildid="+buildid+"&graphtype="+type,
+                                {},function(){$("#build"+type+"grapholder").fadeIn('slow');
+$("#build"+type+"graphoptions").show();
 });
 }
 


### PR DESCRIPTION
Previously, the axis for errors, warnings and build failures was labeled
as 'minutes' even though it should have been dimensionless. Also, the scales for
the different graph types could be very different.