### PR TITLE
More gracefully handle unique key violations on the site table

### DIFF
--- a/app/Model/Site.php
+++ b/app/Model/Site.php
@@ -105,10 +105,30 @@ class Site
         $stmt->bindParam(':outoforder', $this->OutOfOrder);
         $stmt->bindParam(':id', $this->Id);
 
-        if (!pdo_execute($stmt)) {
+        try {
+            if ($stmt->execute()) {
+                return true;
+            }
+            // The UPDATE statement didn't execute cleanly.
+            $error_info = $stmt->errorInfo();
+            $error = $error_info[2];
+            throw new \Exception($error);
+        } catch (\Exception $e) {
+            // This error might be due to a unique key violation.
+            // Check for an existing site with this name and ip.
+            $site = new Site();
+            $site->Name = $this->Name;
+            $site->Ip = $this->Ip;
+            if ($site->Exists()) {
+                $this->Id = $site->Id;
+                return true;
+            }
+
+            // Otherwise log the error and return false.
+            add_log($e->getMessage() . PHP_EOL . $e->getTraceAsString(),
+                    'Site::Update', LOG_ERR);
             return false;
         }
-        return true;
     }
 
     public function LookupIP()

--- a/app/Model/Site.php
+++ b/app/Model/Site.php
@@ -74,15 +74,13 @@ class Site
                 return true;
             }
         }
-        if ($this->Name) {
-            $stmt = $this->PDO->prepare(
-                'SELECT id FROM site WHERE name = ?');
-            pdo_execute($stmt, [$this->Name]);
-            $id = $stmt->fetchColumn();
-            if ($id !== false) {
-                $this->Id = $id;
-                return true;
-            }
+        $stmt = $this->PDO->prepare(
+                'SELECT id FROM site WHERE name = :name AND ip = :ip');
+        pdo_execute($stmt, [':name' => $this->Name, ':ip' => $this->Ip]);
+        $id = $stmt->fetchColumn();
+        if ($id !== false) {
+            $this->Id = $id;
+            return true;
         }
         return false;
     }

--- a/tests/test_sitemodel.php
+++ b/tests/test_sitemodel.php
@@ -81,6 +81,45 @@ class SiteModelTestCase extends KWWebTestCase
             return 1;
         }
 
+        // Create two sites.
+        // They have the same name but different ip addresses.
+        $site3 = new Site();
+        $site3->Name = 'testsite3';
+        $site3->Ip = '';
+        if (!$site3->Insert()) {
+            $this->fail('Insert failed for site 3');
+        }
+        $site_3_id = $site3->Id;
+        $site3->Id = null;
+        if (!$site3->Exists()) {
+            $this->fail('site 3 does not exist');
+        }
+        if ($site3->Id != $site_3_id) {
+            $this->fail("Expected $site_3_id but found {$site3->Id} for site 3 ID");
+        }
+
+        $site4 = new Site();
+        $site4->Name = 'testsite3';
+        $site4->Ip = '127.0.0.1';
+        if (!$site4->Insert()) {
+            $this->fail('Insert failed for site 4');
+        }
+        $site_4_id = $site4->Id;
+        $site4->Id = null;
+        if (!$site4->Exists()) {
+            $this->fail('site 4 does not exist');
+        }
+        if ($site4->Id != $site_4_id) {
+            $this->fail("Expected $site_4_id but found {$site4->Id} for site 4 ID");
+        }
+
+        if ($site3->Id == $site4->Id) {
+            $this->fail("Site 3 and Site 4 have the same Id");
+        }
+
+        $stmt = $this->PDO->prepare('DELETE FROM site WHERE id = ?');
+        pdo_execute($stmt, [$site_3_id]);
+        pdo_execute($stmt, [$site_4_id]);
         return 0;
     }
 }

--- a/tests/test_sitemodel.php
+++ b/tests/test_sitemodel.php
@@ -117,6 +117,17 @@ class SiteModelTestCase extends KWWebTestCase
             $this->fail("Site 3 and Site 4 have the same Id");
         }
 
+        // Verify that we handle unique key constraint violations gracefully.
+        $site3->Ip = '127.0.0.1';
+        $site3->Update();
+        $log_contents = file_get_contents($this->logfilename);
+        if (strpos($log_contents, 'PdoError') !== false) {
+            $this->fail('PDO error logged for unique constraint violation');
+        }
+        if ($site3->Id != $site4->Id) {
+            $this->fail("Site 3 and Site 4 do not have the same Id");
+        }
+
         $stmt = $this->PDO->prepare('DELETE FROM site WHERE id = ?');
         pdo_execute($stmt, [$site_3_id]);
         pdo_execute($stmt, [$site_4_id]);


### PR DESCRIPTION
We have a unique key in the site table on (name, ip).  Take better care to ensure that this constraint does not cause SQL errors to be logged unnecessarily.

* Search for existing sites by name AND ip address.
* If a unique key violation would occur during an UPDATE statement, return the existing record instead.