### PR TITLE
Only expire build rules from the same project

### DIFF
--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -135,9 +135,12 @@ function rest_post()
         // Mark any previous buildgroup rule as finished as of this time.
         $now = gmdate(FMT_DATETIME);
         pdo_query(
-            "UPDATE build2grouprule SET endtime='$now'
-                WHERE buildtype='$buildtype' AND buildname='$buildname' AND
-                siteid='$siteid' AND endtime='1980-01-01 00:00:00'");
+            "UPDATE build2grouprule
+            SET endtime='$now'
+            WHERE buildtype='$buildtype' AND buildname='$buildname' AND
+            siteid='$siteid' AND endtime='1980-01-01 00:00:00' AND
+            groupid IN
+            (SELECT id FROM buildgroup WHERE projectid = '$build->ProjectId')");
 
         // Create the rule for the new buildgroup.
         // (begin time is set by default by mysql)

--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -34,34 +34,30 @@ if ($method != 'GET' && !can_administrate_project($build->ProjectId)) {
 // Route based on what type of request this is.
 switch ($method) {
     case 'DELETE':
-        rest_delete();
+        rest_delete($build);
         break;
     case 'POST':
-        rest_post();
+        rest_post($build);
         break;
     case 'PUT':
-        rest_put();
+        rest_put($build);
         break;
     case 'GET':
     default:
-        rest_get();
+        rest_get($build);
         break;
 }
 
 /* Handle DELETE requests */
-function rest_delete()
+function rest_delete($build)
 {
-    global $build;
     add_log('Build #' . $build->Id . ' removed manually', 'buildAPI');
     remove_build($build->Id);
 }
 
 /* Handle POST requests */
-function rest_post()
+function rest_post($build)
 {
-    /** @var Build $build */
-    global $build;
-
     $buildtype = $build->Type;
     $buildname = $build->Name;
     $siteid = $build->SiteId;
@@ -137,15 +133,13 @@ function rest_post()
 }
 
 /* Handle PUT requests */
-function rest_put()
+function rest_put($build)
 {
-    global $buildid;
 }
 
 /* Handle GET requests */
-function rest_get()
+function rest_get($build)
 {
-    global $build;
     $response = [];
 
     // Are we looking for what went wrong with this build?

--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -32,25 +32,8 @@ $build = get_request_build();
 
 $method = $_SERVER['REQUEST_METHOD'];
 // Make sure the user is an admin before proceeding with non-read-only methods.
-if ($method != 'GET') {
-    $userid = $_SESSION['cdash']['loginid'];
-    if (!isset($userid) || !is_numeric($userid)) {
-        $response['error'] = 'Not a valid userid!';
-        echo json_encode($response);
-        return;
-    }
-
-    $Project = new Project;
-    $User = new User;
-    $User->Id = $userid;
-    $Project->Id = $build->ProjectId;
-
-    $role = $Project->GetUserRole($userid);
-    if ($User->IsAdmin() === false && $role <= 1) {
-        $response['error'] = 'You do not have permission to access this page';
-        echo json_encode($response);
-        return;
-    }
+if ($method != 'GET' && !can_administrate_project($build->ProjectId)) {
+    return;
 }
 
 // Route based on what type of request this is.

--- a/public/api/v1/build.php
+++ b/public/api/v1/build.php
@@ -22,12 +22,7 @@ use CDash\Model\Project;
 use CDash\Model\User;
 
 init_api_request();
-$response = array();
-
-// Connect to database.
-@$db = pdo_connect("$CDASH_DB_HOST", "$CDASH_DB_LOGIN", "$CDASH_DB_PASS");
-pdo_select_db("$CDASH_DB_NAME", $db);
-
+$response = [];
 $build = get_request_build();
 
 $method = $_SERVER['REQUEST_METHOD'];
@@ -151,7 +146,7 @@ function rest_put()
 function rest_get()
 {
     global $build;
-    $response = array();
+    $response = [];
 
     // Are we looking for what went wrong with this build?
     if (isset($_GET['getproblems'])) {

--- a/tests/js/e2e_tests/viewBuildError.js
+++ b/tests/js/e2e_tests/viewBuildError.js
@@ -21,12 +21,12 @@ describe("viewBuildError", function() {
   });
 
   it("displays build errors inline", function() {
-    browser.get('viewBuildError.php?buildid=69&type=0');
+    browser.get('viewBuildError.php?buildid=71&type=0');
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });
 
   it("displays build errors inline on parent builds", function() {
-    browser.get('viewBuildError.php?buildid=68&type=0');
+    browser.get('viewBuildError.php?buildid=70&type=0');
     expect(browser.getPageSource()).toContain("some-test-subproject");
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });

--- a/tests/kwtest/kw_web_tester.php
+++ b/tests/kwtest/kw_web_tester.php
@@ -392,24 +392,12 @@ class KWWebTestCase extends WebTestCase
         }
 
         // Login as admin.
-        $client = new GuzzleHttp\Client(['cookies' => true]);
-        global $CDASH_BASE_URL;
-        try {
-            $response = $client->request('POST',
-                    $CDASH_BASE_URL . '/user.php',
-                    ['form_params' => [
-                        'login' => $username,
-                        'passwd' => $password,
-                        'sent' => 'Login >>']]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        $client = $this->getGuzzleClient($username, $password);
 
         // Create project.
         try {
             $response = $client->request('POST',
-                    $CDASH_BASE_URL . '/api/v1/project.php',
+                    $this->url . '/api/v1/project.php',
                     ['json' => [$submit_button => true, 'project' => $settings]]);
         } catch (GuzzleHttp\Exception\ClientException $e) {
             $this->fail($e->getMessage());
@@ -461,25 +449,13 @@ class KWWebTestCase extends WebTestCase
     public function deleteProject($projectid)
     {
         // Login as admin.
-        $client = new GuzzleHttp\Client(['cookies' => true]);
-        global $CDASH_BASE_URL;
-        try {
-            $response = $client->request('POST',
-                    $CDASH_BASE_URL . '/user.php',
-                    ['form_params' => [
-                        'login' => 'simpletest@localhost',
-                        'passwd' => 'simpletest',
-                        'sent' => 'Login >>']]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        $client = $this->getGuzzleClient();
 
         // Delete project.
         $project_array = array('Id' => $projectid);
         try {
             $response = $client->delete(
-                    $CDASH_BASE_URL . '/api/v1/project.php',
+                    $this->url . '/api/v1/project.php',
                     ['json' => ['project' => $project_array]]);
         } catch (GuzzleHttp\Exception\ClientException $e) {
             $this->fail($e->getMessage());
@@ -492,6 +468,24 @@ class KWWebTestCase extends WebTestCase
         if ($project->Exists()) {
             $this->fail("Project $projectid still exists after it should have been deleted");
         }
+    }
+
+    public function getGuzzleClient($username = 'simpletest@localhost',
+                                    $password = 'simpletest')
+    {
+        $client = new GuzzleHttp\Client(['cookies' => true]);
+        try {
+            $response = $client->request('POST',
+                    $this->url . '/user.php',
+                    ['form_params' => [
+                    'login' => $username,
+                    'passwd' => $password,
+                    'sent' => 'Login >>']]);
+        } catch (GuzzleHttp\Exception\ClientException $e) {
+            $this->fail($e->getMessage());
+            return false;
+        }
+        return $client;
     }
 
     public function addLineToConfig($line_to_add)

--- a/tests/test_buildgrouprule.php
+++ b/tests/test_buildgrouprule.php
@@ -7,7 +7,6 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 require_once 'include/pdo.php';
 
-use CDash\Config;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;
@@ -18,8 +17,6 @@ class BuildGroupRuleTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
-        $this->Config = Config::getInstance();
-        $this->base_url = $this->Config->get('CDASH_BASE_URL');
         $this->PDO = Database::getInstance()->getPdo();
     }
 
@@ -134,18 +131,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         $build2->Id = add_build($build2);
 
         // Login as admin.
-        $client = new GuzzleHttp\Client(['cookies' => true]);
-        try {
-            $response = $client->request('POST',
-                    $this->base_url . '/user.php',
-                    ['form_params' => [
-                        'login' => 'simpletest@localhost',
-                        'passwd' => 'simpletest',
-                        'sent' => 'Login >>']]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        $client = $this->getGuzzleClient();
 
         // Mark both builds as expected.  This will define buildgroup rules
         // for each.
@@ -158,7 +144,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
             ];
             try {
                 $response = $client->request('POST',
-                        $this->base_url .  '/api/v1/build.php',
+                        $this->url .  '/api/v1/build.php',
                         ['json' => $payload]);
             } catch (GuzzleHttp\Exception\ClientException $e) {
                 $this->fail($e->getMessage());
@@ -176,7 +162,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         ];
         try {
             $response = $client->request('POST',
-                    $this->base_url .  '/api/v1/build.php',
+                    $this->url .  '/api/v1/build.php',
                     ['json' => $payload]);
         } catch (GuzzleHttp\Exception\ClientException $e) {
             $this->fail($e->getMessage());

--- a/tests/test_buildgrouprule.php
+++ b/tests/test_buildgrouprule.php
@@ -7,6 +7,8 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 require_once 'include/pdo.php';
 
+use CDash\Config;
+use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
@@ -16,6 +18,9 @@ class BuildGroupRuleTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
+        $this->Config = Config::getInstance();
+        $this->base_url = $this->Config->get('CDASH_BASE_URL');
+        $this->PDO = Database::getInstance()->getPdo();
     }
 
     public function testBuildGroupRule()
@@ -100,5 +105,105 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         // This also deletes the rules.
         $group1->Delete();
         $group2->Delete();
+    }
+
+    public function testOnlyExpireRulesFromSameProject()
+    {
+        // Clean up any previous runs of this test case.
+        $stmt = $this->PDO->prepare(
+            "SELECT id FROM build WHERE name = 'no-project-leakage'");
+        pdo_execute($stmt);
+        while ($row = $stmt->fetch()) {
+            remove_build($row['id']);
+        }
+        $this->PDO->exec(
+            "DELETE FROM build2grouprule WHERE buildname = 'no-project-leakage'");
+
+        // Create two similar builds that belong to different projects.
+        $build1 = new Build();
+        $build1->Name = 'no-project-leakage';
+        $build1->SiteId = 1;
+        $build1->StartTime = gmdate(FMT_DATETIME, time() - 100);
+        $build1->Type = 'Experimental';
+        $build2 = clone $build1;
+
+        $build1->ProjectId = 1;
+        $build1->Id = add_build($build1);
+
+        $build2->ProjectId = 2;
+        $build2->Id = add_build($build2);
+
+        // Login as admin.
+        $client = new GuzzleHttp\Client(['cookies' => true]);
+        try {
+            $response = $client->request('POST',
+                    $this->base_url . '/user.php',
+                    ['form_params' => [
+                        'login' => 'simpletest@localhost',
+                        'passwd' => 'simpletest',
+                        'sent' => 'Login >>']]);
+        } catch (GuzzleHttp\Exception\ClientException $e) {
+            $this->fail($e->getMessage());
+            return false;
+        }
+
+        // Mark both builds as expected.  This will define buildgroup rules
+        // for each.
+        foreach ([$build1, $build2] as $build) {
+            // Mark this build as expected.
+            $payload = [
+                'buildid'  => $build->Id,
+                'groupid'  => $build->GroupId,
+                'expected' => 1
+            ];
+            try {
+                $response = $client->request('POST',
+                        $this->base_url .  '/api/v1/build.php',
+                        ['json' => $payload]);
+            } catch (GuzzleHttp\Exception\ClientException $e) {
+                $this->fail($e->getMessage());
+            }
+        }
+
+        // Change the group of one of the builds.
+        $group = new BuildGroup();
+        $group->SetProjectId($build1->ProjectId);
+        $group->SetName('Continuous');
+        $payload = [
+            'buildid'    => $build1->Id,
+            'expected'   => 1,
+            'newgroupid' => $group->GetId()
+        ];
+        try {
+            $response = $client->request('POST',
+                    $this->base_url .  '/api/v1/build.php',
+                    ['json' => $payload]);
+        } catch (GuzzleHttp\Exception\ClientException $e) {
+            $this->fail($e->getMessage());
+        }
+
+        // Check the database.
+        // We expect to find one finished rule and two active ones.
+        $num_active = 0;
+        $num_finished = 0;
+        $stmt = $this->PDO->prepare(
+                "SELECT * FROM build2grouprule
+                WHERE buildname = 'no-project-leakage' AND
+                      siteid = 1 AND
+                      buildtype = 'Experimental'");
+        pdo_execute($stmt);
+        while ($row = $stmt->fetch()) {
+            if ($row['endtime'] == '1980-01-01 00:00:00') {
+                $num_active++;
+            } else {
+                $num_finished++;
+            }
+        }
+        if ($num_active !== 2) {
+            $this->fail("Expected two active rules, found $num_active");
+        }
+        if ($num_finished !== 1) {
+            $this->fail("Expected one finished rule, found $num_finished");
+        }
     }
 }

--- a/tests/test_managemeasurements.php
+++ b/tests/test_managemeasurements.php
@@ -104,19 +104,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         }
 
         // Login as admin.
-        $client = new GuzzleHttp\Client(['cookies' => true]);
-        global $CDASH_BASE_URL;
-        try {
-            $response = $client->request('POST',
-                    $CDASH_BASE_URL . '/user.php',
-                    ['form_params' => [
-                        'login' => 'simpletest@localhost',
-                        'passwd' => 'simpletest',
-                        'sent' => 'Login >>']]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        $client = $this->getGuzzleClient();
 
         // POST to manageMeasurements.php to add 'Processors' as a
         // test measurement for these projects.
@@ -133,7 +121,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             ];
             try {
                 $response = $client->request('POST',
-                        $CDASH_BASE_URL . '/api/v1/manageMeasurements.php',
+                        $this->url . '/api/v1/manageMeasurements.php',
                         ['json' => ['projectid' => $projectid, 'measurements' => $measurements]]);
             } catch (GuzzleHttp\Exception\ClientException $e) {
                 $this->fail($e->getMessage());

--- a/tests/test_timeline.php
+++ b/tests/test_timeline.php
@@ -7,7 +7,6 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'include/common.php';
 require_once 'include/pdo.php';
 
-use CDash\Config;
 use CDash\Database;
 use CDash\Model\Build;
 
@@ -17,8 +16,6 @@ class TimelineTestCase extends KWWebTestCase
     {
         parent::__construct();
         $this->PDO = Database::getInstance()->getPdo();
-        $this->Config = Config::getInstance();
-        $this->base_url = $this->Config->get('CDASH_BASE_URL');
     }
 
     private function toggle_expected($client, $build, $expected)
@@ -31,7 +28,7 @@ class TimelineTestCase extends KWWebTestCase
         ];
         try {
             $response = $client->request('POST',
-                    $this->base_url .  '/api/v1/build.php',
+                    $this->url .  '/api/v1/build.php',
                     ['json' => $payload]);
         } catch (GuzzleHttp\Exception\ClientException $e) {
             $this->fail($e->getMessage());
@@ -72,18 +69,7 @@ class TimelineTestCase extends KWWebTestCase
         }
 
         // Login as admin.
-        $client = new GuzzleHttp\Client(['cookies' => true]);
-        try {
-            $response = $client->request('POST',
-                    $this->base_url . '/user.php',
-                    ['form_params' => [
-                        'login' => 'simpletest@localhost',
-                        'passwd' => 'simpletest',
-                        'sent' => 'Login >>']]);
-        } catch (GuzzleHttp\Exception\ClientException $e) {
-            $this->fail($e->getMessage());
-            return false;
-        }
+        $client = $this->getGuzzleClient();
 
         // Mark this build as expected.
         $this->toggle_expected($client, $build, 1);


### PR DESCRIPTION
Fix a bug involving cross-talk between projects that contain similarly named builds.

Also clean up the build.php API endpoint a bit.