### PR TITLE
Assign buildids at submission time

### DIFF
--- a/app/Middleware/Queue/SubmissionService.php
+++ b/app/Middleware/Queue/SubmissionService.php
@@ -167,7 +167,7 @@ class SubmissionService
     {
         try {
             $fh = fopen($message->file, 'r');
-            do_submit($fh, $message->project, $message->md5, $message->checksum);
+            do_submit($fh, $message->project, null, $message->md5, $message->checksum);
         } catch (\Exception $e) {
             Log::getInstance()->error($e);
             throw $e;

--- a/include/ctestparser.php
+++ b/include/ctestparser.php
@@ -224,8 +224,8 @@ function parse_put_submission($filehandler, $projectid, $expected_md5)
 }
 
 /** Main function to parse the incoming xml from ctest */
-function ctest_parse($filehandler, $projectid, $expected_md5 = '', $do_checksum = true,
-                     $scheduleid = 0)
+function ctest_parse($filehandler, $projectid, $buildid = null,
+                     $expected_md5 = '', $do_checksum = true, $scheduleid = 0)
 {
     require_once 'include/common.php';
     include 'include/version.php';
@@ -355,9 +355,12 @@ function ctest_parse($filehandler, $projectid, $expected_md5 = '', $do_checksum 
         }
     }
 
-    $statusarray = array();
+    $statusarray = [];
     $statusarray['status'] = 'OK';
     $statusarray['message'] = '';
+    if (!is_null($buildid)) {
+        $statusarray['buildId'] = $buildid;
+    }
     if ($do_checksum == true) {
         $md5sum = md5_file($filename);
         $md5error = false;

--- a/include/ctestparserutils.php
+++ b/include/ctestparserutils.php
@@ -1,7 +1,6 @@
 <?php
 
 use CDash\Config;
-use CDash\Model\BuildGroup;
 use CDash\Model\BuildUpdate;
 use CDash\Model\ClientJobSchedule;
 
@@ -26,10 +25,6 @@ function add_build($build, $clientscheduleid = 0)
     if (!$build->Exists() && $build->Append && empty($build->Id)) {
         $build->Id = $buildid;
     }
-
-    // Find the groupid
-    $buildGroup = new BuildGroup();
-    $build->GroupId = $buildGroup->GetGroupIdFromRule($build);
 
     $build->Save();
 

--- a/include/fnProcessFile.php
+++ b/include/fnProcessFile.php
@@ -36,7 +36,7 @@ function ProcessFile($projectid, $filename, $md5)
     }
 
     if (@$fp) {
-        do_submit($fp, $projectid, $md5, false, $config->get('PHP_ERROR_SUBMISSION_ID'));
+        do_submit($fp, $projectid, null, $md5, false, $config->get('PHP_ERROR_SUBMISSION_ID'));
         $config->set('PHP_ERROR_SUBMISSION_ID', 0);
 
         @fclose($fp);

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,9 @@
       "dev": true
     },
     "ansi_up": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-2.0.3.tgz",
-      "integrity": "sha1-K10x33ISHat46jT1str2JuAVeKI="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-3.0.0.tgz",
+      "integrity": "sha1-J/Rdj0V9nO/1nk6gPI5vE8GjA+g="
     },
     "arr-diff": {
       "version": "1.1.0",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,6 +169,7 @@ add_php_test(buildproperties)
 add_php_test(timestatus)
 add_php_test(bazeljson)
 add_php_test(buildrelationship)
+add_php_test(submission_assign_buildid)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/case/CDash/Middleware/Queue/SubmissionServiceTest.php
+++ b/tests/case/CDash/Middleware/Queue/SubmissionServiceTest.php
@@ -19,7 +19,7 @@ namespace CDash\Middleware\Queue;
 use Bernard\Message\DefaultMessage;
 use CDash\Middleware\Queue;
 
-function do_submit($fh, $project_id, $expected_md5 = '', $do_checksum = true, $submission_id = 0)
+function do_submit($fh, $project_id, $buildid = null, $expected_md5 = '', $do_checksum = true, $submission_id = 0)
 {
     SubmissionServiceTest::checkExpectedArguments([
         'do_submit',

--- a/tests/data/AssignBuildId/Configure.xml
+++ b/tests/data/AssignBuildId/Configure.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="assign_buildid"
+	BuildStamp="20180918-0100-Nightly"
+	Name="localhost"
+	>
+	<Configure>
+		<StartConfigureTime>1537280827</StartConfigureTime>
+		<ConfigureCommand>"/usr/bin/cmake" "-GUnix Makefiles" "/tmp/src"</ConfigureCommand>
+		<Log>
+-- Configuring done
+-- Generating done
+</Log>
+		<ConfigureStatus>0</ConfigureStatus>
+		<EndConfigureTime>1537280828</EndConfigureTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Configure>
+</Site>

--- a/tests/kwtest/kw_web_tester.php
+++ b/tests/kwtest/kw_web_tester.php
@@ -309,10 +309,8 @@ class KWWebTestCase extends WebTestCase
         return true;
     }
 
-    public function submission($projectname, $file, $header = null)
+    private function check_submission_result($result)
     {
-        $url = $this->url . "/submit.php?project=$projectname";
-        $result = $this->uploadfile($url, $file, $header);
         if ($result === false) {
             return false;
         }
@@ -329,6 +327,32 @@ class KWWebTestCase extends WebTestCase
             return false;
         }
         return true;
+    }
+
+    public function submission($projectname, $file, $header = null)
+    {
+        $url = $this->url . "/submit.php?project=$projectname";
+        $result = $this->uploadfile($url, $file, $header);
+        return $this->check_submission_result($result);
+    }
+
+    public function submission_assign_buildid($file, $project, $build, $site,
+            $stamp, $subproject = null, $header = null)
+    {
+        $url = $this->url . "/submit.php?project=$project&build=$build&site=$site&stamp=$stamp";
+        if (!is_null($subproject)) {
+            $url .= "&subproject=$subproject";
+        }
+
+        $result = $this->uploadfile($url, $file, $header);
+        $pattern = '#<buildId>([0-9]+)</buildId>#';
+        if ($this->check_submission_result($result) &&
+                preg_match($pattern, $result, $matches) &&
+                isset($matches[1])) {
+            return $matches[1];
+        }
+
+        return false;
     }
 
     public function uploadfile($url, $filename, $header = null)

--- a/tests/test_submission_assign_buildid.php
+++ b/tests/test_submission_assign_buildid.php
@@ -1,0 +1,30 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+
+use CDash\Model\Build;
+
+class SubmissionAssignBuildIdTestCase extends KWWebTestCase
+{
+    public function testSubmissionAssignBuildId()
+    {
+        $file_to_submit = dirname(__FILE__) .  '/data/AssignBuildId/Configure.xml';
+        $buildid = $this->submission_assign_buildid(
+                $file_to_submit, 'InsightExample', 'assign_buildid',
+                'localhost', '20180918-0100-Nightly');
+        if (!$buildid || !is_numeric($buildid)) {
+            $this->fail('Did not receive a numeric buildid for submission');
+        }
+
+        $build = new Build();
+        $build->Id = $buildid;
+        if (!$build->Exists()) {
+            $this->fail("Build #$buildid does not exist");
+        }
+
+        $build->FillFromId($buildid);
+        $this->assertEqual('assign_buildid', $build->Name);
+
+        remove_build($buildid);
+    }
+}


### PR DESCRIPTION
Assign a buildid upon submit time (rather than parse time) if CTest provides us with enough information to do so.