### PR TITLE
New optional column: Proc Time

### DIFF
--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -141,6 +141,7 @@ function echo_main_dashboard_JSON($project_instance, $date)
     }
     $response['banners'] = $banners;
     $site_response = array();
+    $show_proc_time = false;
 
     // If parentid is set we need to lookup the date for this build
     // because it is not specified as a query string parameter.
@@ -183,6 +184,17 @@ function echo_main_dashboard_JSON($project_instance, $date)
             'SELECT COUNT(buildid) FROM build2uploadfile WHERE buildid = ?');
         pdo_execute($stmt, [$parentid]);
         $response['uploadfilecount'] = $stmt->fetchColumn();
+
+        // For parent builds, we support an additional advanced column called
+        // 'Proc Time'.  This is only shown if this project is setup to display
+        // an extra test measurement called 'Processors'.
+        $stmt = $PDO->prepare(
+            "SELECT id FROM measurement
+            WHERE projectid = ? and name = 'Processors'");
+        pdo_execute($stmt, [$projectid]);
+        if ($stmt->fetchColumn() !== false) {
+            $show_proc_time = true;
+        }
     } else {
         $response['parentid'] = -1;
     }
@@ -1502,6 +1514,68 @@ function echo_main_dashboard_JSON($project_instance, $date)
             $response['coveragegroups'][] = $group;
         }
     }
+
+    // Compute 'Proc Time' here (if necessary).
+    $proc_time_verified = false;
+    if ($show_proc_time) {
+        $test_timing = [];
+        // Look up how long each test took for each build.
+        $stmt = $PDO->prepare(
+            'SELECT b2t.buildid, b2t.testid, b2t.time
+            FROM build2test b2t
+            JOIN build b on (b.id = b2t.buildid)
+            WHERE b.parentid = ?');
+        pdo_execute($stmt, [$parentid]);
+        while ($row = $stmt->fetch()) {
+            $buildid = $row['buildid'];
+            $testid = $row['testid'];
+            $test_duration = $row['time'];
+            if (!array_key_exists($buildid, $test_timing)) {
+                $test_timing[$buildid] = [];
+            }
+            $test_timing[$buildid][$testid] = $test_duration;
+        }
+
+        // Multiply test duration by number of processors for any tests
+        // that have the 'Processor' measurement defined.
+        $stmt = $PDO->prepare(
+            "SELECT b2t.buildid, b2t.testid, tm.value
+            FROM build2test b2t
+            JOIN testmeasurement tm ON (b2t.testid = tm.testid)
+            JOIN build b ON (b.id = b2t.buildid)
+            WHERE b.parentid = ?
+            AND tm.name = 'Processors'");
+        pdo_execute($stmt, [$parentid]);
+        while ($row = $stmt->fetch()) {
+            $buildid = $row['buildid'];
+            $testid = $row['testid'];
+            $nprocs = $row['value'];
+            if (!is_numeric($nprocs)) {
+                continue;
+            }
+            $proc_time_verified = true;
+            $test_timing[$buildid][$testid] *= $nprocs;
+        }
+
+        // Compute procTime = duration * nprocs and record it for each build.
+        // We assume only one buildgroup for subproject results.
+        foreach ($buildgroups_response[0]['builds'] as $i => $build_response) {
+            $buildid = $build_response['id'];
+            if (!array_key_exists('test', $build_response)) {
+                continue;
+            }
+            if (!array_key_exists($buildid, $test_timing)) {
+                continue;
+            }
+
+            $proc_time = array_sum($test_timing[$buildid]);
+            $buildgroups_response[0]['builds'][$i]['test']['procTime'] =
+                time_difference($proc_time, true);
+            $buildgroups_response[0]['builds'][$i]['test']['procTimeFull'] =
+                $proc_time;
+        }
+    }
+    $response['showProcTime'] = $proc_time_verified;
 
     $response['buildgroups'] = $buildgroups_response;
     $response['enableTestTiming'] = $project_array['showtesttime'];

--- a/public/api/v1/testSummary.php
+++ b/public/api/v1/testSummary.php
@@ -115,8 +115,14 @@ $getcolumnnumber = pdo_query(
         ");
 
 $columns = array();
+$response['hasprocessors'] = false;
+$processors_idx = -1;
 while ($row = pdo_fetch_array($getcolumnnumber)) {
     $columns[] = $row['name'];
+    if ($row['name'] == 'Processors') {
+        $processors_idx = count($columns) - 1;
+        $response['hasprocessors'] = true;
+    }
 }
 $response['columns'] = $columns;
 
@@ -321,6 +327,16 @@ if ($columncount > 0) {
 foreach ($builds_response as $i => $build_response) {
     $buildid = $builds_response[$i]['buildid'];
     $builds_response[$i]['measurements'] = $test_measurements[$buildid];
+    if ($response['hasprocessors']) {
+        // Show an additional column "proc time" if these tests have
+        // the Processor measurement.
+        $num_procs = $test_measurements[$buildid][$processors_idx];
+        if (!$num_procs) {
+            $num_procs = 1;
+        }
+        $builds_response[$i]['proctime'] =
+            floatval($builds_response[$i]['time'] * $num_procs);
+    }
 }
 
 $response['builds'] = $builds_response;

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -326,8 +326,14 @@ AND measurement.testpage=1
 GROUP by testmeasurement.name
 "); // We need to keep the count of columns for correct column-data assign
 
+$response['hasprocessors'] = false;
+$processors_idx = -1;
 while ($row = pdo_fetch_array($getcolumnnumber)) {
     $columns[] = $row['name'];
+    if ($row['name'] == 'Processors') {
+        $processors_idx = count($columns) - 1;
+        $response['hasprocessors'] = true;
+    }
 }
 $response['columnnames'] = $columns;
 
@@ -433,6 +439,18 @@ while ($row = pdo_fetch_array($result)) {
 
     $labels_found = ($CDASH_DB_TYPE != 'pgsql' && !empty($marshaledTest['labels']));
     $marshaledTest['measurements'] = $test_measurements[$marshaledTest['id']];
+    if ($response['hasprocessors']) {
+        // Show an additional column "proc time" if these tests have
+        // the Processor measurement.
+        $num_procs = $test_measurements[$marshaledTest['id']][$processors_idx];
+        if (!$num_procs) {
+            $num_procs = 1;
+        }
+        $marshaledTest['procTimeFull'] =
+            $marshaledTest['execTimeFull'] * $num_procs;
+        $marshaledTest['procTime'] =
+            time_difference($marshaledTest['procTimeFull'], true, '', true);
+    }
     $tests[] = $marshaledTest;
 }
 

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -227,6 +227,14 @@ CDash.filter("showEmptyBuildsLast", function () {
     }
     $scope.cdash.showtimecolumns = show_time_columns;
 
+    // Determine if we should display an extra column in the 'Test' section.
+    $scope.cdash.extratestcolumns = 0;
+    if ($scope.cdash.advancedview) {
+      if ($scope.cdash.showtimecolumns || $scope.cdash.showProcTime) {
+        $scope.cdash.extratestcolumns = 1;
+      }
+    }
+
     if (!$scope.cdash.feed) {
       $scope.showFeed = false;
     }

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -236,7 +236,7 @@
               <td ng-if="::buildgroup.hasupdatedata" align="center" colspan="{{::1 + cdash.showtimecolumns}}" width="5%" class="timeheader botl">Update</td>
               <td ng-if="::buildgroup.hasconfiguredata" align="center" colspan="{{::2 + cdash.showtimecolumns}}" width="10%" class="timeheader botl">Configure</td>
               <td ng-if="::buildgroup.hascompilationdata" align="center" colspan="{{::2 + cdash.showtimecolumns}}" width="10%" class="timeheader botl">Build</td>
-              <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 +  + cdash.showtimecolumns}}" width="15%" class="timeheader botl">Test</td>
+              <td ng-if="::buildgroup.hastestdata" align="center" colspan="{{::3 + cdash.extratestcolumns}}" width="15%" class="timeheader botl">Test</td>
               <td ng-if="::cdash.showstarttime" align="center" width="20%" class="timeheader botl"></td>
               <td ng-if="::cdash.showorder" align="center" width="5%" class="timeheader botl"></td>
               <td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
@@ -309,6 +309,13 @@
                   ng-click="updateOrderByFields(buildgroup, 'test.timefull', $event)">
                 Time
                 <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.timefull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.timefull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+              </th>
+
+              <th align="center" width="5%" style="cursor: pointer"
+                  ng-if="::buildgroup.hastestdata && cdash.advancedview != 0 && cdash.showProcTime"
+                  ng-click="updateOrderByFields(buildgroup, 'test.procTimeFull', $event)">
+                Proc Time
+                <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-test.procTimeFull') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('test.procTimeFull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
               <th align="center" width="20%" style="cursor: pointer"

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -365,6 +365,11 @@
   </div>
 </td>
 
+<td align="center"
+    ng-if="::buildgroup.hastestdata && cdash.advancedview != 0 && cdash.showProcTime">
+  {{::build.test.procTime}}
+</td>
+
 <td align="center" ng-if="::cdash.showstarttime">
   <span ng-if="::!build.builddate" class="builddateelapsed" alt="Expected submit time: {{::build.expectedstarttime}}">
     Expected build

--- a/public/views/testSummary.html
+++ b/public/views/testSummary.html
@@ -74,6 +74,15 @@
               <span class="glyphicon" ng-class="orderByFields.indexOf('-time') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('time') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
             </th>
 
+            <th ng-if="::cdash.hasprocessors" class="header"
+                ng-click="updateOrderByFields('time', $event)"
+                tooltip-popup-delay="1500"
+                tooltip-append-to-body="true"
+                uib-tooltip="Seconds * number of processors">
+              Proc Time
+              <span class="glyphicon" ng-class="orderByFields.indexOf('-proctime') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('proctime') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+            </th>
+
             <th class="header" ng-click="updateOrderByFields('update.revision', $event)">
               Build Revision
               <span class="glyphicon" ng-class="orderByFields.indexOf('-update.revision') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('update.revision') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -108,6 +117,10 @@
 
           <td>
             {{::build.time}}
+          </td>
+
+          <td ng-if="::cdash.hasprocessors">
+            {{::build.proctime}}
           </td>
 
           <td>

--- a/public/views/viewTest.html
+++ b/public/views/viewTest.html
@@ -171,6 +171,15 @@
                 <span class="glyphicon" ng-class="orderByFields.indexOf('-execTimeFull') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('execTimeFull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
               </th>
 
+              <th ng-if="::cdash.hasprocessors" width="9%" class="header"
+                  ng-click="updateOrderByFields('procTimeFull', $event)"
+                  tooltip-popup-delay="1500"
+                  tooltip-append-to-body="true"
+                  uib-tooltip="Elapsed time * number of processors">
+                Proc Time
+                <span class="glyphicon" ng-class="orderByFields.indexOf('-procTimeFull') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('procTimeFull') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+              </th>
+
               <th ng-if="::cdash.displaydetails == 1" width="13%" class="header" ng-click="updateOrderByFields('details', $event)">
                 Details
                 <span class="glyphicon" ng-class="orderByFields.indexOf('-details') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('details') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -233,6 +242,11 @@
             <td align="right">
               <span style="display:none">{{::test.execTimeFull}}</span>
               {{::test.execTime}}
+            </td>
+
+            <td ng-if="::cdash.hasprocessors" align="right">
+              <span style="display:none">{{::test.procTimeFull}}</span>
+              {{::test.procTime}}
             </td>
 
             <td ng-if="::cdash.displaydetails == 1">

--- a/tests/data/TestMeasurements/Test_subproj.xml
+++ b/tests/data/TestMeasurements/Test_subproj.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="subprojects_measurements_example"
+        BuildStamp="20170829-1456-Experimental"
+        Name="livonia-linux"
+        Generator="ctest-3.9.20170829-g5eb6d2"
+        CompilerName=""
+        CompilerVersion=""
+        OSName="Linux"
+        Hostname="livonia-linux"
+        OSRelease="3.13.0-35-generic"
+        OSVersion="#62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014"
+        OSPlatform="x86_64"
+        Is64Bits="1"
+        VendorString="GenuineIntel"
+        VendorID="Intel Corporation"
+        FamilyID="6"
+        ModelID="69"
+        ProcessorCacheSize="4096"
+        NumberOfLogicalCPU="4"
+        NumberOfPhysicalCPU="1"
+        TotalVirtualMemory="7627"
+        TotalPhysicalMemory="7890"
+        LogicalProcessorsPerPhysical="4"
+        ProcessorClockFrequency="756"
+        >
+        <Subproject name="MyExperimentalFeature">
+                <Label>MyExperimentalFeature</Label>
+        </Subproject>
+        <Subproject name="MyProductionCode">
+                <Label>MyProductionCode</Label>
+        </Subproject>
+        <Testing>
+                <StartDateTime>Aug 29 10:56 EDT</StartDateTime>
+                <StartTestTime>1504018591</StartTestTime>
+                <TestList>
+                        <Test>./MyExperimentalFeature/experimentalFail1</Test>
+                        <Test>./MyExperimentalFeature/experimentalFail2</Test>
+                        <Test>./MyProductionCode/production</Test>
+                </TestList>
+                <Test Status="failed">
+                        <Name>experimentalFail1</Name>
+                        <Path>./MyExperimentalFeature</Path>
+                        <FullName>./MyExperimentalFeature/experimentalFail1</FullName>
+                        <FullCommandLine>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyExperimentalFeature/experimental "5"</FullCommandLine>
+                        <Results>
+                                <NamedMeasurement type="text/string" name="Exit Code">
+                                        <Value>Failed</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Exit Value">
+                                        <Value>0</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="Execution Time">
+                                        <Value>1.1</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="Processors">
+                                    <Value>2</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Fail Reason">
+                                        <Value>Required regular expression not found.Regex=[Test!
+]</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Completion Status">
+                                        <Value>Completed</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Command Line">
+                                        <Value>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyExperimentalFeature/experimental "5"</Value>
+                                </NamedMeasurement>
+                                <Measurement>
+                                        <Value>This does happen.
+</Value>
+                                </Measurement>
+                        </Results>
+                        <Labels>
+                                <Label>MyExperimentalFeature</Label>
+                        </Labels>
+                </Test>
+                <Test Status="failed">
+                        <Name>experimentalFail2</Name>
+                        <Path>./MyExperimentalFeature</Path>
+                        <FullName>./MyExperimentalFeature/experimentalFail2</FullName>
+                        <FullCommandLine>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyExperimentalFeature/experimental "-5"</FullCommandLine>
+                        <Results>
+                                <NamedMeasurement type="text/string" name="Exit Code">
+                                        <Value>Failed</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Exit Value">
+                                        <Value>0</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="Execution Time">
+                                        <Value>2.2</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="Processors">
+                                    <Value>3</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Fail Reason">
+                                        <Value>Required regular expression not found.Regex=[Test!
+]</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Completion Status">
+                                        <Value>Completed</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Command Line">
+                                        <Value>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyExperimentalFeature/experimental "-5"</Value>
+                                </NamedMeasurement>
+                                <Measurement>
+                                        <Value>This does happen.
+</Value>
+                                </Measurement>
+                        </Results>
+                        <Labels>
+                                <Label>MyExperimentalFeature</Label>
+                        </Labels>
+                </Test>
+                <Test Status="passed">
+                        <Name>production</Name>
+                        <Path>./MyProductionCode</Path>
+                        <FullName>./MyProductionCode/production</FullName>
+                        <FullCommandLine>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyProductionCode/production</FullCommandLine>
+                        <Results>
+                                <NamedMeasurement type="numeric/double" name="Execution Time">
+                                        <Value>3.3</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="Processors">
+                                    <Value>4</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Completion Status">
+                                        <Value>Completed</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="text/string" name="Command Line">
+                                        <Value>/home/betsy/cmake_build/Tests/CTestTestSubprojects/MyProductionCode/production</Value>
+                                </NamedMeasurement>
+                                <Measurement>
+                                        <Value>This does happen.
+</Value>
+                                </Measurement>
+                        </Results>
+                        <Labels>
+                                <Label>MyProductionCode</Label>
+                        </Labels>
+                </Test>
+                <EndDateTime>Aug 29 10:56 EDT</EndDateTime>
+                <EndTestTime>1504018594</EndTestTime>
+                <ElapsedMinutes>0</ElapsedMinutes>
+        </Testing>
+</Site>

--- a/tests/test_managemeasurements.php
+++ b/tests/test_managemeasurements.php
@@ -121,13 +121,20 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         foreach ($jsonobj['tests'] as $test) {
             $test_name = $test['name'];
             $num_procs = $test['measurements'][0];
+            $proc_time = $test['procTimeFull'];
             if ($test_name == 'Test3Procs') {
                 if ($num_procs != 3) {
                     $this->fail("Expected 3 processors on viewTest.php, found $num_procs");
                 }
+                if ($proc_time != 4.2) {
+                    $this->fail("Expected 4.2 proc time, found $proc_time");
+                }
             } elseif ($test_name == 'Test5Procs') {
                 if ($num_procs != 5) {
                     $this->fail("Expected 5 processors on viewTest.php, found $num_procs");
+                }
+                if ($proc_time != 6.5) {
+                    $this->fail("Expected 6.5 proc time, found $proc_time");
                 }
             } else {
                 $this->fail("Unexpected test $test_name");
@@ -153,6 +160,10 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         $found = $jsonobj['builds'][0]['measurements'][0];
         if ($found != 5) {
             $this->fail("Expected 5 processors on testSummary.php, found $found");
+        }
+        $found = $jsonobj['builds'][0]['proctime'];
+        if ($found != 6.5) {
+            $this->fail("Expected proctime to be 6.5, found $found");
         }
     }
 }

--- a/tests/test_managemeasurements.php
+++ b/tests/test_managemeasurements.php
@@ -22,7 +22,8 @@ class ManageMeasurementsTestCase extends KWWebTestCase
 
         $this->PDO = get_link_identifier()->getPdo();
         $this->BuildId = null;
-        $this->MeasurementId = null;
+        $this->SubProjectBuildId = null;
+        $this->MeasurementIds = [];
     }
 
     public function __destruct()
@@ -30,9 +31,12 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         if (!is_null($this->BuildId)) {
             remove_build($this->BuildId);
         }
-        if (!is_null($this->MeasurementId)) {
+        if (!is_null($this->SubProjectBuildId)) {
+            remove_build($this->SubProjectBuildId);
+        }
+        foreach ($this->MeasurementIds as $measurement_id) {
             $this->PDO->exec(
-                "DELETE FROM measurement WHERE id = $this->MeasurementId");
+                "DELETE FROM measurement WHERE id = $measurement_id");
         }
     }
 
@@ -41,7 +45,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         // Submit a test file with a named measurement.
         $testDataFile = dirname(__FILE__) .  '/data/TestMeasurements/Test.xml';
         if (!$this->submission('InsightExample', $testDataFile)) {
-            $this->fail("Failed to submit test data");
+            $this->fail("Failed to submit Test.xml");
             return false;
         }
 
@@ -50,6 +54,24 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             "SELECT id FROM build WHERE name = 'test_measurements_example'");
         $this->BuildId = $stmt->fetchColumn();
         if (!$this->BuildId > 0) {
+            $this->fail("Expected positive integer for build ID, found $this->BuildId");
+        }
+
+        // Submit subproject test data too.
+        $projectFile = dirname(__FILE__) .  '/data/MultipleSubprojects/Project.xml';
+        if (!$this->submission('SubProjectExample', $projectFile)) {
+            $this->fail("Failed to submit Project.xml");
+            return false;
+        }
+        $testDataFile = dirname(__FILE__) .  '/data/TestMeasurements/Test_subproj.xml';
+        if (!$this->submission('SubProjectExample', $testDataFile)) {
+            $this->fail("Failed to submit Test_subproj.xml");
+            return false;
+        }
+        $stmt = $this->PDO->query(
+            "SELECT id FROM build WHERE name = 'subprojects_measurements_example' AND parentid = -1");
+        $this->SubProjectBuildId = $stmt->fetchColumn();
+        if (!$this->SubProjectBuildId > 0) {
             $this->fail("Expected positive integer for build ID, found $this->BuildId");
         }
 
@@ -69,37 +91,41 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         }
 
         // POST to manageMeasurements.php to add 'Processors' as a
-        // test measurement for this project.
-        $projectid = get_project_id('InsightExample');
-        $measurements = [];
-        $measurements[] = [
-            'id' => -1,
-            'name' => 'Processors',
-            'summarypage' => 1,
-            'testpage' => 1
-        ];
-        try {
-            $response = $client->request('POST',
-                    $CDASH_BASE_URL . '/api/v1/manageMeasurements.php',
-                    ['json' => ['projectid' => $projectid, 'measurements' => $measurements]]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        // test measurement for these projects.
+        $measurement_ids = [];
+        $this->ProjectId =  get_project_id('InsightExample');
+        $this->SubProjectId =  get_project_id('SubProjectExample');
+        foreach ([$this->ProjectId, $this->SubProjectId] as $projectid) {
+            $measurements = [];
+            $measurements[] = [
+                'id' => -1,
+                'name' => 'Processors',
+                'summarypage' => 1,
+                'testpage' => 1
+            ];
+            try {
+                $response = $client->request('POST',
+                        $CDASH_BASE_URL . '/api/v1/manageMeasurements.php',
+                        ['json' => ['projectid' => $projectid, 'measurements' => $measurements]]);
+            } catch (GuzzleHttp\Exception\ClientException $e) {
+                $this->fail($e->getMessage());
+                return false;
+            }
 
-        // Response should have the ID of the newly created measurement.
-        $response_array = json_decode($response->getBody(), true);
-        $this->MeasurementId = $response_array['id'];
-        if (!$this->MeasurementId > 0) {
-            $this->fail("Expected positive integer for measurement ID, found $this->MeasurementId");
-        }
-
-        // Check that the measurement actually got added to the database.
-        $stmt = $this->PDO->query(
-            "SELECT id FROM measurement WHERE id = $this->MeasurementId");
-        $found = $stmt->fetchColumn();
-        if ($found != $this->MeasurementId) {
-            $this->fail("Expected $this->MeasurementId but found $found for DB measurement ID");
+            // Response should have the ID of the newly created measurement.
+            $response_array = json_decode($response->getBody(), true);
+            $measurement_id = $response_array['id'];
+            if (!$measurement_id > 0) {
+                $this->fail("Expected positive integer for measurement ID, found $measurement_id");
+            }
+            $this->MeasurementIds[] = $measurement_id;
+            // Check that the measurement actually got added to the database.
+            $stmt = $this->PDO->query(
+                    "SELECT id FROM measurement WHERE id = $measurement_id");
+            $found = $stmt->fetchColumn();
+            if ($found != $measurement_id) {
+                $this->fail("Expected $measurement_id but found $found for DB measurement ID");
+            }
         }
 
         // Verify that the 'Processors' measurement is displayed on viewTest.php.
@@ -142,7 +168,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         }
 
         // Verify that 'Processors' is also displayed on testSummary.php.
-        $this->get($this->url . "/api/v1/testSummary.php?project=$projectid&name=Test5Procs&date=2017-08-29");
+        $this->get($this->url . "/api/v1/testSummary.php?project=$this->ProjectId&name=Test5Procs&date=2017-08-29");
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $found = $jsonobj['columncount'];
@@ -164,6 +190,52 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         $found = $jsonobj['builds'][0]['proctime'];
         if ($found != 6.5) {
             $this->fail("Expected proctime to be 6.5, found $found");
+        }
+
+        // Perform similar checks for the subproject case.
+        $this->get($this->url . "/api/v1/viewTest.php?buildid=$this->SubProjectBuildId");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $found = $jsonobj['columncount'];
+        if ($found != 1) {
+            $this->fail("Expected 1 extra column on viewTest.php, found $found");
+        }
+        $found = $jsonobj['columnnames'][0];
+        if ($found != 'Processors') {
+            $this->fail("Expected extra column to be called 'Processors', found $found");
+        }
+        $found = count($jsonobj['tests']);
+        if ($found != 3) {
+            $this->fail("Expected three tests, found $found");
+        }
+        foreach ($jsonobj['tests'] as $test) {
+            $test_name = $test['name'];
+            $num_procs = $test['measurements'][0];
+            $proc_time = $test['procTimeFull'];
+            if ($test_name == 'experimentalFail1') {
+                if ($num_procs != 2) {
+                    $this->fail("Expected 2 processors on viewTest.php, found $num_procs");
+                }
+                if ($proc_time != 2.2) {
+                    $this->fail("Expected 2.2 proc time, found $proc_time");
+                }
+            } elseif ($test_name == 'experimentalFail2') {
+                if ($num_procs != 3) {
+                    $this->fail("Expected 3 processors on viewTest.php, found $num_procs");
+                }
+                if ($proc_time != 6.6) {
+                    $this->fail("Expected 6.6 proc time, found $proc_time");
+                }
+            } elseif ($test_name == 'production') {
+                if ($num_procs != 4) {
+                    $this->fail("Expected 4 processors on viewTest.php, found $num_procs");
+                }
+                if ($proc_time != 13.2) {
+                    $this->fail("Expected 13.2 proc time, found $proc_time");
+                }
+            } else {
+                $this->fail("Unexpected test $test_name");
+            }
         }
     }
 }

--- a/tests/test_managemeasurements.php
+++ b/tests/test_managemeasurements.php
@@ -237,5 +237,27 @@ class ManageMeasurementsTestCase extends KWWebTestCase
                 $this->fail("Unexpected test $test_name");
             }
         }
+
+        // Verify that correct Proc Time values are shown on index.php for
+        // subproject builds.
+        $this->get($this->url . "/api/v1/index.php?project=SubProjectExample&parentid=$this->SubProjectBuildId");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        foreach ($buildgroup['builds'] as $build) {
+            $label = $build['label'];
+            $found = $build['test']['procTimeFull'];
+            $expected = null;
+            if ($label == 'MyExperimentalFeature') {
+                $expected = 8.8;
+            } elseif ($label == 'MyProductionCode') {
+                $expected = 13.2;
+            } else {
+                $this->fail("Unexpected build label $label");
+            }
+            if ($expected != $found) {
+                $this->fail("Expected proc time to be $expected but found $found for subproject build $label");
+            }
+        }
     }
 }


### PR DESCRIPTION
For tests with the optional extra measurement 'Processors', we now show an additional column: Proc Time.  This shows how long a test took to run multiplied by the number of processors it used.