### PR TITLE
Rename Object to ModelType

### DIFF
--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -158,7 +158,7 @@ class Build
         if (empty($this->ProjectId)) {
             add_log('ProjectId not set' . $subproject, 'Build::SetSubProject', LOG_ERR,
                 $this->ProjectId, $this->Id,
-                Object::BUILD, $this->Id);
+                ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -203,7 +203,7 @@ class Build
         $Label->Insert();
 
         add_log('New subproject detected: ' . $subproject, 'Build::SetSubProject',
-            LOG_INFO, $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+            LOG_INFO, $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
         return true;
     }
 
@@ -747,7 +747,7 @@ class Build
         } else {
             add_log('No Build::Id - cannot call $label->Insert...', 'Build::InsertLabelAssociations', LOG_ERR,
                 $this->ProjectId, $this->Id,
-                Object::BUILD, $this->Id);
+                ModelType::BUILD, $this->Id);
             return false;
         }
     }
@@ -1012,7 +1012,7 @@ class Build
     {
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::GetMissingTests', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -1067,7 +1067,7 @@ class Build
     {
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::GetTests', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -1146,7 +1146,7 @@ class Build
     {
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::GetErrorDifferences', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -1219,7 +1219,7 @@ class Build
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::ComputeDifferences', LOG_ERR,
                 $this->ProjectId, $this->Id,
-                Object::BUILD, $this->Id);
+                ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -1239,7 +1239,7 @@ class Build
     {
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::ComputeConfigureDifferences',
-                LOG_ERR, $this->ProjectId, $this->Id, Object::BUILD,
+                LOG_ERR, $this->ProjectId, $this->Id, ModelType::BUILD,
                 $this->Id);
             return false;
         }
@@ -1315,13 +1315,13 @@ class Build
     {
         if (!$this->Id) {
             add_log('BuildId is not set', 'Build::ComputeTestTiming', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
         if (!$this->ProjectId) {
             add_log('ProjectId is not set', 'Build::ComputeTestTiming', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -1483,7 +1483,7 @@ class Build
     {
         if (!$this->Id) {
             add_log('Id is not set', 'Build::ComputeUpdateStatistics', LOG_ERR,
-                $this->ProjectId, $this->Id, Object::BUILD, $this->Id);
+                $this->ProjectId, $this->Id, ModelType::BUILD, $this->Id);
             return false;
         }
 
@@ -2095,7 +2095,7 @@ class Build
                 add_log("$buildid is its own parent",
                         'Build::UpdateBuild', LOG_ERR,
                         $this->ProjectId, $this->Id,
-                        Object::BUILD, $this->Id);
+                        ModelType::BUILD, $this->Id);
                 return;
             }
             $this->UpdateBuild($parentid, $newErrors, $newWarnings);
@@ -2445,7 +2445,7 @@ class Build
             add_log("Attempt to mark build $this->Id as its own parent",
                     'Build::SetParentId', LOG_ERR,
                 $this->ProjectId, $this->Id,
-                Object::BUILD, $this->Id);
+                ModelType::BUILD, $this->Id);
             return;
         }
         $this->ParentId = $parentid;

--- a/app/Model/BuildConfigure.php
+++ b/app/Model/BuildConfigure.php
@@ -118,13 +118,13 @@ class BuildConfigure
         if (!$this->BuildId) {
             add_log('BuildId not set',
                     'BuildConfigure::Exists', LOG_ERR,
-                    0, 0, Object::CONFIGURE, 0);
+                    0, 0, ModelType::CONFIGURE, 0);
             return false;
         }
         if (!is_numeric($this->BuildId)) {
             add_log('BuildId is not numeric',
                     'BuildConfigure::Exists', LOG_ERR,
-                    0, 0, Object::CONFIGURE, 0);
+                    0, 0, ModelType::CONFIGURE, 0);
             return false;
         }
 
@@ -148,7 +148,7 @@ class BuildConfigure
         if (!$this->Exists()) {
             add_log('this configure does not exist',
                     'BuildConfigure::Delete', LOG_ERR,
-                    0, 0, Object::CONFIGURE, 0);
+                    0, 0, ModelType::CONFIGURE, 0);
             return false;
         }
 
@@ -191,7 +191,7 @@ class BuildConfigure
         } else {
             add_log('No BuildConfigure::BuildId - cannot call $label->Insert...',
                 'BuildConfigure::InsertLabelAssociations', LOG_ERR,
-                0, $this->BuildId, Object::CONFIGURE, $this->BuildId);
+                0, $this->BuildId, ModelType::CONFIGURE, $this->BuildId);
         }
     }
 
@@ -202,14 +202,14 @@ class BuildConfigure
         if (!$this->BuildId) {
             add_log('BuildId not set',
                     'BuildConfigure::Insert', LOG_ERR,
-                    0, 0, Object::CONFIGURE, $this->Id);
+                    0, 0, ModelType::CONFIGURE, $this->Id);
             return false;
         }
 
         if ($this->ExistsByBuildId()) {
             add_log('This build already has a configure',
                     'BuildConfigure::Insert', LOG_ERR,
-                    0, $this->BuildId, Object::CONFIGURE, $this->Id);
+                    0, $this->BuildId, ModelType::CONFIGURE, $this->Id);
             return false;
         }
 

--- a/app/Model/Coverage.php
+++ b/app/Model/Coverage.php
@@ -61,7 +61,7 @@ class Coverage
             add_log('No buildid or coveragefile',
                 'Coverage::InsertLabelAssociations', LOG_ERR,
                 0, $buildid,
-                Object::COVERAGE, $this->CoverageFile->Id);
+                ModelType::COVERAGE, $this->CoverageFile->Id);
         }
     }
 

--- a/app/Model/CoverageFileLog.php
+++ b/app/Model/CoverageFileLog.php
@@ -55,13 +55,13 @@ class CoverageFileLog
     {
         if (!$this->BuildId || !is_numeric($this->BuildId)) {
             add_log('BuildId not set', 'CoverageFileLog::Insert()', LOG_ERR,
-                0, $this->BuildId, Object::COVERAGE, $this->FileId);
+                0, $this->BuildId, ModelType::COVERAGE, $this->FileId);
             return false;
         }
 
         if (!$this->FileId || !is_numeric($this->FileId)) {
             add_log('FileId not set', 'CoverageFileLog::Insert()', LOG_ERR,
-                0, $this->BuildId, Object::COVERAGE, $this->FileId);
+                0, $this->BuildId, ModelType::COVERAGE, $this->FileId);
             return false;
         }
 

--- a/app/Model/DynamicAnalysis.php
+++ b/app/Model/DynamicAnalysis.php
@@ -128,7 +128,7 @@ class DynamicAnalysis
         } else {
             add_log('No DynamicAnalysis::Id - cannot call $label->Insert...',
                 'DynamicAnalysis::InsertLabelAssociations', LOG_ERR,
-                0, $this->BuildId, Object::DYNAMICANALYSIS, $this->Id);
+                0, $this->BuildId, ModelType::DYNAMICANALYSIS, $this->Id);
         }
     }
 
@@ -157,7 +157,7 @@ class DynamicAnalysis
         }
         if ($this->Log === false) {
             add_log('Unable to decompress dynamic analysis log',
-                'DynamicAnalysis::Insert', LOG_ERR, 0, $this->BuildId, Object::DYNAMICANALYSIS, $this->Id);
+                'DynamicAnalysis::Insert', LOG_ERR, 0, $this->BuildId, ModelType::DYNAMICANALYSIS, $this->Id);
             $this->Log = '';
         }
 

--- a/app/Model/ModelType.php
+++ b/app/Model/ModelType.php
@@ -14,7 +14,7 @@
 
 namespace CDash\Model;
 
-class Object
+class ModelType
 {
     const PROJECT = 1;
     const BUILD = 2;

--- a/app/Model/Test.php
+++ b/app/Model/Test.php
@@ -113,7 +113,7 @@ class Test
             add_log('No Test::Id or buildid - cannot call $label->Insert...',
                 'Test::InsertLabelAssociations', LOG_ERR,
                 $this->ProjectId, $buildid,
-                Object::TEST, $this->Id);
+                ModelType::TEST, $this->Id);
         }
     }
 

--- a/app/Model/UserProject.php
+++ b/app/Model/UserProject.php
@@ -168,7 +168,7 @@ class UserProject
     {
         if (!$this->UserId) {
             add_log('UserId not set', 'UserProject UpdateCredentials()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 
@@ -200,7 +200,7 @@ class UserProject
 
         if (!$this->UserId) {
             add_log('UserId not set', 'UserProject AddCredential()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 
@@ -226,13 +226,13 @@ class UserProject
     {
         if (!$this->ProjectId) {
             add_log('ProjectId not set', 'UserProject FillFromRepositoryCredential()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 
         if (!$this->RepositoryCredential) {
             add_log('RepositoryCredential not set', 'UserProject FillFromRepositoryCredential()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 
@@ -264,13 +264,13 @@ class UserProject
     {
         if (!$this->ProjectId) {
             add_log('ProjectId not set', 'UserProject FillFromUserId()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 
         if (!$this->UserId) {
             add_log('UserId not set', 'UserProject FillFromUserId()', LOG_ERR,
-                $this->ProjectId, 0, Object::USER, $this->UserId);
+                $this->ProjectId, 0, ModelType::USER, $this->UserId);
             return false;
         }
 


### PR DESCRIPTION
This fixes CDash with PHP 7.2 as Object is a language type and shouldn't
be used for variable names!

Fixes #709