### PR TITLE
Link back to parent build

### DIFF
--- a/public/api/v1/buildSummary.php
+++ b/public/api/v1/buildSummary.php
@@ -59,7 +59,11 @@ $current_buildid = $build->GetCurrentBuildId();
 $next_buildid = $build->GetNextBuildId();
 
 $menu = array();
-$menu['back'] = 'index.php?project=' . urlencode($project->Name) . '&date=' . get_dashboard_date_from_build_starttime($build->StartTime, $project->NightlyTime);
+if ($build->GetParentId() > 0) {
+    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . "&parentid={$build->GetParentId()}";
+} else {
+    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . '&date=' . get_dashboard_date_from_build_starttime($build->StartTime, $project->NightlyTime);
+}
 
 if ($previous_buildid > 0) {
     $menu['previous'] = "buildSummary.php?buildid=$previous_buildid";

--- a/public/api/v1/viewBuildError.php
+++ b/public/api/v1/viewBuildError.php
@@ -79,7 +79,11 @@ $date = get_dashboard_date_from_build_starttime($build->StartTime, $project_arra
 get_dashboard_JSON_by_name($projectname, $date, $response);
 
 $menu = array();
-$menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . $date;
+if ($build->GetParentId() > 0) {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . "&parentid={$build->GetParentId()}";
+} else {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . $date;
+}
 
 $previous_buildid = $build->GetPreviousBuildId();
 $current_buildid = $build->GetCurrentBuildId();

--- a/public/api/v1/viewDynamicAnalysis.php
+++ b/public/api/v1/viewDynamicAnalysis.php
@@ -47,7 +47,11 @@ get_dashboard_JSON($project->Name, $date, $response);
 $response['title'] = "$project->Name : Dynamic Analysis";
 
 $menu = [];
-$menu['back'] = "index.php?project=$project->Name&date=$date";
+if ($build->GetParentId() > 0) {
+    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . "&parentid={$build->GetParentId()}";
+} else {
+    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . "&date=$date";
+}
 
 $previousbuildid = get_previous_buildid_dynamicanalysis($build->ProjectId, $build->SiteId, $build->Type, $build->Name, $build->StartTime);
 if ($previousbuildid > 0) {

--- a/public/api/v1/viewNotes.php
+++ b/public/api/v1/viewNotes.php
@@ -43,7 +43,11 @@ get_dashboard_JSON_by_name($projectname, $date, $response);
 
 // Menu
 $menu = array();
-$menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . $date;
+if ($build->GetParentId() > 0) {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . "&parentid={$build->GetParentId()}";
+} else {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . $date;
+}
 
 $previous_buildid = $build->GetPreviousBuildId();
 $current_buildid = $build->GetCurrentBuildId();

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -128,7 +128,11 @@ if (isset($_GET['onlypassed'])) {
 }
 
 $nightlytime = get_project_property($projectname, 'nightlytime');
-$menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . get_dashboard_date_from_build_starttime($starttime, $nightlytime);
+if ($build->GetParentId() > 0) {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . "&parentid={$build->GetParentId()}";
+} else {
+    $menu['back'] = 'index.php?project=' . urlencode($projectname) . '&date=' . get_dashboard_date_from_build_starttime($starttime, $nightlytime);
+}
 
 // Get the IDs of the four previous builds.
 // These are used to check the recent history of this test.

--- a/public/views/buildSummary.html
+++ b/public/views/buildSummary.html
@@ -6,6 +6,7 @@
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash</title>
   </head>

--- a/public/views/buildSummary.html
+++ b/public/views/buildSummary.html
@@ -40,7 +40,6 @@
       <br/>
 
       <b>Stamp: </b>{{::cdash.build.stamp}}
-      (<a ng-href="{{::cdash.build.relatedBuildsLink}}"/>related builds</a>)
       <br/>
 
       <b>Time: </b>{{::cdash.build.time}}

--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -81,7 +81,11 @@
           </ul>
         </li>
         <li id="Back" ng-if="cdash.menu.back">
-          <a href="{{cdash.menu.back}}{{cdash.extrafilterurl}}">Back</a>
+          <a ng-href="{{cdash.menu.back}}{{cdash.extrafilterurl}}"
+             tooltip-popup-delay="1500"
+             tooltip-append-to-body="true"
+             tooltip-placement="bottom"
+             uib-tooltip="Go back up one level in the hierarchy of results">Up</a>
         </li>
         <li ng-if="cdash.showcalendar">
           <a id="cal" href="javascript:;" ng-click="toggleCalendar()">Calendar</a>

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -357,6 +357,27 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                     }
                 }
             }
+
+            // Verify that 'Back' links to the parent build.
+            $pages = [
+                'buildSummary.php',
+                'viewBuildError.php',
+                'viewDynamicAnalysis.php',
+                'viewNotes.php',
+                'viewTest.php'
+            ];
+            $child_buildid = $builds[0]['id'];
+
+            foreach ($pages as $page) {
+                $this->get($this->url . "/api/v1/$page?buildid=$child_buildid");
+                $content = $this->getBrowser()->getContent();
+                $jsonobj = json_decode($content, true);
+                $expected = "index.php?project=SubProjectExample&parentid=$parentid";
+                $found = $jsonobj['menu']['back'];
+                if (strpos($found, $expected) === false) {
+                    throw new Exception("$expected not found in back link for $page ($found)");
+                }
+            }
         } catch (Exception $e) {
             $success = false;
             $error_message = $e->getMessage();


### PR DESCRIPTION
When reviewing build results for a particular SubProject, the 'Back' link should take you back to the parent build.  Previously it took you back to the results for the current testing day, which is one step further up.