### PR TITLE
Make all queues disabled by default

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -69,7 +69,7 @@ return [
             'prefix' => 'bernard:',
         ],
         Driver::SQS => [
-            'enabled' => true,
+            'enabled' => false,
             'profile' => 'CDASH',
             'region' => 'us-east-1',
             'version' => 'latest',


### PR DESCRIPTION
SQS being enabled by default could potentially trip up users of other message queue services.