### PR TITLE
Update coverage parsers for all-at-once SubProject builds

### DIFF
--- a/models/build.php
+++ b/models/build.php
@@ -2519,4 +2519,25 @@ class Build
 
         return $query->fetchAll($fetchStyle);
     }
+
+    /**
+     * Return a SubProject build for a particular parent if it exists.
+     */
+    public static function GetSubProjectBuild($parentid, $subprojectid)
+    {
+        $pdo = get_link_identifier()->getPdo();
+        $stmt = $pdo->prepare(
+            'SELECT b.id FROM build b
+            JOIN subproject2build sp2b ON (sp2b.buildid = b.id)
+            WHERE b.parentid = ? AND sp2b.subprojectid = ?');
+        pdo_execute($stmt, [$parentid, $subprojectid]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            return null;
+        }
+        $build = new Build();
+        $build->Id = $row['id'];
+        $build->FillFromId($build->Id);
+        return $build;
+    }
 }

--- a/tests/data/MultipleSubprojects/Coverage.xml
+++ b/tests/data/MultipleSubprojects/Coverage.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="CTestTest-Linux-c++-Subprojects"
+        BuildStamp="20160728-1932-Experimental"
+        Name="livonia-linux"
+        Generator="ctest-3.6.20160726-g3e55f-dirty"
+        CompilerName=""
+        CompilerVersion=""
+        OSName="Linux"
+        Hostname="livonia-linux"
+        OSRelease="3.13.0-35-generic"
+        OSVersion="#62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014"
+        OSPlatform="x86_64"
+        Is64Bits="1"
+        VendorString="GenuineIntel"
+        VendorID="Intel Corporation"
+        FamilyID="6"
+        ModelID="69"
+        ProcessorCacheSize="4096"
+        NumberOfLogicalCPU="4"
+        NumberOfPhysicalCPU="1"
+        TotalVirtualMemory="7627"
+        TotalPhysicalMemory="7890"
+        LogicalProcessorsPerPhysical="4"
+        ProcessorClockFrequency="756"
+        >
+	<Coverage>
+		<StartDateTime>Jul 28 15:32 EDT</StartDateTime>
+		<StartTime>1469734335</StartTime>
+		<File Name="experimental.c" FullPath="./MyExperimentalFeature/experimental.c" Covered="true">
+			<LOCTested>7</LOCTested>
+			<LOCUnTested>3</LOCUnTested>
+			<PercentCoverage>70.00</PercentCoverage>
+			<CoverageMetric>0.85</CoverageMetric>
+			<Labels>
+				<Label>MyExperimentalFeature</Label>
+				<Label>NotASubproject</Label>
+			</Labels>
+		</File>
+		<File Name="production.c" FullPath="./MyProductionCode/production.c" Covered="true">
+			<LOCTested>7</LOCTested>
+			<LOCUnTested>3</LOCUnTested>
+			<PercentCoverage>70.00</PercentCoverage>
+			<CoverageMetric>0.85</CoverageMetric>
+			<Labels>
+				<Label>NotASubproject</Label>
+				<Label>MyProductionCode</Label>
+			</Labels>
+		</File>
+		<LOCTested>14</LOCTested>
+		<LOCUntested>6</LOCUntested>
+		<LOC>20</LOC>
+		<PercentCoverage>70.00</PercentCoverage>
+		<EndDateTime>Jul 28 15:32 EDT</EndDateTime>
+		<EndTime>1469734335</EndTime>
+		<ElapsedMinutes>0.00</ElapsedMinutes>
+	</Coverage>
+</Site>

--- a/tests/data/MultipleSubprojects/CoverageLog.xml
+++ b/tests/data/MultipleSubprojects/CoverageLog.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="CTestTest-Linux-c++-Subprojects"
+        BuildStamp="20160728-1932-Experimental"
+        Name="livonia-linux"
+        Generator="ctest-3.6.20160726-g3e55f-dirty"
+        CompilerName=""
+        CompilerVersion=""
+        OSName="Linux"
+        Hostname="livonia-linux"
+        OSRelease="3.13.0-35-generic"
+        OSVersion="#62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014"
+        OSPlatform="x86_64"
+        Is64Bits="1"
+        VendorString="GenuineIntel"
+        VendorID="Intel Corporation"
+        FamilyID="6"
+        ModelID="69"
+        ProcessorCacheSize="4096"
+        NumberOfLogicalCPU="4"
+        NumberOfPhysicalCPU="1"
+        TotalVirtualMemory="7627"
+        TotalPhysicalMemory="7890"
+        LogicalProcessorsPerPhysical="4"
+        ProcessorClockFrequency="756"
+        >
+	<CoverageLog>
+		<StartDateTime>Jul 28 15:32 EDT</StartDateTime>
+		<StartTime>1469734335</StartTime>
+		<File Name="experimental.c" FullPath="./MyExperimentalFeature/experimental.c">
+			<Report>
+				<Line Number="0" Count="-1">#include &lt;stdio.h&gt;</Line>
+				<Line Number="1" Count="-1"></Line>
+				<Line Number="2" Count="-1">int main(void)</Line>
+				<Line Number="3" Count="-1">{</Line>
+				<Line Number="4" Count="5">  int i = 0;</Line>
+				<Line Number="5" Count="5">  if (i &gt; 0) {</Line>
+				<Line Number="6" Count="0">    printf("This doesn't happen.\n");</Line>
+				<Line Number="7" Count="0">    printf("Neither does this.\n");</Line>
+				<Line Number="8" Count="0">  }</Line>
+				<Line Number="9" Count="5">  i = i + 1;</Line>
+				<Line Number="10" Count="5">  if (i &gt; 0) {</Line>
+				<Line Number="11" Count="5">    printf("This does happen.\n");</Line>
+				<Line Number="12" Count="5">  }</Line>
+				<Line Number="13" Count="-1"></Line>
+				<Line Number="14" Count="5">  return 0;</Line>
+				<Line Number="15" Count="-1">}</Line>
+			</Report>
+		</File>
+		<File Name="production.c" FullPath="./MyProductionCode/production.c">
+			<Report>
+				<Line Number="0" Count="-1">#include &lt;stdio.h&gt;</Line>
+				<Line Number="1" Count="-1"></Line>
+				<Line Number="2" Count="-1">int main(void)</Line>
+				<Line Number="3" Count="-1">{</Line>
+				<Line Number="4" Count="1">  int j = 0;</Line>
+				<Line Number="5" Count="1">  if (j &gt; 0) {</Line>
+				<Line Number="6" Count="0">    printf("This doesn't happen.\n");</Line>
+				<Line Number="7" Count="0">    printf("Neither does this.\n");</Line>
+				<Line Number="8" Count="0">  }</Line>
+				<Line Number="9" Count="1">  j = j + 1;</Line>
+				<Line Number="10" Count="1">  if (j &gt; 0) {</Line>
+				<Line Number="11" Count="1">    printf("This does happen.\n");</Line>
+				<Line Number="12" Count="1">  }</Line>
+				<Line Number="13" Count="-1"></Line>
+				<Line Number="14" Count="1">  return 0;</Line>
+				<Line Number="15" Count="-1">}</Line>
+			</Report>
+		</File>
+		<EndDateTime>Jul 28 15:32 EDT</EndDateTime>
+		<EndTime>1469734335</EndTime>
+	</CoverageLog>
+</Site>

--- a/tests/data/MultipleSubprojects/Project.xml
+++ b/tests/data/MultipleSubprojects/Project.xml
@@ -677,11 +677,15 @@
     </EmailAddresses>
   </SubProject>
   <SubProject name="MyThirdPartyDependency">
+    <Path>packages/with_subpackages</Path>
   </SubProject>
   <SubProject name="MyExperimentalFeature">
+      <Path>MyExperimentalFeature</Path>
   </SubProject>
   <SubProject name="MyProductionCode">
+    <Path>MyProductionCode</Path>
   </SubProject>
   <SubProject name="EmptySubproject">
+      <Path>EmptySubproject</Path>
   </SubProject>
 </Project>

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -33,6 +33,16 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             return 1;
         }
 
+        if (!$this->submission('SubProjectExample', "$rep/Coverage.xml")) {
+            $this->fail('failed to submit Coverage.xml');
+            return 1;
+        }
+
+        if (!$this->submission('SubProjectExample', "$rep/CoverageLog.xml")) {
+            $this->fail('failed to submit CoverageLog.xml');
+            return 1;
+        }
+
         if (!$this->submission('SubProjectExample', "$rep/Test.xml")) {
             $this->fail('failed to submit Test.xml');
             return 1;
@@ -124,7 +134,26 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
             $numtestnotrun = $buildgroup['numtestnotrun'];
             if ($numtestnotrun != 1) {
-                throw new Exception('Expected 1tests to not run, found ' . $numtestnotrun);
+                throw new Exception('Expected 1 test not run, found ' . $numtestnotrun);
+            }
+
+            // Check coverage
+            $numcoverages = count($jsonobj['coverages']);
+            if ($numcoverages != 1) {
+                throw new Exception("Expected 1 coverage build, found $numcoverages");
+            }
+            $cov = $jsonobj['coverages'][0];
+            $percent = $cov['percentage'];
+            if ($percent != 70) {
+                throw new Exception("Expected 70% coverage, found $percent");
+            }
+            $loctested = $cov['loctested'];
+            if ($loctested != 14) {
+                throw new Exception("Expected 14 LOC tested, found $loctested");
+            }
+            $locuntested = $cov['locuntested'];
+            if ($locuntested != 6) {
+                throw new Exception("Expected 6 LOC untested, found $locuntested");
             }
 
             // View parent build
@@ -139,6 +168,11 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
             if ($jsonobj['parenthasnotes'] !== true) {
                 throw new Exception("parenthasnotes not set to true when expected");
+            }
+
+            $numcoverages = count($jsonobj['coverages']);
+            if ($numcoverages != 2) {
+                throw new Exception("Expected 2 subproject coverages, found $numcoverages");
             }
 
             $buildgroup = array_pop($jsonobj['buildgroups']);

--- a/xml_handlers/coverage_handler.php
+++ b/xml_handlers/coverage_handler.php
@@ -175,8 +175,8 @@ class CoverageHandler extends AbstractHandler
 
         if ($parent == 'COVERAGE') {
             switch ($element) {
-                case 'STARTBUILDTIME':
-                    $this->StartTimeStamp .= $data;
+                case 'STARTTIME':
+                    $this->StartTimeStamp = $data;
                     break;
                 case 'STARTDATETIME':
                     $this->StartTimeStamp = str_to_time($data, $this->Build->GetStamp());

--- a/xml_handlers/coverage_handler.php
+++ b/xml_handlers/coverage_handler.php
@@ -17,6 +17,7 @@
 require_once 'xml_handlers/abstract_handler.php';
 require_once 'models/coverage.php';
 require_once 'models/label.php';
+require_once 'models/project.php';
 
 class CoverageHandler extends AbstractHandler
 {
@@ -24,8 +25,9 @@ class CoverageHandler extends AbstractHandler
     private $EndTimeStamp;
 
     private $Coverage;
+    private $Coverages;
     private $CoverageFile;
-    private $CoverageSummary;
+    private $CoverageSummaries;
     private $Label;
 
     /** Constructor */
@@ -34,7 +36,11 @@ class CoverageHandler extends AbstractHandler
         parent::__construct($projectID, $scheduleID);
         $this->Build = new Build();
         $this->Site = new Site();
-        $this->CoverageSummary = new CoverageSummary();
+        $this->Coverages = [];
+        $this->CoverageSummaries = [];
+        $this->Project = new Project();
+        $this->Project->Id = $this->projectid;
+        $this->HasSubProjects = $this->Project->GetNumberOfSubProjects() > 0;
     }
 
     /** startElement */
@@ -107,14 +113,53 @@ class CoverageHandler extends AbstractHandler
                 $this->Build->UpdateBuild($this->Build->Id, -1, -1);
             }
 
-            $GLOBALS['PHP_ERROR_BUILD_ID'] = $this->Build->Id;
-            $this->CoverageSummary->BuildId = $this->Build->Id;
+            foreach ($this->Coverages as $coverageInfo) {
+                $coverage = $coverageInfo[0];
+                $coverageFile = $coverageInfo[1];
+                $buildid = $this->Build->Id;
+                if ($this->HasSubProjects) {
+                    // Make sure this file gets associated with the correct SubProject.
+                    $subproject = SubProject::GetSubProjectFromPath(
+                            $coverageFile->FullPath, $this->projectid);
+                    if (!is_null($subproject)) {
+                        // Find the sibling build that performed this SubProject.
+                        $subprojectBuild = Build::GetSubProjectBuild(
+                                $this->Build->GetParentId(), $subproject->GetId());
+                        if (is_null($subprojectBuild)) {
+                            // Build doesn't exist yet, add it here.
+                            $subprojectBuild = new Build();
+                            $subprojectBuild->Name = $this->Build->Name;
+                            $subprojectBuild->ProjectId = $this->projectid;
+                            $subprojectBuild->SiteId = $this->Build->SiteId;
+                            $subprojectBuild->SetParentId($this->Build->GetParentId());
+                            $subprojectBuild->SetStamp($this->Build->GetStamp());
+                            $subprojectBuild->SetSubProject($subproject->GetName());
+                            $subprojectBuild->StartTime = $this->Build->StartTime;
+                            $subprojectBuild->EndTime = $this->Build->EndTime;
+                            $subprojectBuild->SubmitTime = gmdate(FMT_DATETIME);
+                            add_build($subprojectBuild, 0);
+                        }
+                        $buildid = $subprojectBuild->Id;
+                    }
+                }
+                if (!array_key_exists($buildid, $this->CoverageSummaries)) {
+                    $coverageSummary = new CoverageSummary();
+                    $coverageSummary->BuildId = $buildid;
+                    $this->CoverageSummaries[$buildid] = $coverageSummary;
+                }
+                $this->CoverageSummaries[$buildid]->AddCoverage($coverage);
+            }
 
-            // Insert coverage summary
-            $this->CoverageSummary->Insert(true);
-            $this->CoverageSummary->ComputeDifference();
+            // Insert coverage summaries
+            foreach ($this->CoverageSummaries as $coverageSummary) {
+                $GLOBALS['PHP_ERROR_BUILD_ID'] = $coverageSummary->BuildId;
+                $coverageSummary->Insert(true);
+                $coverageSummary->ComputeDifference();
+            }
         } elseif ($name == 'FILE') {
-            $this->CoverageSummary->AddCoverage($this->Coverage);
+            // Store this data.
+            // We will insert it once we're done parsing the whole file.
+            $this->Coverages[] = [$this->Coverage, $this->CoverageFile];
         } elseif ($name == 'LABEL') {
             if (isset($this->Coverage)) {
                 $this->Coverage->AddLabel($this->Label);

--- a/xml_handlers/coverage_log_handler.php
+++ b/xml_handlers/coverage_log_handler.php
@@ -16,6 +16,7 @@
 
 require_once 'xml_handlers/abstract_handler.php';
 require_once 'models/coverage.php';
+require_once 'models/project.php';
 
 class CoverageLogHandler extends AbstractHandler
 {
@@ -92,13 +93,46 @@ class CoverageLogHandler extends AbstractHandler
                 // Otherwise make sure that it's up-to-date.
                 $this->Build->UpdateBuild($this->Build->Id, -1, -1);
             }
+
+            // Does this project have subprojects?
+            $project = new Project();
+            $project->Id = $this->projectid;
+            $has_subprojects = $project->GetNumberOfSubProjects() > 0;
+
             // Record the coverage data that we parsed from this file.
             foreach ($this->CoverageFiles as $coverageInfo) {
                 $coverageFile = $coverageInfo[0];
                 $coverageFileLog = $coverageInfo[1];
                 $coverageFile->TrimLastNewline();
-                $coverageFile->Update($this->Build->Id);
-                $coverageFileLog->BuildId = $this->Build->Id;
+
+                $buildid = $this->Build->Id;
+                if ($has_subprojects) {
+                    // Make sure this file gets associated with the correct
+                    // subproject based on its path.
+                    $subproject = SubProject::GetSubProjectFromPath(
+                            $coverageFile->FullPath, $this->projectid);
+                    if (!is_null($subproject)) {
+                        $subprojectBuild = Build::GetSubProjectBuild(
+                                $this->Build->GetParentId(), $subproject->GetId());
+                        if (is_null($subprojectBuild)) {
+                            // This SubProject build doesn't exist yet, add it here.
+                            $subprojectBuild = new Build();
+                            $subprojectBuild->ProjectId = $this->projectid;
+                            $subprojectBuild->Name = $this->Build->Name;
+                            $subprojectBuild->SiteId = $this->Build->SiteId;
+                            $subprojectBuild->SetParentId($this->Build->GetParentId());
+                            $subprojectBuild->SetStamp($this->Build->GetStamp());
+                            $subprojectBuild->SetSubProject($subproject->GetName());
+                            $subprojectBuild->StartTime = $this->Build->StartTime;
+                            $subprojectBuild->EndTime = $this->Build->EndTime;
+                            $subprojectBuild->SubmitTime = gmdate(FMT_DATETIME);
+                            add_build($subprojectBuild, 0);
+                        }
+                        $buildid = $subprojectBuild->Id;
+                    }
+                }
+                $coverageFile->Update($buildid);
+                $coverageFileLog->BuildId = $buildid;
                 $coverageFileLog->FileId = $coverageFile->Id;
                 $coverageFileLog->Insert(true);
             }

--- a/xml_handlers/coverage_log_handler.php
+++ b/xml_handlers/coverage_log_handler.php
@@ -162,6 +162,9 @@ class CoverageLogHandler extends AbstractHandler
             case 'LINE':
                 $this->CurrentLine .= $data;
                 break;
+            case 'STARTTIME':
+                $this->StartTimeStamp = $data;
+                break;
             case 'STARTDATETIME':
                 $this->StartTimeStamp =
                     str_to_time($data, $this->Build->GetStamp());


### PR DESCRIPTION
Teach our coverage XML parsers about the SubProject PATH property.  This allows them to correctly assign coverage on a per-SubProject basis by identifying which source files belong to each SubProject.