### PR TITLE
Fix undefined variable $User in project API

### DIFF
--- a/models/project.php
+++ b/models/project.php
@@ -1567,13 +1567,12 @@ class Project
         }
 
         // Add administrator to the project.
-        $User = new User;
         $UserProject = new UserProject();
         $UserProject->Role = 2;
         $UserProject->EmailType = 3;// receive all emails
         $UserProject->ProjectId = $this->Id;
-        $User->Id = 1; // administrator
-        $User->AddProject($UserProject);
+        $UserProject->UserId = 1; // administrator
+        $UserProject->Save();
     }
 
     public function AddBlockedBuild($buildname, $sitename, $ip)

--- a/models/user.php
+++ b/models/user.php
@@ -46,13 +46,6 @@ class User
         $this->PDO = get_link_identifier()->getPdo();
     }
 
-    /** Add a project to the user */
-    public function AddProject($project)
-    {
-        $project->UserId = $this->Id;
-        $project->Save();
-    }
-
     /** Return if the user is admin */
     public function IsAdmin()
     {

--- a/public/api/v1/project.php
+++ b/public/api/v1/project.php
@@ -248,12 +248,12 @@ function create_project(&$response)
     global $userid;
     if ($userid != 1) {
         // Global admin is already added, so no need to do it again.
-        $User->Id = $userid;
         $UserProject = new UserProject();
+        $UserProject->UserId = $userid;
         $UserProject->ProjectId = $Project->Id;
         $UserProject->Role = 2;
         $UserProject->EmailType = 3;// receive all emails
-        $User->AddProject($UserProject);
+        $UserProject->Save();
     }
 
     $response['projectcreated'] = 1;

--- a/tests/test_updateonlyuserstats.php
+++ b/tests/test_updateonlyuserstats.php
@@ -73,7 +73,8 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
             $user->Institution = 'Kitware';
             $user->Admin = 0;
             $user->Save();
-            $user->AddProject($userproject);
+            $userproject->UserId = $user->Id;
+            $userproject->Save();
             $this->Users[] = $user;
         }
     }


### PR DESCRIPTION
Instead of defining $User, we take a simpler approach and call Save() on the UserProject model.