### PR TITLE
Selectively include Google Analytics snippet

### DIFF
--- a/public/views/partials/footer.html
+++ b/public/views/partials/footer.html
@@ -16,9 +16,13 @@
 </div>
 
 <!-- Google Analytics -->
-<script src="//google-analytics.com/ga.js" type="text/javascript" ng-if"cdash.googletracker">
-<script type="text/javascript" ng-if="cdash.googletracker">
+<script type="text/ng-template" id="google-analytics-snippet">
+<script src="//google-analytics.com/ga.js" type="text/javascript">
+<script type="text/javascript">
   var pageTracker = _gat._getTracker("{{cdash.googletracker}}");
   pageTracker._initData();
   pageTracker._trackPageview();
 </script>
+</script>
+
+<ng-include src="'google-analytics-snippet'" ng-if="cdash.googletracker"></ng-include>


### PR DESCRIPTION
The current implementation always requests the Google Analytics snippet
from Google's server (even after fixing the typo in ng-if). Fix this
by moving the actual script loading into an inline template and only
including it if a Google Analytics token is provided in the
configuration.