### PR TITLE
Fix query in GetConfigureForBuild

### DIFF
--- a/models/buildconfigure.php
+++ b/models/buildconfigure.php
@@ -286,7 +286,10 @@ class BuildConfigure
             return false;
         }
 
-        $sql = "SELECT * FROM configure WHERE buildid=?";
+        $sql =
+            'SELECT * FROM configure c
+            JOIN build2configure b2c ON c.id = b2c.configureid
+            WHERE buildid = ?';
         $query = $this->PDO->prepare($sql);
 
         pdo_execute($query, [$this->BuildId]);

--- a/tests/test_buildconfigure.php
+++ b/tests/test_buildconfigure.php
@@ -69,6 +69,10 @@ class BuildConfigureTestCase extends KWWebTestCase
             $this->fail("configure->Insert returned true");
         }
 
+        if (!$configure->GetConfigureForBuild(PDO::FETCH_ASSOC)) {
+            $this->fail("configure->GetConfigureForBuild returned false");
+        }
+
         if ($configure->Delete()) {
             $this->fail("configure->Delete returned true");
         }


### PR DESCRIPTION
This still assumed that the configure table has a column for buildid, but this field has been moved to the build2configure table.