### PR TITLE
Fix unauthenticated display of createProject.php

### DIFF
--- a/public/api/v1/createProject.php
+++ b/public/api/v1/createProject.php
@@ -16,6 +16,7 @@
 
 include dirname(dirname(dirname(__DIR__))) . '/config/config.php';
 require_once 'include/pdo.php';
+$noforcelogin = 1;
 include 'public/login.php';
 require_once 'include/common.php';
 require_once 'include/pdo.php';

--- a/tests/test_createprojectpermissions.php
+++ b/tests/test_createprojectpermissions.php
@@ -17,6 +17,14 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
 
     public function testCreateProjectPermissions()
     {
+        // Test the unauthenticated case.
+        $response = $this->get($this->url . '/api/v1/createProject.php');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'requirelogin'));
+        $response = $this->get($this->url . '/api/v1/createProject.php?projectid=5');
+        $response = json_decode($response);
+        $this->assertTrue(property_exists($response, 'requirelogin'));
+
         // Tests for global administrator.
         $this->login();
 


### PR DESCRIPTION
createProject.php's API endpoint was accidentally attempting to
redirect to the login page.

Instead, it should note whether or not the user is logged in and
respond with an appropriate error if they are not authorized to
access this page for a given project.  This is consistent with how
the rest of our API endpoints operate.