### PR TITLE
removes separation of timeout tests, changes fail to not passing

### DIFF
--- a/include/sendemail.php
+++ b/include/sendemail.php
@@ -495,18 +495,17 @@ function get_email_summary($buildid, $errors, $errorkey, $maxitems, $maxchars, $
             $information .= "\n";
 
             foreach ($tests as $test) {
-                $info = $test['name'] . ' (' . $serverURI . '/testDetails.php?test=' . $test['id'] . '&build=' . $buildid . ")\n";
+                $info = "{$test['name']} {$test['details']} ({$serverURI}/testDetails.php?test={$test['id']}&build={$buildid}\n";
                 $information .= substr($info, 0, $maxchars);
             }
             $information .= "\n";
             return $information;
         };
 
-        $information .= $AddTestsToEmail($build->GetFailedTests($maxitems), 'Tests failing');
+        $information .= $AddTestsToEmail($build->GetFailedTests($maxitems), 'Tests not passing');
         if ($emailtesttimingchanged) {
             $information .= $AddTestsToEmail($build->GetFailedTimeStatusTests($maxitems, $testtimemaxstatus), 'Tests failing time status');
         }
-        $information .= $AddTestsToEmail($build->GetTimedoutTests($maxitems), 'Test timeouts');
         $information .= $AddTestsToEmail($build->GetNotRunTests($maxitems), 'Tests not run');
     } elseif ($errorkey == 'dynamicanalysis_errors') {
         $da_query = pdo_query("SELECT name,id FROM dynamicanalysis WHERE status IN ('failed','notrun') AND buildid="
@@ -1131,7 +1130,7 @@ function send_email_to_address($emailaddress, $emailtext, $Build, $Project)
                 $messagePlainText .= "Errors: $value\n";
                 break;
             case 'test_errors':
-                $messagePlainText .= "Tests failing: $value\n";
+                $messagePlainText .= "Tests not passing: $value\n";
                 break;
             case 'dynamicanalysis_errors':
                 $messagePlainText .= "Dynamic analysis tests failing: $value\n";

--- a/include/sendemail.php
+++ b/include/sendemail.php
@@ -495,7 +495,7 @@ function get_email_summary($buildid, $errors, $errorkey, $maxitems, $maxchars, $
             $information .= "\n";
 
             foreach ($tests as $test) {
-                $info = "{$test['name']} {$test['details']} ({$serverURI}/testDetails.php?test={$test['id']}&build={$buildid})\n";
+                $info = "{$test['name']} | {$test['details']} | ({$serverURI}/testDetails.php?test={$test['id']}&build={$buildid})\n";
                 $information .= substr($info, 0, $maxchars);
             }
             $information .= "\n";

--- a/include/sendemail.php
+++ b/include/sendemail.php
@@ -495,14 +495,14 @@ function get_email_summary($buildid, $errors, $errorkey, $maxitems, $maxchars, $
             $information .= "\n";
 
             foreach ($tests as $test) {
-                $info = "{$test['name']} {$test['details']} ({$serverURI}/testDetails.php?test={$test['id']}&build={$buildid}\n";
+                $info = "{$test['name']} {$test['details']} ({$serverURI}/testDetails.php?test={$test['id']}&build={$buildid})\n";
                 $information .= substr($info, 0, $maxchars);
             }
             $information .= "\n";
             return $information;
         };
 
-        $information .= $AddTestsToEmail($build->GetFailedTests($maxitems), 'Tests not passing');
+        $information .= $AddTestsToEmail($build->GetFailedTests($maxitems), 'Tests failing');
         if ($emailtesttimingchanged) {
             $information .= $AddTestsToEmail($build->GetFailedTimeStatusTests($maxitems, $testtimemaxstatus), 'Tests failing time status');
         }

--- a/models/build.php
+++ b/models/build.php
@@ -1037,7 +1037,7 @@ class Build
      */
     public function GetFailedTests($maxitems = 0)
     {
-        $criteria = "b2t.status = 'failed' AND t.details NOT LIKE '%%Timeout%%'";
+        $criteria = "b2t.status = 'failed'";
         return $this->GetTests($criteria, $maxitems);
     }
 

--- a/tests/data/EmailProjectExample/cdash_3.log
+++ b/tests/data/EmailProjectExample/cdash_3.log
@@ -11,7 +11,7 @@ Build Name: Win32-MSVC2009
 Build Time: 2009-02-23T05:02:04 EST
 Type: Nightly
 Warnings: 3
-Tests failing: 3
+Tests not passing: 3
 Dynamic analysis tests failing: 10
 
 
@@ -30,10 +30,10 @@ Dynamic analysis tests failing: 10
 
 
 
-*Tests failing*
-DashboardSendTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 

--- a/tests/data/EmailProjectExample/cdash_3.log
+++ b/tests/data/EmailProjectExample/cdash_3.log
@@ -30,7 +30,7 @@ Dynamic analysis tests failing: 10
 
 
 
-*Tests not passing*
+*Tests failing*
 DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)

--- a/tests/data/EmailProjectExample/cdash_3.log
+++ b/tests/data/EmailProjectExample/cdash_3.log
@@ -31,9 +31,9 @@ Dynamic analysis tests failing: 10
 
 
 *Tests failing*
-DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+DashboardSendTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 

--- a/tests/data/EmailProjectExample/cdash_committeremail.log
+++ b/tests/data/EmailProjectExample/cdash_committeremail.log
@@ -13,7 +13,7 @@ Type: Nightly
 Tests not passing: 4
 
 
-*Tests not passing*
+*Tests failing*
 curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
@@ -37,7 +37,7 @@ Type: Nightly
 Tests not passing: 4
 
 
-*Tests not passing*
+*Tests failing*
 curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)

--- a/tests/data/EmailProjectExample/cdash_committeremail.log
+++ b/tests/data/EmailProjectExample/cdash_committeremail.log
@@ -14,10 +14,10 @@ Tests not passing: 4
 
 
 *Tests failing*
-curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+curl | Completed | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+DashboardSendTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>
@@ -38,10 +38,10 @@ Tests not passing: 4
 
 
 *Tests failing*
-curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+curl | Completed | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+DashboardSendTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/EmailProjectExample/cdash_committeremail.log
+++ b/tests/data/EmailProjectExample/cdash_committeremail.log
@@ -10,14 +10,14 @@ Site: Dash20.kitware
 Build Name: Win32-MSVC2009
 Build Time: 2009-02-23T05:02:05 EST
 Type: Nightly
-Tests failing: 4
+Tests not passing: 4
 
 
-*Tests failing*
-curl (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-DashboardSendTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>
@@ -34,14 +34,14 @@ Site: Dash20.kitware
 Build Name: Win32-MSVC2009
 Build Time: 2009-02-23T05:02:05 EST
 Type: Nightly
-Tests failing: 4
+Tests not passing: 4
 
 
-*Tests failing*
-curl (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-DashboardSendTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+DashboardSendTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/SubProjectExample/cdash_2.log
+++ b/tests/data/SubProjectExample/cdash_2.log
@@ -15,7 +15,7 @@ Tests not passing: 1
 
 
 *Tests failing*
-NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+NOX_FiniteDifferenceIsorropiaColoring | Completed (Failed) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>
@@ -37,7 +37,7 @@ Tests not passing: 1
 
 
 *Tests failing*
-NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+NOX_FiniteDifferenceIsorropiaColoring | Completed (Failed) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/SubProjectExample/cdash_2.log
+++ b/tests/data/SubProjectExample/cdash_2.log
@@ -11,11 +11,11 @@ Site: godel.sandia.gov
 Build Name: Linux-GCC-4.1.2-SERIAL_RELEASE
 Build Time: 2009-08-06T08:19:56 EDT
 Type: Nightly
-Tests failing: 1
+Tests not passing: 1
 
 
-*Tests failing*
-NOX_FiniteDifferenceIsorropiaColoring (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>
@@ -33,11 +33,11 @@ Site: godel.sandia.gov
 Build Name: Linux-GCC-4.1.2-SERIAL_RELEASE
 Build Time: 2009-08-06T08:19:56 EDT
 Type: Nightly
-Tests failing: 1
+Tests not passing: 1
 
 
-*Tests failing*
-NOX_FiniteDifferenceIsorropiaColoring (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/SubProjectExample/cdash_2.log
+++ b/tests/data/SubProjectExample/cdash_2.log
@@ -14,7 +14,7 @@ Type: Nightly
 Tests not passing: 1
 
 
-*Tests not passing*
+*Tests failing*
 NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
@@ -36,7 +36,7 @@ Type: Nightly
 Tests not passing: 1
 
 
-*Tests not passing*
+*Tests failing*
 NOX_FiniteDifferenceIsorropiaColoring Completed (Failed) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 

--- a/tests/data/TimeoutsAndMissingTests/cdash_4.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_4.log
@@ -14,8 +14,8 @@ Tests not passing: 2
 
 
 *Tests failing*
-SleepTimer1 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-SleepTimer2 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+SleepTimer1 | Completed (Timeout) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+SleepTimer2 | Completed (Timeout) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/TimeoutsAndMissingTests/cdash_4.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_4.log
@@ -13,7 +13,7 @@ Type: Nightly
 Tests not passing: 2
 
 
-*Tests not passing*
+*Tests failing*
 SleepTimer1 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 SleepTimer2 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 

--- a/tests/data/TimeoutsAndMissingTests/cdash_4.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_4.log
@@ -10,12 +10,12 @@ Site: Dash20.kitware
 Build Name: OSX-SIERRA-10.12.1
 Build Time: 2009-02-23T05:04:13 EST
 Type: Nightly
-Tests failing: 2
+Tests not passing: 2
 
 
-*Test timeouts*
-SleepTimer1 (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-SleepTimer2 (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+SleepTimer1 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+SleepTimer2 Completed (Timeout) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 -CDash on <NA>

--- a/tests/data/TimeoutsAndMissingTests/cdash_5.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_5.log
@@ -14,7 +14,7 @@ Tests not passing: 3
 Missing tests: 3
 
 
-*Tests not passing*
+*Tests failing*
 curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)

--- a/tests/data/TimeoutsAndMissingTests/cdash_5.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_5.log
@@ -15,9 +15,9 @@ Missing tests: 3
 
 
 *Tests failing*
-curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+curl | Completed | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest | Completed (OTHER_FAULT) | (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 

--- a/tests/data/TimeoutsAndMissingTests/cdash_5.log
+++ b/tests/data/TimeoutsAndMissingTests/cdash_5.log
@@ -10,14 +10,14 @@ Site: Dash20.kitware
 Build Name: Win32-MSVC2009
 Build Time: 2009-02-26T05:04:00 EST
 Type: Nightly
-Tests failing: 3
+Tests not passing: 3
 Missing tests: 3
 
 
-*Tests failing*
-curl (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-StringActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
-MathActionsTest (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+*Tests not passing*
+curl Completed (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+StringActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
+MathActionsTest Completed (OTHER_FAULT) (http://<NA>/<NA>/testDetails.php?test=<NA>&build=<NA>)
 
 
 


### PR DESCRIPTION
- This change removes the separation of time out tests and failed tests in the email
- This change add the details of failure to the notification
- This changes "test failing" to "tests not passing"