### PR TITLE
Fix build starttime bug for upload handler

### DIFF
--- a/include/ctestparserutils.php
+++ b/include/ctestparserutils.php
@@ -56,7 +56,7 @@ function extract_type_from_buildstamp($buildstamp)
 /** Extract the date from the build stamp */
 function extract_date_from_buildstamp($buildstamp)
 {
-    return substr($buildstamp, 0, strrpos($buildstamp, '-'));
+    return substr($buildstamp, 0, strpos($buildstamp, '-', strpos($buildstamp, '-') + 1));
 }
 
 /** Return timestamp from string


### PR DESCRIPTION
The function extract_date_from_buildstamp() did not properly handle the case
where the build's group name contained a '-'.  This caused the build to appear
as if it started at the beginning of the UNIX epoch (1980).