### PR TITLE
Fix builderror links from precontext and postcontext

### DIFF
--- a/public/views/partials/buildError.html
+++ b/public/views/partials/buildError.html
@@ -46,11 +46,11 @@
       <span class="nobr"> {{cdash.errortypename}} </span>
     </th>
     <td>
-      <pre ng-if="error.precontext" class="compiler-output">{{error.precontext}}</pre>
+      <pre ng-if="error.precontext" class="compiler-output" ng-bind-html="error.precontext"></pre>
       <b>
         <pre class="compiler-output" ng-bind-html="error.text"></pre>
       </b>
-      <pre ng-if="error.postcontext" class="compiler-output">{{error.postcontext}}</pre>
+      <pre ng-if="error.postcontext" class="compiler-output" ng-bind-html="error.postcontext"></pre>
     </td>
   </tr>
 


### PR DESCRIPTION
For references to source files in the pre and post context fields, show the user an actual link as opposed to the literal text `<a href='...>`