### PR TITLE
Add terminal colors to ctest launcher captured output as well

### DIFF
--- a/public/views/partials/buildError.html
+++ b/public/views/partials/buildError.html
@@ -120,7 +120,7 @@
       <span class="nobr"> Standard Output </span>
     </th>
     <td>
-      <pre class="compiler-output" name="stdout">{{error.stdoutput}}</pre>
+      <pre class="compiler-output" name="stdout" ng-bind-html="error.stdoutput | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
     </td>
   </tr>
 
@@ -129,7 +129,7 @@
       <span class="nobr"> Standard Error </span>
     </th>
     <td>
-      <pre class="compiler-output" name="stderr">{{error.stderror}}</pre>
+      <pre class="compiler-output" name="stderr" ng-bind-html="error.stderror | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This is meant to fix issue #637. Seems to work in local testing.