### PR TITLE
Cache busting for partials

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@
       del = require('del'),
       concat = require('gulp-concat'),
       eslint = require('gulp-eslint'),
+      fsPath = require('fs-path'),
       newer = require('gulp-newer'),
       replace = require('gulp-replace'),
       rename = require("gulp-rename"),
@@ -19,6 +20,12 @@
   } else {
       version = new Date().getTime();
   }
+
+
+  // Record timestamp for use by Angular.
+  gulp.task('record-version', function() {
+    fsPath.writeFileSync('public/build/js/version.js', "angular.module('CDash').constant('VERSION', '" + version + "');");
+  });
 
 
   gulp.task('quality', function() {
@@ -38,7 +45,7 @@
   });
 
 
- gulp.task('uglify-1stparty', function() {
+ gulp.task('uglify-1stparty', ['record-version'], function() {
    return gulp.src(['public/js/cdashmenu.js',
              'public/js/cdashIndexTable.js',
              'public/js/cdashSortable.js',
@@ -46,6 +53,7 @@
              'public/js/linechart.js',
              'public/js/bulletchart.js',
              'public/js/cdash_angular.js',
+             'public/build/js/version.js',
              'public/js/directives/**.js',
              'public/js/filters/**.js',
              'public/js/services/**.js',
@@ -132,5 +140,5 @@
   });
 
 
-  gulp.task('default', ['quality', 'uglify', 'clean', 'replace']);
+  gulp.task('default', ['clean', 'quality', 'uglify', 'replace']);
 }());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,9 +112,23 @@
         .pipe(replace('@@version', version))
         .pipe(gulp.dest('public/build/views/'));
 
+    gulp.src(['public/views/partials/*.html'])
+        .pipe(replace('@@version', version))
+        .pipe(rename(function (path) {
+          path.basename += "_" + version;
+        }))
+        .pipe(gulp.dest('public/build/views/partials/'));
+
     gulp.src(['public/local/views/*.html'])
         .pipe(replace('@@version', version))
         .pipe(gulp.dest('public/build/local/views/'));
+
+    gulp.src(['public/local/views/partials*.html'])
+        .pipe(replace('@@version', version))
+        .pipe(rename(function (path) {
+          path.basename += "_" + version;
+        }))
+        .pipe(gulp.dest('public/build/local/views/partials/'));
   });
 
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "angular-ui-bootstrap": "^2.0.0",
     "angular-ui-sortable": "^0.14.3",
     "as-jqplot": "^1.0.8",
+    "fs-path": "0.0.23",
     "ng-file-upload": "^12.0.4"
   },
   "devDependencies": {

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -587,8 +587,8 @@ CDash.filter("showEmptyBuildsLast", function () {
   };
 
 })
-.directive('build', function() {
+.directive('build', function(VERSION) {
   return {
-    templateUrl: 'views/partials/build.html'
+    templateUrl: 'build/views/partials/build_' + VERSION + '.html'
   }
 });

--- a/public/js/controllers/viewBuildError.js
+++ b/public/js/controllers/viewBuildError.js
@@ -55,8 +55,8 @@ CDash.controller('BuildErrorController',
     $scope.pageChanged = function() {
       $scope.setPage($scope.pagination.currentPage);
     };
-  }).directive('buildError', function () {
+  }).directive('buildError', function (VERSION) {
       return {
-          templateUrl: 'views/partials/buildError.html'
+          templateUrl: 'build/views/partials/buildError_' + VERSION + '.html'
       };
   });

--- a/public/js/directives/daterange.js
+++ b/public/js/directives/daterange.js
@@ -1,7 +1,7 @@
-CDash.directive('daterange', function () {
+CDash.directive('daterange', function (VERSION) {
   return {
     restrict: 'A',
-    templateUrl: 'views/partials/daterange.html',
+    templateUrl: 'build/views/partials/daterange_' + VERSION + '.html',
     link: function (scope, element, attrs, ngModelCtrl) {
       var format = "yy-mm-dd",
 

--- a/public/views/buildSummary.html
+++ b/public/views/buildSummary.html
@@ -13,7 +13,7 @@
 
   <body bgcolor="#ffffff" ng-controller="BuildSummaryController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
 
@@ -593,6 +593,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/compareCoverage.html
+++ b/public/views/compareCoverage.html
@@ -17,7 +17,7 @@
 
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <br/>
 
@@ -30,7 +30,7 @@
           <span ng-show="showfilters != 0">Hide Filters</span>
         </a>
       </div>
-      <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+      <ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
 
       <!-- Coverage -->
       <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
@@ -121,6 +121,6 @@
       </table>
 
       <!-- FOOTER -->
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/createProject.html
+++ b/public/views/createProject.html
@@ -17,7 +17,7 @@
   <body bgcolor="#ffffff" ng-controller="CreateProjectController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.projectcreated == 1">
@@ -1390,6 +1390,6 @@
       </form>
     </div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -17,7 +17,7 @@
 
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div id="index_content" ng-if="!loading && cdash.requirelogin != 1 && !cdash.error">
       <div id="index_top" ng-if="::cdash.updates">
@@ -96,7 +96,7 @@
         </div>
 
         <!-- Filters -->
-        <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+        <ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
       </div> <!-- End index-top -->
 
       <div ng-show="showFeed" id="feed" ng-include="::'ajax/getfeed.php?projectid='+ cdash.projectid"></div>
@@ -136,7 +136,7 @@
       </div>
 
       <!-- Display subproject dependencies -->
-      <ng-include ng-if="::cdash.subproject.dependencies.length > 0" ng-init="cdash.tableName = 'SubProject Dependencies'; cdash.subprojects = cdash.subproject.dependencies" src="'views/partials/subProjectTable.html'"></ng-include>
+      <ng-include ng-if="::cdash.subproject.dependencies.length > 0" ng-init="cdash.tableName = 'SubProject Dependencies'; cdash.subprojects = cdash.subproject.dependencies" src="'build/views/partials/subProjectTable_@@version.html'"></ng-include>
 
       <!-- BuildGroups -->
       <div ng-repeat="buildgroup in ::cdash.buildgroups | orderBy:'position'">
@@ -570,6 +570,6 @@
       </table>
     </div> <!-- end index content -->
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/manageBuildGroup.html
+++ b/public/views/manageBuildGroup.html
@@ -14,7 +14,7 @@
   </head>
   <body bgcolor="#ffffff" ng-controller="ManageBuildGroupController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div class="container" ng-if="cdash.requirelogin != 1 && !loading">
@@ -380,6 +380,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/manageOverview.html
+++ b/public/views/manageOverview.html
@@ -13,7 +13,7 @@
 
   <body bgcolor="#ffffff" ng-controller="ManageOverviewController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
     <div class="container" style="height:400px;">
       <div class="row">
@@ -107,6 +107,6 @@
     <br/>
     <br/>
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/manageSubProject.html
+++ b/public/views/manageSubProject.html
@@ -13,7 +13,7 @@
 
   <body bgcolor="#ffffff" ng-controller="ManageSubProjectController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div class="container" ng-if="!loading && cdash.requirelogin != 1">
@@ -231,6 +231,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/overview.html
+++ b/public/views/overview.html
@@ -16,7 +16,7 @@
 
   <body bgcolor="#ffffff" ng-controller="OverviewController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
       <table class="table-bordered table-responsive table-condensed container-fluid">
@@ -162,6 +162,6 @@
       </table> <!-- end of static analysis -->
     </div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/queryTests.html
+++ b/public/views/queryTests.html
@@ -16,7 +16,7 @@
 
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading">
@@ -29,7 +29,7 @@
     <span ng-show="showfilters != 0">Hide Filters</span>
   </a>
 </div>
-<ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+<ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
 
 <!-- Hide a div for javascript to know if time status is on -->
 <div ng-if="cdash.project.showtesttime == 1" id="showtesttimediv" style="display:none"></div>
@@ -151,6 +151,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/testDetails.html
+++ b/public/views/testDetails.html
@@ -13,7 +13,7 @@
 
   <body bgcolor="#ffffff" ng-controller="TestDetailsController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
 
@@ -152,6 +152,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/testOverview.html
+++ b/public/views/testOverview.html
@@ -14,7 +14,7 @@
 
   <body bgcolor="#ffffff" ng-controller="TestOverviewController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
@@ -26,7 +26,7 @@
             <span ng-show="showfilters != 0">Hide Filters</span>
           </a>
         </div>
-        <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+        <ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
 
         <div class="form-inline pull-right">
           <select class="form-group"
@@ -141,6 +141,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/testSummary.html
+++ b/public/views/testSummary.html
@@ -15,7 +15,7 @@
   <body bgcolor="#ffffff" ng-controller="TestSummaryController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading">
@@ -122,6 +122,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/userStatistics.html
+++ b/public/views/userStatistics.html
@@ -15,7 +15,7 @@
   <body bgcolor="#ffffff" ng-controller="UserStatisticsController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
@@ -148,6 +148,6 @@
       </table>
     </div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/viewBuildError.html
+++ b/public/views/viewBuildError.html
@@ -28,7 +28,7 @@
   <body bgcolor="#ffffff" ng-controller="BuildErrorController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
@@ -138,6 +138,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/viewNotes.html
+++ b/public/views/viewNotes.html
@@ -14,7 +14,7 @@
   <body bgcolor="#ffffff" ng-controller="ViewNotesController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div ng-if="cdash.requirelogin != 1 && !cdash.error">
       <br/>
@@ -67,6 +67,6 @@
     </div>
 
     <!-- FOOTER -->
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/viewProjects.html
+++ b/public/views/viewProjects.html
@@ -102,6 +102,6 @@
     </table>
 
     <!-- FOOTER -->
-    <ng-include src="'views/partials/footer.html'"></ng-include>
+    <ng-include src="'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/viewSubProjects.html
+++ b/public/views/viewSubProjects.html
@@ -13,7 +13,7 @@
 
   <body ng-controller="ViewSubProjectsController">
     <div ng-if="cdash.requirelogin == 1" ng-include="'login.php'"></div>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
 
     <div id="content" ng-if="!loading && cdash.requirelogin != 1">
       <table ng-show="cdash.banners.length > 0" border="0" width="100%">
@@ -130,7 +130,7 @@
 
 
       <!-- SubProjects table -->
-      <ng-include ng-init="cdash.tableName = 'SubProjects'" src="'views/partials/subProjectTable.html'"></ng-include>
+      <ng-include ng-init="cdash.tableName = 'SubProjects'" src="'build/views/partials/subProjectTable_@@version.html'"></ng-include>
 
       <table width="100%" cellspacing="0" cellpadding="0">
         <tr>
@@ -152,6 +152,6 @@
     <br/>
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>

--- a/public/views/viewTest.html
+++ b/public/views/viewTest.html
@@ -15,7 +15,7 @@
 
     <div ng-if="::cdash.requirelogin == 1" ng-include="'login.php'"></div>
 
-    <ng-include ng-if="::cdash.requirelogin != 1" src="::cdash.header || 'views/partials/header.html'"></ng-include>
+    <ng-include ng-if="::cdash.requirelogin != 1" src="::cdash.header || 'build/views/partials/header_@@version.html'"></ng-include>
     <br/>
 
     <div ng-if="cdash.requirelogin != 1 && !loading && !cdash.error">
@@ -113,7 +113,7 @@
           <span ng-show="showfilters != 0">Hide Filters</span>
         </a>
       </div>
-      <ng-include src="'views/partials/filterdataTemplate.html'"></ng-include>
+      <ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
 
       <div ng-switch="::cdash.display">
         <h3 ng-switch-when="onlypassed">{{::cdash.numPassed}} tests passed.</h3>
@@ -275,6 +275,6 @@
 
     <!-- FOOTER -->
     <br/>
-    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'views/partials/footer.html'"></ng-include>
+    <ng-include ng-if="cdash.requirelogin != 1" src="cdash.footer || 'build/views/partials/footer_@@version.html'"></ng-include>
   </body>
 </html>


### PR DESCRIPTION
A while back we implemented cache busting for CDash's javascript code.  The idea behind cache busting is that users shouldn't have to delete their cache when we make changes to the site.

One part of CDash that's still being cached is our "partials": chunks of HTML code that can be shared among views.  This PR implements cache busting for these partials.