### PR TITLE
Consider the revision filter as a date clause

### DIFF
--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -996,14 +996,11 @@ function get_filterdata_from_request($page_id = '')
 
         $sql_field = $pageSpecificFilters->getSqlField($field);
 
-        if ($field == 'buildstarttime') {
-            $filterdata['hasdateclause'] = 1;
-        }
-
-        // Treat the buildstamp field as if it were a date clause so that the
+        // The following filter types are considered 'date clauses' so that the
         // default date clause of "builds from today only" is not used...
         //
-        if ($field == 'buildstamp') {
+        if ($field == 'buildstarttime' || $field == 'buildstamp' ||
+            $field == 'revision') {
             $filterdata['hasdateclause'] = 1;
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,7 @@ add_php_test(createprojectpermissions)
 add_php_test(testgraphpermissions)
 add_php_test(extracttar)
 add_php_test(pdoexecutelogserrors)
+add_php_test(revisionfilteracrossdates)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/test_revisionfilteracrossdates.php
+++ b/tests/test_revisionfilteracrossdates.php
@@ -1,0 +1,30 @@
+<?php
+//
+// After including cdash_test_case.php, subsequent require_once calls are
+// relative to the top of the CDash source tree
+//
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+class RevisionFilterIgnoresDateTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testRevisionFilterIgnoresDate()
+    {
+        // Verify that the revision filter can find builds that did not occur
+        // during the current testing day.
+        $this->get($this->url . '/api/v1/index.php?project=Trilinos&filtercount=1&showfilters=1&field1=revision&compare1=61&value1=91143198be7f9790c9b57de4051f134ce6070838');
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+
+        $expected = 3;
+        $found = count($buildgroup['builds']);
+        if ($found !== $expected) {
+            $this->fail("Expected $expected builds, found $found");
+        }
+    }
+}


### PR DESCRIPTION
When the revision filter is specified, return any matching builds
regardless of when they occurred.