### PR TITLE
Revamp unlink_uploaded_file

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -1193,15 +1193,32 @@ function remove_children($parentid)
 function unlink_uploaded_file($fileid)
 {
     global $CDASH_UPLOAD_DIRECTORY;
-    $query = pdo_query("SELECT sha1sum, filename, filesize FROM uploadfile WHERE id='$fileid' AND isurl=0");
-    $uploadfile_array = pdo_fetch_array($query);
-    $sha1sum = $uploadfile_array['sha1sum'];
-    $symlinkname = $uploadfile_array['filename'];
-    $filesize = $uploadfile_array['filesize'];
+    $pdo = get_link_identifier()->getPdo();
+    $stmt = $pdo->prepare(
+        'SELECT sha1sum, filename, filesize FROM uploadfile
+        WHERE id = ? AND isurl = 0');
 
-    $query = pdo_query("SELECT count(*) FROM uploadfile WHERE sha1sum='$sha1sum' AND id != '$fileid'");
-    $count_array = pdo_fetch_array($query);
-    $shareCount = $count_array[0];
+    if (!pdo_execute($stmt, [$fileid])) {
+        return 0;
+    }
+    $row = $stmt->fetch();
+    if (!$row) {
+        return 0;
+    }
+
+    $sha1sum = $row['sha1sum'];
+    $symlinkname = $row['filename'];
+    $filesize = $row['filesize'];
+
+    $shareCount = 0;
+    $stmt = $pdo->prepare(
+        'SELECT COUNT(*) FROM uploadfile
+        WHERE sha1sum = :sha1sum AND id != :fileid');
+    $stmt->bindParam(':sha1sum', $sha1sum);
+    $stmt->bindParam(':fileid', $fileid);
+    if (pdo_execute($stmt)) {
+        $shareCount = $stmt->fetchColumn();
+    }
 
     if ($shareCount == 0) {
         //If only one name maps to this content

--- a/tests/test_autoremovebuilds_on_submit.php
+++ b/tests/test_autoremovebuilds_on_submit.php
@@ -100,6 +100,12 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
             return 1;
         }
 
+        // Make sure we didn't inadvertently delete the whole upload directory.
+        global $CDASH_ROOT_DIR;
+        if (!file_exists("$CDASH_ROOT_DIR/public/upload")) {
+            $this->fail('upload diretory does not exist');
+        }
+
         $this->pass('Passed');
         $this->stopCodeCoverage();
     }


### PR DESCRIPTION
I noticed one of our later build deletion tests was removing the
entire upload directory.  This is not good.

* Return early if no files to delete were found in the database.
* Update this function to use PDO.
* Add a new test case to make sure this problem stays fixed.