### PR TITLE
Fix erroneous indentation at the beginning of notes

### DIFF
--- a/public/views/viewNotes.html
+++ b/public/views/viewNotes.html
@@ -58,9 +58,7 @@
           <b>{{note.time}} -- {{note.name}}</b>
         </div>
         <br/>
-        <pre>
-          {{note.text}}
-        </pre>
+        <pre>{{note.text}}</pre>
         <br/>
       </div>
       <br/>


### PR DESCRIPTION
`<pre>` tags are sensitive to whitespace, so we need to be careful to inline them compactly in our views.