### PR TITLE
Fix -- Removes test calling protected constructor

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -4,14 +4,6 @@ use CDash\Singleton;
 
 class ConfigTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException Error
-     */
-    public function testConstructorWithKeywordNew()
-    {
-        $config = new Config();
-    }
-
     public function testGetInstance()
     {
         $config = Config::getInstance();


### PR DESCRIPTION
- PHPUnit is not trapping the Error thrown when a protected constructor is called.
bryon.bean@kitware.com