### PR TITLE
Assume timestamps will be present in XML files

### DIFF
--- a/tests/data/UpdateAppend/Update_1.xml
+++ b/tests/data/UpdateAppend/Update_1.xml
@@ -4,6 +4,7 @@
   <BuildName>test_updateappend</BuildName>
   <BuildStamp>20150823-2202-10_PM</BuildStamp>
   <StartDateTime>Sun Aug 23 22:04:14 MDT 2015</StartDateTime>
+  <StartTime>1440389054</StartTime>
   <UpdateCommand>Command 1</UpdateCommand>
   <UpdateType>GIT</UpdateType>
   <UpdateReturnStatus></UpdateReturnStatus>
@@ -12,6 +13,7 @@
   <PriorRevision>2</PriorRevision>
   <Path>mypath</Path>
   <EndDateTime>Sun Aug 23 22:04:15 MDT 2015</EndDateTime>
+  <EndTime>1440389055</EndTime>
 </Update>
 
 

--- a/tests/data/UpdateAppend/Update_2.xml
+++ b/tests/data/UpdateAppend/Update_2.xml
@@ -4,6 +4,7 @@
   <BuildName>test_updateappend</BuildName>
   <BuildStamp>20150823-2202-10_PM</BuildStamp>
   <StartDateTime>Sun Aug 23 22:05:10 MDT 2015</StartDateTime>
+  <StartTime>1440389110</StartTime>
   <UpdateCommand>Command 2</UpdateCommand>
   <UpdateType>SVN</UpdateType>
   <Directory>
@@ -52,4 +53,5 @@
   <UpdateReturnStatus>FAILED</UpdateReturnStatus>
   <ElapsedMinutes>0.4</ElapsedMinutes>
   <EndDateTime>Sun Aug 23 22:08:10 MDT 2015</EndDateTime>
+  <EndTime>1440389290</EndTime>
 </Update>

--- a/tests/data/UpdateAppend/Update_3.xml
+++ b/tests/data/UpdateAppend/Update_3.xml
@@ -4,6 +4,7 @@
   <BuildName>test_updateappend</BuildName>
   <BuildStamp>20150823-2202-10_PM</BuildStamp>
   <StartDateTime>Sun Aug 23 22:15:00 MDT 2015</StartDateTime>
+  <StartTime>1440389700</StartTime>
   <UpdateCommand>Command 3</UpdateCommand>
   <Revision>3</Revision>
   <PriorRevision>4</PriorRevision>
@@ -32,4 +33,5 @@
   <UpdateReturnStatus></UpdateReturnStatus>
   <ElapsedMinutes>5.5</ElapsedMinutes>
   <EndDateTime>Sun Aug 23 22:20:30 MDT 2015</EndDateTime>
+  <EndTime>1440390030</EndTime>
 </Update>

--- a/xml_handlers/configure_handler.php
+++ b/xml_handlers/configure_handler.php
@@ -214,19 +214,11 @@ class ConfigureHandler extends AbstractHandler implements ActionableBuildInterfa
 
         if ($parent == 'CONFIGURE') {
             switch ($element) {
-                case 'STARTDATETIME':
-                    $this->StartTimeStamp = str_to_time($data, $this->BuildStamp);
-                    break;
                 case 'STARTCONFIGURETIME':
                     $this->StartTimeStamp = $data;
                     break;
                 case 'ENDCONFIGURETIME':
                     $this->EndTimeStamp = $data;
-                    break;
-                case 'ELAPSEDMINUTES':
-                    if ($this->EndTimeStamp === 0) {
-                        $this->EndTimeStamp = $this->StartTimeStamp + $data * 60;
-                    }
                     break;
                 case 'BUILDCOMMAND':
                     $this->Configure->Command .= $data;

--- a/xml_handlers/coverage_handler.php
+++ b/xml_handlers/coverage_handler.php
@@ -178,11 +178,8 @@ class CoverageHandler extends AbstractHandler
                 case 'STARTTIME':
                     $this->StartTimeStamp = $data;
                     break;
-                case 'STARTDATETIME':
-                    $this->StartTimeStamp = str_to_time($data, $this->Build->GetStamp());
-                    break;
-                case 'ELAPSEDMINUTES':
-                    $this->EndTimeStamp = $this->StartTimeStamp + $data * 60;
+                case 'ENDTIME':
+                    $this->EndTimeStamp = $data;
                     break;
             }
         } elseif ($parent == 'FILE') {

--- a/xml_handlers/coverage_log_handler.php
+++ b/xml_handlers/coverage_log_handler.php
@@ -165,13 +165,8 @@ class CoverageLogHandler extends AbstractHandler
             case 'STARTTIME':
                 $this->StartTimeStamp = $data;
                 break;
-            case 'STARTDATETIME':
-                $this->StartTimeStamp =
-                    str_to_time($data, $this->Build->GetStamp());
-                break;
-            case 'ENDDATETIME':
-                $this->EndTimeStamp =
-                    str_to_time($data, $this->Build->GetStamp());
+            case 'ENDTIME':
+                $this->EndTimeStamp = $data;
                 break;
         }
     }

--- a/xml_handlers/testing_handler.php
+++ b/xml_handlers/testing_handler.php
@@ -273,22 +273,15 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
         $parent = $this->getParent();
         $element = $this->getElement();
 
-        if ($parent == 'TESTING' && $element == 'STARTDATETIME') {
-            // Defer to StartTestTime as it has higher precision.
-            if (!isset($this->StartTimeStamp)) {
-                $this->StartTimeStamp =
-                    str_to_time($data, $this->BuildInformation->BuildStamp);
+        if ($parent == 'TESTING') {
+            switch ($element) {
+                case 'STARTTESTTIME':
+                    $this->StartTimeStamp = $data;
+                    break;
+                case 'ENDTESTTIME':
+                    $this->EndTimeStamp = $data;
+                    break;
             }
-        } elseif ($parent == 'TESTING' && $element == 'STARTTESTTIME') {
-            $this->StartTimeStamp = $data;
-        } elseif ($parent == 'TESTING' && $element == 'ENDDATETIME') {
-            // Defer to EndTestTime as it has higher precision.
-            if (!isset($this->EndTimeStamp)) {
-                $this->EndTimeStamp =
-                    str_to_time($data, $this->BuildInformation->BuildStamp);
-            }
-        } elseif ($parent == 'TESTING' && $element == 'ENDTESTTIME') {
-            $this->EndTimeStamp = $data;
         } elseif ($parent == 'TEST') {
             switch ($element) {
                 case 'NAME':

--- a/xml_handlers/update_handler.php
+++ b/xml_handlers/update_handler.php
@@ -165,14 +165,8 @@ class UpdateHandler extends AbstractHandler implements ActionableBuildInterface
                 case 'STARTTIME':
                     $this->StartTimeStamp = $data;
                     break;
-                case 'STARTDATETIME':
-                    $this->StartTimeStamp = str_to_time($data, $this->getBuildStamp());
-                    break;
                 case 'ENDTIME':
                     $this->EndTimeStamp = $data;
-                    break;
-                case 'ENDDATETIME':
-                    $this->EndTimeStamp = str_to_time($data, $this->getBuildStamp());
                     break;
                 case 'UPDATECOMMAND':
                     $this->Update->Command .= $data;


### PR DESCRIPTION
Since v2.6, CTest has included in its XML files numeric timestamps that indicate
when each step started and ended.  It is safe to assume that any submissions to a
up-to-date CDash server will include these fields.