### PR TITLE
Clean up buildgroup API endpoint

### DIFF
--- a/public/api/v1/buildgroup.php
+++ b/public/api/v1/buildgroup.php
@@ -82,20 +82,20 @@ function rest_get()
     }
 
     $dependencies = $BuildGroup->GetDependencies();
-    $dependencies_response = array();
-    $available_dependencies_response = array();
+    $dependencies_response = [];
+    $available_dependencies_response = [];
 
     while ($row = pdo_fetch_array($query)) {
         if ($row['id'] == $buildgroupid) {
             continue;
         }
         if (is_array($dependencies) && in_array($row['id'], $dependencies)) {
-            $dep = array();
+            $dep = [];
             $dep['id'] = $row['id'];
             $dep['name'] = $row['name'];
             $dependencies_response[] = $dep;
         } else {
-            $avail = array();
+            $avail = [];
             $avail['id'] = $row['id'];
             $avail['name'] = $row['name'];
             $available_dependencies_response[] = $avail;
@@ -193,7 +193,7 @@ function rest_post()
         $BuildGroup->Save();
 
         // Respond with a JSON representation of this new buildgroup
-        $response = array();
+        $response = [];
         $response['id'] = $BuildGroup->GetId();
         $response['name'] = $BuildGroup->GetName();
         $response['autoremovetimeframe'] = $BuildGroup->GetAutoRemoveTimeFrame();
@@ -336,7 +336,7 @@ function rest_post()
             echo_error(pdo_error());
         } else {
             // Respond with a JSON representation of this new rule.
-            $response = array();
+            $response = [];
             $response['match'] =
                 htmlspecialchars(pdo_real_escape_string($_POST['match']));
             $response['siteid'] = $siteid;
@@ -410,7 +410,7 @@ function get_buildgroupid()
 
 function echo_error($msg)
 {
-    $response = array();
+    $response = [];
     $response['error'] = $msg;
     echo json_encode($response);
 }

--- a/public/api/v1/buildgroup.php
+++ b/public/api/v1/buildgroup.php
@@ -184,8 +184,9 @@ function rest_post()
 
         // Avoid creating a group that uses one of the default names.
         if ($name == 'Nightly' || $name == 'Experimental' || $name == 'Continuous') {
-            echo_error("You cannot create a group named 'Nightly','Experimental' or 'Continuous'");
-            return;
+            $error_msg =
+                "You cannot create a group named 'Nightly','Experimental' or 'Continuous'";
+            json_error_response(['error' => $error_msg], 400);
         }
 
         $type = htmlspecialchars(pdo_real_escape_string($_POST['type']));
@@ -248,8 +249,8 @@ function rest_post()
         // Move builds to a new group.
         $group = $_POST['group'];
         if ($group['id'] < 1) {
-            echo_error('Please select a group for these builds');
-            return;
+            $error_msg = 'Please select a group for these builds';
+            json_error_response(['error' => $error_msg], 400);
         }
 
         $builds = $_POST['builds'];
@@ -299,8 +300,8 @@ function rest_post()
         $group = $_POST['group'];
         $groupid = $group['id'];
         if ($groupid < 1) {
-            echo_error('Please select a BuildGroup to define.');
-            return;
+            $error_msg = 'Please select a BuildGroup to define.';
+            json_error_response(['error' => $error_msg], 400);
         }
 
         $nameMatch = '%' .
@@ -404,11 +405,4 @@ function rest_put()
             json_error_response(['error' => 'Failed to save BuildGroup'], 500);
         }
     }
-}
-
-function echo_error($msg)
-{
-    $response = [];
-    $response['error'] = $msg;
-    echo json_encode($response);
 }

--- a/public/api/v1/buildgroup.php
+++ b/public/api/v1/buildgroup.php
@@ -339,27 +339,27 @@ function rest_post()
             'INSERT INTO build2grouprule
             (groupid, buildname, siteid, parentgroupid)
             VALUES (?, ?, ?, ?)');
-       if (!pdo_execute($stmt, [$groupid, $match, $siteid, $parentgroupid])) {
+        if (!pdo_execute($stmt, [$groupid, $match, $siteid, $parentgroupid])) {
             json_error_response(['error' => pdo_error()], 500);
-       }
+        }
 
-       // Respond with a JSON representation of this new rule.
-       $response = [];
-       $response['match'] = $_POST['match'];
-       $response['siteid'] = $siteid;
-       if ($siteid > 0) {
-           $response['sitename'] = $_POST['site']['name'];
-       } else {
-           $response['sitename'] = 'Any';
-       }
-       $response['parentgroupid'] = $parentgroupid;
-       if ($parentgroupid > 0) {
-           $response['parentgroupname'] = $_POST['buildgroup']['name'];
-       } else {
-           $response['parentgroupname'] = 'Any';
-       }
-       echo json_encode(cast_data_for_JSON($response));
-       return;
+        // Respond with a JSON representation of this new rule.
+        $response = [];
+        $response['match'] = $_POST['match'];
+        $response['siteid'] = $siteid;
+        if ($siteid > 0) {
+            $response['sitename'] = $_POST['site']['name'];
+        } else {
+            $response['sitename'] = 'Any';
+        }
+        $response['parentgroupid'] = $parentgroupid;
+        if ($parentgroupid > 0) {
+            $response['parentgroupname'] = $_POST['buildgroup']['name'];
+        } else {
+            $response['parentgroupname'] = 'Any';
+        }
+        echo json_encode(cast_data_for_JSON($response));
+        return;
     }
 }
 

--- a/public/api/v1/buildgroup.php
+++ b/public/api/v1/buildgroup.php
@@ -122,13 +122,12 @@ function rest_delete()
     if (isset($_GET['wildcard'])) {
         // Delete a wildcard build group rule.
         $wildcard = json_decode($_GET['wildcard'], true);
-        $buildgroupid = pdo_real_escape_numeric($wildcard['buildgroupid']);
-        $match = htmlspecialchars(pdo_real_escape_string($wildcard['match']));
+        $buildgroupid = $wildcard['buildgroupid'];
+        $match = $wildcard['match'];
         if (!empty($match)) {
             $match = "%$match%";
         }
-        $buildtype =
-            htmlspecialchars(pdo_real_escape_string($wildcard['buildtype']));
+        $buildtype = $wildcard['buildtype'];
 
         $stmt = $pdo->prepare(
             'DELETE FROM build2grouprule
@@ -141,15 +140,15 @@ function rest_delete()
     if (isset($_GET['dynamic'])) {
         // Delete a dynamic build group rule.
         $dynamic = json_decode($_GET['dynamic'], true);
-        $buildgroupid = pdo_real_escape_numeric($dynamic['id']);
+        $buildgroupid = $dynamic['id'];
 
         $rule = json_decode($_GET['rule'], true);
-        $match = htmlspecialchars(pdo_real_escape_string($rule['match']));
+        $match = $rule['match'];
         if (!empty($match)) {
             $match = "%$match%";
         }
-        $parentgroupid = pdo_real_escape_numeric($rule['parentgroupid']);
-        $siteid = pdo_real_escape_numeric($rule['siteid']);
+        $parentgroupid = $rule['parentgroupid'];
+        $siteid = $rule['siteid'];
 
         $sql =
             'DELETE FROM build2grouprule WHERE groupid = ? AND buildname = ?';
@@ -261,7 +260,7 @@ function rest_post()
         }
 
         foreach ($builds as $buildinfo) {
-            $groupid = pdo_real_escape_numeric($group['id']);
+            $groupid = $group['id'];
 
             $Build = new Build();
             $buildid = pdo_real_escape_numeric($buildinfo['id']);
@@ -304,9 +303,8 @@ function rest_post()
             json_error_response(['error' => $error_msg], 400);
         }
 
-        $nameMatch = '%' .
-            htmlspecialchars(pdo_real_escape_string($_POST['nameMatch'])) . '%';
-        $type = htmlspecialchars(pdo_real_escape_string($_POST['type']));
+        $nameMatch = '%' . $_POST['nameMatch'] . '%';
+        $type = $_POST['type'];
         $stmt = $pdo->prepare(
             'INSERT INTO build2grouprule (groupid, buildtype, buildname, siteid)
             VALUES (?, ?, ?, ?)');
@@ -317,25 +315,24 @@ function rest_post()
 
     if (isset($_POST['dynamic']) && !empty($_POST['dynamic'])) {
         // Add a build row to a dynamic group
-        $groupid = pdo_real_escape_numeric($_POST['dynamic']['id']);
+        $groupid = $_POST['dynamic']['id'];
 
         if (empty($_POST['buildgroup'])) {
             $parentgroupid = 0;
         } else {
-            $parentgroupid = pdo_real_escape_numeric($_POST['buildgroup']['id']);
+            $parentgroupid = $_POST['buildgroup']['id'];
         }
 
         if (empty($_POST['site'])) {
             $siteid = 0;
         } else {
-            $siteid = pdo_real_escape_numeric($_POST['site']['id']);
+            $siteid = $_POST['site']['id'];
         }
 
         if (empty($_POST['match'])) {
             $match = '';
         } else {
-            $match = '%' .
-                htmlspecialchars(pdo_real_escape_string($_POST['match'])) . '%';
+            $match = '%' . $_POST['match'] . '%';
         }
 
         $stmt = $pdo->prepare(
@@ -348,19 +345,16 @@ function rest_post()
 
        // Respond with a JSON representation of this new rule.
        $response = [];
-       $response['match'] =
-           htmlspecialchars(pdo_real_escape_string($_POST['match']));
+       $response['match'] = $_POST['match'];
        $response['siteid'] = $siteid;
        if ($siteid > 0) {
-           $response['sitename'] =
-               htmlspecialchars(pdo_real_escape_string($_POST['site']['name']));
+           $response['sitename'] = $_POST['site']['name'];
        } else {
            $response['sitename'] = 'Any';
        }
        $response['parentgroupid'] = $parentgroupid;
        if ($parentgroupid > 0) {
-           $response['parentgroupname'] =
-               htmlspecialchars(pdo_real_escape_string($_POST['buildgroup']['name']));
+           $response['parentgroupname'] = $_POST['buildgroup']['name'];
        } else {
            $response['parentgroupname'] = 'Any';
        }

--- a/public/api/v1/buildgroup.php
+++ b/public/api/v1/buildgroup.php
@@ -178,12 +178,15 @@ function rest_delete()
 
         $rule = json_decode($_GET['rule'], true);
         $match = htmlspecialchars(pdo_real_escape_string($rule['match']));
+        if (!empty($match)) {
+            $match = "%$match%";
+        }
         $parentgroupid = pdo_real_escape_numeric($rule['parentgroupid']);
         $siteid = pdo_real_escape_numeric($rule['siteid']);
 
         $sql =
             "DELETE FROM build2grouprule
-       WHERE groupid='$buildgroupid' AND buildname = '%$match%'";
+            WHERE groupid='$buildgroupid' AND buildname = '$match'";
         if ($siteid > 0) {
             $sql .= " AND siteid = '$siteid'";
         }

--- a/public/js/controllers/manageBuildGroup.js
+++ b/public/js/controllers/manageBuildGroup.js
@@ -242,9 +242,9 @@ CDash.filter('filter_builds', function() {
         var idx = $scope.cdash.dynamics.indexOf(dynamic);
         if (idx > -1) {
           if ($scope.cdash.dynamics[idx].rules) {
-            $scope.cdash.dynamics[idx].rules.push(rule);
+            $scope.cdash.dynamics[idx].rules.push(s.data);
           } else {
-            $scope.cdash.dynamics[idx].rules = [rule];
+            $scope.cdash.dynamics[idx].rules = [s.data];
           }
         }
         $("#dynamic_defined").show();

--- a/tests/js/e2e_tests/manageBuildGroup.js
+++ b/tests/js/e2e_tests/manageBuildGroup.js
@@ -99,7 +99,7 @@ describe("manageBuildGroup", function() {
   });
 
 
-  it("can define a dynamic row", function() {
+  it("can define dynamic rows", function() {
     // Fill out the form & submit it.
     browser.get('manageBuildGroup.php?projectid=5#/dynamic');
     element(by.name('dynamicSelection')).element(by.cssContainingText('option', 'latestBuildGroup')).click();
@@ -109,31 +109,44 @@ describe("manageBuildGroup", function() {
     matchField.sendKeys('sameImage');
     element(by.buttonText('Add content to BuildGroup')).click();
     browser.waitForAngular();
+
+    element(by.name('dynamicSelection')).element(by.cssContainingText('option', 'latestBuildGroup')).click();
+    element(by.name('parentBuildGroupSelection')).element(by.cssContainingText('option', 'Experimental')).click();
+    matchField.clear();
+    element(by.buttonText('Add content to BuildGroup')).click();
+    browser.waitForAngular();
   });
 
 
-  it("can verify a dynamic row", function() {
+  it("can verify dynamic rows", function() {
     // Find the "latestBuildGroup" table on this page and verify that it has
-    // exactly one row.
+    // exactly two rows`.
     browser.get("index.php?project=InsightExample");
-    expect(element(By.partialLinkText("latestBuildGroup")).element(by.xpath('../../../../..')).all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(1);
+    expect(element(By.partialLinkText("latestBuildGroup")).element(by.xpath('../../../../..')).all(by.repeater('build in buildgroup.pagination.filteredBuilds')).count()).toBe(2);
   });
 
 
-  it("can delete a dynamic row", function() {
+  it("can delete dynamic rows", function() {
     // Select our dynamic group.
     browser.get('manageBuildGroup.php?projectid=5#/dynamic');
     element(by.name('dynamicSelection')).element(by.cssContainingText('option', 'latestBuildGroup')).click();
 
-    // Wait for its delete icon to appear.
+    // Wait for delete icons to appear.
     var deleteIcon = element(by.id('dynamic')).all(by.className('glyphicon-trash')).get(0);
     deleteIcon.isDisplayed().then(function () {
-
-      // Click on it & verify that no rows are present.
+      // Click on them & verify that no rows are present.
+      deleteIcon.click();
+      browser.waitForAngular();
+      deleteIcon = element(by.id('dynamic')).all(by.className('glyphicon-trash')).get(0);
       deleteIcon.click();
       browser.waitForAngular();
       expect(element(by.name("existingdynamicrows")).isPresent()).toBeFalsy();
-      });
+
+      // Reload the page to make sure they're really gone.
+      browser.get('manageBuildGroup.php?projectid=5#/dynamic');
+      element(by.name('dynamicSelection')).element(by.cssContainingText('option', 'latestBuildGroup')).click();
+      expect(element(by.name("existingdynamicrows")).isPresent()).toBeFalsy();
+    });
   });
 
 


### PR DESCRIPTION
Fix a bug that prevented project admins from deleting  a dynamic build rule if the "build name contains" field was left empty upon creation.

Also update this file to use common API functions and PDO.