### PR TITLE
Terminate submissionConsumer upon SQL error

### DIFF
--- a/app/Middleware/Queue.php
+++ b/app/Middleware/Queue.php
@@ -17,23 +17,23 @@
 namespace CDash\Middleware;
 
 use Bernard\Driver;
+use Bernard\EventListener;
 use Bernard\Message;
-use Bernard\Middleware;
-use Bernard\Middleware\MiddlewareBuilder;
 use Bernard\Producer;
 use Bernard\QueueFactory;
 use Bernard\QueueFactory\PersistentFactory;
 use Bernard\Router;
 use Bernard\Router\SimpleRouter;
 use Bernard\Serializer;
-use Bernard\Serializer\SimpleSerializer;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
 use CDash\Middleware\Queue\Consumer;
 use CDash\Middleware\Queue\DriverFactory;
 
 /**
  * Class Queue
  * @package CDash\Middleware
- * @see https://github.com/bernardphp/bernard/blob/c452caa6de208b0274449cde1c48eb32fb9f59f9/example/bootstrap.php
+ * @see https://github.com/bernardphp/bernard/blob/1.0.0-alpha9/example/bootstrap.php
  */
 class Queue
 {
@@ -43,14 +43,14 @@ class Queue
     /** @var Serializer $serializer */
     protected $serializer;
 
-    /** @var MiddlewareBuilder $middlewareBuilder */
-    protected $middlewareBuilder;
+    /** @var EventDispatcher $eventDispatcher */
+    protected $eventDispatcher;
 
-    /** @var Middleware\ErrorLogFactory $errorLogFactory */
-    protected $errorLogFactory;
+    /** @var EventListener\ErrorLogSubscriber $errorLogSubscriber */
+    protected $errorLogSubscriber;
 
-    /** @var Middleware\FailuresFactory $failuresFactory */
-    protected $failuresFactory;
+    /** @var EventListener\FailureSubscriber $failureSubscriber */
+    protected $failureSubscriber;
 
     /** @var  QueueFactory $queueFactory*/
     protected $queueFactory;
@@ -75,6 +75,20 @@ class Queue
     {
         $this->driver = $driver;
         $this->services = $services;
+
+        // Because of the way FailureSubscriber works, we need a producer even
+        // if we're only consuming messages. That means we need to initialize
+        // all these member objects in the constructor.
+        $this->serializer = new Serializer();
+        $this->queueFactory = new PersistentFactory($this->getDriver(), $this->serializer);
+        $this->eventDispatcher = new EventDispatcher();
+        $this->producer = new Producer($this->queueFactory, $this->eventDispatcher);
+
+        $this->errorLogSubscriber = new EventListener\ErrorLogSubscriber();
+        $this->eventDispatcher->addSubscriber($this->errorLogSubscriber);
+
+        $this->failureSubscriber = new EventListener\FailureSubscriber($this->producer);
+        $this->eventDispatcher->addSubscriber($this->failureSubscriber);
     }
 
     /**
@@ -87,84 +101,6 @@ class Queue
             $this->driver = DriverFactory::create();
         }
         return $this->driver;
-    }
-
-    /**
-     * @return Serializer|SimpleSerializer
-     */
-    protected function getSerializer()
-    {
-        if (!$this->serializer) {
-            $this->serializer = new SimpleSerializer();
-        }
-        return $this->serializer;
-    }
-
-    /**
-     * @return MiddlewareBuilder
-     */
-    protected function getMiddlewareBuilder()
-    {
-        if (!$this->middlewareBuilder) {
-            $this->middlewareBuilder = new MiddlewareBuilder();
-        }
-        return $this->middlewareBuilder;
-    }
-
-    /**
-     * @return Middleware\ErrorLogFactory
-     */
-    protected function getErrorLogFactory()
-    {
-        if (!$this->errorLogFactory) {
-            $this->errorLogFactory = new Middleware\ErrorLogFactory();
-        }
-        return $this->errorLogFactory;
-    }
-
-    /**
-     * @return Middleware\FailuresFactory
-     */
-    protected function getFailuresFactory()
-    {
-        if (!$this->failuresFactory) {
-            $this->failuresFactory = new Middleware\FailuresFactory($this->getQueueFactory());
-        }
-        return $this->failuresFactory;
-    }
-
-    /**
-     * @return MiddlewareBuilder
-     */
-    protected function getConsumerMiddleware()
-    {
-        $chain = $this->getMiddlewareBuilder();
-        $chain->push($this->getErrorLogFactory());
-        $chain->push($this->getFailuresFactory());
-
-        return $chain;
-    }
-
-    /**
-     * @return QueueFactory|PersistentFactory
-     */
-    protected function getQueueFactory()
-    {
-        if (!$this->queueFactory) {
-            $this->queueFactory = new PersistentFactory($this->getDriver(), $this->getSerializer());
-        }
-        return $this->queueFactory;
-    }
-
-    /**
-     * @return Producer
-     */
-    protected function getProducer()
-    {
-        if (!$this->producer) {
-            $this->producer = new Producer($this->getQueueFactory(), $this->getMiddlewareBuilder());
-        }
-        return $this->producer;
     }
 
     /**
@@ -184,7 +120,7 @@ class Queue
     protected function getConsumer()
     {
         if (!$this->consumer) {
-            $this->consumer = new Consumer($this->getRouter(), $this->getConsumerMiddleware());
+            $this->consumer = new Consumer($this->getRouter(), $this->eventDispatcher);
         }
         return $this->consumer;
     }
@@ -194,8 +130,7 @@ class Queue
      */
     public function produce(Message $message)
     {
-        $queue = $this->getProducer();
-        $queue->produce($message);
+        $this->producer->produce($message);
     }
 
     /**
@@ -204,10 +139,8 @@ class Queue
      */
     public function consume($name, array $options = [])
     {
-        $queues = $this->getQueueFactory();
         $consumer = $this->getConsumer();
-
-        $consumer->consume($queues->create($name), $options);
+        $consumer->consume($this->queueFactory->create($name), $options);
     }
 
     /**

--- a/app/Middleware/Queue.php
+++ b/app/Middleware/Queue.php
@@ -117,7 +117,7 @@ class Queue
     /**
      * @return Consumer
      */
-    protected function getConsumer()
+    public function getConsumer()
     {
         if (!$this->consumer) {
             $this->consumer = new Consumer($this->getRouter(), $this->eventDispatcher);

--- a/app/Middleware/Queue/DriverFactory.php
+++ b/app/Middleware/Queue/DriverFactory.php
@@ -35,16 +35,12 @@ class DriverFactory
     const DOCTRINE = 'Doctrine';
     const FLAT_FILE = 'FlatFile';
     const IRON_MQ = 'IronMQ';
-    const PHP_REDIS = 'PhpRedis';
-    const PREDIS = 'Predis';
-    const SQS = 'SQS';
-
-    // Begin NOT Available in Bernard ~0.12
-    const MEMORY = 'Memory';
     const INTEROP = 'Interop';
     const MONGO = 'MongoDB';
     const PHEANSTALK = 'Pheanstalk';
-    // End NOT Available in Bernard ~0.12
+    const PHP_REDIS = 'PhpRedis';
+    const PREDIS = 'Predis';
+    const SQS = 'SQS';
 
     /**
      * @param array $configuration

--- a/app/Middleware/Queue/SubmissionService.php
+++ b/app/Middleware/Queue/SubmissionService.php
@@ -19,7 +19,7 @@ namespace CDash\Middleware\Queue;
 require_once dirname(__DIR__) . '/../../include/do_submit.php';
 
 use Bernard\Message;
-use Bernard\Message\DefaultMessage;
+use Bernard\Message\PlainMessage;
 use CDash\Log;
 use CDash\Middleware\Queue;
 
@@ -91,7 +91,7 @@ class SubmissionService
      * Returns a submission message for Queue::produce
      *
      * @param array $parameters
-     * @return DefaultMessage
+     * @return PlainMessage
      * @throws \Exception
      */
     public static function createMessage(array $parameters)
@@ -114,7 +114,7 @@ class SubmissionService
             throw new \Exception($message);
         }
         $name = isset($parameters['queue_name']) ? $parameters['queue_name'] : self::NAME;
-        return new DefaultMessage($name, $parameters);
+        return new PlainMessage($name, $parameters);
     }
 
     /**

--- a/app/Middleware/Queue/SubmissionService.php
+++ b/app/Middleware/Queue/SubmissionService.php
@@ -20,6 +20,7 @@ require_once dirname(__DIR__) . '/../../include/do_submit.php';
 
 use Bernard\Message;
 use Bernard\Message\PlainMessage;
+use CDash\Config;
 use CDash\Log;
 use CDash\Middleware\Queue;
 
@@ -83,7 +84,7 @@ class SubmissionService
     const NAME = 'DoSubmit';
 
     /** @var string[] - Fields required for processing */
-    protected static $required = ['file', 'project', 'checksum', 'md5'];
+    protected static $required = ['file', 'project', 'checksum', 'md5', 'ip'];
 
     protected $queueName;
 
@@ -167,13 +168,14 @@ class SubmissionService
     {
         try {
             $fh = fopen($message->file, 'r');
+            $config = Config::getInstance();
+            $config->set('CDASH_REMOTE_ADDR', $message->ip);
             do_submit($fh, $message->project, null, $message->md5, $message->checksum);
         } catch (\Exception $e) {
             Log::getInstance()->error($e);
             throw $e;
         }
     }
-
 
     /**
      * Registers this service with a Queue

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-mbstring": "*",
     "ext-pdo": "*",
     "ext-xsl": "*",
-    "bernard/bernard": "~0.12",
+    "bernard/bernard": "1.0.0-alpha9",
     "guzzlehttp/guzzle": "~6.2",
     "monolog/monolog": "~1.19",
     "paragonie/random_compat": "2.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b5803aead6510e145e002f4575c03a",
+    "content-hash": "35ca65235467c04222c0534cf9c9c337",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -87,57 +87,176 @@
             "time": "2018-07-06T17:41:33+00:00"
         },
         {
-            "name": "bernard/bernard",
-            "version": "v0.12.4",
+            "name": "beberlei/assert",
+            "version": "v2.9.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/bernardphp/bernard.git",
-                "reference": "c452caa6de208b0274449cde1c48eb32fb9f59f9"
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bernardphp/bernard/zipball/c452caa6de208b0274449cde1c48eb32fb9f59f9",
-                "reference": "c452caa6de208b0274449cde1c48eb32fb9f59f9",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/ec9e4cf0b63890edce844ee3922e2b95a526e936",
+                "reference": "ec9e4cf0b63890edce844ee3922e2b95a526e936",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "replace": {
-                "henrikbjorn/bernard": "self.version"
+                "ext-mbstring": "*",
+                "php": ">=5.3"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "~2.4",
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4.8.35|^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2018-06-11T17:15:25+00:00"
+        },
+        {
+            "name": "bernard/bernard",
+            "version": "1.0.0-alpha9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bernardphp/bernard.git",
+                "reference": "1144b4dd9b87f22091dfceabb91d74f295ade034"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bernardphp/bernard/zipball/1144b4dd9b87f22091dfceabb91d74f295ade034",
+                "reference": "1144b4dd9b87f22091dfceabb91d74f295ade034",
+                "shasum": ""
+            },
+            "require": {
+                "beberlei/assert": "~2.1",
+                "bernard/normalt": "~1.0",
+                "php": "^5.6 || ^7.0",
+                "symfony/event-dispatcher": "^2.7|^3.0|^4.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~2.4|~3.0",
                 "doctrine/dbal": "~2.3",
-                "iron-io/iron_mq": "~1.4",
-                "jms/serializer": "~0.12",
+                "iron-io/iron_mq": "~4.0",
+                "league/container": "~2.3",
+                "pda/pheanstalk": "~3.0",
+                "php-amqplib/php-amqplib": "~2.5",
+                "phpspec/phpspec": "^2.4",
+                "phpunit/phpunit": "^5.5|^6.0",
                 "pimple/pimple": "~1.0",
                 "predis/predis": "~0.8",
                 "psr/log": "~1.0",
-                "symfony/console": "~2.0",
-                "symfony/dependency-injection": "~2.0",
-                "symfony/serializer": "~2.2"
+                "queue-interop/amqp-interop": "^0.6",
+                "queue-interop/queue-interop": "^0.6",
+                "symfony/console": "^2.7|^3.0|^4.0",
+                "symfony/dependency-injection": "^2.7|^3.0|^4.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending messages to AWS services like Simple Queue Service",
+                "doctrine/dbal": "Allow sending messages to simulated message queue in a database via doctrine dbal",
+                "iron-io/iron_mq": "Allow sending messages to IronMQ",
+                "mongodb/mongodb": "Allow sending messages to a MongoDB server via PHP Driver",
+                "pda/pheanstalk": "Allow sending messages to Beanstalk using pheanstalk",
+                "php-amqplib/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",
+                "predis/predis": "Allow sending messages to Redis using predis",
+                "queue-interop/amqp-interop": "Allow sending messages using amqp interop compatible transports",
+                "queue-interop/queue-interop": "Allow sending messages using queue interop compatible transports"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.10.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Bernard": "src/"
-                },
-                "files": [
-                    "src/Bernard/functions.php"
-                ]
+                "psr-4": {
+                    "Bernard\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Message queue implemented in PHP with Redis as a backend.",
-            "time": "2017-11-05T18:32:45+00:00"
+            "description": "Message queue abstraction layer",
+            "homepage": "https://github.com/bernardphp/bernard",
+            "keywords": [
+                "bernard",
+                "message",
+                "message queue",
+                "queue"
+            ],
+            "time": "2018-02-13T07:52:58+00:00"
+        },
+        {
+            "name": "bernard/normalt",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bernardphp/normalt.git",
+                "reference": "9ed9b6bbc657bb1e5a52ff4da6607e32152b390e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bernardphp/normalt/zipball/9ed9b6bbc657bb1e5a52ff4da6607e32152b390e",
+                "reference": "9ed9b6bbc657bb1e5a52ff4da6607e32152b390e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6||^7.0",
+                "symfony/serializer": "^2.3 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "doctrine/common": "^2.1",
+                "phpspec/phpspec": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Normalt\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Normalt is a extension to Symfony Serializer that only implements the Normalization part",
+            "keywords": [
+                "denormalization",
+                "normalization"
+            ],
+            "time": "2018-01-13T09:47:09+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -2169,6 +2288,203 @@
                 "mailer"
             ],
             "time": "2018-01-23T07:37:21+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/fdd5abcebd1061ec647089c6c41a07ed60af09f8",
+                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.3|~4.0",
+                "symfony/expression-language": "~2.8|~3.0|~4.0",
+                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-04-06T07:35:25+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v3.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "40031683816470610af87c2d03ea86d1cf0f0104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/40031683816470610af87c2d03ea86d1cf0f0104",
+                "reference": "40031683816470610af87c2d03ea86d1cf0f0104",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "phpdocumentor/type-resolver": "<0.2.1",
+                "symfony/dependency-injection": "<3.2",
+                "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
+                "symfony/property-info": "<3.1",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.1|~4.0",
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.2|~4.0",
+                "symfony/http-foundation": "~2.8|~3.0|~4.0",
+                "symfony/property-access": "~2.8|~3.0|~4.0",
+                "symfony/property-info": "~3.1|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/http-foundation": "To use the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-07-26T11:58:24+00:00"
         }
     ],
     "packages-dev": [
@@ -3466,69 +3782,6 @@
             "time": "2018-06-25T11:10:40+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v3.4.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/fdd5abcebd1061ec647089c6c41a07ed60af09f8",
-                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-04-06T07:35:25+00:00"
-        },
-        {
             "name": "symfony/filesystem",
             "version": "v3.4.12",
             "source": {
@@ -3626,61 +3879,6 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "time": "2018-06-19T20:52:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2018-04-30T19:57:29+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3951,7 +4149,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "bernard/bernard": 15
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/include/ctestparser.php
+++ b/include/ctestparser.php
@@ -303,8 +303,13 @@ function ctest_parse($filehandler, $projectid, $buildid = null,
     }
 
     // Try to get the IP of the build
+    $ip = null;
     $config = Config::getInstance();
-    $ip = $config->get('CDASH_REMOTE_ADDR') ?: isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : null;
+    if ($config->get('CDASH_REMOTE_ADDR')) {
+        $ip = $config->get('CDASH_REMOTE_ADDR');
+    } elseif (array_key_exists('REMOTE_ADDR', $_SERVER)) {
+        $ip = $_SERVER['REMOTE_ADDR'];
+    }
 
     if ($handler == null) {
         echo 'no handler found';

--- a/include/ctestparser.php
+++ b/include/ctestparser.php
@@ -32,6 +32,10 @@ use CDash\Config;
 use CDash\Model\BuildFile;
 use CDash\Model\Project;
 
+class CDashParseException extends RuntimeException
+{
+}
+
 // Helper function to display the message
 function displayReturnStatus($statusarray)
 {
@@ -215,7 +219,7 @@ function parse_put_submission($filehandler, $projectid, $expected_md5)
 
     // Parse the file.
     if ($handler->Parse($filename) === false) {
-        throw new Exception('Failed to parse file ' . $filename);
+        throw new CDashParseException('Failed to parse file ' . $filename);
     }
 
     check_for_immediate_deletion($filename);
@@ -243,7 +247,7 @@ function ctest_parse($filehandler, $projectid, $buildid = null,
         if (parse_put_submission($filehandler, $projectid, $expected_md5)) {
             return true;
         }
-    } catch (Exception $e) {
+    } catch (CDashParseException $e) {
         add_log($e->getMessage(), 'ctest_parse', LOG_ERR);
         return false;
     }

--- a/include/do_submit.php
+++ b/include/do_submit.php
@@ -20,6 +20,9 @@ use Bernard\Producer;
 use Bernard\QueueFactory\PersistentFactory;
 use Bernard\Serializer;
 use CDash\Config;
+use CDash\Middleware\Queue;
+use CDash\Middleware\Queue\DriverFactory as QueueDriverFactory;
+use CDash\Middleware\Queue\SubmissionService;
 use CDash\Model\AuthToken;
 use CDash\Model\Build;
 use CDash\Model\BuildFile;
@@ -476,15 +479,16 @@ function put_submit_file()
     }
 
     if ($config->get('CDASH_BERNARD_COVERAGE_SUBMISSION')) {
-        $factory = new PersistentFactory($config->get('CDASH_BERNARD_DRIVER'), new Serializer());
-        $producer = new Producer($factory, new EventDispatcher());
-
-        $producer->produce(new PlainMessage('DoSubmit', array(
-            'coverage_submission' => true,
-            'filename' => $filename,
-            'expected_md5' => $md5sum,
-            'projectid' => $projectid,
-            'submission_ip' => $_SERVER['REMOTE_ADDR'])));
+        $driver = QueueDriverFactory::create();
+        $queue = new Queue($driver);
+        $message = SubmissionService::createMessage([
+            'file' => $filename,
+            'project' => $projectid,
+            'md5' => $md5sum,
+            'checksum' => true,
+            'ip' => $_SERVER['REMOTE_ADDR']
+        ]);
+        $queue->produce($message);
     } elseif ($config->get('CDASH_ASYNCHRONOUS_SUBMISSION')) {
         // Create a new entry in the submission table for this file.
         $bytes = filesize($filename);

--- a/include/do_submit.php
+++ b/include/do_submit.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 
 //error_reporting(0); // disable error reporting
-use Bernard\Message\DefaultMessage;
+use Bernard\Message\PlainMessage;
 use Bernard\Producer;
 use Bernard\QueueFactory\PersistentFactory;
 use Bernard\Serializer;
@@ -479,7 +479,7 @@ function put_submit_file()
         $factory = new PersistentFactory($config->get('CDASH_BERNARD_DRIVER'), new Serializer());
         $producer = new Producer($factory, new EventDispatcher());
 
-        $producer->produce(new DefaultMessage('DoSubmit', array(
+        $producer->produce(new PlainMessage('DoSubmit', array(
             'coverage_submission' => true,
             'filename' => $filename,
             'expected_md5' => $md5sum,

--- a/public/submissionConsumer.php
+++ b/public/submissionConsumer.php
@@ -1,8 +1,14 @@
 <?php
 require dirname(__DIR__) . '/config/config.php';
 
+use CDash\Database;
 use CDash\Middleware\Queue;
 use CDash\Middleware\Queue\SubmissionService;
+
+// Configure PDO to throw an exception if any SQL errors occur while
+// processing submissions.
+Database::getInstance()->getPdo()->setAttribute(
+        PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $service_container = \CDash\ServiceContainer::getInstance();
 
@@ -13,4 +19,11 @@ $queue = $service_container->create(Queue::class);
 $submission_service = $service_container->create(SubmissionService::class);
 
 $submission_service->register($queue);
-$queue->consume($submission_service->getConsumerName());
+
+try {
+    $queue->consume($submission_service->getConsumerName(), ['stop-on-error' => true]);
+} catch (\Exception $e) {
+    // Exit gracefully if an exception occurs.
+    $queue->getConsumer()->shutdown();
+    exit(1);
+}

--- a/public/submit.php
+++ b/public/submit.php
@@ -149,6 +149,7 @@ if ($config->get('CDASH_BERNARD_SUBMISSION')) {
             'project' => $projectid,
             'md5' => $expected_md5,
             'checksum' => true,
+            'ip' => $_SERVER['REMOTE_ADDR']
         ]);
 
         $queue->produce($message);

--- a/tests/case/CDash/Middleware/Queue/SubmissionServiceTest.php
+++ b/tests/case/CDash/Middleware/Queue/SubmissionServiceTest.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Middleware\Queue;
 
-use Bernard\Message\DefaultMessage;
+use Bernard\Message\PlainMessage;
 use CDash\Middleware\Queue;
 
 function do_submit($fh, $project_id, $buildid = null, $expected_md5 = '', $do_checksum = true, $submission_id = 0)
@@ -94,7 +94,7 @@ class SubmissionServiceTest extends \PHPUnit_Framework_TestCase
     {
         $message = SubmissionService::createMessage($this->parameters);
 
-        $this->assertInstanceOf(DefaultMessage::class, $message);
+        $this->assertInstanceOf(PlainMessage::class, $message);
         $this->assertEquals(SubmissionService::NAME, $message->getName());
         $this->assertEquals($this->parameters['file'], $message->file);
         $this->assertEquals($this->parameters['project'], $message->project);

--- a/tests/case/CDash/Middleware/QueueTest.php
+++ b/tests/case/CDash/Middleware/QueueTest.php
@@ -17,7 +17,7 @@
 namespace CDash\Middleware\Queue;
 
 use Bernard\Driver;
-use Bernard\Message\DefaultMessage;
+use Bernard\Message\PlainMessage;
 use CDash\Middleware\Queue;
 
 class QueueTest extends \PHPUnit_Framework_TestCase
@@ -47,8 +47,8 @@ class QueueTest extends \PHPUnit_Framework_TestCase
 
         $sut->addService('IsA', $mock_service);
 
-        $m1 = new DefaultMessage('IsA', ['isA' => true]);
-        $m2 = new DefaultMessage('IsA', ['isA' => false]);
+        $m1 = new PlainMessage('IsA', ['isA' => true]);
+        $m2 = new PlainMessage('IsA', ['isA' => false]);
 
         $sut->produce($m1);
         $sut->produce($m2);


### PR DESCRIPTION
Currently, if a `submissionConsumer.php` process loses its connection to the SQL server, it will still attempt (and fail) to process submissions.

This PR takes the following steps to fix this behavior:
* configure PDO to throw an exception upon SQL errors
* configure Bernard to terminate a consumer when an exception is thrown

These changes will allow us to use `systemd` to automatically restart consumers when such an error occurs. 