### PR TITLE
Make it easier to filter SubProject coverage results

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -590,6 +590,41 @@ class ViewTestPhpFilters extends DefaultFilters
     }
 }
 
+class CompareCoveragePhpFilters extends DefaultFilters
+{
+    public function getDefaultFilter()
+    {
+        return array(
+            'field' => 'subproject',
+            'fieldtype' => 'string',
+            'compare' => 61,
+            'value' => ''
+        );
+    }
+
+    public function getFilterDefinitionsXML()
+    {
+        $xml = '';
+        $xml .= getFilterDefinitionXML('subproject', 'SubProject', 'string', '', '');
+        return $xml;
+    }
+
+    public function getSqlField($field)
+    {
+        $sql_field = '';
+        switch (strtolower($field)) {
+            case 'subproject':
+                $sql_field = 'sp.name';
+                break;
+
+            default:
+                trigger_error("unknown field: $field", E_USER_WARNING);
+                break;
+        }
+        return $sql_field;
+    }
+}
+
 // Factory method to create page specific filters:
 //
 function createPageSpecificFilters($page_id)
@@ -598,33 +633,31 @@ function createPageSpecificFilters($page_id)
         case 'index.php':
         case 'project.php':
         case 'indexchildren.php':
-        case 'compareCoverage.php': {
             return new IndexPhpFilters();
-        }
             break;
 
-        case 'queryTests.php': {
+        case 'queryTests.php':
             return new QueryTestsPhpFilters();
-        }
             break;
 
         case 'viewCoverage.php':
-        case 'getviewcoverage.php': {
+        case 'getviewcoverage.php':
             return new ViewCoveragePhpFilters();
-        }
             break;
 
-        case 'viewTest.php': {
+        case 'viewTest.php':
             return new ViewTestPhpFilters();
-        }
             break;
 
-        default: {
+        case 'compareCoverage.php':
+            return new CompareCoveragePhpFilters();
+            break;
+
+        default:
             trigger_error('unknown $page_id value: ' . $page_id .
                 ' Add a new subclass of DefaultFilters for ' . $page_id,
                 E_USER_WARNING);
             return new DefaultFilters();
-        }
             break;
     }
 }

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -472,6 +472,17 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $coverage_groups[$groupId]['position'] = $group->GetPosition();
             $coverage_groups[$groupId]['coverages'] = array();
         }
+        if (count($groups) > 1) {
+            // Add a Total group too.
+            $coverage_groups[0] = array();
+            $coverageThreshold = $project_array['coveragethreshold'];
+            $coverage_groups[0]['thresholdgreen'] = $coverageThreshold;
+            $coverage_groups[0]['thresholdyellow'] = $coverageThreshold * 0.7;
+            $coverage_groups[0]['label'] = 'Total';
+            $coverage_groups[0]['loctested'] = 0;
+            $coverage_groups[0]['locuntested'] = 0;
+            $coverage_groups[0]['position'] = 0;
+        }
     }
 
     // Fetch all the rows of builds into a php array.
@@ -1149,6 +1160,11 @@ function echo_main_dashboard_JSON($project_instance, $date)
                         $coverage_groups[$groupId]['thresholdgreen'];
                     $coverage_groups[$groupId]['loctested'] += $loctested;
                     $coverage_groups[$groupId]['locuntested'] += $locuntested;
+                    if (count($coverage_groups) > 1) {
+                        // Add to Total.
+                        $coverage_groups[0]['loctested'] += $loctested;
+                        $coverage_groups[0]['locuntested'] += $locuntested;
+                    }
                 }
             }
 

--- a/public/js/controllers/compareCoverage.js
+++ b/public/js/controllers/compareCoverage.js
@@ -5,6 +5,9 @@ CDash.controller('CompareCoverageController',
     // Hide filters by default.
     $scope.showfilters = false;
 
+    // Check for filters.
+    $rootScope.queryString['filterstring'] = filters.getString();
+
     $scope.sortCoverage = { orderByFields: [] };
 
     $http({
@@ -12,6 +15,10 @@ CDash.controller('CompareCoverageController',
       method: 'GET',
       params: $rootScope.queryString
     }).success(function(cdash) {
+      // Check if we should display filters.
+      if (cdash.filterdata && cdash.filterdata.showfilters == 1) {
+        $scope.showfilters = true;
+      }
 
       renderTimer.initialRender($scope, cdash);
 

--- a/public/views/compareCoverage.html
+++ b/public/views/compareCoverage.html
@@ -23,6 +23,15 @@
 
     <div id="compare_coverage_content" ng-if="!loading && cdash.requirelogin != 1 && !cdash.error">
 
+      <!-- Filters -->
+      <div id="labelshowfilters">
+        <a id="label_showfilters" ng-click="showfilters_toggle()">
+          <span ng-show="showfilters == 0">Show Filters</span>
+          <span ng-show="showfilters != 0">Hide Filters</span>
+        </a>
+      </div>
+      <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+
       <!-- Coverage -->
       <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
         <thead>

--- a/public/views/compareCoverage.html
+++ b/public/views/compareCoverage.html
@@ -58,7 +58,10 @@
           <tr class="parent_row">
             <td class="paddt" align="left">
               <b>{{group.label}}</b>
-              <div class="glyphicon"  ng-click="group.hidden = ! group.hidden" ng-class="{'glyphicon-chevron-down': !group.hidden, 'glyphicon-chevron-right': group.hidden}"></div>
+              <div class="glyphicon"
+                   ng-if="::group.label !== 'Total'"
+                   ng-click="group.hidden = ! group.hidden"
+                   ng-class="{'glyphicon-chevron-down': !group.hidden, 'glyphicon-chevron-right': group.hidden}"></div>
             </td>
 
             <td align="center" ng-repeat="build in cdash.builds" ng-class="{'normal': group[build.key] >= group.thresholdgreen, 'warning': group[build.key] < group.thresholdgreen && group[build.key] >= group.thresholdyellow, 'error': group[build.key] < group.thresholdyellow}">

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -365,7 +365,10 @@
           <tr class="parent_row">
             <td class="paddt" align="left">
               <b>{{::group.label}}</b>
-              <div class="glyphicon"  ng-click="group.hidden = ! group.hidden" ng-class="{'glyphicon-chevron-down': !group.hidden, 'glyphicon-chevron-right': group.hidden}"></div>
+              <div class="glyphicon"
+                   ng-if="::group.label !== 'Total'"
+                   ng-click="group.hidden = ! group.hidden"
+                   ng-class="{'glyphicon-chevron-down': !group.hidden, 'glyphicon-chevron-right': group.hidden}"></div>
             </td>
 
             <td align="center" ng-class="::{'normal': group.percentage >= group.thresholdgreen, 'warning': group.percentage < group.thresholdgreen && group.percentage >= group.thresholdyellow, 'error': group.percentage < group.thresholdyellow}">

--- a/tests/js/e2e_tests/subprojectGroupOrder.js
+++ b/tests/js/e2e_tests/subprojectGroupOrder.js
@@ -33,7 +33,7 @@ describe("subProjectGroupOrder", function() {
     browser.get('index.php?project=CrossSubProjectExample&date=2016-02-09');
     element(by.linkText('subproject_coverage_example')).click();
 
-    // Make sure that Production is the first group listed.
-    expect(element(by.repeater('group in ::cdash.coveragegroups').row(0)).getInnerHtml()).toContain("Production");
+    // Make sure that Production is the first group listed after Total.
+    expect(element(by.repeater('group in ::cdash.coveragegroups').row(1)).getInnerHtml()).toContain("Production");
   });
 });

--- a/tests/test_aggregatesubprojectcoverage.php
+++ b/tests/test_aggregatesubprojectcoverage.php
@@ -215,8 +215,8 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $num_groups = count($jsonobj['coveragegroups']);
-        if ($num_groups != 3) {
-            $this->fail("Expected 3 coverage groups, found $num_groups");
+        if ($num_groups != 4) {
+            $this->fail("Expected 4 coverage groups, found $num_groups");
             return false;
         }
         foreach ($jsonobj['coveragegroups'] as $coverage_group) {

--- a/tests/test_aggregatesubprojectcoverage.php
+++ b/tests/test_aggregatesubprojectcoverage.php
@@ -189,6 +189,107 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
         return $success;
     }
 
+    public function testCompareCoverage()
+    {
+        $answers = array(
+            'Total' => array(
+                'debug' => 68.97,
+                'release' => 51.35,
+                'aggregate' => 72.97),
+            'Third Party' => array(
+                'debug' => 100,
+                'release' => 53.85,
+                'aggregate' => 69.23),
+            'Experimental' => array(
+                'debug' => 62.5,
+                'release' => 50,
+                'aggregate' => 75),
+            'Production' => array(
+                'debug' => 62.5,
+                'release' => 50,
+                'aggregate' => 75));
+        $this->compareCoverageCheck('', $answers);
+    }
+
+    public function testCompareCoverageWithFilters()
+    {
+        $extra_url = '&filtercount=1&showfilters=1&field1=subproject&compare1=62&value1=MyReleaseOnlyFeature';
+        $answers = array(
+            'Total' => array(
+                'debug' => 68.97,
+                'release' => 51.72,
+                'aggregate' => 79.31),
+            'Third Party' => array(
+                'debug' => 100,
+                'release' => 60,
+                'aggregate' => 100),
+            'Experimental' => array(
+                'debug' => 62.5,
+                'release' => 50,
+                'aggregate' => 75),
+            'Production' => array(
+                'debug' => 62.5,
+                'release' => 50,
+                'aggregate' => 75));
+        $this->compareCoverageCheck($extra_url, $answers);
+    }
+
+    public function compareCoverageCheck($extra_url, $answers)
+    {
+        // Load test data from API.
+        $this->get($this->url . "/api/v1/compareCoverage.php?project=CrossSubProjectExample&date=2016-02-16$extra_url");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+
+        // Verify correct number of builds.
+        $num_builds = count($jsonobj['builds']);
+        if ($num_builds !== 3) {
+            $this->fail("Expected 3 builds, found $num_builds");
+        }
+
+        // Figure out how to distinguish between our coverage builds.
+        $builds = array();
+        foreach ($jsonobj['builds'] as $build) {
+            switch ($build['name']) {
+                case 'debug_coverage':
+                    $builds['debug'] = $build['key'];
+                    break;
+                case 'release_coverage':
+                    $builds['release'] = $build['key'];
+                    break;
+                case 'Aggregate Coverage':
+                    $builds['aggregate'] = $build['key'];
+                    break;
+                default:
+                    $this->fail('Unexpected build: ' . $build['name']);
+                    break;
+            }
+        }
+
+        // Verify number of groups.
+        $num_groups = count($jsonobj['coveragegroups']);
+        if ($num_groups !== 4) {
+            $this->fail("Expected 4 coveragegroups, found $num_groups");
+        }
+
+        // Verify coverage percentage numbers.
+        foreach ($jsonobj['coveragegroups'] as $group) {
+            $groupname = $group['label'];
+            if (!array_key_exists($groupname, $answers)) {
+                $this->fail("Unexpected group: $groupname");
+                continue;
+            }
+
+            foreach ($builds as $buildtype => $key) {
+                $expected = $answers[$groupname][$buildtype];
+                $found = $group[$key];
+                if ($expected !== $found) {
+                    $this->fail("Expected $expected but found $found for $buildtype $groupname");
+                }
+            }
+        }
+    }
+
     public function checkCoverage($coverage, $expected_loctested,
                                   $expected_locuntested, $expected_percentage,
                                   $name)

--- a/tests/test_crosssubprojectcoverage.php
+++ b/tests/test_crosssubprojectcoverage.php
@@ -154,13 +154,22 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $num_groups = count($jsonobj['coveragegroups']);
-        if ($num_groups != 3) {
-            $this->fail("Expected 3 coverage groups, found $num_groups");
+        if ($num_groups != 4) {
+            $this->fail("Expected 4 coverage groups, found $num_groups");
             return false;
         }
         foreach ($jsonobj['coveragegroups'] as $coverage_group) {
-            $coverage = array_pop($coverage_group['coverages']);
             $group_name = $coverage_group['label'];
+            if ($group_name === 'Total') {
+                if ($coverage_group['loctested'] !== 25) {
+                    $this->fail("Expected 25 total loctested");
+                }
+                if ($coverage_group['locuntested'] !== 10) {
+                    $this->fail("Expected 10 total locuntested");
+                }
+                continue;
+            }
+            $coverage = array_pop($coverage_group['coverages']);
             switch ($group_name) {
                 case 'Third Party':
                     $success &=


### PR DESCRIPTION
Make it easier for CDash users to view coverage results for the set of SubProjects that they care about.

1) Add a **Total** row to group-by-group coverage results on index.php and compareCoverage.php.
2) Add a **SubProject** filter to compareCoverage.php.