### PR TITLE
Don't check old groupid when expiring buildgroup rules

### DIFF
--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -140,9 +140,8 @@ function rest_post()
         $now = gmdate(FMT_DATETIME);
         pdo_query(
             "UPDATE build2grouprule SET endtime='$now'
-                WHERE groupid='$prevgroupid' AND buildtype='$buildtype' AND
-                buildname='$buildname' AND siteid='$siteid' AND
-                endtime='1980-01-01 00:00:00'");
+                WHERE buildtype='$buildtype' AND buildname='$buildname' AND
+                siteid='$siteid' AND endtime='1980-01-01 00:00:00'");
 
         // Create the rule for the new buildgroup.
         // (begin time is set by default by mysql)


### PR DESCRIPTION
Somehow we ended up in a state where old build2grouprule rows were not getting
marked as finished when moving a build to a new group.  The result was two
active rules matching the build, with the oldest one winning out due to database
ordering.  This meant that builds would not move even after an admin told them
to.

We make this behavior more robust by expiring all matching rules before creating
the new one.