### PR TITLE
Allow tar extraction errors to be logged

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -2164,6 +2164,20 @@ function create_aggregate_build($build, $siteid=null)
     return $aggregate_build;
 }
 
+function extract_tar_archive_tar($filename, $dirName)
+{
+    try {
+        $tar = new Archive_Tar($filename);
+        $tar->setErrorHandling(PEAR_ERROR_CALLBACK, function ($pear_error) {
+            throw new PEAR_Exception($pear_error->getMessage());
+        });
+        return $tar->extract($dirName);
+    } catch (PEAR_Exception $e) {
+        add_log($e->getMessage(), 'extract_tar', LOG_ERR);
+        return false;
+    }
+}
+
 function extract_tar($filename, $dirName)
 {
     if (class_exists('PharData')) {
@@ -2175,9 +2189,7 @@ function extract_tar($filename, $dirName)
         }
 
         return true;
+    } else {
+        return extract_tar_archive_tar($filename, $dirName);
     }
-
-    $tar = new Archive_Tar($filename);
-    $tar->setErrorHandling(PEAR_ERROR_PRINT);
-    return $tar->extract($dirName);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ add_php_test(uniquediffs)
 add_php_test(imagecomparison)
 add_php_test(createprojectpermissions)
 add_php_test(testgraphpermissions)
+add_php_test(extracttar)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/test_extracttar.php
+++ b/tests/test_extracttar.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+
+class ExtractTarTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testExtractTarArchiveTarWithInvalidFile()
+    {
+        $result = extract_tar_archive_tar(dirname(__FILE__) . '/../config/config.php', 'foo');
+
+        $this->assertFalse($result);
+        $this->assertTrue(is_readable($this->logfilename));
+
+        $logfileContents = file_get_contents($this->logfilename);
+
+        $this->assertTrue($this->findString($logfileContents, 'ERROR'));
+        $this->assertTrue($this->findString($logfileContents, 'extract_tar'));
+    }
+}


### PR DESCRIPTION
Before the errors from extract_tar using Archive_Tar were just being output via print, now we can catch them and log them to the CDash logging system.