### PR TITLE
Allow global admins to access all private projects

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -418,6 +418,11 @@ function checkUserPolicy($userid, $projectid, $onlyreturn = 0)
             return false;
         }
     } elseif (@$projectid > 0) {
+        // Global admins have access to all projects.
+        if ($user->IsAdmin()) {
+            return true;
+        }
+
         $project = new Project();
         $project->Id = $projectid;
         $project->Fill();


### PR DESCRIPTION
Before this change, a CDash-wide admin would still need to be subscribed to
an individual private project in order to be able to view it.