### PR TITLE
Prevent Project handler from overwriting user permissions

### DIFF
--- a/xml_handlers/project_handler.php
+++ b/xml_handlers/project_handler.php
@@ -217,13 +217,15 @@ class ProjectHandler extends AbstractHandler
                     $userid = $User->Id;
                 }
 
-                // Insert into the UserProject
                 $UserProject = new UserProject();
-                $UserProject->EmailType = 3; // any build
-                $UserProject->EmailCategory = 54; // everything except warnings
                 $UserProject->UserId = $userid;
                 $UserProject->ProjectId = $this->projectid;
-                $UserProject->Save();
+                if (!$UserProject->FillFromUserId()) {
+                    // This user wasn't already subscribed to this project.
+                    $UserProject->EmailType = 3; // any build
+                    $UserProject->EmailCategory = 54; // everything except warnings
+                    $UserProject->Save();
+                }
 
                 // Insert the labels for this user
                 $LabelEmail = new LabelEmail;


### PR DESCRIPTION
We noticed a bug where users were being stripped of their administrative
access to a project.  This was tracked down to the Project.xml parser.
If a user was listed as a contact for a SubProject (via an `<Email>` element)
then their subscription to the project would be replaced with a default
(non-administrative) role.

We now check for a previously existing subscription before saving one
with default permissions.