### PR TITLE
buildError.html: correct assignment operator that should be a comparison

### DIFF
--- a/public/views/partials/buildError.html
+++ b/public/views/partials/buildError.html
@@ -65,8 +65,8 @@
 
   <tr ng-if="error.labels">
     <th class="measurement">
-      <div ng-if="error.labels.length=1">Label</div>
-      <div ng-if="error.labels.length>1">Labels</div>
+      <div ng-if="error.labels.length == 1">Label</div>
+      <div ng-if="error.labels.length > 1">Labels</div>
     </th>
     <td>
       <div ng-repeat="label in error.labels">


### PR DESCRIPTION
buildErrors were only showing the first label in the
list due to an '=' that should have been '=='.