### PR TITLE
Support for Disabled tests

### DIFF
--- a/models/build.php
+++ b/models/build.php
@@ -1062,13 +1062,14 @@ class Build
     }
 
     /**
-     * Get this build's tests whose status is "Not Run".
+     * Get this build's tests whose status is "Not Run" and whose details
+     * is not 'Disabled'.
      *
      * @return array
      */
     public function GetNotRunTests($maxitems = 0)
     {
-        $criteria = "b2t.status = 'notrun'";
+        $criteria = "b2t.status = 'notrun' AND t.details != 'Disabled'";
         return $this->GetTests($criteria, $maxitems);
     }
 

--- a/models/buildtest.php
+++ b/models/buildtest.php
@@ -130,6 +130,9 @@ class BuildTest
     public static function marshal($data, $buildid, $projectid, $projectshowtesttime, $testtimemaxstatus, $testdate)
     {
         $marshaledStatus = self::marshalStatus($data['status']);
+        if ($data['details'] === 'Disabled') {
+            $marshaledStatus = array('Not Run', 'disabled-test');
+        }
         $marshaledData = array(
             'id' => $data['id'],
             'buildid' => $buildid,

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -259,7 +259,6 @@ if ($onlypassed) {
 } elseif ($onlyfailed) {
     $status = "AND bt.status='failed'";
 } elseif ($onlynotrun) {
-    $displaydetails = 0;
     $status = "AND bt.status='notrun'";
 } elseif ($onlytimestatus) {
     $status = "AND bt.timestatus>='$testtimemaxstatus'";

--- a/public/css/cdash.css
+++ b/public/css/cdash.css
@@ -3,11 +3,13 @@
 .warning { background-color : #fdb66d; }
 .error { background-color : #de6868; }
 .missing {background-color: #dfdfdf; }
+.disabled-test { background-color : #ffff99; }
 
-.tabb tbody tr.odd td.normal { background-color: #7DB04A; }
-.tabb tbody tr.odd td.warning { background-color: #FCA854; }
-.tabb tbody tr.odd td.error { background-color: #D95454; }
+.tabb tbody tr.odd td.normal { background-color: #7db04a; }
+.tabb tbody tr.odd td.warning { background-color: #fca854; }
+.tabb tbody tr.odd td.error { background-color: #d95454; }
 .tabb tbody tr.odd td.missing { background-color: #cdcdcd; }
+.tabb tbody tr.odd td.disabled-test { background-color: #eeee00; }
 
 .Passed { background-color : #8aba5a; }
 .Failed { background-color : #fdba76; }

--- a/public/css/colorblind.css
+++ b/public/css/colorblind.css
@@ -1,10 +1,12 @@
 @import url("common.css");
 .normal  { background-color : #91bfdb; }
 .warning { background-color : #ffffbf; }
+.disabled-test { background-color : #fee090; }
 .error   { background-color : #fc8d59; }
 
 .tabb tbody tr.odd td.normal { background-color: #88b3ce; }
 .tabb tbody tr.odd td.warning { background-color: #eeeeb3; }
+.tabb tbody tr.odd td.disabled-test { background-color: #edcf7f; }
 .tabb tbody tr.odd td.error { background-color: #ef8553; }
 
 .Passed  { background-color : #91bfdb; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,7 @@ add_php_test(extracttar)
 add_php_test(pdoexecutelogserrors)
 add_php_test(revisionfilteracrossdates)
 add_php_test(timeoutsandmissingtests)
+add_php_test(disabledtests)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/data/DisabledTests/Test.xml
+++ b/tests/data/DisabledTests/Test.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_disabled"
+	BuildStamp="20170213-0100-Nightly"
+	Name="localhost"
+	Generator="ctest-3.8.20170206-gb4a85"
+	CompilerName=""
+	CompilerVersion=""
+	OSName="Linux"
+	Hostname="elysium"
+	OSRelease="3.13.0-106-generic"
+	OSVersion="#153-Ubuntu SMP Tue Dec 6 15:44:32 UTC 2016"
+	OSPlatform="x86_64"
+	Is64Bits="1"
+	VendorString="GenuineIntel"
+	VendorID="Intel Corporation"
+	FamilyID="6"
+	ModelID="45"
+	ProcessorCacheSize="12288"
+	NumberOfLogicalCPU="12"
+	NumberOfPhysicalCPU="1"
+	TotalVirtualMemory="32690"
+	TotalPhysicalMemory="32100"
+	LogicalProcessorsPerPhysical="12"
+	ProcessorClockFrequency="1200"
+	>
+	<Testing>
+		<StartDateTime>Feb 13 10:17 EST</StartDateTime>
+		<StartTestTime>1486999078</StartTestTime>
+		<TestList>
+			<Test>./ThisTestWillNotRun</Test>
+			<Test>./ThisTestIsDisabled</Test>
+		</TestList>
+		<Test Status="notrun">
+			<Name>ThisTestWillNotRun</Name>
+			<Path>.</Path>
+			<FullName>./ThisTestWillNotRun</FullName>
+			<FullCommandLine></FullCommandLine>
+			<Results>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Unable to find executable</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value></Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value>Unable to find executable: /tmp/bin/main</Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<Test Status="notrun">
+			<Name>ThisTestIsDisabled</Name>
+			<Path>.</Path>
+			<FullName>./ThisTestIsDisabled</FullName>
+			<FullCommandLine></FullCommandLine>
+			<Results>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Disabled</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value></Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value></Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<EndDateTime>Feb 13 10:17 EST</EndDateTime>
+		<EndTestTime>1486999078</EndTestTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Testing>
+</Site>

--- a/tests/test_disabledtests.php
+++ b/tests/test_disabledtests.php
@@ -1,0 +1,76 @@
+<?php
+//
+// After including cdash_test_case.php, subsequent require_once calls are
+// relative to the top of the CDash source tree
+//
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+require_once 'include/pdo.php';
+
+class DisabledTestsTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testDisabledTests()
+    {
+        $this->deleteLog($this->logfilename);
+
+        // Submit testing data.
+        $rep = dirname(__FILE__) . '/data/DisabledTests';
+        $file = "$rep/Test.xml";
+        if (!$this->submission('EmailProjectExample', $file)) {
+            return;
+        }
+
+        // Find the buildid we just created.
+        $pdo = get_link_identifier()->getPdo();
+        $stmt = $pdo->query("SELECT id FROM build WHERE name = 'test_disabled'");
+        $row = $stmt->fetch();
+        $buildid = $row['id'];
+        if ($buildid < 1) {
+            $this->fail('No buildid found when expected');
+        }
+
+        // Verify one disabled test and one test missing its executable.
+        $this->get("$this->url/api/v1/viewTest.php?buildid=$buildid");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        if ($jsonobj['numNotRun'] !== 2) {
+            $this->fail("Did not find 2 'Not Run' tests when expected");
+        }
+
+        $verified_disabled = false;
+        $verified_missingexe = false;
+        foreach ($jsonobj['tests'] as $test) {
+            if ($test['status'] !== 'Not Run') {
+                $this->fail("Test has a status other than 'Not Run'");
+            }
+            if ($test['details'] === 'Disabled') {
+                $verified_disabled = true;
+            }
+            if ($test['details'] === 'Unable to find executable') {
+                $verified_missingexe = true;
+            }
+        }
+        if (!$verified_disabled) {
+            $this->fail('Did not find Disabled test');
+        }
+        if (!$verified_missingexe) {
+            $this->fail('Did not find test with missing executable');
+        }
+
+        // Verify email was sent for the missing exe but not for the disabled test.
+        $log_contents = file_get_contents($this->logfilename);
+        if (strpos($log_contents, 'ThisTestWillNotRun') === false) {
+            $this->fail("No email sent for test 'ThisTestWillNotRun'");
+        }
+        if (strpos($log_contents, 'ThisTestIsDisabled') !== false) {
+            $this->fail("Erroneous email sent for test 'ThisTestIsDisabled'");
+        }
+
+        remove_build($buildid);
+    }
+}


### PR DESCRIPTION
A new test property in CMake will allow developers to mark a test as _disabled_.  Disabled tests are another type of _Not Run_ test.  Internally, this distinction is stored in the Details field of the test.
    
`viewTest.php` has been updated to show the details column for Not Run tests.  Disabled tests are shown in a different color on this page.
    
CDash's summary email has been updated to not include disabled tests in its list of Not Run tests.