### PR TITLE
Allow project admins to edit their own projects

### DIFF
--- a/public/api/v1/project.php
+++ b/public/api/v1/project.php
@@ -73,7 +73,7 @@ function rest_post()
 
     // If we should create a new project.
     if (isset($_REQUEST['Submit'])) {
-        if (!valid_user($reponse)) {
+        if (!valid_user($response)) {
             return;
         }
         create_project($response);
@@ -158,7 +158,7 @@ function get_project(&$response)
         return false;
     }
     // Make sure we have an authenticated user that has access to this project.
-    if (!valid_user($reponse, $projectid)) {
+    if (!valid_user($response, $Project)) {
         return false;
     }
 

--- a/tests/kwtest/kw_web_tester.php
+++ b/tests/kwtest/kw_web_tester.php
@@ -305,7 +305,8 @@ class KWWebTestCase extends WebTestCase
     }
 
     // Create or update a project and verify the changes made.
-    public function createProject($input_settings, $update = false)
+    public function createProject($input_settings, $update = false,
+            $username = 'simpletest@localhost', $password = 'simpletest')
     {
         require_once 'models/project.php';
 
@@ -358,8 +359,8 @@ class KWWebTestCase extends WebTestCase
             $response = $client->request('POST',
                     $CDASH_BASE_URL . '/user.php',
                     ['form_params' => [
-                        'login' => 'simpletest@localhost',
-                        'passwd' => 'simpletest',
+                        'login' => $username,
+                        'passwd' => $password,
                         'sent' => 'Login >>']]);
         } catch (GuzzleHttp\Exception\ClientException $e) {
             $this->fail($e->getMessage());

--- a/tests/test_createprojectpermissions.php
+++ b/tests/test_createprojectpermissions.php
@@ -68,6 +68,13 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
         $response = $this->get($this->url . '/api/v1/createProject.php?projectid=5');
         $response = json_decode($response);
         $this->assertFalse(property_exists($response, 'error'));
+        $username = 'user1@kw';
+        $password = 'user1';
+        $settings = ['Id' => 5, 'Description' => 'This is a new desc'];
+        $this->createProject($settings, true, $username, $password);
+        // Revert description back to its original value.
+        $settings = ['Id' => 5, 'Description' => 'Project Insight test for cdash testing'];
+        $this->createProject($settings, true, $username, $password);
 
         // Cannot edit other projects.
         $response = $this->get($this->url . '/api/v1/createProject.php?projectid=4');


### PR DESCRIPTION
This fixes a bug that prevented project admins from saving changes
they have made to their project.  They could load the createProject.php
page but clicking the "Update Project" button did nothing.

We also improve the relevant test as part of this commit.