### PR TITLE
Fix for Trillinos-ATDM issue #41

### DIFF
--- a/include/sendemail.php
+++ b/include/sendemail.php
@@ -1083,8 +1083,18 @@ function generate_broken_build_message($emailtext, $Build, $Project)
     // Title
     $titleerrors .= '):';
     $title = 'FAILED ' . $titleerrors . ' ' . $Project->Name;
+    // In the sendmail.php file, in the sendmail function configure errors are now handled
+    // with their own logic, and the sendmail logic removes the 'configure_error' key therefore
+    // we should be able to verify that the following is a configure category by checking to see
+    // if the 'configure_error' key exists in the category array of keys.
+    $categories = array_keys($emailtext['category']);
 
-    if ($Build->GetSubProjectName()) {
+    $useSubProjectName = $Build->GetSubProjectName() &&
+        !in_array('configure_errors', $categories);
+
+    // Because a configure error is not subproject specific, remove this from the output
+    // if this is a configure_error.
+    if ($useSubProjectName) {
         $title .= '/' . $Build->GetSubProjectName();
     }
     $title .= ' - ' . $Build->Name . ' - ' . $Build->Type;
@@ -1102,15 +1112,9 @@ function generate_broken_build_message($emailtext, $Build, $Project)
 
     $body .= 'Project: ' . $Project->Name . "\n";
 
-    // In the sendmail.php file, in the sendmail function configure errors are now handled
-    // with their own logic, and the sendmail logic removes the 'configure_error' key therefore
-    // we should be able to verify that the following is a configure category by checking to see
-    // if the 'configure_error' key exists in the category array of keys.
-    $categories = array_keys($emailtext['category']);
-
     // Because a configure error is not subproject specific, remove this from the output
     // if this is a configure_error.
-    if ($Build->GetSubProjectName() && !in_array('configure_errors', $categories)) {
+    if ($useSubProjectName) {
         $body .= 'SubProject: ' . $Build->GetSubProjectName() . "\n";
     }
 

--- a/tests/data/MultipleSubprojects/EmailOutput.log
+++ b/tests/data/MultipleSubprojects/EmailOutput.log
@@ -1,5 +1,5 @@
 [<NA> <NA>] cdash.DEBUG: simpletest@localhost {"function":"TESTING: EMAIL","build_id":"<NA>","pid":<NA>} 
-[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample/MyExperimentalFeature - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
+[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
 [<NA> <NA>] cdash.DEBUG: A submission to CDash for the project SubProjectExample has configure errors.
 You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.
 
@@ -40,7 +40,7 @@ Error: example error #1
 -CDash on 
  {"function":"TESTING: EMAILBODY","build_id":"<NA>","pid":<NA>} 
 [<NA> <NA>] cdash.DEBUG: nox-noemail@noemail {"function":"TESTING: EMAIL","build_id":"<NA>","pid":<NA>} 
-[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample/MyExperimentalFeature - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
+[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
 [<NA> <NA>] cdash.DEBUG: A submission to CDash for the project SubProjectExample has configure errors.
 You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.
 
@@ -81,7 +81,7 @@ Error: example error #1
 -CDash on 
  {"function":"TESTING: EMAILBODY","build_id":"<NA>","pid":<NA>} 
 [<NA> <NA>] cdash.DEBUG: optika-noemail@noemail {"function":"TESTING: EMAIL","build_id":"<NA>","pid":<NA>} 
-[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample/MyThirdPartyDependency - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
+[<NA> <NA>] cdash.DEBUG: FAILED (c=1): SubProjectExample - CTestTest-Linux-c++-Subprojects - Experimental {"function":"TESTING: EMAILTITLE","build_id":"<NA>","pid":<NA>} 
 [<NA> <NA>] cdash.DEBUG: A submission to CDash for the project SubProjectExample has configure errors.
 You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.
 


### PR DESCRIPTION
- This fix addresses a subproject name appearing in the subject of a configure error email
- https://gitlab.kitware.com/snl/project-1/issues/41