### PR TITLE
Don't emit any output before starting the session

### DIFF
--- a/public/ajax/buildinfogroup.php
+++ b/public/ajax/buildinfogroup.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -139,4 +138,3 @@ if ($testfailing) {
 
 
 </table>
-</html>

--- a/public/ajax/buildnote.php
+++ b/public/ajax/buildnote.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -52,6 +51,3 @@ while ($note_array = pdo_fetch_array($note)) {
     echo 'by <b>' . $user->FirstName . ' ' . $user->LastName . '</b>' . ' (' . date('H:i:s T', $timestamp) . ')';
     echo '<pre>' . substr($note_array['note'], 0, 100) . '</pre>'; // limit 100 chars
 }
-?>
-
-</html>

--- a/public/ajax/expectedbuildgroup.php
+++ b/public/ajax/expectedbuildgroup.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -222,4 +221,3 @@ $group = pdo_query("SELECT name,id FROM buildgroup WHERE id!='$buildgroupid' AND
         ?>
     </table>
 </form>
-</html>

--- a/public/ajax/expectedinfo.php
+++ b/public/ajax/expectedinfo.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -70,4 +69,3 @@ if (pdo_num_rows($lastbuild) > 0) {
             </font></td>
     </tr>
 </table>
-</html>

--- a/public/ajax/finduserproject.php
+++ b/public/ajax/finduserproject.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -71,4 +70,3 @@ echo pdo_error();
 
 </table>
 
-</html>

--- a/public/ajax/findusers.php
+++ b/public/ajax/findusers.php
@@ -1,4 +1,3 @@
-<html>
 <?php
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
@@ -93,5 +92,3 @@ echo pdo_error();
     ?>
 
 </table>
-
-</html>


### PR DESCRIPTION
These AJAX endpoints should not echo <html> tags.