### PR TITLE
fixes false positive by filling and updating simpletest user

### DIFF
--- a/tests/test_recoverpassword.php
+++ b/tests/test_recoverpassword.php
@@ -36,6 +36,8 @@ class RecoverPasswordTestCase extends KWWebTestCase
         // fix the password so others can still login...
         $user = new User();
         $userid = $user->GetIdFromEmail('simpletest@localhost');
+        $user->Id = $userid;
+        $user->Fill();
         $user->Password = User::PasswordHash('simpletest');
         if (!$user->Save()) {
             $this->fail('user->Save() returned false');

--- a/tests/test_recoverpassword.php
+++ b/tests/test_recoverpassword.php
@@ -35,8 +35,7 @@ class RecoverPasswordTestCase extends KWWebTestCase
 
         // fix the password so others can still login...
         $user = new User();
-        $userid = $user->GetIdFromEmail('simpletest@localhost');
-        $user->Id = $userid;
+        $user->Id = $user->GetIdFromEmail('simpletest@localhost');
         $user->Fill();
         $user->Password = User::PasswordHash('simpletest');
         if (!$user->Save()) {


### PR DESCRIPTION
Not sure how this works without this fix. Did something change recently with `User:: GetIdFromEmail`?