### PR TITLE
Remove the Move Builds tab from manageBuildGroup

### DIFF
--- a/public/views/manageBuildGroup.html
+++ b/public/views/manageBuildGroup.html
@@ -50,11 +50,6 @@
             </a>
           </li>
           <li role="presentation">
-            <a href="#move" aria-controls="move" role="tab" data-toggle="tab">
-              <strong>Move Builds</strong>
-            </a>
-          </li>
-          <li role="presentation">
             <a href="#wildcard" aria-controls="wildcard" role="tab" data-toggle="tab">
               <strong>Wildcard BuildGroups</strong>
             </a>
@@ -219,54 +214,6 @@
               </div>
             </div>
           </div> <!-- create new BuildGroup -->
-
-          <div role="tabpanel" class="tab-pane" id="move">
-            <div class="form-horizontal">
-
-              <div class="form-group">
-                <label for="globalMoveSelectionType"> Show:</label>
-                <select name="globalMoveSelectionType" ng-model="filteredBuildGroup" ng-options="buildgroup as buildgroup.name for buildgroup in cdash.buildgroups | orderBy:'name'" class="form-control">
-                  <option value="">All</option>
-                </select>
-                <p class="help-block">
-                  expected builds and those submitted in the past 7 days
-                </p>
-              </div>
-
-              <div class="form-group">
-                <select name="movebuilds[]" size="15" multiple="multiple" id="movebuilds" ng-model="movebuilds" ng-options="build as build.name for build in cdash.currentbuilds | orderBy:'name' | filter_builds:filteredBuildGroup" class="repeat-item form-control">
-                </select>
-              </div>
-
-              <div class="form-group">
-                <label for="destBuildGroupSelection"> Move to BuildGroup: </label>
-                <select name="destBuildGroupSelection" ng-model="destBuildGroupSelection" ng-options="buildgroup as buildgroup.name for buildgroup in cdash.buildgroups | orderBy:'name'" class="form-control">
-                  <option value="">Choose...</option>
-                </select>
-                <p class="help-block">
-                  (select a group even if you want only expected)
-                </p>
-              </div>
-
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input type="checkbox"
-                      ng-model="expected"
-                      name="expectedMove"
-                      ng-true-value="1"
-                      ng-false-value="0"/>
-                    Expected
-                  </label>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <button type="submit" class="btn btn-default" ng-click="moveBuilds(movebuilds, destBuildGroupSelection, expected)">Move selected build(s) to group</button>
-                <img id="builds_moved" src="img/check.gif" style="display: none; height:16px; width=16px; margin-top:9px;" />
-              </div>
-            </div>
-          </div> <!-- global move -->
 
           <div role="tabpanel" class="tab-pane" id="wildcard">
             <div class="form-horizontal">

--- a/tests/js/e2e_tests/manageBuildGroup.js
+++ b/tests/js/e2e_tests/manageBuildGroup.js
@@ -63,22 +63,6 @@ describe("manageBuildGroup", function() {
   });
 
 
-  it("can assign a build to a group", function() {
-    browser.get('manageBuildGroup.php?projectid=5#/move');
-
-    // Select a build & a destination group, and then click the move button.
-    element(by.name('movebuilds[]')).element(by.cssContainingText('option', 'simple')).click();
-    element(by.name('destBuildGroupSelection')).element(by.cssContainingText('option', 'aaaNewBuildGroup')).click();
-    element(by.buttonText('Move selected build(s) to group')).click();
-    browser.waitForAngular();
-
-    // Make sure that our moved build appears in the correct group when
-    // we reload the page.
-    browser.get('manageBuildGroup.php?projectid=5#/move');
-    expect(element(by.name('movebuilds[]')).element(by.cssContainingText('option', 'simple')).getText()).toEqual("CDashTestingSite CDash-CTest-simple [Experimental] aaaNewBuildGroup");
-  });
-
-
   it("can create a wildcard rule", function() {
     // Fill out the wildcard rule form & submit it.
     browser.get('manageBuildGroup.php?projectid=5#/wildcard');
@@ -119,10 +103,10 @@ describe("manageBuildGroup", function() {
     // Fill out the form & submit it.
     browser.get('manageBuildGroup.php?projectid=5#/dynamic');
     element(by.name('dynamicSelection')).element(by.cssContainingText('option', 'latestBuildGroup')).click();
-    element(by.name('parentBuildGroupSelection')).element(by.cssContainingText('option', 'aaaNewBuildGroup')).click();
+    element(by.name('parentBuildGroupSelection')).element(by.cssContainingText('option', 'Experimental')).click();
     var matchField = element(by.name('dynamicBuildNameMatch'));
     matchField.clear();
-    matchField.sendKeys('simple');
+    matchField.sendKeys('sameImage');
     element(by.buttonText('Add content to BuildGroup')).click();
     browser.waitForAngular();
   });


### PR DESCRIPTION
The queries required to render this tab take too long to complete.
Admins should now use index.php to move builds instead.