### PR TITLE
Set default timezone to UTC

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,9 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 $CDASH_ROOT_DIR = str_replace('\\', '/', dirname(dirname(__FILE__)));
 set_include_path(get_include_path() . PATH_SEPARATOR . $CDASH_ROOT_DIR);
 
+// Default timezone for PHP.
+date_default_timezone_set('UTC');
+
 // Hostname of the database server or name of unix socket
 $CDASH_DB_HOST = 'localhost';
 // Login for database access


### PR DESCRIPTION
PHP now throws a warning if you do not set a default timezone.