### PR TITLE
add docker build and supporting files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=cdash

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update                                                             \
  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/              \
                                 --with-jpeg-dir=/usr/include/                  \
  && docker-php-ext-install -j$(nproc) bcmath bz2 gd pdo_mysql pdo_pgsql xsl    \
- && pecl install xdebug-2.5.5                                                  \
  && docker-php-ext-enable xdebug                                               \
  && (                                                                          \
       echo '544e09ee 996cdf60 ece3804a bc52599c'                               \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update                                                             \
  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/              \
                                 --with-jpeg-dir=/usr/include/                  \
  && docker-php-ext-install -j$(nproc) bcmath bz2 gd pdo_mysql pdo_pgsql xsl    \
- && docker-php-ext-enable xdebug                                               \
  && (                                                                          \
       echo '544e09ee 996cdf60 ece3804a bc52599c'                               \
     ; echo '22b1f40f 4323403c 44d44fdf dd586475'                               \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-MAINTAINER Omar Padron "omar.padron@kitware.com"
+LABEL maintainer="Kitware, Inc. <software.kitware.com>"
 
 RUN apt-get update                                                             \
  && apt-get install -y gnupg                                                   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:7.0-apache
+
+MAINTAINER Omar Padron "omar.padron@kitware.com"
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash                       \
+ && apt-get install -y git libbz2-dev libfreetype6-dev libjpeg62-turbo-dev     \
+    libmcrypt-dev libpng12-dev libpq-dev libxslt-dev libxss1 nodejs unzip wget \
+    zip                                                                        \
+ && docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql               \
+ && docker-php-ext-configure gd --with-freetype-dir=/usr/include/              \
+                                --with-jpeg-dir=/usr/include/                  \
+ && docker-php-ext-install -j$(nproc) bcmath bz2 gd pdo_mysql pdo_pgsql xsl    \
+ && pecl install xdebug-2.5.5                                                  \
+ && docker-php-ext-enable xdebug                                               \
+ && (                                                                          \
+      echo '544e09ee 996cdf60 ece3804a bc52599c'                               \
+    ; echo '22b1f40f 4323403c 44d44fdf dd586475'                               \
+    ; echo 'ca9813a8 58088ffb c1f233e9 b180f061'                               \
+    ) | tr -d "\\n " | sed 's/$/  -/g' > checksum                              \
+ && curl -o - 'https://getcomposer.org/installer'                              \
+ |  tee composer-setup.php                                                     \
+ |  sha384sum -c checksum                                                      \
+ && rm checksum                                                                \
+ || ( rm -f checksum composer-setup.php && false )                             \
+ && php composer-setup.php --install-dir=/usr/local/bin --filename=composer    \
+ && php -r "unlink('composer-setup.php');"                                     \
+ && composer self-update --no-interaction
+
+RUN mkdir -p /var/www                                             \
+ && git clone git://github.com/kitware/cdash /var/www/cdash       \
+ && rm -rf /var/www/cdash/.git                                    \
+ && cd /var/www/cdash                                             \
+ && composer install --no-interaction --no-progress --prefer-dist \
+ && npm install                                                   \
+ && node_modules/.bin/gulp                                        \
+ && chmod 777 backup log public/rss public/upload                 \
+ && rm -rf /var/www/html                                          \
+ && ln -s /var/www/cdash/public /var/www/html
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+WORKDIR /var/www/cdash
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5m \
+  CMD ["curl", "-f", "http://localhost/viewProjects.php"]
+
+ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,16 +26,32 @@ RUN apt-get update                                                             \
  && php -r "unlink('composer-setup.php');"                                     \
  && composer self-update --no-interaction
 
-RUN mkdir -p /var/www                                             \
- && git clone git://github.com/kitware/cdash /var/www/cdash       \
- && rm -rf /var/www/cdash/.git                                    \
- && cd /var/www/cdash                                             \
- && composer install --no-interaction --no-progress --prefer-dist \
- && npm install                                                   \
- && node_modules/.bin/gulp                                        \
- && chmod 777 backup log public/rss public/upload                 \
- && rm -rf /var/www/html                                          \
- && ln -s /var/www/cdash/public /var/www/html
+RUN mkdir -p /var/www/cdash
+COPY php.ini /var/www/cdash/php.ini
+COPY xml_handlers /var/www/cdash/xml_handlers
+COPY app /var/www/cdash/app
+COPY composer.lock /var/www/cdash/composer.lock
+COPY public /var/www/cdash/public
+COPY scripts /var/www/cdash/scripts
+COPY sql /var/www/cdash/sql
+COPY package.json /var/www/cdash/package.json
+COPY .php_cs /var/www/cdash/.php_cs
+COPY config /var/www/cdash/config
+COPY log /var/www/cdash/log
+COPY gulpfile.js /var/www/cdash/gulpfile.js
+COPY backup /var/www/cdash/backup
+COPY include /var/www/cdash/include
+COPY bootstrap /var/www/cdash/bootstrap
+COPY composer.json /var/www/cdash/composer.json
+
+RUN cd /var/www/cdash                                                      \
+ && composer install --no-interaction --no-progress --prefer-dist --no-dev \
+ && npm install                                                            \
+ && node_modules/.bin/gulp                                                 \
+ && chmod 777 backup log public/rss public/upload                          \
+ && rm -rf /var/www/html                                                   \
+ && ln -s /var/www/cdash/public /var/www/html                              \
+ && rm -rf composer.lock package.json gulpfile.js composer.json
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 
-LABEL maintainer="Kitware, Inc. <software.kitware.com>"
+LABEL maintainer="Kitware, Inc. <cdash@public.kitware.com>"
 
 RUN apt-get update                                                             \
  && apt-get install -y gnupg                                                   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM php:7.0-apache
 
 MAINTAINER Omar Padron "omar.padron@kitware.com"
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash                       \
+RUN apt-get update                                                             \
+ && apt-get install -y gnupg                                                   \
+ && curl -sL https://deb.nodesource.com/setup_6.x | bash                       \
  && apt-get install -y git libbz2-dev libfreetype6-dev libjpeg62-turbo-dev     \
-    libmcrypt-dev libpng12-dev libpq-dev libxslt-dev libxss1 nodejs unzip wget \
+    libmcrypt-dev libpng-dev libpq-dev libxslt-dev libxss1 nodejs unzip wget   \
     zip                                                                        \
  && docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql               \
  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/              \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.3'
+services:
+  cdash:
+    image: "kitware/cdash"
+    build: .
+    depends_on:
+      - mysql
+    links:
+      - mysql
+    ports:
+     - "8080:80"
+    environment:
+      CDASH_ROOT_ADMIN_PASS: secret
+
+      CDASH_CONFIG: |
+        $$CDASH_DB_HOST = 'mysql';
+        $$CDASH_DB_NAME = 'cdash';
+        $$CDASH_DB_TYPE = 'mysql';
+        $$CDASH_DB_LOGIN = 'root';
+        $$CDASH_DB_PORT = '';
+        $$CDASH_DB_PASS = '';
+        $$CDASH_DB_CONNECTION_TYPE = 'host';
+
+      CDASH_STATIC_USERS: |
+        USER jdoe@acme.com jdoe_secret
+          John Doe "ACME Inc."
+
+        ADMIN admin@example.org admin_secret
+          Admin User "Example Foundation"
+
+        donotreply@example.org oldsecret newsecret
+
+        strange.name@gmail.com strange_secret
+        INFO Str@nge N@me "Str@nge Rese@rch Gr0up LLC."
+
+        DELETE remove.this.user@example.org delete_secret
+
+  mysql:
+    image: "mysql/mysql-server:5.5"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ROOT_PASSWORD: ''
+      MYSQL_DATABASE: 'cdash'
+      MYSQL_ROOT_HOST: '%'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,554 @@
+#!/bin/bash
+
+declare -a __exit_callbacks
+onexit() {
+    __exit_callbacks[${#__exit_callbacks[@]}]="$@"
+}
+
+do_exit() {
+    if [ -z "$exit_code" ] ; then
+        exit_code="$1"
+        local n
+        n=${#__exit_callbacks[@]}
+        for ((; n--; )) ; do
+            eval "${__exit_callbacks[$n]}"
+        done
+    fi
+}
+
+EXEC() {
+    do_exit 0
+    exec "$@"
+}
+
+trap "do_exit 1; exit $exit_code" INT TERM QUIT
+trap "do_exit 0; exit $exit_code" EXIT
+
+onexit 'if [ -n "$tmpdir" -a -d "$tmpdir" ] ; then rm -r "$tmpdir" ; fi'
+
+ensure_tmp() {
+    if [ -z "$tmpdir" ] ; then
+        tmpdir="$( mktemp -d )"
+    fi
+}
+
+# poor man's CDash client
+mksession() {
+    local result
+    ensure_tmp
+    mkdir -p "$tmpdir/sessions"
+    until mkdir "$result" 2> /dev/null ; do
+        result="$tmpdir/sessions/$RANDOM"
+    done
+    echo "$result"
+}
+
+ajax() {
+    local method
+    local session
+    local route
+    local curl_args
+    local arg
+
+    method="$1" ; shift
+    session="$1" ; shift
+    route="$1" ; shift
+
+    if [ "$method" '=' 'POST' ] ; then
+        for arg in "$@" ; do
+            curl_args="$curl_args --form '$arg'"
+        done
+    fi
+
+    local oldcookies
+    local newcookies
+
+    oldcookies="$session/cookies.txt"
+    newcookies="$session/cookies.tmp"
+
+    if [ "$session" '!=' '-' ] ; then
+        if [ -f "$oldcookies" ] ; then
+            curl_args="$curl_args --cookie '$oldcookies'"
+        fi
+        curl_args="$curl_args --cookie-jar '$newcookies'"
+    fi
+
+    local port="$PORT"
+    if [ -n "$port" ] ; then
+        port=":$port"
+    fi
+
+    curl_args="$curl_args 'http://localhost${port}/$route"
+
+    if [ "$method" '=' 'GET' ] ; then
+        arg="$1" ; shift
+        if [ -n "$arg" ] ; then
+            curl_args="${curl_args}?$arg"
+        fi
+
+        for arg in "$@" ; do
+            curl_args="${curl_args}&$arg"
+        done
+    fi
+
+    curl_args="${curl_args}'"
+
+    eval "curl $curl_args" 2>&-
+
+    if [ "$session" '!=' '-' ] ; then
+        if [ -f "$newcookies" ] ; then
+            mv "$newcookies" "$oldcookies"
+        fi
+    fi
+
+    sleep 0.2
+}
+
+get() {
+    ajax GET "$@"
+}
+
+post() {
+    ajax POST "$@"
+}
+
+user_prefix="__user"
+user_set() {
+    email="$1" ; shift
+    key="$1" ; shift
+    value="$1" ; shift
+    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
+    eval "${user_prefix}_${email_hash}_${key}=\"${value}\""
+}
+
+user_get() {
+    email="$1" ; shift
+    key="$1" ; shift
+    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
+    eval "echo \"\$${user_prefix}_${email_hash}_${key}\""
+}
+
+DEBUG() {
+    if [ -n "$DEBUG" ] ; then
+        echo -n "DEBUG:: "
+        echo "$@"
+    fi
+}
+
+if [ -z "$CDASH_ROOT_ADMIN_PASS" ] ; then
+    cat << ____EOF
+error: This container requires the CDASH_ROOT_ADMIN_PASS
+       environment variable to be defined.
+____EOF
+    exit 1
+fi 1>&2
+
+local_config_file="/var/www/cdash/config/config.local.php"
+
+(
+    echo '<?php'
+    if [ '!' -z ${CDASH_CONFIG+x} ] ; then
+        echo "$CDASH_CONFIG"
+    fi
+) > "$local_config_file"
+
+PORT="$(( (RANDOM % 20000) + 10000 ))"
+sed -i 's/^Listen [0-9][0-9]*/Listen '"$PORT"'/g' /etc/apache2/ports.conf
+sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:'"$PORT"'>/g' \
+    /etc/apache2/sites-enabled/000-default.conf
+echo "\$CDASH_FULL_EMAIL_WHEN_ADDING_USER = '1';" >> "$local_config_file"
+
+/usr/sbin/apache2ctl -D FOREGROUND &
+apache_pid="$!"
+onexit '
+if [ -n "$apache_pid" ] ; then
+    /usr/sbin/apache2ctl graceful-stop
+    wait
+fi'
+
+sleep 10
+
+# ENSURE ROOT ADMIN USER
+final_root_pass="$CDASH_ROOT_ADMIN_PASS"
+if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
+    final_root_pass="$CDASH_ROOT_ADMIN_NEW_PASS"
+fi
+
+post - install.php admin_email='rootadmin@docker.container' \
+                   admin_password="$final_root_pass"        \
+                   Submit=Install &> /dev/null
+
+if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
+    root_session="$( mksession )"
+    post "$root_session" user.php login='rootadmin@docker.container' \
+                                  passwd="$final_root_pass"          \
+                                  sent='Login >>'                    \
+        | grep 'Wrong email or password'                             \
+        | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
+
+    if [ "$?" '!=' '0' -a \
+         "$CDASH_ROOT_ADMIN_PASS" '!=' "$final_root_pass" ] ; then
+
+        # login failure
+        post "$root_session" user.php login='rootadmin@docker.container' \
+                                      passwd="$CDASH_ROOT_ADMIN_PASS"    \
+                                      sent='Login >>'                    \
+            | grep 'Wrong email or password'                             \
+            | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
+
+        if [ "$?" '=' '0' ] ; then
+            post "$root_session" editUser.php      \
+                oldpasswd="$CDASH_ROOT_ADMIN_PASS" \
+                passwd="$final_root_pass"          \
+                passwd2="$final_root_pass"         \
+                updatepassword='Update Password' &> /dev/null
+        else
+            echo "Warning: could not log in as the root admin user:" \
+                 "Wrong email or password" >&2
+            root_login_failed=1
+        fi
+    fi
+fi
+
+if [ "$root_login_failed" '!=' '1' ] ; then
+    declare -a users_list
+    if [ '!' -z ${CDASH_STATIC_USERS+x} ] ; then
+        ensure_tmp
+        mkfifo "$tmpdir/fifo"
+        eval "exec 3<>$tmpdir/fifo"
+        unlink "$tmpdir/fifo"
+
+        echo "$CDASH_STATIC_USERS" >&3
+        echo EOF >&3
+
+        oldifs="$IFS"
+        IFS=$'\n'
+
+        while read -u 3 line ; do
+            processed_line="$( echo "$line" |
+                     sed $'s/\t\t*/ /g' | sed 's/  */ /g' | sed 's/#.*//g')"
+
+            if [ "$processed_line" '=' 'EOF' ] ; then
+                break
+            fi
+
+            if [ -z "$( echo "$processed_line" | sed $'s/[ \t]*//g' )" ] ; then
+                DEBUG "SKIPPING LINE"
+                DEBUG "[$line]"
+                continue
+            fi
+
+            eval "entry=($processed_line)"
+            _disp=
+            _email=
+            _pass=
+            _newpass=
+
+            if [ "${entry[0]}" '=' 'USER'   -o \
+                 "${entry[0]}" '=' 'ADMIN'  -o \
+                 "${entry[0]}" '=' 'DELETE' ] ; then
+
+                # explicit user entry line
+                _disp="${entry[0]}"
+                _email="${entry[1]}"
+                _pass="${entry[2]}"
+                _newpass="${entry[3]}"
+                parsed_user=1
+
+            elif [ "${entry[0]}" '!=' "${entry[0]/@*}" ] ; then
+                # implicit user entry line
+                _disp=USER
+                _email="${entry[0]}"
+                _pass="${entry[1]}"
+                _newpass="${entry[2]}"
+                parsed_user=1
+
+            elif [ "${entry[0]}" '=' 'INFO' ] ; then
+                # explicit user info line
+                first="${entry[1]}"
+                last="${entry[2]}"
+                institution="${entry[3]}"
+                parsed_user=0
+
+            else
+                # implicit user info line
+                first="${entry[0]}"
+                last="${entry[1]}"
+                institution="${entry[2]}"
+                parsed_user=0
+            fi
+
+            if [ -n "$email" ] ; then
+                user_set "$email" disp "$disp"
+                user_set "$email" pass "$pass"
+                user_set "$email" newpass "$newpass"
+
+                if [ "$parsed_user" '=' '0' ] ; then
+                    user_set "$email" first "$first"
+                    user_set "$email" last "$last"
+                    user_set "$email" institution "$institution"
+                fi
+
+                if [ "$( user_get "$email" listed )" '!=' 1 ] ; then
+                    users_list[${#users_list[@]}]="$email"
+                    user_set "$email" listed 1
+                fi
+            fi
+
+            email="$_email"
+            disp="$_disp"
+            pass="$_pass"
+            newpass="$_newpass"
+
+            if [ -n "$DEBUG" ] ; then
+                if [ "$parsed_user" '=' '0' ] ; then
+                    DEBUG "PARSED USER INFO"
+                    DEBUG "  First Name:  |$first|"
+                    DEBUG "  Last Name:   |$last|"
+                    DEBUG "  Institution: |$institution|"
+                else
+                    DEBUG "PARSED USER ENTRY"
+                    DEBUG "  email:        |$email|"
+                    DEBUG "  disposition:  |$disp|"
+                    DEBUG "  password:     |$pass|"
+                    DEBUG "  new password: |$newpass|"
+                fi
+            fi
+        done
+
+        if [ -n "$email" ] ; then
+            user_set "$email" disp "$disp"
+            user_set "$email" pass "$pass"
+            user_set "$email" newpass "$newpass"
+
+            if [ "$( user_get "$email" listed )" '!=' 1 ] ; then
+                users_list[${#users_list[@]}]="$email"
+                user_set "$email" listed 1
+            fi
+        fi
+
+        exec 3<&-
+        IFS="$oldifs"
+    fi
+
+    DEBUG "BEGIN DUMP OF USER TABLE"
+    if [ -n "$DEBUG" ] ; then
+        for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
+            email="${users_list[$i]}"
+
+            for tuple in "disp" "pass" "newpass" "first:NONE" \
+                         "last:NONE" "institution:NONE" ; do
+                fragment="${tuple/:*}"
+                tuple="${tuple:$(( ${#fragment} + 1 ))}"
+                param="$fragment"
+                fragment="${tuple/:*}"
+                tuple="${tuple:$(( ${#fragment} + 1 ))}"
+                default="$fragment"
+
+                value="$( user_get "$email" "$param" )"
+                if [ -z "$value" -a -n "$default" ] ; then
+                    value="$default"
+                fi
+                eval "${param}=\"$value\""
+            done
+            DEBUG "$i:"
+            DEBUG "  $email"
+            DEBUG "  disposition: $disp"
+            DEBUG "  password: $pass"
+            DEBUG "  new pass: $newpass"
+            DEBUG "  First Name: $first"
+            DEBUG "  Last Name: $last"
+            DEBUG "  Institution: $institution"
+        done
+    fi
+
+    for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
+        email="${users_list[$i]}"
+        if [ "$email" '=' 'rootadmin@docker.conatiner' ] ; then
+            echo 'Warning: refusing to modify the root admin account!' \
+                 "Use the CDASH_ROOT_ADMIN_NEW_PASS environment variable" \
+                 "to update the root account password." >&2
+            continue
+        fi
+
+        if [ -z "$root_session" ] ; then
+            root_session="$( mksession )"
+
+            # LOGIN AS ROOT ADMIN USER
+            post "$root_session" user.php              \
+                    login='rootadmin@docker.container' \
+                    passwd="$final_root_pass"          \
+                    sent='Login >>'                    \
+                | grep 'Wrong email or password'       \
+                | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
+
+            if [ "$?" '!=' '0' ] ; then
+                echo "Warning: could not log in as the root admin user:" \
+                     "Wrong email or password" >&2
+                break
+            fi
+        fi
+
+        for tuple in "disp" "pass" "newpass" "first:NONE" \
+                     "last:NONE" "institution:NONE" ; do
+            fragment="${tuple/:*}"
+            tuple="${tuple:$(( ${#fragment} + 1 ))}"
+            param="$fragment"
+            fragment="${tuple/:*}"
+            tuple="${tuple:$(( ${#fragment} + 1 ))}"
+            default="$fragment"
+
+            value="$( user_get "$email" "$param" )"
+            if [ -z "$value" -a -n "$default" ] ; then
+                value="$default"
+            fi
+            eval "${param}=\"$value\""
+        done
+
+        ids=($(                                                    \
+            get "$root_session" ajax/findusers.php search="$email" \
+                | grep '<input'                                    \
+                | grep 'name="userid"'                             \
+                | grep 'type="hidden"'                             \
+                | sed 's/..*value="\([0-9][0-9]*\)"..*/\1/g'))
+
+        user_id="${ids[0]}"
+
+        if [ "$disp" '=' 'DELETE' ] ; then
+            # REMOVE USER
+            DEBUG "REMOVING USER: $email"
+            if [ -n "$user_id" ] ; then
+                post "$root_session" manageUsers.php          \
+                                     userid="$user_id"        \
+                                     removeuser="remove user" &> /dev/null
+            else
+                echo "Warning: could not remove user" \
+                     "$email: user not found" >&2
+            fi
+
+            continue
+        fi
+
+        final_pass="$pass"
+        if [ -n "$newpass" ] ; then
+            final_pass="$newpass"
+        fi
+
+        login_pass="$pass"
+
+        if [ -z "$user_id" ] ; then
+            login_pass="$final_pass"
+
+            # CREATE USER
+            DEBUG "CREATING USER: $email"
+            post "$root_session" manageUsers.php             \
+                                  fname="$first"             \
+                                  lname="$last"              \
+                                  email="$email"             \
+                                  passwd="$final_pass"       \
+                                  passwd2="$final_pass"      \
+                                  institution="$institution" \
+                                  adduser='Add user >>' &> /dev/null
+
+            ids=($(                                                    \
+                get "$root_session" ajax/findusers.php search="$email" \
+                    | grep '<input'                                    \
+                    | grep 'name="userid"'                             \
+                    | grep 'type="hidden"'                             \
+                    | sed 's/..*value="\([0-9][0-9]*\)"..*/\1/g'))
+
+            user_id="${ids[0]}"
+
+            if [ -z "$user_id" ] ; then
+                echo "Warning: unable to create user account" \
+                     "$email: unknown error" >&2
+                continue
+            fi
+         fi
+
+         if [ "$disp" '=' 'ADMIN' ] ; then
+             DEBUG "PROMOTING USER: $email"
+             post "$root_session" manageUsers.php        \
+                                  userid="$user_id"      \
+                                  makeadmin="make admin" &> /dev/null
+         fi
+
+         if [ "$disp" '=' 'USER' ] ; then
+             DEBUG "DEMOTING USER: $email"
+             post "$root_session" manageUsers.php                   \
+                                  userid="$user_id"                 \
+                                  makenormaluser="make normal user" \
+                                  &> /dev/null
+         fi
+
+        user_session="$( mksession )"
+
+        # LOGIN AS NORMAL USER
+        login_success=0
+        DEBUG "LOGGING IN AS USER: $email"
+        post "$user_session" user.php login="$email"        \
+                                      passwd="$login_pass"  \
+                                      sent='Login >>'       \
+            | grep 'Wrong email or password'                \
+            | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
+
+        if [ "$?" '=' '0' ] ; then # login success
+            login_success=1
+        elif [ "$login_pass" '!=' "$newpass" ] ; then # login failure
+            login_pass="$newpass"
+            DEBUG "LOGGING IN (FALLBACK) AS USER: $email"
+            post "$user_session" user.php login="$email"        \
+                                          passwd="$login_pass"  \
+                                          sent='Login >>'       \
+                | grep 'Wrong email or password'                \
+                | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
+
+            if [ "$?" '=' '0' ] ; then
+                login_success=1
+            fi
+        fi
+
+        if [ "$login_success" '=' '0' ] ; then
+            echo "Warning: could not log in as user" \
+                 "$email: Wrong email or password" >&2
+            continue
+        fi
+
+        DEBUG "UPDATING USER PROFILE: $email"
+        post "$user_session" editUser.php fname="$first"                 \
+                                          lname="$last"                  \
+                                          email="$email"                 \
+                                          institution="$institution"     \
+                                          updateprofile='Update Profile' \
+                                          &> /dev/null
+
+        if [ -n "$newpass" -a "$login_pass" '!=' "$newpass" ] ; then
+            # update user's password
+            DEBUG "UPDATING USER PASSWORD: $email"
+            post "$user_session" editUser.php    \
+                oldpasswd="$login_pass"          \
+                passwd="$newpass"                \
+                passwd2="$newpass"               \
+                updatepassword='Update Password' &> /dev/null
+        fi
+
+        get "$user_session" user.php logout=1 &> /dev/null
+    done
+
+    get "$root_session" user.php logout=1 &> /dev/null
+fi
+
+/usr/sbin/apache2ctl graceful-stop
+unset apache_pid
+wait
+sleep 10
+
+sed -i 's/^Listen [0-9][0-9]*/Listen 80/g' /etc/apache2/ports.conf
+sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:80>/g' \
+    /etc/apache2/sites-enabled/000-default.conf
+tmp="$( mktemp )"
+head -n -1 "$local_config_file" > "$tmp"
+cat "$tmp" > "$local_config_file"
+rm "$tmp"
+
+EXEC /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -168,32 +168,36 @@ fi'
 
 sleep 10
 
+if [ -z "$CDASH_ROOT_ADMIN_EMAIL" ] ; then
+    CDASH_ROOT_ADMIN_EMAIL="root@docker.container"
+fi
+
 # ENSURE ROOT ADMIN USER
 final_root_pass="$CDASH_ROOT_ADMIN_PASS"
 if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
     final_root_pass="$CDASH_ROOT_ADMIN_NEW_PASS"
 fi
 
-post - install.php admin_email='rootadmin@docker.container' \
-                   admin_password="$final_root_pass"        \
+post - install.php admin_email="$CDASH_ROOT_ADMIN_EMAIL" \
+                   admin_password="$final_root_pass"     \
                    Submit=Install &> /dev/null
 
 if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
     root_session="$( mksession )"
-    post "$root_session" user.php login='rootadmin@docker.container' \
-                                  passwd="$final_root_pass"          \
-                                  sent='Login >>'                    \
-        | grep 'Wrong email or password'                             \
+    post "$root_session" user.php login="$CDASH_ROOT_ADMIN_EMAIL" \
+                                  passwd="$final_root_pass"       \
+                                  sent='Login >>'                 \
+        | grep 'Wrong email or password'                          \
         | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
 
     if [ "$?" '!=' '0' -a \
          "$CDASH_ROOT_ADMIN_PASS" '!=' "$final_root_pass" ] ; then
 
         # login failure
-        post "$root_session" user.php login='rootadmin@docker.container' \
-                                      passwd="$CDASH_ROOT_ADMIN_PASS"    \
-                                      sent='Login >>'                    \
-            | grep 'Wrong email or password'                             \
+        post "$root_session" user.php login="$CDASH_ROOT_ADMIN_EMAIL" \
+                                      passwd="$CDASH_ROOT_ADMIN_PASS" \
+                                      sent='Login >>'                 \
+            | grep 'Wrong email or password'                          \
             | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
 
         if [ "$?" '=' '0' ] ; then
@@ -364,7 +368,7 @@ if [ "$root_login_failed" '!=' '1' ] ; then
 
     for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
         email="${users_list[$i]}"
-        if [ "$email" '=' 'rootadmin@docker.conatiner' ] ; then
+        if [ "$email" '=' 'root' ] ; then
             echo 'Warning: refusing to modify the root admin account!' \
                  "Use the CDASH_ROOT_ADMIN_NEW_PASS environment variable" \
                  "to update the root account password." >&2
@@ -375,11 +379,11 @@ if [ "$root_login_failed" '!=' '1' ] ; then
             root_session="$( mksession )"
 
             # LOGIN AS ROOT ADMIN USER
-            post "$root_session" user.php              \
-                    login='rootadmin@docker.container' \
-                    passwd="$final_root_pass"          \
-                    sent='Login >>'                    \
-                | grep 'Wrong email or password'       \
+            post "$root_session" user.php           \
+                    login="$CDASH_ROOT_ADMIN_EMAIL" \
+                    passwd="$final_root_pass"       \
+                    sent='Login >>'                 \
+                | grep 'Wrong email or password'    \
                 | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
 
             if [ "$?" '!=' '0' ] ; then

--- a/docker.md
+++ b/docker.md
@@ -49,8 +49,8 @@ Example:
 
 The email and password, respectively, for the "root" administrator user, or the
 initial administrator user that is created during the CDash `install.php`
-procedure.  The `CDASH_ROOT_ADMIN_PASS` variable the only one that is strictly
-required.  The default root admin email is `root@docker.container`.
+procedure.  The `CDASH_ROOT_ADMIN_PASS` variable is the only one that is
+strictly required.  The default root admin email is `root@docker.container`.
 
 The initial "root" administrator user is managed by the container.  The
 container uses this user account to log in and provision the service as well as

--- a/docker.md
+++ b/docker.md
@@ -13,7 +13,7 @@ $EDITOR local-configuration.php
 docker run \
     -e CDASH_CONFIG="$( cat local-configuration.php )" \
     ... \
-    kitware/cdash-docker
+    kitware/cdash
 ```
 
 Note: When setting this variable in a docker-compose file, take care to ensure

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,122 @@
+## Container Variables
+
+### `CDASH_CONFIG`
+
+The contents, verbatim, to be included in the local CDash configuration file
+(`/var/www/cdash/config/config.local.php`), excluding the initial `<?php` line.
+When running the container on the command line, consider writing the contents to
+a local file:
+
+```bash
+$EDITOR local-configuration.php
+...
+docker run \
+    -e CDASH_CONFIG="$( cat local-configuration.php )" \
+    ... \
+    kitware/cdash-docker
+```
+
+Note: When setting this variable in a docker-compose file, take care to ensure
+that dollar signs (`$`) are properly escaped.  Otherwise, the resulting contents
+of the file may be subject to variable interpolation.
+
+Example:
+
+```YAML
+
+...
+
+  # wrong: this string syntax is subject to interpolation
+  # The contents will depend on the CDASH_DB_... variables as they are set at
+  # container creation time
+  CDASH_CONFIG: |
+    $CDASH_DB_HOST = 'mysql';
+    $CDASH_DB_NAME = 'cdash';
+    $CDASH_DB_TYPE = 'mysql';
+    ...
+
+  # correct: use $$ to represent a literal `$`
+  CDASH_CONFIG: |
+    $$CDASH_DB_HOST = 'mysql';
+    $$CDASH_DB_NAME = 'cdash';
+    $$CDASH_DB_TYPE = 'mysql';
+    ...
+
+...
+```
+
+### `CDASH_ROOT_ADMIN_EMAIL` and `CDASH_ROOT_ADMIN_PASS`
+
+The email and password, respectively, for the "root" administrator user, or the
+initial administrator user that is created during the CDash `install.php`
+procedure.  The `CDASH_ROOT_ADMIN_PASS` variable the only one that is strictly
+required.  The default root admin email is `root@docker.container`.
+
+The initial "root" administrator user is managed by the container.  The
+container uses this user account to log in and provision the service as well as
+set up static users.  This account is meant primarily to automate setup of the
+CDash service and not as a regular administrator account.  To set up a
+predefined administrator account, see `CDASH_STATIC_USERS`.
+
+### `CDASH_ROOT_ADMIN_NEW_PASS`
+
+Set this variable to change the password for the root administrator account.  If
+set, the container will attempt to use this password when logging in as the root
+account.  If the login is unsuccessful, it will try logging in using the
+(presumably former) password set in `CDASH_ROOT_ADMIN_PASS`.  If this second
+attempt is successful, it will update the root account so that its password is
+reset to the value of `CDASH_ROOT_ADMIN_NEW_PASS`.
+
+### `CDASH_STATIC_USERS`
+
+A multiline value representing the set of user accounts to prepare as part of
+the container's initialization process.  This value may contain comments that
+start with `#` and lines with only white space; these parts of the text are
+ignored.
+
+Each user account identified in the set is created using the information
+provided.  If the account already exists, its details are modified to match the
+information provided.  Existing accounts that are not identified in the set are
+not modified.
+
+The representation for each user account begins with a line of the following
+form:
+
+```
+[USER|ADMIN|DELETE] EMAIL PASSWORD [NEW_PASSWORD]
+```
+
+Where `EMAIL` is the user's email address, `PASSWORD` is the user's password,
+and `NEW_PASSWORD` (if provided) is the user's new password.  If `NEW_PASSWORD`
+is provided, the user's password is updated using the same procedure as that
+with `CDASH_ROOT_ADMIN_NEW_PASS`.
+
+This entry line may begin with an additional token.  A token of `USER` indicates
+that the entry is for a normal (non-admin) account.  A token of `ADMIN`
+indicates that the entry is for an administrator account.  A token of `DELETE`
+indicates that any account with the given email (if found) should be deleted.
+If no such token is provided, `USER` is assumed by default.
+
+An entry may include an additional, optional line.  Such lines must be of the
+following form:
+
+```
+[INFO] FIRST_NAME [LAST_NAME] [INSTITUTION]
+```
+
+Where `FIRST_NAME` is the user's first name, `LAST_NAME` is the user's last
+name, and `INSTITUTION` is the name of the institution with which the user is
+affiliated.
+
+This second line may begin with an additional token with the value `INFO`, which
+may be provided to distinguish this second line from a line representing a new
+user account, in case the user's first name contains an `@` character.  For such
+unusual cases, include this token so that the name is not mistaken for an email
+address.
+
+Note: for `DELETE` entries, all that is needed is the account's email address,
+and for either `PASSWORD` or `NEW_PASSWORD` (if provided) to be set to the
+password needed to log in as that user.  You may provide additional information
+for the account, but it will not be used since the account will be deleted.
+
+Note: for tokens with spaces, wrap them in quotes (`"`).


### PR DESCRIPTION
Adds a Dockerfile that builds a complete image for running CDash.

Also includes an entrypoint script for the image, with some logic to maintain a statically-defined set of initial users, and a docker-compose.yml file demonstrating how to run the CDash image alongside another image running mysql.

If merged, it would then be pretty easy to point a docker hub account at this repo and automatically deliver new builds with every subsequent merge.