### PR TITLE
Display link to parent notes on index.php

### DIFF
--- a/public/ajax/buildinfogroup.php
+++ b/public/ajax/buildinfogroup.php
@@ -117,11 +117,10 @@ if ($testfailing) {
                     </b></font></td>
         </tr>
         <?php
-
 } // end buildfailing?>
 
     <?php if ($testfailing) {
-    ?>
+                            ?>
         <tr>
             <td bgcolor="#DDDDDD" id="nob"><font size="2">Tests have been failing since <b>
                         <?php
@@ -136,8 +135,7 @@ if ($testfailing) {
                     </b></font></td>
         </tr>
         <?php
-
-} ?>
+                        } ?>
 
 
 </table>

--- a/public/ajax/expectedbuildgroup.php
+++ b/public/ajax/expectedbuildgroup.php
@@ -218,7 +218,6 @@ $group = pdo_query("SELECT name,id FROM buildgroup WHERE id!='$buildgroupid' AND
                     </font></td>
             </tr>
             <?php
-
         }
         ?>
     </table>

--- a/public/ajax/finduserproject.php
+++ b/public/ajax/finduserproject.php
@@ -66,7 +66,6 @@ echo pdo_error();
         </tr>
 
         <?php
-
     }
     ?>
 

--- a/public/ajax/findusers.php
+++ b/public/ajax/findusers.php
@@ -82,7 +82,6 @@ echo pdo_error();
             ?>
                             <input name="removeuser" type="submit" onclick="return confirmRemove()" value="remove user">
                             <?php
-
         } ?>
                         <input name="search" type="hidden" value='<?php echo $search ?>'>
                     </form>
@@ -90,7 +89,6 @@ echo pdo_error();
         </tr>
 
         <?php
-
     }
     ?>
 

--- a/public/ajax/getfeed.php
+++ b/public/ajax/getfeed.php
@@ -114,11 +114,9 @@ foreach ($feeds as $f) {
     <?php echo get_feed_link($f['type'], $f['buildid'], $f['description']); ?>
     <br/>
     <?php
-
 } ?>
 <?php if (count($feeds) > 0) {
-    ?>
+        ?>
     <div id="feedmore"><a href="viewFeed.php?projectid=<?php echo $projectid; ?>">See full feed</a></div>
     <?php
-
-} ?>
+    } ?>

--- a/public/ajax/showtestfailuregraph.php
+++ b/public/ajax/showtestfailuregraph.php
@@ -121,7 +121,6 @@ for ($beginning_timestamp = $starttime; $beginning_timestamp > $starttime - 3600
             ?>
         $.plot($("#testfailuregrapholder"), [{label: "# builds failed", data: d1}], options);
         <?php
-
         } else {
             ?>
         $.plot($("#testfailuregrapholder"), [{label: "# builds failed", data: d1}],
@@ -131,7 +130,6 @@ for ($beginning_timestamp = $starttime; $beginning_timestamp > $starttime - 3600
                     max: <?php echo $t + 100000000 ?>}
             }));
         <?php
-
         } ?>
     });
 

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -79,6 +79,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
     require_once 'models/build.php';
     require_once 'models/subproject.php';
 
+    $PDO = get_link_identifier()->getPdo();
     $response = array();
 
     $db = pdo_connect("$CDASH_DB_HOST", "$CDASH_DB_LOGIN", "$CDASH_DB_PASS");
@@ -143,6 +144,16 @@ function echo_main_dashboard_JSON($project_instance, $date)
         $parent_build->Id = $parentid;
         $date = $parent_build->GetDate();
         $response['parentid'] = $parentid;
+
+        // Check if the parent build has any notes.
+        $stmt = $PDO->prepare(
+            'SELECT COUNT(buildid) FROM build2note WHERE buildid = ?');
+        pdo_execute($stmt, [$parentid]);
+        if ($stmt->fetchColumn() > 0) {
+            $response['parenthasnotes'] = true;
+        } else {
+            $response['parenthasnotes'] = false;
+        }
     } else {
         $response['parentid'] = -1;
     }

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -124,6 +124,11 @@
         <div id="buildname" align="left">
           <b>Build Name</b>: {{::cdash.buildname}}
           <img ng-if="::cdash.buildplatform" class="icon" alt="platform" ng-src="img/platform_{{::cdash.buildplatform}}.png"/>
+          <a title="View notes"
+             ng-if="::cdash.parenthasnotes"
+             ng-href="viewNotes.php?buildid={{::cdash.parentid}}">
+            <img src="img/document.png" alt="Notes" class="icon"/>
+          </a>
           <a ng-if="::cdash.changelink" target="_blank" ng-href="{{::cdash.changelink}}">
             <img class="smallicon" ng-src="{{::cdash.changeicon}}"/>
           </a>

--- a/tests/data/MultipleSubprojects/Notes.xml
+++ b/tests/data/MultipleSubprojects/Notes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
+<Site BuildName="CTestTest-Linux-c++-Subprojects" BuildStamp="20160728-1932-Experimental" Name="livonia-linux" Generator="ctest-3.6.20160726-g3e55f-dirty">
+	<Notes>
+		<Note Name="/tmp/foo.txt">
+			<Time>1.46973e+09</Time>
+			<DateTime>Jul 28 15:32 EDT</DateTime>
+			<Text>foo
+</Text>
+		</Note>
+	</Notes>
+</Site>

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -38,6 +38,11 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             return 1;
         }
 
+        if (!$this->submission('SubProjectExample', "$rep/Notes.xml")) {
+            $this->fail('failed to submit Notes.xml');
+            return 1;
+        }
+
         // Get the buildids that we just created so we can delete it later.
         $buildids = array();
         $buildid_results = pdo_query(
@@ -130,6 +135,10 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             $num_children = $jsonobj['numchildren'];
             if ($num_children != 4) {
                 throw new Exception("Expected 4 subprojects, found $num_children");
+            }
+
+            if ($jsonobj['parenthasnotes'] !== true) {
+                throw new Exception("parenthasnotes not set to true when expected");
             }
 
             $buildgroup = array_pop($jsonobj['buildgroups']);


### PR DESCRIPTION
For our new method of submitting SubProject builds all at once, any notes submitted get assigned to the parent build, not the individual children SubProject builds.  In this case, we now display a link to such Notes at the top of the page, alongside other bits of information that are common among the children.