### PR TITLE
Use newer version of random_compat to avoid UUID collisions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "google/apiclient": "~1.1",
     "guzzlehttp/guzzle": "~6.0",
     "monolog/monolog": "~1.19",
-    "paragonie/random_compat": "~1.4",
+    "paragonie/random_compat": "2.0.4",
     "pear/archive_tar": "~1.4",
     "predis/predis": "~0.8",
     "ramsey/uuid": "~3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f27bb9654be639a3fef6ded320367634",
-    "content-hash": "6a16c82df57a5c346065a8bc5662932d",
+    "hash": "ed502a534794ac4a9b31d90bf586fd44",
+    "content-hash": "abf194b6760b4e6c0fa6427241be6339",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -465,16 +465,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.4.1",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
-                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
                 "shasum": ""
             },
             "require": {
@@ -509,7 +509,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-03-18 20:34:03"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "pear/archive_tar",


### PR DESCRIPTION
See https://github.com/ramsey/uuid/issues/80 for details.

@mgrauer @zackgalbreath 

Will leave this WIP until I verify it's fixed the issue.

This was responsible for the "Checksum failure on file.." issue, the submission process was creating multiple jobs (with different files/checksums) underneath the same submission uuid.