### PR TITLE
Make e-notation disabling check case insensitive

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -2132,7 +2132,7 @@ function cast_data_for_JSON($value)
     }
     // Do not support E notation for numbers (ie 6.02e23).
     // This can cause checksums (such as git commits) to be converted to 0.
-    if (is_numeric($value) && strpos($value, 'e') === false) {
+    if (is_numeric($value) && stripos($value, 'e') === false) {
         if (is_nan($value) || is_infinite($value)) {
             // Special handling for values that are not supported by JSON.
             return 0;


### PR DESCRIPTION
Prevent PHP from interpreting strings containing 'e' or 'E' as a number.