### PR TITLE
session_set_cookie_params: only set lifetime

### DIFF
--- a/app/Controller/Auth/Session.php
+++ b/app/Controller/Auth/Session.php
@@ -52,20 +52,10 @@ class Session
     {
         $lifetime = $this->config->get('CDASH_COOKIE_EXPIRATION_TIME');
         $maxlife = $lifetime + self::EXTEND_GC_LIFETIME;
-        $baseUrl = $this->config->getBaseUrl();
-        $url = parse_url($baseUrl);
-        $secure = false; // send only over a https connection
-        $httponly = true; // make cookie only accessible via http, e.g. not javascript
 
         $this->system->session_name('CDash');
         $this->system->session_cache_limiter($cache_policy);
-        $this->system->session_set_cookie_params(
-            $lifetime,
-            $url['path'],
-            $url['host'],
-            $secure,
-            $httponly
-        );
+        $this->system->session_set_cookie_params($lifetime);
         $this->system->ini_set('session.gc_maxlifetime', $maxlife);
         $this->system->session_start();
     }

--- a/include/CDash/System.php
+++ b/include/CDash/System.php
@@ -87,9 +87,9 @@ class System
      * @param $httponly
      * @return void
      */
-    public function session_set_cookie_params($lifetime, $path, $domain, $secure, $httponly)
+    public function session_set_cookie_params($lifetime)
     {
-        session_set_cookie_params($lifetime, $path, $domain, $secure, $httponly);
+        session_set_cookie_params($lifetime);
     }
 
     /**


### PR DESCRIPTION
Change how session_set_cookie_params() is called so that we only pass in
first parameter (lifetime).  This is how the function was called in CDash
before the recent addition of the Session class.  We were concerned that
restricting the cookie to a certain domain may cause login to fail on some
CDash installations.