### PR TITLE
Cache invalidation for CSS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
   var gulp = require('gulp'),
       del = require('del'),
       concat = require('gulp-concat'),
+      concatCss = require('gulp-concat-css'),
       eslint = require('gulp-eslint'),
       fsPath = require('fs-path'),
       newer = require('gulp-newer'),
@@ -117,6 +118,17 @@
  });
 
 
+ gulp.task('css', function() {
+    gulp.src(['public/css/cdash.css', 'public/css/common.css'])
+        .pipe(concatCss('cdash_' + version + '.css'))
+        .pipe(gulp.dest('public/build/css/'));
+
+    gulp.src(['public/css/colorblind.css', 'public/css/common.css'])
+        .pipe(concatCss('colorblind_' + version + '.css'))
+        .pipe(gulp.dest('public/build/css/'));
+ });
+
+
   gulp.task('replace', function(){
     gulp.src(['public/views/*.html'])
         .pipe(replace('@@version', version))
@@ -142,5 +154,5 @@
   });
 
 
-  gulp.task('default', ['clean', 'quality', 'uglify', 'replace']);
+  gulp.task('default', ['clean', 'quality', 'uglify', 'css', 'replace']);
 }());

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-angular": "^0.12.0",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
+    "gulp-concat-css": "^3.1.0",
     "gulp-eslint": "^1.0.0",
     "gulp-newer": "^1.1.0",
     "gulp-rename": "^1.2.2",

--- a/public/js/controllers/head.js
+++ b/public/js/controllers/head.js
@@ -15,9 +15,9 @@ CDash.controller('HeadController', function HeadController($rootScope, $document
   // Pick which CSS file to use based on user settings.
   var colorblind = $rootScope.readCookie('colorblind');
   if (colorblind == 1) {
-    $rootScope.cssfile = "css/colorblind.css";
+    $rootScope.cssfile = "colorblind";
   } else {
-    $rootScope.cssfile = "css/cdash.css";
+    $rootScope.cssfile = "cdash";
   }
 
   // Load query string parameters into javascript object.

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -539,11 +539,11 @@ CDash.filter("showEmptyBuildsLast", function () {
 
   $scope.colorblind_toggle = function() {
     if ($scope.cdash.filterdata.colorblind) {
-      $rootScope.cssfile = "css/colorblind.css";
+      $rootScope.cssfile = "colorblind";
       $.cookie("colorblind", 1, { expires: 365 } );
 
     } else {
-      $rootScope.cssfile = "css/cdash.css";
+      $rootScope.cssfile = "cdash";
       $.cookie("colorblind", 0, { expires: 365 } );
     }
   };

--- a/public/views/buildProperties.html
+++ b/public/views/buildProperties.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/nv.d3.css"/>
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />

--- a/public/views/buildSummary.html
+++ b/public/views/buildSummary.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash</title>

--- a/public/views/compareCoverage.html
+++ b/public/views/compareCoverage.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <link rel="stylesheet" type="text/css" href="css/jqModal.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>

--- a/public/views/createProject.html
+++ b/public/views/createProject.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{::cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
 <!--

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <link rel="stylesheet" type="text/css" href="css/jqModal.css" />
     <link rel="stylesheet" type="text/css" href="css/nv.d3.css"/>

--- a/public/views/manageBuildGroup.html
+++ b/public/views/manageBuildGroup.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery.qtip.min.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>

--- a/public/views/manageMeasurements.html
+++ b/public/views/manageMeasurements.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Manage Measurements</title>

--- a/public/views/manageOverview.html
+++ b/public/views/manageOverview.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" href="css/jquery-ui-1.10.4.css"/>
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/manageSubProject.html
+++ b/public/views/manageSubProject.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title>CDash - Manage SubProjects</title>

--- a/public/views/overview.html
+++ b/public/views/overview.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/nv.d3.css"/>
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery.jqplot.min.css"/>

--- a/public/views/queryTests.html
+++ b/public/views/queryTests.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/testDetails.html
+++ b/public/views/testDetails.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/je_compare_style-1.0.0.css" />
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash</title>

--- a/public/views/testOverview.html
+++ b/public/views/testOverview.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/testSummary.html
+++ b/public/views/testSummary.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{::cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/user.html
+++ b/public/views/user.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{::cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash - My Profile</title>

--- a/public/views/userStatistics.html
+++ b/public/views/userStatistics.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{::cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/viewBuildError.html
+++ b/public/views/viewBuildError.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="css/jquery.qtip.min.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <link rel="stylesheet" type="text/css" href="css/jqModal.css" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <style type="text/css">
      code {

--- a/public/views/viewConfigure.html
+++ b/public/views/viewConfigure.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Configure</title>

--- a/public/views/viewDynamicAnalysis.html
+++ b/public/views/viewDynamicAnalysis.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Dynamic Analysis</title>
   </head>

--- a/public/views/viewDynamicAnalysisFile.html
+++ b/public/views/viewDynamicAnalysisFile.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Dynamic Analysis</title>
   </head>

--- a/public/views/viewNotes.html
+++ b/public/views/viewNotes.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title>{{cdash.title || "CDash : View notes"}}</title>

--- a/public/views/viewProjects.html
+++ b/public/views/viewProjects.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" type="text/css" href="css/jquery.qtip.min.css" />
     <link rel="stylesheet" type="text/css" href="css/jqModal.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/viewSubProjects.html
+++ b/public/views/viewSubProjects.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>

--- a/public/views/viewTest.html
+++ b/public/views/viewTest.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{::cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash</title>

--- a/public/views/viewUpdate.html
+++ b/public/views/viewUpdate.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" type="text/css" ng-href="{{cssfile}}" />
+    <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css"/>
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Update</title>


### PR DESCRIPTION
CDash users will no longer have to delete their caches to get the latest
version of our CSS rules. This is similar to what we already do for our
Javascript files and HTML views.