### PR TITLE
Add new filter where + was clicked

### DIFF
--- a/public/js/controllers/filters.js
+++ b/public/js/controllers/filters.js
@@ -243,7 +243,7 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
       compare: parent_filter.compare,
       value: parent_filter.value,
     };
-    $scope.filterdata.filters.push(filter);
+    $scope.filterdata.filters.splice(index, 0, filter);
   };
 
   // Remove a filter from our list.

--- a/tests/js/e2e_tests/filterLabels.js
+++ b/tests/js/e2e_tests/filterLabels.js
@@ -85,4 +85,29 @@ describe("filterLabels", function() {
     expect(element(by.id('numtests')).getText()).toBe('Query Tests: 409 matches');
   });
 
+  it("new filter is added in the right place", function() {
+    // Show filters on index.php.
+    browser.get('index.php?project=Trilinos&date=2011-07-22');
+    element(by.id('settings')).click();
+    var link = element(by.id('label_showfilters'));
+    link.click();
+
+    // Add two filters to the form.
+    element(by.id('id_field1')).$('[value="label"]').click();
+    element(by.id('id_compare1')).$('[value="63"]').click();
+    element(by.id('id_value1')).sendKeys('a');
+
+    element(by.name('add1')).click();
+    element(by.id('id_value2')).clear();
+    element(by.id('id_value2')).sendKeys('b');
+
+    // Add a third one in between the two.
+    element(by.name('add1')).click();
+
+    // Verify that the second filter in the list is now 'a', not 'b'.
+    expect(element(by.id('id_value2')).getAttribute('value')).toBe('a');
+    expect(element(by.id('id_value3')).getAttribute('value')).toBe('b');
+  });
+
+
 });


### PR DESCRIPTION
When the user clicks the '+' button to add a new filter search term,
the new blank row was getting added at the bottom of the list.
This commit improves this behavior by adding this new row below
the '+' button that the user clicked.