### PR TITLE
Add SubProject position column

### DIFF
--- a/include/index_functions.php
+++ b/include/index_functions.php
@@ -122,6 +122,7 @@ function get_index_query($userupdatesql='')
         das.checker, das.numdefects,
         sp.id AS subprojectid,
         sp.groupid AS subprojectgroup,
+        sp.position AS subprojectposition,
         g.name AS groupname,gp.position,g.id AS groupid,
         (SELECT count(buildid) FROM label2build WHERE buildid=b.id) AS numlabels,
         (SELECT count(buildid) FROM build2uploadfile WHERE buildid=b.id) AS builduploadfiles

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -847,6 +847,13 @@ function echo_main_dashboard_JSON($project_instance, $date)
         }
         $build_response['label'] = $build_label;
 
+        // Report subproject position for this build (if any).
+        if ($build_array['subprojectposition']) {
+            $build_response['position'] = $build_array['subprojectposition'];
+        } else {
+            $build_response['position'] = 0;
+        }
+
         // Calculate this build's total duration.
         $duration = strtotime($build_array['endtime']) -
             strtotime($build_array['starttime']);

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -809,6 +809,9 @@ if (isset($_GET['upgrade-2-6'])) {
     // Support for authenticated submissions.
     AddTableField('project', 'authenticatesubmissions', 'tinyint(1)', 'smallint', '0');
 
+    // Add position field to subproject table.
+    AddTableField('subproject', 'position', 'smallint(6) unsigned', 'smallint', '0');
+
     // Set the database version
     setVersion();
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -183,7 +183,8 @@
               <td ng-if="::buildgroup.hasconfiguredata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Configure</td>
               <td ng-if="::buildgroup.hascompilationdata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Build</td>
               <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 +  + cdash.advancedview}}" width="15%" class="timeheader botl">Test</td>
-              <td align="center" width="20%" class="timeheader botl"></td>
+              <td ng-if="::cdash.showstarttime" align="center" width="20%" class="timeheader botl"></td>
+              <td ng-if="::cdash.showorder" align="center" width="5%" class="timeheader botl"></td>
               <td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
             </tr>
 
@@ -256,9 +257,18 @@
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <th align="center" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'builddatefull', $event)">
+              <th align="center" width="20%" style="cursor: pointer"
+                  ng-if="::cdash.showstarttime"
+                  ng-click="updateOrderByFields(buildgroup, 'builddatefull', $event)">
                 Start Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-builddatefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('builddatefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+              </th>
+
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::cdash.showorder"
+                  ng-click="updateOrderByFields(buildgroup, 'position', $event)">
+                Order
+                <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-position') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('position') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
               <th ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" rowspan="2" width="5%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(buildgroup, 'label', $event)">

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -362,7 +362,7 @@
   </div>
 </td>
 
-<td align="center">
+<td align="center" ng-if="::cdash.showstarttime">
   <span ng-if="::!build.builddate" class="builddateelapsed" alt="Expected submit time: {{::build.expectedstarttime}}">
     Expected build
   </span>
@@ -372,6 +372,10 @@
       {{::build.builddateelapsed}}
     </span>
   </div>
+</td>
+
+<td align="center" ng-if="::cdash.showorder">
+  {{::build.position}}
 </td>
 
 <!-- display the labels -->

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -907,6 +907,7 @@ CREATE TABLE `subproject` (
   `projectid` int(11) NOT NULL,
   `groupid` int(11) NOT NULL,
   `path` varchar(512) NOT NULL default '',
+  `position` smallint(6) unsigned NOT NULL default '0',
   `starttime` timestamp NOT NULL default '1980-01-01 00:00:00',
   `endtime` timestamp NOT NULL default '1980-01-01 00:00:00',
   PRIMARY KEY  (`id`),

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -825,6 +825,7 @@ CREATE TABLE "subproject" (
   "projectid" bigint NOT NULL,
   "groupid" bigint NOT NULL,
   "path" character varying(512) DEFAULT '' NOT NULL,
+  "position" smallint DEFAULT '0' NOT NULL,
   "starttime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
   "endtime" timestamp(0) DEFAULT '1980-01-01 00:00:00' NOT NULL,
   PRIMARY KEY ("id"),

--- a/tests/data/MultipleSubprojects/Project_2.xml
+++ b/tests/data/MultipleSubprojects/Project_2.xml
@@ -1,0 +1,10 @@
+<Project name="SubProjectExample">
+  <SubProject name="MyProductionCode">
+  </SubProject>
+  <SubProject name="MyExperimentalFeature">
+  </SubProject>
+  <SubProject name="EmptySubproject">
+  </SubProject>
+  <SubProject name="MyThirdPartyDependency">
+  </SubProject>
+</Project>

--- a/xml_handlers/project_handler.php
+++ b/xml_handlers/project_handler.php
@@ -25,6 +25,7 @@ class ProjectHandler extends AbstractHandler
 {
     private $Project;
     private $SubProject;
+    private $SubProjectPosition;
     private $Dependencies; // keep an array of dependencies in order to remove them
     private $SubProjects; // keep an array of subprojects in order to remove them
     private $CurrentDependencies; // The dependencies of the current SubProject.
@@ -44,6 +45,8 @@ class ProjectHandler extends AbstractHandler
         $this->Project = new Project();
         $this->Project->Id = $projectid;
         $this->Project->Fill();
+
+        $this->SubProjectPosition = 1;
     }
 
     /** startElement function */
@@ -162,7 +165,9 @@ class ProjectHandler extends AbstractHandler
             }
         } elseif ($name == 'SUBPROJECT') {
             // Insert the SubProject.
+            $this->SubProject->SetPosition($this->SubProjectPosition);
             $this->SubProject->Save();
+            $this->SubProjectPosition++;
 
             // Insert the label.
             $Label = new Label;


### PR DESCRIPTION
Now that we are building SubProjects all at once we can no longer rely on build start time to sort them in dependency order.  Instead, we keep track of the order that the SubProjects are listed in Project.xml and add this as a new sort column on index.php.