### PR TITLE
Don't check old groupid when moving a build

### DIFF
--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -124,12 +124,7 @@ function rest_post()
         $newgroupid = pdo_real_escape_numeric($_POST['newgroupid']);
 
         // Remove the build from its previous group.
-        $prevgroup = pdo_fetch_array(pdo_query(
-            "SELECT groupid as id FROM build2group WHERE buildid='$buildid'"));
-        $prevgroupid = $prevgroup['id'];
-        pdo_query(
-            "DELETE FROM build2group
-                WHERE groupid='$prevgroupid' AND buildid='$buildid'");
+        pdo_query("DELETE FROM build2group WHERE buildid='$buildid'");
 
         // Insert it into the new group.
         pdo_query(
@@ -140,9 +135,8 @@ function rest_post()
         $now = gmdate(FMT_DATETIME);
         pdo_query(
             "UPDATE build2grouprule SET endtime='$now'
-                WHERE groupid='$prevgroupid' AND buildtype='$buildtype' AND
-                buildname='$buildname' AND siteid='$siteid' AND
-                endtime='1980-01-01 00:00:00'");
+                WHERE buildtype='$buildtype' AND buildname='$buildname' AND
+                siteid='$siteid' AND endtime='1980-01-01 00:00:00'");
 
         // Create the rule for the new buildgroup.
         // (begin time is set by default by mysql)

--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -124,12 +124,12 @@ function rest_post()
         $newgroupid = pdo_real_escape_numeric($_POST['newgroupid']);
 
         // Remove the build from its previous group.
-        pdo_query("DELETE FROM build2group WHERE buildid='$buildid'");
+        pdo_query("DELETE FROM build2group WHERE buildid='$build->Id'");
 
         // Insert it into the new group.
         pdo_query(
             "INSERT INTO build2group(groupid,buildid)
-                VALUES ('$newgroupid','$buildid')");
+                VALUES ('$newgroupid','$build->Id')");
 
         // Mark any previous buildgroup rule as finished as of this time.
         $now = gmdate(FMT_DATETIME);


### PR DESCRIPTION
Somehow we ended up in a state where old build2grouprule rows were not getting
marked as finished when moving a build to a new group.  The result was two
active rules matching the build, with the oldest one winning out due to database
ordering.  This meant that builds would not move even after an admin told them
to.

We make this behavior more robust by not checking the old groupid when moving
a build to a new group.