### PR TITLE
Add track option to JUnit test parser

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_php_test(timeoutsandmissingtests)
 add_php_test(disabledtests)
 add_php_test(multiplesubprojects)
 add_php_test(authtoken)
+add_php_test(junithandler)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/data/JUNit_example.xml
+++ b/tests/data/JUNit_example.xml
@@ -10,6 +10,9 @@
     <testcase name="AlsoFails" classname="bar4" status="run" time="0.2">
       <failure type="NotEnoughFoo"> details about failure </failure>
     </testcase>
-    <testcase name="DoesNotRun" classname="bar5" status="notrun" time="0.0"></testcase>
+    <testcase name="AnotherFailure" classname="bar5" status="run" time="0.0">
+      <error type="TooMuchFoo"> details about error </error>
+    </testcase>
+    <testcase name="DoesNotRun" classname="bar6" status="notrun" time="0.0"></testcase>
   </testsuite>
 </testsuites>

--- a/tests/data/JUNit_example.xml
+++ b/tests/data/JUNit_example.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="junit-test-build" timestamp="2017-05-17T12:00:00" hostname="localhost" tests="5" failures="2" disabled="1" errors="0" time="0.0">
+    <properties>
+      <property name="track" value="my-custom-track"/>
+    </properties>
+    <testcase name="Passes" classname="bar1" status="run" time="0.0"></testcase>
+    <testcase name="PassesToo" classname="bar2" status="run" time="0.1"></testcase>
+    <testcase name="Fails" classname="bar3" status="fail" time="0.2"></testcase>
+    <testcase name="AlsoFails" classname="bar4" status="run" time="0.2">
+      <failure type="NotEnoughFoo"> details about failure </failure>
+    </testcase>
+    <testcase name="DoesNotRun" classname="bar5" status="notrun" time="0.0"></testcase>
+  </testsuite>
+</testsuites>

--- a/tests/test_junithandler.php
+++ b/tests/test_junithandler.php
@@ -1,0 +1,83 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+require_once 'include/pdo.php';
+require_once 'models/authtoken.php';
+require_once 'models/project.php';
+require_once 'models/user.php';
+require_once 'models/userproject.php';
+
+
+class JUnitHandlerTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->PDO = get_link_identifier()->getPdo();
+        $this->Project = null;
+    }
+
+    public function __destruct()
+    {
+        if ($this->Project) {
+            remove_project_builds($this->Project->Id);
+            $this->Project->Delete();
+        }
+    }
+
+    public function testJUnitHandler()
+    {
+        // Login as admin.
+        $this->login();
+
+        // Create project.
+        $settings = [
+            'Name' => 'JUnitHandlerProject',
+            'Public' => 1
+        ];
+        $projectid = $this->createProject($settings);
+        if ($projectid < 1) {
+            $this->fail('Failed to create project');
+        }
+        $this->Project = new Project();
+        $this->Project->Id = $projectid;
+
+        // Submit our test data.
+        $xml = dirname(__FILE__) . '/data/JUNit_example.xml';
+        if (!$this->submission('JUnitHandlerProject', $xml)) {
+            $this->fail('Failed to submit test data');
+        }
+
+        // Get newly created buildid.
+        $stmt = $this->PDO->query("SELECT id, stamp FROM build WHERE name = 'junit-test-build'");
+        $row = $stmt->fetch();
+        $buildid = $row['id'];
+        if ($buildid < 1) {
+            $this->fail('Failed to create build');
+        }
+
+        // Verify that we honored its custom track.
+        $stamp = $row['stamp'];
+        $expected = '20170517-1200-my-custom-track';
+        if ($stamp !== $expected) {
+            $this->fail("Expected stamp to be $expected, found $stamp");
+        }
+
+        // Make sure the testing results look correct.
+        $this->get("$this->url/api/v1/viewTest.php?buildid=$buildid");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        if ($jsonobj['numPassed'] !== 2) {
+            $this->fail("Did not find 2 'Passed' tests when expected");
+        }
+        if ($jsonobj['numFailed'] !== 2) {
+            $this->fail("Did not find 2 'Failed' tests when expected");
+        }
+        if ($jsonobj['numNotRun'] !== 1) {
+            $this->fail("Did not find 1 'Not Run' test when expected");
+        }
+        if (trim($jsonobj['totaltime']) !== '500ms') {
+            $this->fail("Did not find 500ms totaltime when expected");
+        }
+    }
+}

--- a/tests/test_junithandler.php
+++ b/tests/test_junithandler.php
@@ -2,10 +2,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'include/common.php';
 require_once 'include/pdo.php';
-require_once 'models/authtoken.php';
 require_once 'models/project.php';
-require_once 'models/user.php';
-require_once 'models/userproject.php';
 
 
 class JUnitHandlerTestCase extends KWWebTestCase
@@ -70,8 +67,8 @@ class JUnitHandlerTestCase extends KWWebTestCase
         if ($jsonobj['numPassed'] !== 2) {
             $this->fail("Did not find 2 'Passed' tests when expected");
         }
-        if ($jsonobj['numFailed'] !== 2) {
-            $this->fail("Did not find 2 'Failed' tests when expected");
+        if ($jsonobj['numFailed'] !== 3) {
+            $this->fail("Did not find 3 'Failed' tests when expected");
         }
         if ($jsonobj['numNotRun'] !== 1) {
             $this->fail("Did not find 1 'Not Run' test when expected");

--- a/xml_handlers/testing_junit_handler.php
+++ b/xml_handlers/testing_junit_handler.php
@@ -201,10 +201,13 @@ class TestingJUnitHandler extends AbstractHandler
             // Mark this test as failed if it has a <failure> tag.
             $this->CurrentBuildTest->Status = 'failed';
         } elseif ($name == 'TESTCASE') {
+            // Update our tally of passing/failing/notrun tests.
             if ($this->CurrentBuildTest->Status == 'passed') {
                 $this->NumberTestsPassed++;
             } elseif ($this->CurrentBuildTest->Status == 'failed') {
                 $this->NumberTestsFailed++;
+            } elseif ($this->CurrentBuildTest->Status == 'notrun') {
+                $this->NumberTestsNotRun++;
             }
             // Record this test in the database.
             $this->CurrentTest->Insert();

--- a/xml_handlers/testing_junit_handler.php
+++ b/xml_handlers/testing_junit_handler.php
@@ -111,7 +111,7 @@ class TestingJUnitHandler extends AbstractHandler
             } else {
                 $this->Append = false;
             }
-        } elseif ($name == 'FAILURE') {
+        } elseif ($name == 'FAILURE' || $name == 'ERROR') {
             $this->CurrentTest->Details = $attributes['TYPE'];
         } elseif ($name == 'PROPERTY' && $parent == 'PROPERTIES') {
             $this->TestProperties .= $attributes['NAME'] . '=' . $attributes['VALUE'] . "\n";
@@ -207,8 +207,8 @@ class TestingJUnitHandler extends AbstractHandler
     public function endElement($parser, $name)
     {
         parent::endElement($parser, $name);
-        if ($name == 'FAILURE') {
-            // Mark this test as failed if it has a <failure> tag.
+        if ($name == 'FAILURE' || $name == 'ERROR') {
+            // Mark this test as failed if it has a <failure> or <error> tag.
             $this->CurrentBuildTest->Status = 'failed';
         } elseif ($name == 'TESTCASE') {
             // Update our tally of passing/failing/notrun tests.

--- a/xml_handlers/testing_junit_handler.php
+++ b/xml_handlers/testing_junit_handler.php
@@ -145,8 +145,17 @@ class TestingJUnitHandler extends AbstractHandler
                 $this->CurrentBuildTest->Time = $attributes['TIME'];
             }
 
-            // Default is that the test passes unless there is a <failure> tag
+            // Default is that the test passes.
             $this->CurrentBuildTest->Status = 'passed';
+            if (array_key_exists('STATUS', $attributes)) {
+                $status = $attributes['STATUS'];
+                if (stripos($status, 'fail') !== false) {
+                    $this->CurrentBuildTest->Status = 'failed';
+                }
+                if (strcasecmp($status, 'notrun') === 0) {
+                    $this->CurrentBuildTest->Status = 'notrun';
+                }
+            }
 
             $this->CurrentTest->Name = $attributes['NAME'];
             $this->CurrentTest->Path = $attributes['CLASSNAME'];

--- a/xml_handlers/testing_junit_handler.php
+++ b/xml_handlers/testing_junit_handler.php
@@ -25,20 +25,24 @@ class TestingJUnitHandler extends AbstractHandler
 {
     private $StartTimeStamp;
     private $EndTimeStamp;
-    private $UpdateEndTime; // should we update the end time of the build
+    // Should we update the end time of the build?
+    private $UpdateEndTime;
 
-    private $Test;
-    private $BuildTest;
+    private $Tests;
+    private $CurrentTest;
+    private $BuildTests;
+    private $CurrentBuildTest;
     private $Append;
 
-    // Keep a record of the number of tests passed, failed and notrun
-    // This works only because we have one test file per submission
+    // Keep a record of the number of tests passed, failed and notrun.
+    // This works only because we have one test file per submission.
     private $NumberTestsFailed;
     private $NumberTestsNotRun;
     private $NumberTestsPassed;
     private $TestProperties;
     private $HasSiteTag;
     private $BuildAdded;
+    private $TotalTestDuration;
 
     /** Constructor */
     public function __construct($projectID, $scheduleID)
@@ -46,6 +50,9 @@ class TestingJUnitHandler extends AbstractHandler
         parent::__construct($projectID, $scheduleID);
         $this->Build = new Build();
         $this->Site = new Site();
+        $this->BuildTests = [];
+        $this->Tests = [];
+
         $this->UpdateEndTime = false;
         $this->NumberTestsFailed = 0;
         $this->NumberTestsNotRun = 0;
@@ -53,6 +60,7 @@ class TestingJUnitHandler extends AbstractHandler
         $this->TestProperties = '';
         $this->HasSiteTag = false;
         $this->BuildAdded = false;
+        $this->TotalTestDuration = 0;
     }
 
     /** Destructor */
@@ -101,7 +109,7 @@ class TestingJUnitHandler extends AbstractHandler
                 $this->Append = false;
             }
         } elseif ($name == 'FAILURE') {
-            $this->Test->Details = $attributes['TYPE'];
+            $this->CurrentTest->Details = $attributes['TYPE'];
         } elseif ($name == 'PROPERTY' && $parent == 'PROPERTIES') {
             $this->TestProperties .= $attributes['NAME'] . '=' . $attributes['VALUE'] . "\n";
             if ($this->HasSiteTag == false) {
@@ -128,54 +136,20 @@ class TestingJUnitHandler extends AbstractHandler
                 }
             }
         } elseif ($name == 'TESTCASE' && count($attributes) > 0) {
-            if ($this->BuildAdded == false) {
-                $this->Build->SaveTotalTestsTime(0);
-
-                $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
-                $this->Build->ProjectId = $this->projectid;
-                $this->Build->GetIdFromName($this->SubProjectName);
-                $this->Build->RemoveIfDone();
-
-                // If the build doesn't exist we add it
-                if ($this->Build->Id == 0) {
-                    $this->Build->ProjectId = $this->projectid;
-                    $this->Build->StartTime = $start_time;
-                    $this->Build->EndTime = $start_time;
-                    $this->Build->SubmitTime = gmdate(FMT_DATETIME);
-                    $this->Build->SetSubProject($this->SubProjectName);
-                    $this->Build->Append = $this->Append;
-                    $this->Build->InsertErrors = false;
-                    add_build($this->Build, $this->scheduleid);
-
-                    $this->UpdateEndTime = true;
-                } else {
-                    // Otherwise make sure that the build is up-to-date.
-                    $this->Build->UpdateBuild($this->Build->Id, -1, -1);
-
-                    //if the build already exists factor the number of tests that have
-                    //already been run into our running total
-                    $this->NumberTestsFailed += $this->Build->GetNumberOfFailedTests();
-                    $this->NumberTestsNotRun += $this->Build->GetNumberOfNotRunTests();
-                    $this->NumberTestsPassed += $this->Build->GetNumberOfPassedTests();
-                }
-                $GLOBALS['PHP_ERROR_BUILD_ID'] = $this->Build->Id;
-                $this->BuildAdded = true;
-            }
-
-            $this->Test = new Test();
-            $this->Test->Command = $this->TestProperties;
-            $this->Test->ProjectId = $this->projectid;
-            $this->BuildTest = new BuildTest();
+            $this->CurrentTest = new Test();
+            $this->CurrentTest->Command = $this->TestProperties;
+            $this->CurrentTest->ProjectId = $this->projectid;
+            $this->CurrentBuildTest = new BuildTest();
 
             if (isset($attributes['TIME'])) {
-                $this->BuildTest->Time = $attributes['TIME'];
+                $this->CurrentBuildTest->Time = $attributes['TIME'];
             }
 
             // Default is that the test passes unless there is a <failure> tag
-            $this->BuildTest->Status = 'passed';
+            $this->CurrentBuildTest->Status = 'passed';
 
-            $this->Test->Name = $attributes['NAME'];
-            $this->Test->Path = $attributes['CLASSNAME'];
+            $this->CurrentTest->Name = $attributes['NAME'];
+            $this->CurrentTest->Path = $attributes['CLASSNAME'];
         } elseif ($name == 'TESTSUITE') {
             // If the XML file doesn't have a <Site> tag then we use the information
             // provided by the testsuite.
@@ -215,7 +189,7 @@ class TestingJUnitHandler extends AbstractHandler
 
             $this->StartTimeStamp = $timestamp;
             $this->EndTimeStamp = $this->StartTimeStamp + $attributes['TIME'];
-            $this->Build->SaveTotalTestsTime($attributes['TIME']);
+            $this->TotalTestDuration += $attributes['TIME'];
         }
     }
 
@@ -224,20 +198,20 @@ class TestingJUnitHandler extends AbstractHandler
     {
         parent::endElement($parser, $name);
         if ($name == 'FAILURE') {
-            $this->BuildTest->Status = 'failed';
+            // Mark this test as failed if it has a <failure> tag.
+            $this->CurrentBuildTest->Status = 'failed';
         } elseif ($name == 'TESTCASE') {
-            if ($this->BuildTest->Status == 'passed') {
+            if ($this->CurrentBuildTest->Status == 'passed') {
                 $this->NumberTestsPassed++;
-            } elseif ($this->BuildTest->Status == 'failed') {
+            } elseif ($this->CurrentBuildTest->Status == 'failed') {
                 $this->NumberTestsFailed++;
             }
-            $this->Test->Insert();
-            if ($this->Test->Id > 0) {
-                $this->BuildTest->TestId = $this->Test->Id;
-                $this->BuildTest->BuildId = $this->Build->Id;
-                $this->BuildTest->Insert();
-
-                $this->Test->InsertLabelAssociations($this->Build->Id);
+            // Record this test in the database.
+            $this->CurrentTest->Insert();
+            if ($this->CurrentTest->Id > 0) {
+                $this->CurrentBuildTest->TestId = $this->CurrentTest->Id;
+                $this->Tests[] = $this->CurrentTest;
+                $this->BuildTests[] = $this->CurrentBuildTest;
             } else {
                 add_log('Cannot insert test', 'Test XML parser', LOG_ERR,
                     $this->projectid, $this->Build->Id);
@@ -248,10 +222,55 @@ class TestingJUnitHandler extends AbstractHandler
                 $this->Build->UpdateEndTime($end_time);
             }
 
+            // Add the build if necessary.
+            if ($this->BuildAdded == false) {
+                $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
+                $this->Build->ProjectId = $this->projectid;
+                $this->Build->GetIdFromName($this->SubProjectName);
+                $this->Build->RemoveIfDone();
+
+                // If the build doesn't exist we add it
+                if ($this->Build->Id == 0) {
+                    $this->Build->ProjectId = $this->projectid;
+                    $this->Build->StartTime = $start_time;
+                    $this->Build->EndTime = $start_time;
+                    $this->Build->SubmitTime = gmdate(FMT_DATETIME);
+                    $this->Build->SetSubProject($this->SubProjectName);
+                    $this->Build->Append = $this->Append;
+                    $this->Build->InsertErrors = false;
+                    add_build($this->Build, $this->scheduleid);
+                    $this->UpdateEndTime = true;
+                } else {
+                    // Otherwise make sure that the build is up-to-date.
+                    $this->Build->UpdateBuild($this->Build->Id, -1, -1);
+
+                    //if the build already exists factor the number of tests that have
+                    //already been run into our running total
+                    $this->NumberTestsFailed += $this->Build->GetNumberOfFailedTests();
+                    $this->NumberTestsNotRun += $this->Build->GetNumberOfNotRunTests();
+                    $this->NumberTestsPassed += $this->Build->GetNumberOfPassedTests();
+                }
+                $GLOBALS['PHP_ERROR_BUILD_ID'] = $this->Build->Id;
+                $this->BuildAdded = true;
+            }
+
+            // Add the tests for this build.
+            foreach ($this->BuildTests as $buildtest) {
+                $buildtest->BuildId = $this->Build->Id;
+                $buildtest->Insert();
+            }
+
+            // Set any label associations for tests.
+            foreach ($this->Tests as $test) {
+                $test->InsertLabelAssociations($this->Build->Id);
+            }
+
             // Update the number of tests in the Build table
             $this->Build->UpdateTestNumbers($this->NumberTestsPassed,
                 $this->NumberTestsFailed,
                 $this->NumberTestsNotRun);
+
+            $this->Build->SaveTotalTestsTime($this->TotalTestDuration);
             $this->Build->ComputeTestTiming();
         }
     }
@@ -261,7 +280,7 @@ class TestingJUnitHandler extends AbstractHandler
     {
         $element = $this->getElement();
         if ($element == 'FAILURE') {
-            $this->Test->Output .= $data;
+            $this->CurrentTest->Output .= $data;
         }
     }
 }


### PR DESCRIPTION
Give submitters a way to specify non-Nightly builds in JUnit test XML files.