### PR TITLE
Fix display of timeline chart on testOverview.php

### DIFF
--- a/public/views/testOverview.html
+++ b/public/views/testOverview.html
@@ -6,7 +6,8 @@
     <meta name="robots" content="noindex,nofollow" />
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="stylesheet" type="text/css" ng-href="build/css/{{cssfile}}_@@version.css" />
-    <link rel="stylesheet" href="css/bootstrap.min.css"/>
+    <link rel="stylesheet" type="text/css" href="css/nv.d3.css"/>
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="css/jquery-ui-1.10.4.css" />
     <script src="js/CDash_@@version.min.js"></script>
     <title ng-bind="title">CDash : Test Overview</title>


### PR DESCRIPTION
This chart had a black background (instead of transparent) because we forgot to include a CSS file.