### PR TITLE
Fix createProject.php permissions bug

### DIFF
--- a/public/api/v1/createProject.php
+++ b/public/api/v1/createProject.php
@@ -73,16 +73,20 @@ $User = new User;
 $User->Id = $userid;
 $role = $Project->GetUserRole($userid);
 
-// If we are editing a project make sure we have the right to do so
-if (!is_null($projectid)
-    && !(isset($_SESSION['cdash']['user_can_create_project']) &&
-        $_SESSION['cdash']['user_can_create_project'] == 1)
-    && !$User->IsAdmin()
-) {
-    $response['error'] = 'You do not have permission to access this page.';
-    echo json_encode($response);
-    return;
-} elseif (!is_null($projectid) && (!$User->IsAdmin() && $role <= 1)) {
+// Check if the user has permission to create/edit the project.
+$userHasAccess = false;
+if ($edit) {
+    if ($User->IsAdmin() || $role > 1) {
+        $userHasAccess = true;
+    }
+} else {
+    if ($User->IsAdmin() ||
+        (isset($_SESSION['cdash']['user_can_create_project']) &&
+         $_SESSION['cdash']['user_can_create_project'] == 1)) {
+        $userHasAccess = true;
+    }
+}
+if (!$userHasAccess) {
     $response['error'] = 'You do not have permission to access this page.';
     echo json_encode($response);
     return;

--- a/public/api/v1/createProject.php
+++ b/public/api/v1/createProject.php
@@ -44,22 +44,12 @@ if (!isset($userid) || !is_numeric($userid)) {
     return;
 }
 
-$edit = isset($_GET['edit']) && !empty($_GET['edit']);
-
 $projectid = null;
 if (isset($_GET['projectid']) && !empty($_GET['projectid'])) {
     $projectid = pdo_real_escape_numeric($_GET['projectid']);
 }
 
 $Project = new Project;
-
-// If the projectid is not set and there is only one project we go directly to the page
-if ($edit && is_null($projectid)) {
-    $projectids = $Project->GetIds();
-    if (count($projectids) == 1) {
-        $projectid = $projectids[0];
-    }
-}
 
 // If the projectid is set, make sure that it's valid
 $Project->Id = $projectid;
@@ -73,13 +63,15 @@ $User = new User;
 $User->Id = $userid;
 $role = $Project->GetUserRole($userid);
 
-// Check if the user has permission to create/edit the project.
+// Check if the user has the necessary permissions.
 $userHasAccess = false;
-if ($edit) {
+if (!is_null($projectid)) {
+    // Can they edit this project?
     if ($User->IsAdmin() || $role > 1) {
         $userHasAccess = true;
     }
 } else {
+    // Can they create a new project?
     if ($User->IsAdmin() ||
         (isset($_SESSION['cdash']['user_can_create_project']) &&
          $_SESSION['cdash']['user_can_create_project'] == 1)) {
@@ -105,7 +97,7 @@ $response['manageclient'] =  $CDASH_MANAGE_CLIENTS;
 $nRepositories = 0;
 $repositories_response = array();
 
-if ($edit || !is_null($projectid)) {
+if (!is_null($projectid)) {
     $response['title'] = 'CDash - Edit Project';
     $response['edit'] = 1;
 } else {

--- a/public/api/v1/createProject.php
+++ b/public/api/v1/createProject.php
@@ -44,19 +44,18 @@ if (!isset($userid) || !is_numeric($userid)) {
     return;
 }
 
-$projectid = null;
-if (isset($_GET['projectid']) && !empty($_GET['projectid'])) {
-    $projectid = pdo_real_escape_numeric($_GET['projectid']);
-}
-
 $Project = new Project;
+$projectid = null;
+if (isset($_GET['projectid'])) {
+    $projectid = pdo_real_escape_numeric($_GET['projectid']);
 
-// If the projectid is set, make sure that it's valid
-$Project->Id = $projectid;
-if (!is_null($projectid) && $projectid > 0 && !$Project->Exists()) {
-    $response['error'] = 'This project does not exist.';
-    echo json_encode($response);
-    return;
+    // Make sure projectid is valid if one was specified.
+    $Project->Id = $projectid;
+    if (!$Project->Exists()) {
+        $response['error'] = 'This project does not exist.';
+        echo json_encode($response);
+        return;
+    }
 }
 
 $User = new User;

--- a/public/header.xsl
+++ b/public/header.xsl
@@ -178,7 +178,7 @@
         <xsl:if test="cdash/user/admin=1">
         <li id="admin">
         <a href="#">Settings</a><ul>
-        <li><a><xsl:attribute name="href">createProject.php?edit=1&#x26;projectid=<xsl:value-of select="cdash/dashboard/projectid"/></xsl:attribute>Project</a></li>
+        <li><a><xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="cdash/dashboard/projectid"/></xsl:attribute>Project</a></li>
         <li><a><xsl:attribute name="href">manageProjectRoles.php?projectid=<xsl:value-of select="cdash/dashboard/projectid"/></xsl:attribute>Users</a></li>
         <li><a><xsl:attribute name="href">manageBuildGroup.php?projectid=<xsl:value-of select="cdash/dashboard/projectid"/></xsl:attribute>Groups</a></li>
         <li><a><xsl:attribute name="href">manageCoverage.php?projectid=<xsl:value-of select="cdash/dashboard/projectid"/></xsl:attribute>Coverage</a></li>

--- a/public/headeradminproject.xsl
+++ b/public/headeradminproject.xsl
@@ -51,7 +51,7 @@
         <ul id="navigation">
         <li id="admin">
         <a href="#">Settings</a><ul>
-        <li><a><xsl:attribute name="href">createProject.php?edit=1&#x26;projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>Project</a></li>
+        <li><a><xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>Project</a></li>
         <li><a><xsl:attribute name="href">manageProjectRoles.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>Users</a></li>
         <li><a><xsl:attribute name="href">manageBuildGroup.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>Groups</a></li>
         <li><a><xsl:attribute name="href">manageCoverage.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>Coverage</a></li>

--- a/public/manageClient.xsl
+++ b/public/manageClient.xsl
@@ -42,7 +42,7 @@
 <xsl:if test="count(cdash/project/repository)=0">
   You should set the <a>
   <xsl:attribute name="href">
-    createProject.php?edit=1&#38;projectid=<xsl:value-of select="cdash/project/id" />#fragment-3
+    createProject.php?projectid=<xsl:value-of select="cdash/project/id" />##tab3
   </xsl:attribute>
   project repository</a> before starting.<br/>
 </xsl:if>

--- a/public/subscribeProject.xsl
+++ b/public/subscribeProject.xsl
@@ -204,7 +204,7 @@
             <td><font color="#900000">*This project has not been configured to send emails.
              <xsl:choose>
                <xsl:when test="/cdash/role>1"><a>
-               <xsl:attribute name="href">createProject.php?edit=1&#38;projectid=<xsl:value-of select="/cdash/project/id"/>#fragment-5</xsl:attribute>Change the project settings.
+               <xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="/cdash/project/id"/>##tab5</xsl:attribute>Change the project settings.
                </a></xsl:when>
                <xsl:otherwise> Contact the project administrator.</xsl:otherwise>
              </xsl:choose>
@@ -280,7 +280,7 @@
             <td><font color="#900000">*This project has not been configured to send emails.
              <xsl:choose>
                <xsl:when test="/cdash/role>1"><a>
-               <xsl:attribute name="href">createProject.php?edit=1&#38;projectid=<xsl:value-of select="/cdash/project/id"/>#fragment-5</xsl:attribute>Change the project settings.
+               <xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="/cdash/project/id"/>##tab5</xsl:attribute>Change the project settings.
                </a></xsl:when>
                <xsl:otherwise> Contact the project administrator.</xsl:otherwise>
              </xsl:choose>
@@ -351,7 +351,7 @@
             <td colspan="2"><font color="#900000">*This project has not been configured to send emails.
              <xsl:choose>
                <xsl:when test="/cdash/role>1"><a>
-               <xsl:attribute name="href">createProject.php?edit=1&#38;projectid=<xsl:value-of select="/cdash/project/id"/>#fragment-5</xsl:attribute>Change the project settings.
+               <xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="/cdash/project/id"/>##tab5</xsl:attribute>Change the project settings.
                </a></xsl:when>
                <xsl:otherwise> Contact the project administrator.</xsl:otherwise>
              </xsl:choose>

--- a/public/user.xsl
+++ b/public/user.xsl
@@ -110,7 +110,7 @@
             <img src="img/manageclient.png" border="0" alt="manageclient" /></a>
           </xsl:if>
           <a class="tooltip" title="Edit project" >
-          <xsl:attribute name="href">createProject.php?edit=1&amp;projectid=<xsl:value-of select="id"/></xsl:attribute>
+          <xsl:attribute name="href">createProject.php?projectid=<xsl:value-of select="id"/></xsl:attribute>
           <img  src="img/edit2.png" border="0" alt="editproject" /></a>
           <a class="tooltip" title="Manage subprojects" >
           <xsl:attribute name="href">manageSubProject.php?projectid=<xsl:value-of select="id"/></xsl:attribute>
@@ -323,7 +323,6 @@
 <tbody>
     <tr class="table-heading1"><td id="nob"><h3>Administration</h3></td></tr>
     <tr class="trodd"><td id="nob"><a href="createProject.php">Create new project</a></td></tr>
-    <tr class="treven"><td id="nob"><a href="createProject.php?edit=1">Edit project</a></td></tr>
     <tr class="trodd"><td id="nob"><a href="manageProjectRoles.php">Manage project roles</a></td></tr>
     <tr class="treven"><td id="nob"><a href="manageSubProject.php">Manage subproject</a></td></tr>
     <tr class="trodd"><td id="nob"><a href="manageBuildGroup.php">Manage project groups</a></td></tr>

--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -133,7 +133,7 @@
           <a href="#">Settings</a>
           <ul>
             <li>
-              <a href="createProject.php?edit=1&projectid={{cdash.projectid}}">
+              <a href="createProject.php?projectid={{cdash.projectid}}">
                 Project
               </a>
             </li>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ add_php_test(truncateoutput)
 add_php_test(csvexport)
 add_php_test(uniquediffs)
 add_php_test(imagecomparison)
+add_php_test(createprojectpermissions)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/test_createprojectpermissions.php
+++ b/tests/test_createprojectpermissions.php
@@ -1,0 +1,74 @@
+<?php
+//
+// After including cdash_test_case.php, subsequent require_once calls are
+// relative to the top of the CDash source tree
+//
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+require_once 'include/pdo.php';
+
+class CreateProjectPermissionsTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->BuildId = null;
+    }
+
+    public function testCreateProjectPermissions()
+    {
+        // Tests for global administrator.
+        $this->login();
+
+        // Can create project.
+        $response = $this->get($this->url . '/api/v1/createProject.php');
+        $response = json_decode($response);
+        $this->assertFalse(property_exists($response, 'error'));
+
+        // Can edit project.
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=5');
+        $response = json_decode($response);
+        $this->assertFalse(property_exists($response, 'error'));
+
+        // Tests for normal user.
+        $this->logout();
+        $this->login('user1@kw', 'user1');
+
+        // Cannot create project.
+        $response = $this->get($this->url . '/api/v1/createProject.php');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'error'));
+
+        // Cannot edit project.
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=5');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'error'));
+
+        // Test for project administrator.
+        $pdo = get_link_identifier()->getPdo();
+        $user_table = qid('user');
+        $stmt = $pdo->prepare("SELECT id FROM $user_table WHERE email=?");
+        $stmt->execute(['user1@kw']);
+        $row = $stmt->fetch();
+        $userid = $row['id'];
+        $pdo->exec("DELETE FROM user2project WHERE userid=$userid");
+        $pdo->exec("INSERT INTO user2project (userid, projectid, role) VALUES ($userid, 5, 2)");
+
+        // Cannot create project.
+        $response = $this->get($this->url . '/api/v1/createProject.php');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'error'));
+
+        // Can edit your own project.
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=5');
+        $response = json_decode($response);
+        $this->assertFalse(property_exists($response, 'error'));
+
+        // Cannot edit other projects.
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=4');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'error'));
+
+        $pdo->exec("DELETE FROM user2project WHERE userid=$userid");
+    }
+}

--- a/tests/test_createprojectpermissions.php
+++ b/tests/test_createprojectpermissions.php
@@ -30,6 +30,11 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
         $response = json_decode($response);
         $this->assertFalse(property_exists($response, 'error'));
 
+        // Emits an error for invalid projectid.
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=0');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'error'));
+
         // Tests for normal user.
         $this->logout();
         $this->login('user1@kw', 'user1');


### PR DESCRIPTION
Project administrators were not allowed to edit their project.  This PR fixes this bug and adds a new test of permissions on `createProject.php`.

This PR also removes the `edit` parameter from createProject.php.  We can tell whether we're creating a new project or editing an existing one based on the presence of the `projectid` parameter.