### PR TITLE
Force an exit on critical PDO errors

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -44,6 +44,9 @@ $CDASH_DB_TYPE = 'mysql';
 // Must be one of host, unix_socket
 $CDASH_DB_CONNECTION_TYPE = 'host';
 
+// PDO error codes which should result in an internal server error
+$CDASH_CRITICAL_PDO_ERRORS = array();
+
 // Support for SSL database connections.
 $CDASH_SSL_KEY = null;
 $CDASH_SSL_CERT = null;

--- a/include/pdocore.php
+++ b/include/pdocore.php
@@ -84,11 +84,15 @@ function pdo_select_db($database, $link_identifier = null)
  */
 function pdo_error($link_identifier = null, $log_error = true)
 {
-    global $CDASH_PRODUCTION_MODE;
+    global $CDASH_PRODUCTION_MODE, $CDASH_CRITICAL_PDO_ERRORS;
     $error_info = get_link_identifier($link_identifier)->getPdo()->errorInfo();
     if (isset($error_info[2]) && $error_info[0] !== '00000') {
         if ($log_error) {
             add_log($error_info[2], 'pdo_error', LOG_ERR);
+        }
+        if (in_array($error_info[1], $CDASH_CRITICAL_PDO_ERRORS)) {
+            http_response_code(500);
+            exit();
         }
         if ($CDASH_PRODUCTION_MODE) {
             return 'SQL error encountered, query hidden.';


### PR DESCRIPTION
Placing the block in `pdo_error` doesn't cover all cases (I don't think), but at least this is a step in the right direction.

The logic for this is to deal with environments (namely GAE) where a request needs to return a non 2xx exit status to be considered a failure. This also deals with shortcomings of CDash where certain functions succeed when database queries fail.