### PR TITLE
Improve "advanced view" for parent builds

### DIFF
--- a/models/build.php
+++ b/models/build.php
@@ -221,7 +221,7 @@ class Build
     }
 
     /** Update the total testing duration */
-    public function SaveTotalTestsTime($duration)
+    public function SaveTotalTestsTime($duration, $update_parent=true)
     {
         if (!$this->Id || !is_numeric($this->Id)) {
             return false;
@@ -250,6 +250,9 @@ class Build
             return false;
         }
 
+        if (!$update_parent) {
+            return true;
+        }
         // If this is a child build, add this duration
         // to the parent's test duration sum.
         $this->SetParentId($this->LookupParentBuildId());

--- a/models/build.php
+++ b/models/build.php
@@ -2264,7 +2264,7 @@ class Build
         pdo_query("UPDATE build SET notified='1' WHERE id=" . qnum($idToNotify));
     }
 
-    public function SetConfigureDuration($duration)
+    public function SetConfigureDuration($duration, $update_parent=true)
     {
         if (!$this->Id || !is_numeric($this->Id)) {
             return;
@@ -2278,6 +2278,9 @@ class Build
         add_last_sql_error('Build:SetConfigureDuration',
             $this->ProjectId, $this->Id);
 
+        if (!$update_parent) {
+            return;
+        }
         // If this is a child build, add this duration
         // to the parent's configure duration sum.
         $this->SetParentId($this->LookupParentBuildId());
@@ -2292,7 +2295,7 @@ class Build
         }
     }
 
-    public function UpdateBuildDuration($duration)
+    public function UpdateBuildDuration($duration, $update_parent=true)
     {
         if ($duration === 0 || !$this->Id || !is_numeric($this->Id)) {
             return;
@@ -2305,6 +2308,9 @@ class Build
         add_last_sql_error('Build:UpdateBuildDuration',
             $this->ProjectId, $this->Id);
 
+        if (!$update_parent) {
+            return;
+        }
         // If this is a child build, add this duration
         // to the parent's sum.
         $this->SetParentId($this->LookupParentBuildId());

--- a/models/build.php
+++ b/models/build.php
@@ -871,7 +871,11 @@ class Build
 
             // Save the information
             if (!empty($this->Information)) {
-                $this->Information->BuildId = $this->Id;
+                if ($this->ParentId > 0) {
+                    $this->Information->BuildId = $this->ParentId;
+                } else {
+                    $this->Information->BuildId = $this->Id;
+                }
                 $this->Information->Save();
             }
 

--- a/models/buildinformation.php
+++ b/models/buildinformation.php
@@ -23,6 +23,7 @@ class BuildInformation
     public $OSVersion;
     public $CompilerName = 'unknown';
     public $CompilerVersion = 'unknown';
+    private $Filled;
     private $PDO;
 
     public function __construct()
@@ -34,6 +35,7 @@ class BuildInformation
         $this->OSVersion = '';
         $this->CompilerName = 'unknown';
         $this->CompilerVersion = 'unknown';
+        $this->Filled = false;
         $this->PDO = get_link_identifier()->getPdo();
     }
 
@@ -96,5 +98,34 @@ class BuildInformation
         $stmt->bindValue(':compilername', $this->CompilerName);
         $stmt->bindValue(':compilerversion', $this->CompilerVersion);
         return pdo_execute($stmt);
+    }
+
+    /** Load information from the database */
+    public function Fill()
+    {
+        if ($this->Filled) {
+            return true;
+        }
+        if ($this->BuildId < 1) {
+            return false;
+        }
+
+        $stmt = $this->PDO->prepare(
+            'SELECT * FROM buildinformation WHERE buildid = ?');
+        if (!pdo_execute($stmt, [$this->BuildId])) {
+            return false;
+        }
+        $row = $stmt->fetch();
+        if (!$row) {
+            return false;
+        }
+
+        $this->OSName = $row['osname'];
+        $this->OSPlatform = $row['osplatform'];
+        $this->OSRelease = $row['osrelease'];
+        $this->OSVersion = $row['osversion'];
+        $this->CompilerName = $row['compilername'];
+        $this->CompilerVersion = $row['compilerversion'];
+        return true;
     }
 }

--- a/public/api/v1/buildSummary.php
+++ b/public/api/v1/buildSummary.php
@@ -129,28 +129,15 @@ $note_array = pdo_fetch_array($note);
 $build_response['note'] = $note_array['c'];
 
 // Find the OS and compiler information
-$buildinformation = pdo_query("SELECT * FROM buildinformation WHERE buildid='$buildid'");
-if (pdo_num_rows($buildinformation) > 0) {
-    $buildinformation_array = pdo_fetch_array($buildinformation);
-    if ($buildinformation_array['osname'] != '') {
-        $build_response['osname'] = $buildinformation_array['osname'];
-    }
-    if ($buildinformation_array['osplatform'] != '') {
-        $build_response['osplatform'] = $buildinformation_array['osplatform'];
-    }
-    if ($buildinformation_array['osrelease'] != '') {
-        $build_response['osrelease'] = $buildinformation_array['osrelease'];
-    }
-    if ($buildinformation_array['osversion'] != '') {
-        $build_response['osversion'] = $buildinformation_array['osversion'];
-    }
-    if ($buildinformation_array['compilername'] != '') {
-        $build_response['compilername'] = $buildinformation_array['compilername'];
-    }
-    if ($buildinformation_array['compilerversion'] != '') {
-        $build_response['compilerversion'] = $buildinformation_array['compilerversion'];
-    }
-}
+$buildinfo = new BuildInformation();
+$buildinfo->BuildId = $buildid;
+$buildinfo->Fill();
+$build_response['osname'] = $buildinfo->OSName;
+$build_response['osplatform'] = $buildinfo->OSPlatform;
+$build_response['osrelease'] = $buildinfo->OSRelease;
+$build_response['osversion'] = $buildinfo->OSVersion;
+$build_response['compilername'] = $buildinfo->CompilerName;
+$build_response['compilerversion'] = $buildinfo->CompilerVersion;
 
 $build_response['generator'] = $build->Generator;
 $build_response['command'] = $build->Command;

--- a/public/api/v1/buildSummary.php
+++ b/public/api/v1/buildSummary.php
@@ -27,18 +27,14 @@ $start = microtime_float();
 $response = array();
 
 $build = get_request_build();
-
-$date = null;
-if (isset($_GET['date'])) {
-    $date = $_GET['date'];
-}
-
 $buildid = $build->Id;
 $siteid = $build->SiteId;
 
 $project = new Project();
 $project->Id = $build->ProjectId;
 $project->Fill();
+
+$date = get_dashboard_date_from_build_starttime($build->StartTime, $project->NightlyTime);
 
 // Format the text to fit the iPhone
 function format_for_iphone($text)
@@ -62,7 +58,7 @@ $menu = array();
 if ($build->GetParentId() > 0) {
     $menu['back'] = 'index.php?project=' . urlencode($project->Name) . "&parentid={$build->GetParentId()}";
 } else {
-    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . '&date=' . get_dashboard_date_from_build_starttime($build->StartTime, $project->NightlyTime);
+    $menu['back'] = 'index.php?project=' . urlencode($project->Name) . "&date=$date";
 }
 
 if ($previous_buildid > 0) {

--- a/public/api/v1/buildSummary.php
+++ b/public/api/v1/buildSummary.php
@@ -130,7 +130,11 @@ $build_response['note'] = $note_array['c'];
 
 // Find the OS and compiler information
 $buildinfo = new BuildInformation();
-$buildinfo->BuildId = $buildid;
+if ($build->GetParentId() > 0) {
+    $buildinfo->BuildId = $build->GetParentId();
+} else {
+    $buildinfo->BuildId = $buildid;
+}
 $buildinfo->Fill();
 $build_response['osname'] = $buildinfo->OSName;
 $build_response['osplatform'] = $buildinfo->OSPlatform;

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -148,8 +148,25 @@ function echo_main_dashboard_JSON($project_instance, $date)
         $parentid = pdo_real_escape_numeric($_GET['parentid']);
         $parent_build = new Build();
         $parent_build->Id = $parentid;
+        $parent_build->FillFromId($parent_build->Id);
         $date = $parent_build->GetDate();
         $response['parentid'] = $parentid;
+
+        $response['stamp'] = $parent_build->GetStamp();
+        $response['starttime'] = $parent_build->StartTime;
+        $response['type'] = $parent_build->Type;
+
+        // Include data about this build from the buildinformation table.
+        require_once 'models/buildinformation.php';
+        $buildinfo = new BuildInformation();
+        $buildinfo->BuildId = $parentid;
+        $buildinfo->Fill();
+        $response['osname'] = $buildinfo->OSName;
+        $response['osplatform'] = $buildinfo->OSPlatform;
+        $response['osrelease'] = $buildinfo->OSRelease;
+        $response['osversion'] = $buildinfo->OSVersion;
+        $response['compilername'] = $buildinfo->CompilerName;
+        $response['compilerversion'] = $buildinfo->CompilerVersion;
 
         // Check if the parent build has any notes.
         $stmt = $PDO->prepare(

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -160,6 +160,12 @@ function echo_main_dashboard_JSON($project_instance, $date)
         } else {
             $response['parenthasnotes'] = false;
         }
+
+        // Check if the parent build has any uploaded files.
+        $stmt = $PDO->prepare(
+            'SELECT COUNT(buildid) FROM build2uploadfile WHERE buildid = ?');
+        pdo_execute($stmt, [$parentid]);
+        $response['uploadfilecount'] = $stmt->fetchColumn();
     } else {
         $response['parentid'] = -1;
     }
@@ -775,6 +781,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $build_response['siteid'] = $siteid;
             $build_response['buildname'] = $build_array['name'];
             $build_response['buildplatform'] = $buildplatform;
+            $build_response['uploadfilecount'] = $build_array['builduploadfiles'];
             if (!is_null($changelink)) {
                 $build_response['changelink'] = $changelink;
                 $build_response['changeicon'] = $changeicon;
@@ -786,7 +793,6 @@ function echo_main_dashboard_JSON($project_instance, $date)
         }
         $build_response['id'] = $build_array['id'];
         $build_response['done'] = $build_array['done'];
-        $build_response['uploadfilecount'] = $build_array['builduploadfiles'];
 
         $build_response['buildnotes'] = $build_array['countbuildnotes'];
         $build_response['notes'] = $build_array['countnotes'];

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -214,11 +214,18 @@ CDash.filter("showEmptyBuildsLast", function () {
 
     // Read simple/advanced view cookie setting.
     var advanced_cookie = $.cookie('cdash_'+$scope.cdash.projectname+'_advancedview');
+    var show_time_columns = 0;
     if(advanced_cookie == 1) {
       $scope.cdash.advancedview = 1;
+      if ($scope.cdash.showstarttime) {
+        // Don't show time columns for all-at-once subproject builds.
+        // This situation is identified by showstarttime being false.
+        show_time_columns = 1;
+      }
     } else {
       $scope.cdash.advancedview = 0;
     }
+    $scope.cdash.showtimecolumns = show_time_columns;
 
     if (!$scope.cdash.feed) {
       $scope.showFeed = false;

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -170,6 +170,25 @@
           <div id="generator" align="left">
           <b>CTest version: </b>{{::cdash.generator}}
           </div>
+
+          <div ng-if="::cdash.showorder">
+            <div ng-if="::cdash.updateduration != false"
+                 id="updateduration" align="left">
+              <b>Update Time: </b>{{::cdash.updateduration}}
+            </div>
+            <div ng-if="::cdash.configureduration != false"
+                 id="configureduration" align="left">
+              <b>Configure Time: </b>{{::cdash.configureduration}}
+            </div>
+            <div ng-if="::cdash.buildduration != false"
+                 id="buildduration" align="left">
+              <b>Build Time: </b>{{::cdash.buildduration}}
+            </div>
+            <div ng-if="::cdash.testduration != false"
+                 id="testduration" align="left">
+              <b>Test Time: </b>{{::cdash.testduration}}
+            </div>
+          </div>
         </div>
 
         <br/>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -214,10 +214,10 @@
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-buildname') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('buildname') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
-              <td ng-if="::buildgroup.hasupdatedata" align="center" colspan="{{::1 + cdash.advancedview}}" width="5%" class="timeheader botl">Update</td>
-              <td ng-if="::buildgroup.hasconfiguredata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Configure</td>
-              <td ng-if="::buildgroup.hascompilationdata" align="center" colspan="{{::2 + cdash.advancedview}}" width="10%" class="timeheader botl">Build</td>
-              <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 +  + cdash.advancedview}}" width="15%" class="timeheader botl">Test</td>
+              <td ng-if="::buildgroup.hasupdatedata" align="center" colspan="{{::1 + cdash.showtimecolumns}}" width="5%" class="timeheader botl">Update</td>
+              <td ng-if="::buildgroup.hasconfiguredata" align="center" colspan="{{::2 + cdash.showtimecolumns}}" width="10%" class="timeheader botl">Configure</td>
+              <td ng-if="::buildgroup.hascompilationdata" align="center" colspan="{{::2 + cdash.showtimecolumns}}" width="10%" class="timeheader botl">Build</td>
+              <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 +  + cdash.showtimecolumns}}" width="15%" class="timeheader botl">Test</td>
               <td ng-if="::cdash.showstarttime" align="center" width="20%" class="timeheader botl"></td>
               <td ng-if="::cdash.showorder" align="center" width="5%" class="timeheader botl"></td>
               <td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
@@ -230,7 +230,7 @@
               </th>
 
               <th align="center" width="5%" style="cursor: pointer"
-                  ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0"
+                  ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0 && cdash.showstarttime"
                   ng-click="updateOrderByFields(buildgroup, 'update.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-update.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('update.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -247,7 +247,7 @@
               </th>
 
               <th align="center" width="5%" style="cursor: pointer"
-                  ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0"
+                  ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0 && cdash.showstarttime"
                   ng-click="updateOrderByFields(buildgroup, 'configure.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-configure.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('configure.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -264,7 +264,7 @@
               </th>
 
               <th align="center" width="5%" style="cursor: pointer"
-                  ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0"
+                  ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0 && cdash.showstarttime"
                   ng-click="updateOrderByFields(buildgroup, 'compilation.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-compilation.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('compilation.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -286,7 +286,7 @@
               </th>
 
               <th align="center" width="5%" style="cursor: pointer"
-                  ng-if="::buildgroup.hastestdata && cdash.advancedview != 0"
+                  ng-if="::buildgroup.hastestdata && cdash.advancedview != 0 && cdash.showstarttime"
                   ng-click="updateOrderByFields(buildgroup, 'test.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -144,6 +144,34 @@
         <div id="numbuilds" align="left">
           <b>Number of SubProjects</b>: {{::cdash.numchildren}}
         </div>
+
+        <div ng-if="::cdash.advancedview != 0">
+          <div id="buildstamp" align="left">
+            <b>Stamp</b>: {{::cdash.stamp}}
+          </div>
+          <div id="buildstarttime" align="left">
+            <b>Build Start Time</b>: {{::cdash.starttime}}
+          </div>
+          <div id="buildtype" align="left">
+            <b>Type</b>: {{::cdash.type}}
+          </div>
+          <div id="osname" align="left">
+            <b>OS Name</b>: {{::cdash.osname}}
+          </div>
+          <div id="osplatform" align="left">
+            <b>OS Platform</b>: {{::cdash.osplatform}}
+          </div>
+          <div id="osrelease" align="left">
+            <b>OS Release</b>: {{::cdash.osrelease}}
+          </div>
+          <div id="osversion" align="left">
+            <b>OS Version</b>: {{::cdash.osversion}}
+          </div>
+          <div id="generator" align="left">
+          <b>CTest version: </b>{{::cdash.generator}}
+          </div>
+        </div>
+
         <br/>
       </div>
 

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -129,6 +129,13 @@
              ng-href="viewNotes.php?buildid={{::cdash.parentid}}">
             <img src="img/document.png" alt="Notes" class="icon"/>
           </a>
+
+          <a ng-if="::cdash.uploadfilecount > 0"
+             ng-href="viewFiles.php?buildid={{::cdash.parentid}}"
+             title="{{::cdash.uploadfilecount}} files uploaded with this build">
+            <img src="img/package.png" alt="Files" class="icon"/>
+          </a>
+
           <a ng-if="::cdash.changelink" target="_blank" ng-href="{{::cdash.changelink}}">
             <img class="smallicon" ng-src="{{::cdash.changeicon}}"/>
           </a>

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -217,7 +217,8 @@
   </div>
 </td>
 
-<td ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0" align="right">
+<td ng-if="::buildgroup.hasupdatedata && cdash.advancedview != 0 && cdash.showstarttime"
+    align="center">
   <div ng-if="::build.hasupdate">
     {{::build.update.time}}
   </div>
@@ -241,7 +242,8 @@
   </div>
 </td>
 
-<td ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0" align="center">
+<td ng-if="::buildgroup.hasconfiguredata && cdash.advancedview != 0 && cdash.showstarttime"
+    align="center">
   <div ng-if="::build.hasconfigure">
     {{::build.configure.time}}
   </div>
@@ -279,7 +281,8 @@
   </div>
 </td>
 
-<td ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0" align="center">
+<td ng-if="::buildgroup.hascompilationdata && cdash.advancedview != 0 && cdash.showstarttime"
+    align="center">
   <div ng-if="::build.hascompilation">
     {{::build.compilation.time}}
   </div>
@@ -330,7 +333,7 @@
 </td>
 
 <td align="center"
-    ng-if="::buildgroup.hastestdata && cdash.advancedview != 0"
+    ng-if="::buildgroup.hastestdata && cdash.advancedview != 0 && cdash.showstarttime"
     ng-class="::{'error': build.test.timestatus > 0, 'normal': build.test.timestatus == 0}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.build.test.ntimediffp > 0 || build.test.ntimediffn > 0}">

--- a/tests/data/MultipleSubprojects/Build.xml
+++ b/tests/data/MultipleSubprojects/Build.xml
@@ -205,8 +205,8 @@ compilation terminated.</StdErr>
                         </Labels>
                 </Failure>
                 <Log Encoding="base64" Compression="bin/gzip"/>
-                <EndDateTime>Jul 28 15:32 EDT</EndDateTime>
-                <EndBuildTime>1469734335</EndBuildTime>
+                <EndDateTime>Jul 28 15:37 EDT</EndDateTime>
+                <EndBuildTime>1469734340</EndBuildTime>
                 <ElapsedMinutes>0</ElapsedMinutes>
         </Build>
 </Site>

--- a/tests/data/MultipleSubprojects/Test.xml
+++ b/tests/data/MultipleSubprojects/Test.xml
@@ -260,8 +260,8 @@
                                 <Label>MyProductionCode</Label>
                         </Labels>
                 </Test>
-                <EndDateTime>Jul 28 15:32 EDT</EndDateTime>
-                <EndTestTime>1469734335</EndTestTime>
+                <EndDateTime>Jul 28 15:36 EDT</EndDateTime>
+                <EndTestTime>1469734339</EndTestTime>
                 <ElapsedMinutes>0</ElapsedMinutes>
         </Testing>
 </Site>

--- a/tests/data/MultipleSubprojects/Upload.xml
+++ b/tests/data/MultipleSubprojects/Upload.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
+<Site BuildName="CTestTest-Linux-c++-Subprojects" BuildStamp="20160728-1932-Experimental" Name="livonia-linux" Generator="ctest-3.6.20160726-g3e55f-dirty">
+	<Upload>
+		<File filename="/tmp/tmp.url">
+			<Content encoding="base64">aHR0cHM6Ly93d3cuZ29vZ2xlLmNvbQo=</Content>
+		</File>
+	</Upload>
+</Site>

--- a/tests/js/e2e_tests/done_build.js
+++ b/tests/js/e2e_tests/done_build.js
@@ -41,7 +41,7 @@ describe("done_build", function() {
   });
 
   it("toggle done for parent build", function() {
-    toggle_done('index.php?project=Trilinos&date=2011-07-22', 1);
+    toggle_done('index.php?project=Trilinos&date=2011-07-22', 2);
   });
 
 });

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -67,10 +67,19 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         $pdo = get_link_identifier()->getPdo();
         $buildids = array();
 
-        $buildid_results = $pdo->query(
-            "SELECT id FROM build WHERE name='CTestTest-Linux-c++-Subprojects'");
-        while ($buildid_array = $buildid_results->fetch()) {
-            $buildids[] = $buildid_array['id'];
+        $build_results = $pdo->query(
+            "SELECT id, buildduration, configureduration FROM build
+            WHERE name='CTestTest-Linux-c++-Subprojects'");
+        while ($build_array = $build_results->fetch()) {
+            $buildids[] = $build_array['id'];
+            $build_duration = $build_array['buildduration'];
+            if ($build_duration != 5) {
+                $this->fail("Expected 5 but found $build_duration for {$build_array['id']}'s build duration");
+            }
+            $configure_duration = $build_array['configureduration'];
+            if ($configure_duration != 1) {
+                $this->fail("Expected 5 but found $configure_duration for {$build_array['id']}'s configure duration");
+            }
         }
 
         if (count($buildids) != 5) {    // parent + 4 subprojects

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -217,6 +217,19 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 throw new Exception("Expected 3 subproject dynamic analyses, found $numdynamicanalyses");
             }
 
+            if ($jsonobj['updateduration'] !== false) {
+                throw new Exception("Expected updateduration to be false, found {$jsonobj['updateduration']}");
+            }
+            if ($jsonobj['configureduration'] != '1s') {
+                throw new Exception("Expected configureduration to be 1s, found {$jsonobj['configureduration']}");
+            }
+            if ($jsonobj['buildduration'] != '5s') {
+                throw new Exception("Expected buildduration to be 5s, found {$jsonobj['buildduration']}");
+            }
+            if ($jsonobj['testduration'] != '4s') {
+                throw new Exception("Expected testduration to be 4s, found {$jsonobj['testduration']}");
+            }
+
             $buildgroup = array_pop($jsonobj['buildgroups']);
             $builds = $buildgroup['builds'];
 

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -320,8 +320,8 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 }
             }
 
-            // Verify that dynamic analysis data was correctly split across SubProjects.
             foreach ($builds as $build) {
+                // Verify that dynamic analysis data was correctly split across SubProjects.
                 $stmt = $pdo->query("SELECT numdefects FROM dynamicanalysissummary WHERE buildid = {$build['id']}");
                 $summary_total = $stmt->fetchColumn();
                 $this->get($this->url . "/api/v1/viewDynamicAnalysis.php?buildid={$build['id']}");
@@ -374,6 +374,13 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                     if ($expected_defect_type != $defect_type) {
                         throw new Exception("Expected type $expected_defect_type for {$build['label']}, found $defect_type");
                     }
+                }
+
+                // Verify that test duration is calculated correctly.
+                $stmt = $pdo->query("SELECT time FROM buildtesttime WHERE buildid = {$build['id']}");
+                $found = $stmt->fetchColumn();
+                if ($found !== false && $found != 4) {
+                    throw new Exception("Expected 4 but found $found for {$build['id']}'s test duration");
                 }
             }
 

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -58,6 +58,11 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             return 1;
         }
 
+        if (!$this->submission('SubProjectExample', "$rep/Upload.xml")) {
+            $this->fail('failed to submit Upload.xml');
+            return 1;
+        }
+
         // Get the buildids that we just created so we can delete it later.
         $pdo = get_link_identifier()->getPdo();
         $buildids = array();
@@ -186,6 +191,11 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
             if ($jsonobj['parenthasnotes'] !== true) {
                 throw new Exception("parenthasnotes not set to true when expected");
+            }
+
+            $num_uploaded_files = $jsonobj['uploadfilecount'];
+            if ($num_uploaded_files  !== 1) {
+                throw new Exception("Expected 1 uploaded file, found $num_uploaded_files");
             }
 
             $numcoverages = count($jsonobj['coverages']);

--- a/xml_handlers/build_handler.php
+++ b/xml_handlers/build_handler.php
@@ -163,6 +163,10 @@ class BuildHandler extends AbstractHandler
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
             $submit_time = gmdate(FMT_DATETIME);
+            // Do not add each build's duration to the parent's tally if this
+            // XML file represents multiple "all-at-once" SubProject builds.
+            $all_at_once = count($this->Builds) > 1;
+            $parent_duration_set = false;
             foreach ($this->Builds as $subproject => $build) {
                 $build->ProjectId = $this->projectid;
                 $build->StartTime = $start_time;
@@ -181,8 +185,16 @@ class BuildHandler extends AbstractHandler
                     $build->AddLabel($label);
                 }
                 add_build($build, $this->scheduleid);
-                $build->UpdateBuildDuration(
-                        $this->EndTimeStamp - $this->StartTimeStamp);
+
+                $duration = $this->EndTimeStamp - $this->StartTimeStamp;
+                $build->UpdateBuildDuration($duration, !$all_at_once);
+                if ($all_at_once && !$parent_duration_set) {
+                    $parent_build = new Build();
+                    $parent_build->Id = $build->GetParentId();
+                    $parent_build->UpdateBuildDuration($duration, false);
+                    $parent_duration_set = true;
+                }
+
                 $build->ComputeDifferences();
 
                 global $CDASH_ENABLE_FEED;

--- a/xml_handlers/configure_handler.php
+++ b/xml_handlers/configure_handler.php
@@ -127,6 +127,14 @@ class ConfigureHandler extends AbstractHandler
         if ($name == 'CONFIGURE') {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
+            // Configure Duration is handled differently if this XML
+            // file represents multiple builds.  We refer to this situation
+            // as an "all at once" SubProject build.  In this case, we do
+            // not want to add each build's configure duration to the parent's
+            // tally.
+            $all_at_once = count($this->Builds) > 1;
+            $parent_duration_set = false;
+
             foreach ($this->Builds as $subproject => $build) {
                 $build->ProjectId = $this->projectid;
                 $build->StartTime = $start_time;
@@ -175,8 +183,14 @@ class ConfigureHandler extends AbstractHandler
                 $build->ComputeConfigureDifferences();
 
                 // Record configure duration with the build.
-                $build->SetConfigureDuration(
-                        $this->EndTimeStamp - $this->StartTimeStamp);
+                $duration = $this->EndTimeStamp - $this->StartTimeStamp;
+                $build->SetConfigureDuration($duration, !$all_at_once);
+                if ($all_at_once && !$parent_duration_set) {
+                    $parent_build = new Build();
+                    $parent_build->Id = $build->GetParentId();
+                    $parent_build->SetConfigureDuration($duration, false);
+                    $parent_duration_set = true;
+                }
             }
 
             // Update the tally of warnings & errors in the parent build,

--- a/xml_handlers/testing_handler.php
+++ b/xml_handlers/testing_handler.php
@@ -229,6 +229,10 @@ class TestingHandler extends AbstractHandler
                 $this->createBuild();
             }
 
+            // Do not accumulate the parent's testing duration if this
+            // XML file represents multiple "all-at-once" SubProject builds.
+            $all_at_once = count($this->Builds) > 1;
+            $parent_duration_set = false;
             foreach ($this->Builds as $subproject => $build) {
                 // Update the number of tests in the Build table
                 $build->UpdateTestNumbers($this->NumberTestsPassed[$subproject],
@@ -238,8 +242,14 @@ class TestingHandler extends AbstractHandler
 
                 if ($this->StartTimeStamp > 0 && $this->EndTimeStamp > 0) {
                     // Update test duration in the Build table.
-                    $build->SaveTotalTestsTime(
-                        $this->EndTimeStamp - $this->StartTimeStamp);
+                    $duration = $this->EndTimeStamp - $this->StartTimeStamp;
+                    $build->SaveTotalTestsTime($duration, !$all_at_once);
+                    if ($all_at_once && !$parent_duration_set) {
+                        $parent_build = new Build();
+                        $parent_build->Id = $build->GetParentId();
+                        $parent_build->SaveTotalTestsTime($duration, false);
+                        $parent_duration_set = true;
+                    }
                 }
 
                 // Update the build's end time to extend through testing.


### PR DESCRIPTION
Show more information that is common to all children at the top of the page.  This includes removing the configure/build/test timing columns for "all at once" SubProject builds.