### PR TITLE
Fix -- Fixes Session Presumes URL Contains Path

### DIFF
--- a/app/Controller/Auth/Session.php
+++ b/app/Controller/Auth/Session.php
@@ -173,11 +173,11 @@ class Session
 
         // This hack will prevent the xsrf possible with this cookie
         // @reference https://stackoverflow.com/a/46971326/1373710
-        $path = "{$url['path']}; samesite=strict";
-        // $name, $value, $expire, $path, $domain, $secure, $httponly
+        $path = isset($url['path']) ? $url['path'] : '/';
+        $cookie_path = "{$path}; samesite=strict";
 
         if ($user->SetCookieKey($key)) {
-            $this->system->setcookie($cookie_name, $cookie_value, $time, $path, $url['host'], $https, true);
+            $this->system->setcookie($cookie_name, $cookie_value, $time, $cookie_path, $url['host'], $https, true);
         }
     }
 }

--- a/tests/case/CDash/Controller/Auth/SessionTest.php
+++ b/tests/case/CDash/Controller/Auth/SessionTest.php
@@ -114,7 +114,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $baseUrl = $config->getBaseUrl();
         $url = parse_url($baseUrl);
         $name = Session::REMEMBER_ME_PREFIX . $url['host'];
-        $path = "{$url['path']}; samesite=strict";
+        $path = isset($url['path']) ? $url['path'] : '/';
+        $cookie_path = "{$path}; samesite=strict";
 
         /** @var User|\PHPUnit_Framework_MockObject_MockObject $mock_user */
         $mock_user = $this->getMockBuilder(User::class)
@@ -135,7 +136,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo($name),
                 $this->equalTo("{$mock_user->Id}{$key}"),
                 $this->greaterThanOrEqual($time),
-                $this->equalTo($path),
+                $this->equalTo($cookie_path),
                 $this->equalTo($url['host']),
                 $this->equalTo(false),
                 $this->equalTo(true)
@@ -158,7 +159,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $baseUrl = $config->getBaseUrl();
         $url = parse_url($baseUrl);
         $name = Session::REMEMBER_ME_PREFIX . $url['host'];
-        $path = "{$url['path']}; samesite=strict";
+        $path = isset($url['path']) ? $url['path'] : '/';
+        $cookie_path = "{$path}; samesite=strict";
 
         /** @var User|\PHPUnit_Framework_MockObject_MockObject $mock_user */
         $mock_user = $this->getMockBuilder(User::class)
@@ -179,7 +181,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo($name),
                 $this->equalTo("{$mock_user->Id}{$key}"),
                 $this->greaterThanOrEqual($time),
-                $this->equalTo($path),
+                $this->equalTo($cookie_path),
                 $this->equalTo($url['host']),
                 $this->equalTo(true),
                 $this->equalTo(true)


### PR DESCRIPTION
Calling `parse_url(...)` on a URL with no path returns an hash with no 'path' key. This fixes the problem of trying to use `$url['path']` when it is not defined.