### PR TITLE
Disregard E notation for numbers in cast_data_for_JSON

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -2076,7 +2076,9 @@ function cast_data_for_JSON($value)
         $value = array_map('cast_data_for_JSON', $value);
         return $value;
     }
-    if (is_numeric($value)) {
+    // Do not support E notation for numbers (ie 6.02e23).
+    // This can cause checksums (such as git commits) to be converted to 0.
+    if (is_numeric($value) && strpos($value, 'e') === false) {
         if (is_nan($value) || is_infinite($value)) {
             // Special handling for values that are not supported by JSON.
             return 0;


### PR DESCRIPTION
This was inadvertently causing some git commit checksums to be converted to 0.