### PR TITLE
make GitHub authentication more robust

### DIFF
--- a/app/Middleware/OAuth2.php
+++ b/app/Middleware/OAuth2.php
@@ -156,7 +156,7 @@ abstract class OAuth2 implements OAuth2Interface
 
         // Use the access token to get the user's email.
         try {
-            $email = $this->getEmail();
+            $email = $this->getEmail($user);
             if (!$email) {
                 throw new Exception('Could not determine email address for user.');
             } else {

--- a/app/Middleware/OAuth2/GitHub.php
+++ b/app/Middleware/OAuth2/GitHub.php
@@ -52,7 +52,7 @@ class GitHub extends OAuth2
     {
         $request = $this->Provider->getAuthenticatedRequest(
                 'GET',
-                'https://api.github.com/user/public_emails',
+                'https://api.github.com/user/emails',
                 $this->Token
                 );
         $this->setEmails(

--- a/app/Middleware/OAuth2/GitLab.php
+++ b/app/Middleware/OAuth2/GitLab.php
@@ -18,6 +18,7 @@ namespace CDash\Middleware\OAuth2;
 use CDash\Config;
 use CDash\Controller\Auth\Session;
 use CDash\Middleware\OAuth2;
+use CDash\Model\User;
 use CDash\System;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use Omines\OAuth2\Client\Provider\Gitlab as GitLabProvider;
@@ -33,7 +34,7 @@ class GitLab extends OAuth2
         $this->Email = '';
     }
 
-    public function getEmail()
+    public function getEmail(User $user)
     {
         if (empty($this->Email)) {
             $this->loadEmail();

--- a/app/Middleware/OAuth2/Google.php
+++ b/app/Middleware/OAuth2/Google.php
@@ -32,7 +32,7 @@ class Google extends OAuth2
             [ 'scope' => ['https://www.googleapis.com/auth/userinfo.email'] ];
     }
 
-    public function getEmail()
+    public function getEmail(User $user)
     {
         $this->loadOwnerDetails();
         $email = strtolower($this->OwnerDetails->getEmail());

--- a/app/Middleware/OAuth2/OAuth2Interface.php
+++ b/app/Middleware/OAuth2/OAuth2Interface.php
@@ -13,6 +13,7 @@
 =========================================================================*/
 namespace CDash\Middleware\OAuth2;
 
+use CDash\Model\User;
 use League\OAuth2\Client\Provider\AbstractProvider;
 
 interface OAuth2Interface
@@ -31,7 +32,7 @@ interface OAuth2Interface
     /**
      * @return string
      */
-    public function getEmail();
+    public function getEmail(User $user);
 
     /**
      * @return string

--- a/tests/case/CDash/Middleware/OAuth2/GitHubTest.php
+++ b/tests/case/CDash/Middleware/OAuth2/GitHubTest.php
@@ -81,6 +81,7 @@ class GitHubTest extends \PHPUnit_Framework_TestCase
         $emails[] = $email2;
 
         $this->github->setEmails($emails);
-        $this->assertEquals('b@c.com', $this->github->getEmail());
+        $user = $this->getMockBuilder(User::class)->getMock();
+        $this->assertEquals('b@c.com', $this->github->getEmail($user));
     }
 }

--- a/tests/case/CDash/Middleware/OAuth2/GitLabTest.php
+++ b/tests/case/CDash/Middleware/OAuth2/GitLabTest.php
@@ -69,6 +69,7 @@ class GitLabTest extends \PHPUnit_Framework_TestCase
     public function testGetEmail()
     {
         $this->gitlab->setEmail('a@b.com');
-        $this->assertEquals('a@b.com', $this->gitlab->getEmail());
+        $user = $this->getMockBuilder(User::class)->getMock();
+        $this->assertEquals('a@b.com', $this->gitlab->getEmail($user));
     }
 }

--- a/tests/case/CDash/Middleware/OAuth2/GoogleTest.php
+++ b/tests/case/CDash/Middleware/OAuth2/GoogleTest.php
@@ -69,6 +69,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $response = ['emails' => [0 => ['value' => 'a@b.com']]];
         $owner_details = new GoogleUser($response);
         $this->google->setOwnerDetails($owner_details);
-        $this->assertEquals('a@b.com', $this->google->getEmail());
+        $user = $this->getMockBuilder(User::class)->getMock();
+        $this->assertEquals('a@b.com', $this->google->getEmail($user));
     }
 }


### PR DESCRIPTION
Check private email addresses associated with a GitHub account when attempting to authenticate against CDash