### PR TITLE
Encapsulate testing hooks for code coverage

### DIFF
--- a/tests/kwtest/kw_web_tester.php
+++ b/tests/kwtest/kw_web_tester.php
@@ -59,6 +59,16 @@ class KWWebTestCase extends WebTestCase
         $this->configfilename = $cdashpath . '/config/config.local.php';
     }
 
+    public function setUp()
+    {
+        $this->startCodeCoverage();
+    }
+
+    public function tearDown()
+    {
+        $this->stopCodeCoverage();
+    }
+
     public function startCodeCoverage()
     {
         //echo "startCodeCoverage called...\n";

--- a/tests/test_autoremovebuilds.php
+++ b/tests/test_autoremovebuilds.php
@@ -31,8 +31,6 @@ class AutoRemoveBuildsTestCase extends KWWebTestCase
 
     public function testAutoRemoveBuilds()
     {
-        $this->startCodeCoverage();
-
         global $configure;
         $dir = $configure['svnroot'];
 
@@ -70,7 +68,6 @@ class AutoRemoveBuildsTestCase extends KWWebTestCase
             $error = 0;
         }
 
-        $this->stopCodeCoverage();
         return $error;
     }
 }

--- a/tests/test_autoremovebuilds_on_submit.php
+++ b/tests/test_autoremovebuilds_on_submit.php
@@ -49,7 +49,6 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         $this->enableAutoRemoveConfigSetting();
         $this->setAutoRemoveTimeFrame();
         $this->deleteLog($this->logfilename);
-        $this->startCodeCoverage();
 
         $result = $this->db->query("SELECT id FROM project WHERE name = 'EmailProjectExample'");
         $projectid = $result[0]['id'];
@@ -59,7 +58,6 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         $testxml1 = "$rep/1_test.xml";
         if (!$this->submission('EmailProjectExample', $testxml1)) {
             $this->fail('submission 1 failed');
-            $this->stopCodeCoverage();
             return;
         }
 
@@ -81,7 +79,6 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         $testxml2 = "$rep/2_test.xml";
         if (!$this->submission('EmailProjectExample', $testxml2)) {
             $this->fail('submission 2 failed');
-            $this->stopCodeCoverage();
             return 1;
         }
 
@@ -107,6 +104,5 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-        $this->stopCodeCoverage();
     }
 }

--- a/tests/test_banner.php
+++ b/tests/test_banner.php
@@ -18,8 +18,6 @@ class BannerTestCase extends KWWebTestCase
 
     public function testBanner()
     {
-        $this->startCodeCoverage();
-
         $banner = new Banner();
 
         ob_start();
@@ -50,8 +48,6 @@ class BannerTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_builderrordiff.php
+++ b/tests/test_builderrordiff.php
@@ -18,8 +18,6 @@ class BuildErrorDiffTestCase extends KWWebTestCase
 
     public function testBuildErrorDiff()
     {
-        $this->startCodeCoverage();
-
         $builderrordiff = new BuildErrorDiff();
 
         //no buildid
@@ -59,8 +57,6 @@ class BuildErrorDiffTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_buildgroupposition.php
+++ b/tests/test_buildgroupposition.php
@@ -17,8 +17,6 @@ class BuildGroupPositionTestCase extends KWWebTestCase
 
     public function testBuildGroupPosition()
     {
-        $this->startCodeCoverage();
-
         $buildgroupposition = new BuildGroupPosition();
 
         $buildgroupposition->GroupId = 0;
@@ -43,7 +41,6 @@ class BuildGroupPositionTestCase extends KWWebTestCase
         }
         $this->pass('Passed');
 
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_buildgrouprule.php
+++ b/tests/test_buildgrouprule.php
@@ -17,8 +17,6 @@ class BuildGroupRuleTestCase extends KWWebTestCase
 
     public function testBuildGroupRule()
     {
-        $this->startCodeCoverage();
-
         $buildgrouprule = new BuildGroupRule();
 
         $buildgrouprule->GroupId = 0;
@@ -50,8 +48,6 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_buildmodel.php
+++ b/tests/test_buildmodel.php
@@ -69,8 +69,6 @@ class BuildModelTestCase extends KWWebTestCase
 
     public function testBuildModel()
     {
-        $this->startCodeCoverage();
-
         $build = new Build();
         $builderror = new BuildError();
         $builderror->Type = 0;
@@ -202,7 +200,6 @@ class BuildModelTestCase extends KWWebTestCase
         $build->AddError($buildwarning);
         $build->Save();
 
-        $this->stopCodeCoverage();
         return 0;
     }
 

--- a/tests/test_buildtestdiff.php
+++ b/tests/test_buildtestdiff.php
@@ -18,8 +18,6 @@ class BuildTestDiffTestCase extends KWWebTestCase
 
     public function testBuildTestDiff()
     {
-        $this->startCodeCoverage();
-
         $buildtestdiff = new BuildTestDiff();
 
         $buildtestdiff->BuildId = 0;
@@ -58,8 +56,6 @@ class BuildTestDiffTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_buildusernote.php
+++ b/tests/test_buildusernote.php
@@ -18,8 +18,6 @@ class BuildUserNoteTestCase extends KWWebTestCase
 
     public function testBuildUserNote()
     {
-        $this->startCodeCoverage();
-
         $buildusernote = new BuildUserNote();
         $result = $buildusernote->Insert();
         if ($result) {

--- a/tests/test_dailyupdatefile.php
+++ b/tests/test_dailyupdatefile.php
@@ -18,8 +18,6 @@ class DailyUpdateFileTestCase extends KWWebTestCase
 
     public function testDailyUpdateFile()
     {
-        $this->startCodeCoverage();
-
         $dailyupdatefile = new DailyUpdateFile();
 
         //no id, no matching database entry
@@ -79,8 +77,6 @@ class DailyUpdateFileTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_image.php
+++ b/tests/test_image.php
@@ -19,8 +19,6 @@ class ImageTestCase extends KWWebTestCase
 
     public function testImage()
     {
-        $this->startCodeCoverage();
-
         $image = new Image();
 
         //no id, no matching checksum
@@ -74,8 +72,6 @@ class ImageTestCase extends KWWebTestCase
         }
 
         $this->pass('Passed');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_importbuilds.php
+++ b/tests/test_importbuilds.php
@@ -19,8 +19,6 @@ class ImportBuildsTestCase extends KWWebTestCase
 
     public function testImportBuilds()
     {
-        $this->startCodeCoverage();
-
         global $configure;
         $dir = $configure['svnroot'];
         chdir($dir);
@@ -65,8 +63,6 @@ class ImportBuildsTestCase extends KWWebTestCase
         $this->pass('Passed');
         cdash_testsuite_unlink($checkFile);
         $this->deleteLog($this->logfilename);
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_projectmodel.php
+++ b/tests/test_projectmodel.php
@@ -18,8 +18,6 @@ class ProjectModelTestCase extends KWWebTestCase
 
     public function testProjectModel()
     {
-        $this->startCodeCoverage();
-
         $project = new Project();
 
         $this->assertTrue($project->GetNumberOfErrorConfigures(0, 0) === false, 'GetNumberOfErrorConfigures!=false');
@@ -53,8 +51,6 @@ class ProjectModelTestCase extends KWWebTestCase
         $project->AddLogo($contents1, 'gif');
 
         @$project->SendEmailToAdmin('foo', 'hello world');
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_testmodel.php
+++ b/tests/test_testmodel.php
@@ -20,8 +20,6 @@ class TestModelTestCase extends KWWebTestCase
 
     public function testTestModel()
     {
-        $this->startCodeCoverage();
-
         $test = new Test();
         $test->Id = '8967';
         $test->Name = 'dummytest';
@@ -46,8 +44,6 @@ class TestModelTestCase extends KWWebTestCase
         $test->Insert();
 
         $test->GetCrc32();
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }

--- a/tests/test_user.php
+++ b/tests/test_user.php
@@ -18,8 +18,6 @@ class UserTestCase extends KWWebTestCase
 
     public function testUser()
     {
-        $this->startCodeCoverage();
-
         $user = new User();
         $user->Id = 'non_numeric';
 
@@ -69,8 +67,6 @@ class UserTestCase extends KWWebTestCase
 
         // Coverage for update save
         $user->Save();
-
-        $this->stopCodeCoverage();
         return 0;
     }
 }


### PR DESCRIPTION
More reliably generate coverage information for tests that do not
interact with the web server.