### PR TITLE
Look up nightly start time relative to the requested date

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -1336,7 +1336,7 @@ function time2second($time)
  */
 function get_dates($date, $nightlytime)
 {
-    $nightlytime = strtotime($nightlytime);
+    $nightlytime = strtotime($nightlytime, strtotime($date));
 
     $nightlyhour = date('H', $nightlytime);
     $nightlyminute = date('i', $nightlytime);


### PR DESCRIPTION
This should fix the timeline test that started failing once DST began.