### PR TITLE
Speedup project models

### DIFF
--- a/models/project.php
+++ b/models/project.php
@@ -762,7 +762,9 @@ class Project
             return false;
         }
 
-        $project = pdo_query('SELECT count(*) FROM build WHERE projectid=' . qnum($this->Id));
+        $project = pdo_query(
+            'SELECT count(*) FROM build
+            WHERE parentid IN (-1, 0) AND projectid=' . qnum($this->Id));
 
         if (!$project) {
             add_last_sql_error('Project GetTotalNumberOfBuilds', $this->Id);
@@ -780,9 +782,11 @@ class Project
             return false;
         }
 
-        $project = pdo_query('SELECT count(build.id) FROM build WHERE projectid=' . qnum($this->Id) .
-            " AND build.starttime>'$startUTCdate'
-                           AND build.starttime<='$endUTCdate'");
+        $project = pdo_query(
+            'SELECT count(build.id) FROM build WHERE projectid=' . qnum($this->Id) . "
+            AND build.starttime>'$startUTCdate'
+            AND build.starttime<='$endUTCdate'
+            AND parentid IN (-1, 0)");
 
         if (!$project) {
             add_last_sql_error('Project GetNumberOfBuilds', $this->Id);
@@ -800,11 +804,13 @@ class Project
             return false;
         }
         $nbuilds = $this->GetNumberOfBuilds($startUTCdate, $endUTCdate);
-        $project = pdo_query('SELECT starttime FROM build WHERE projectid=' . qnum($this->Id) .
-            " AND build.starttime>'$startUTCdate'
-                             AND build.starttime<='$endUTCdate'
-                             ORDER BY starttime ASC
-                             LIMIT 1");
+        $project = pdo_query(
+            'SELECT starttime FROM build
+            WHERE projectid=' . qnum($this->Id) . "
+            AND starttime>'$startUTCdate'
+            AND starttime<='$endUTCdate'
+            AND parentid IN (-1, 0)
+            ORDER BY starttime ASC LIMIT 1");
         $first_build = pdo_fetch_array($project);
         $first_build = $first_build['starttime'];
         $nb_days = strtotime($endUTCdate) - strtotime($first_build);
@@ -833,6 +839,8 @@ class Project
               AND build.buildwarnings>0";
         if ($childrenOnly) {
             $query .= ' AND build.parentid > 0';
+        } else {
+            $query .= ' AND build.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -865,6 +873,8 @@ class Project
        AND build.builderrors>0";
         if ($childrenOnly) {
             $query .= ' AND build.parentid > 0';
+        } else {
+            $query .= ' AND build.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -886,16 +896,20 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,build2group,buildgroup
-              WHERE build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND build.builderrors=0
-              AND build.buildwarnings=0";
+        $query =
+            'SELECT count(*) FROM build b
+            JOIN build2group b2g ON (b2g.buildid=b.id)
+            JOIN buildgroup bg ON (bg.id=b2g.groupid)
+            WHERE b.projectid=' . qnum($this->Id) . "
+            AND b.starttime>'$startUTCdate'
+            AND b.starttime<='$endUTCdate'
+            AND bg.includesubprojectotal=1
+            AND b.builderrors=0
+            AND b.buildwarnings=0";
         if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
+            $query .= ' AND b.parentid > 0';
+        } else {
+            $query .= ' AND b.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -916,15 +930,19 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,configure,build2group,buildgroup
-              WHERE  configure.buildid=build.id  AND build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND  configure.warnings>0";
+        $query =
+            'SELECT COUNT(*) FROM build b
+            JOIN build2group b2g ON (b2g.buildid = b.id)
+            JOIN buildgroup bg ON (bg.id = b2g.groupid)
+            WHERE b.projectid = ' . qnum($this->Id) . "
+            AND b.starttime > '$startUTCdate'
+            AND b.starttime <= '$endUTCdate'
+            AND b.configurewarnings > 0
+            AND bg.includesubprojectotal = 1";
         if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
+            $query .= ' AND b.parentid > 0';
+        } else {
+            $query .= ' AND b.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -945,15 +963,19 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM build,configure,buildgroup,build2group
-              WHERE  configure.buildid=build.id  AND build.projectid=' . qnum($this->Id) . "
-              AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate'
-              AND configure.status='1'
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1";
+        $query =
+            'SELECT COUNT(*) FROM build b
+            JOIN build2group b2g ON (b2g.buildid = b.id)
+            JOIN buildgroup bg ON (bg.id = b2g.groupid)
+            WHERE b.projectid = ' . qnum($this->Id) . "
+            AND b.starttime > '$startUTCdate'
+            AND b.starttime <= '$endUTCdate'
+            AND b.configureerrors > 0
+            AND bg.includesubprojectotal = 1";
         if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
+            $query .= ' AND b.parentid > 0';
+        } else {
+            $query .= ' AND b.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -974,13 +996,20 @@ class Project
             return false;
         }
 
-        $query = 'SELECT count(*) FROM configure,build,build2group,buildgroup WHERE build.projectid=' . qnum($this->Id) . "
-              AND build2group.buildid=build.id AND build2group.groupid=buildgroup.id
-              AND buildgroup.includesubprojectotal=1
-              AND configure.buildid=build.id AND build.starttime>'$startUTCdate'
-              AND build.starttime<='$endUTCdate' AND configure.status='0'";
+        $query =
+            'SELECT COUNT(*) FROM build b
+            JOIN build2group b2g ON (b2g.buildid = b.id)
+            JOIN buildgroup bg ON (bg.id = b2g.groupid)
+            WHERE b.projectid = ' . qnum($this->Id) . "
+            AND b.starttime > '$startUTCdate'
+            AND b.starttime <= '$endUTCdate'
+            AND b.configureerrors = 0
+            AND b.configurewarnings = 0
+            AND bg.includesubprojectotal = 1";
         if ($childrenOnly) {
-            $query .= ' AND build.parentid > 0';
+            $query .= ' AND b.parentid > 0';
+        } else {
+            $query .= ' AND b.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -1010,6 +1039,8 @@ class Project
               AND build.starttime<='$endUTCdate'";
         if ($childrenOnly) {
             $query .= ' AND build.parentid > 0';
+        } else {
+            $query .= ' AND build.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -1039,6 +1070,8 @@ class Project
               AND build.starttime<='$endUTCdate'";
         if ($childrenOnly) {
             $query .= ' AND build.parentid > 0';
+        } else {
+            $query .= ' AND build.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);
@@ -1068,6 +1101,8 @@ class Project
               AND build.starttime<='$endUTCdate'";
         if ($childrenOnly) {
             $query .= ' AND build.parentid > 0';
+        } else {
+            $query .= ' AND build.parentid IN (-1, 0)';
         }
 
         $project = pdo_query($query);

--- a/public/api/v1/viewSubProjects.php
+++ b/public/api/v1/viewSubProjects.php
@@ -132,23 +132,23 @@ function echo_subprojects_dashboard_JSON($project_instance, $date)
     // Get some information about the project
     $project_response = array();
     $project_response['nbuilderror'] =
-        $Project->GetNumberOfErrorBuilds($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfErrorBuilds($beginning_UTCDate, $end_UTCDate);
     $project_response['nbuildwarning'] =
-        $Project->GetNumberOfWarningBuilds($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfWarningBuilds($beginning_UTCDate, $end_UTCDate);
     $project_response['nbuildpass'] =
-        $Project->GetNumberOfPassingBuilds($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfPassingBuilds($beginning_UTCDate, $end_UTCDate);
     $project_response['nconfigureerror'] =
-        $Project->GetNumberOfErrorConfigures($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfErrorConfigures($beginning_UTCDate, $end_UTCDate);
     $project_response['nconfigurewarning'] =
-        $Project->GetNumberOfWarningConfigures($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfWarningConfigures($beginning_UTCDate, $end_UTCDate);
     $project_response['nconfigurepass'] =
-        $Project->GetNumberOfPassingConfigures($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfPassingConfigures($beginning_UTCDate, $end_UTCDate);
     $project_response['ntestpass'] =
-        $Project->GetNumberOfPassingTests($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfPassingTests($beginning_UTCDate, $end_UTCDate);
     $project_response['ntestfail'] =
-        $Project->GetNumberOfFailingTests($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfFailingTests($beginning_UTCDate, $end_UTCDate);
     $project_response['ntestnotrun'] =
-        $Project->GetNumberOfNotRunTests($beginning_UTCDate, $end_UTCDate, true);
+        $Project->GetNumberOfNotRunTests($beginning_UTCDate, $end_UTCDate);
     if (strlen($Project->GetLastSubmission()) == 0) {
         $project_response['lastsubmission'] = 'NA';
     } else {
@@ -166,6 +166,7 @@ function echo_subprojects_dashboard_JSON($project_instance, $date)
         $subprojProp[$subprojectid] = array('name' => $SubProject->GetName());
     }
     $testSubProj = new SubProject();
+    $testSubProj->SetProjectId($projectid);
     $result = $testSubProj->GetNumberOfErrorBuilds($beginning_UTCDate, $end_UTCDate, true);
     if ($result) {
         foreach ($result as $row) {


### PR DESCRIPTION
Improve the queries used to tally the total number of builds with errors,
warnings, etc. in the project and subproject models.  This improves the
rendering speed of user.php and viewSubProjects.php for projects that
contain subprojects.

* In the project model, when counting builds, only consider parent or standalone
  builds (not children).
* Encapsulate common query structure in subproject model.
* Remove unnecessary echoes from subproject model.
* On viewSubProjects.php, the "Project" section now shows the number of parent
  builds with errors/warnings/etc.