### PR TITLE
Fix user registration

### DIFF
--- a/public/register.php
+++ b/public/register.php
@@ -47,9 +47,9 @@ function register()
         // We copy the data from usertemp to user
         $user = new User();
         $user->Email = $email;
-        $user->Password = $query_array['passwd'];
-        $user->FirstName = $query_array['fname'];
-        $user->LastName = $query_array['lname'];
+        $user->Password = $query_array['password'];
+        $user->FirstName = $query_array['firstname'];
+        $user->LastName = $query_array['lastname'];
         $user->Institution = $query_array['institution'];
         if ($user->Save()) {
             pdo_query("DELETE FROM usertemp WHERE email='$email'");

--- a/tests/test_login.php
+++ b/tests/test_login.php
@@ -4,6 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/pdo.php';
 
 class LoginTestCase extends KWWebTestCase
 {
@@ -12,15 +13,15 @@ class LoginTestCase extends KWWebTestCase
         parent::__construct();
     }
 
-    public function testHomePage()
+    public function testLogin($email='simpletest@localhost', $password='simpletest')
     {
         $content = $this->connect($this->url);
         if ($content == false) {
             return;
         }
         $this->clickLink('Login');
-        $this->setField('login', 'simpletest@localhost');
-        $this->setField('passwd', 'simpletest');
+        $this->setField('login', $email);
+        $this->setField('passwd', $password);
         $this->clickSubmitByName('sent');
         $this->assertNoText('Wrong email or password');
     }
@@ -73,5 +74,41 @@ class LoginTestCase extends KWWebTestCase
         $this->setField('passwd', $passwd);
         $this->setField('passwd2', $passwd);
         $this->setField('institution', $institution);
+    }
+
+    public function testRegistrationWithEmailVerification()
+    {
+        $configLine = '$CDASH_REGISTRATION_EMAIL_VERIFY = true;';
+        $this->addLineToConfig($configLine);
+
+        $url = $this->url . '/register.php';
+        $content = $this->connect($url);
+        if ($content == false) {
+            return $this->fail('Failed to load registration page.');
+        }
+        $email = 'verifytest@kw';
+        $password = 'kitware';
+        $this->fillOutRegisterForm($email, $password);
+        $this->clickSubmitByName('sent', array('url' => 'catchbot'));
+        $this->assertText('A confirmation email has been sent.');
+
+        // Grab registration key directly from database
+        $row = pdo_single_row_query("SELECT registrationkey FROM usertemp WHERE email = '$email'");
+        if (!$row) {
+            return $this->fail('Failed to register user.');
+        }
+
+        $url = $this->url . '/register.php?key=' . $row['registrationkey'];
+        $content = $this->connect($url);
+        if ($content == false) {
+            return $this->fail('Failed to load verification page.');
+        }
+
+        $this->assertText('Registration Complete.');
+
+        // Try to login
+        $this->testLogin($email, $password);
+
+        $this->removeLineFromConfig($configLine);
     }
 }


### PR DESCRIPTION
@zackgalbreath and I noticed this bug since GAE is running a revision closer to master.

It seems like the verification process has been confirming users without properly setting their passwords for a few months now. I'm assuming the reason we didn't catch this earlier is a combination of:
1) Production boxes being on older, stabler versions
2) Our tests didn't actually test the verification step of user registration

The latter being resolved in this PR.