### PR TITLE
Teach cdash_unlink to throw fewer Exceptions

### DIFF
--- a/include/log.php
+++ b/include/log.php
@@ -27,26 +27,13 @@ use \Psr\Log\LogLevel;
 
 function cdash_unlink($filename)
 {
-    $success = unlink($filename);
-
-    //  $try_count = 1;
-    //
-    //  while(file_exists($filename) && $try_count < 60)
-    //  {
-    //    usleep(1000000); // == 1000 ms, == 1.0 seconds
-    //
-    //    $success = unlink($filename);
-    //    $try_count++;
-    //  }
+    unlink($filename);
 
     if (file_exists($filename)) {
         throw new Exception("file still exists after unlink: $filename");
     }
 
-    if (!$success) {
-        throw new Exception("unlink returned non-success: $success for $filename");
-    }
-    return $success;
+    return true;
 }
 
 function to_psr3_level($type)


### PR DESCRIPTION
We're seeing lots of entries like these in our logs:

    Fatal error:Uncaught Exception: unlink returned non-success

Presumably this is due to cdash_unlink attempting to delete a file
that's already been removed.  This is a fairly benign problem that's
undeserving of an uncaught exception.