### PR TITLE
fix -- fixes Private members being output from get_object_vars

### DIFF
--- a/models/project.php
+++ b/models/project.php
@@ -1499,8 +1499,11 @@ class Project
     public function ConvertToJSON()
     {
         $response = array();
-
-        foreach (get_object_vars($this) as $k => $v) {
+        $clone = new ReflectionObject($this);
+        $properties = $clone->getProperties(ReflectionProperty::IS_PUBLIC);
+        foreach ($properties as $property) {
+            $k = $property->getName();
+            $v = $this->$k;
             $response[$k] = $v;
         }
         $response['name_encoded'] = urlencode($this->Name);

--- a/tests/test_projectmodel.php
+++ b/tests/test_projectmodel.php
@@ -53,4 +53,14 @@ class ProjectModelTestCase extends KWWebTestCase
         @$project->SendEmailToAdmin('foo', 'hello world');
         return 0;
     }
+
+    public function testConvertToJsonHasNoPrivateMembers()
+    {
+        $project = new Project();
+        $project->Id = 0;
+
+        $output = $project->ConvertToJSON();
+
+        $this->assertFalse(in_array('PDO', array_keys($output)));
+    }
 }


### PR DESCRIPTION
- This is a workaround for get_object_vars not adhering to output only public member properties
- In reference to: http://public.kitware.com/pipermail/cdash/2017-August/001791.html
bryon.bean@kitware.com