### PR TITLE
Change unique constraint on site table

### DIFF
--- a/app/Model/Site.php
+++ b/app/Model/Site.php
@@ -75,8 +75,8 @@ class Site
             }
         }
         $stmt = $this->PDO->prepare(
-                'SELECT id FROM site WHERE name = :name AND ip = :ip');
-        pdo_execute($stmt, [':name' => $this->Name, ':ip' => $this->Ip]);
+                'SELECT id FROM site WHERE name = :name');
+        pdo_execute($stmt, [':name' => $this->Name]);
         $id = $stmt->fetchColumn();
         if ($id !== false) {
             $this->Id = $id;
@@ -115,10 +115,9 @@ class Site
             throw new \Exception($error);
         } catch (\Exception $e) {
             // This error might be due to a unique key violation.
-            // Check for an existing site with this name and ip.
+            // Check for an existing site with this name.
             $site = new Site();
             $site->Name = $this->Name;
-            $site->Ip = $this->Ip;
             if ($site->Exists()) {
                 $this->Id = $site->Id;
                 return true;
@@ -200,10 +199,9 @@ class Site
             throw new \Exception($error);
         } catch (\Exception $e) {
             // This error might be due to a unique constraint violation.
-            // Query for a previously existing site with this name & ip.
+            // Query for a previously existing site with this name.
             $site = new Site();
             $site->Name = $this->Name;
-            $site->Ip = $this->Ip;
             if ($site->Exists()) {
                 $this->Id = $site->Id;
                 return true;

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -710,9 +710,6 @@ if (isset($_GET['upgrade-2-4'])) {
             pdo_query('ALTER TABLE build ADD UNIQUE KEY (uuid)');
         }
 
-        // Also add a new unique constraint to the site table.
-        AddUniqueConstraintToSiteTable('site');
-
         // Also add a new unique constraint to the subproject table.
         if ($db_type === 'pgsql') {
             pdo_query('ALTER TABLE subproject ADD UNIQUE (name, projectid, endtime)');
@@ -818,6 +815,9 @@ if (isset($_GET['upgrade-2-6'])) {
     // Support for bugtracker issue creation.
     AddTableField('project', 'bugtrackernewissueurl', 'varchar(255)', 'character varying(255)', '');
     AddTableField('project', 'bugtrackertype', 'varchar(16)', 'character varying(16)', '');
+
+    // Add new unique constraint to the site table.
+    AddUniqueConstraintToSiteTable('site');
 
     // Set the database version
     setVersion();

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -464,7 +464,7 @@ CREATE TABLE `site` (
   `longitude` varchar(10) NOT NULL default '',
   `outoforder` tinyint(4) NOT NULL default '0',
   PRIMARY KEY  (`id`),
-  UNIQUE KEY `name_ip` (`name`, `ip`)
+  UNIQUE KEY `name` (`name`)
 ) ;
 
 --

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -366,10 +366,9 @@ CREATE TABLE "site" (
   "latitude" character varying(10) DEFAULT '' NOT NULL,
   "longitude" character varying(10) DEFAULT '' NOT NULL,
   "outoforder" smallint DEFAULT '0' NOT NULL,
-  PRIMARY KEY ("id"),
-  CONSTRAINT "name_ip1" UNIQUE ("name", "ip")
+  PRIMARY KEY ("id")
 );
-CREATE INDEX "name_ip2" on "site" ("name", "ip");
+CREATE UNIQUE INDEX "site_name" on "site" ("name");
 
 --
 -- Table: siteinformation

--- a/tests/test_sitemodel.php
+++ b/tests/test_sitemodel.php
@@ -81,11 +81,9 @@ class SiteModelTestCase extends KWWebTestCase
             return 1;
         }
 
-        // Create two sites.
-        // They have the same name but different ip addresses.
+        // Create two sites with different names.
         $site3 = new Site();
         $site3->Name = 'testsite3';
-        $site3->Ip = '';
         if (!$site3->Insert()) {
             $this->fail('Insert failed for site 3');
         }
@@ -99,8 +97,7 @@ class SiteModelTestCase extends KWWebTestCase
         }
 
         $site4 = new Site();
-        $site4->Name = 'testsite3';
-        $site4->Ip = '127.0.0.1';
+        $site4->Name = 'testsite4';
         if (!$site4->Insert()) {
             $this->fail('Insert failed for site 4');
         }
@@ -118,14 +115,14 @@ class SiteModelTestCase extends KWWebTestCase
         }
 
         // Verify that we handle unique key constraint violations gracefully.
-        $site3->Ip = '127.0.0.1';
+        $site3->Id = $site_4_id;
         $site3->Update();
         $log_contents = file_get_contents($this->logfilename);
         if (strpos($log_contents, 'PdoError') !== false) {
             $this->fail('PDO error logged for unique constraint violation');
         }
-        if ($site3->Id != $site4->Id) {
-            $this->fail("Site 3 and Site 4 do not have the same Id");
+        if ($site3->Id != $site3->Id) {
+            $this->fail("Site 3 Id not returned from Update()");
         }
 
         $stmt = $this->PDO->prepare('DELETE FROM site WHERE id = ?');

--- a/tests/test_upgrade.php
+++ b/tests/test_upgrade.php
@@ -405,7 +405,7 @@ class UpgradeTestCase extends KWWebTestCase
         $keepers = array();
 
         // Insert sites into our testing table that will violate
-        // the (name, ip) unique constraint.
+        // the unique constraint on the name column.
         //
         // Case 1: No lat/lon info, so the lowest number siteid will be kept.
         $nolatlon_keeper = ++$i;
@@ -414,7 +414,7 @@ class UpgradeTestCase extends KWWebTestCase
             INSERT INTO $table_name
             (id, name, ip)
             VALUES
-            ($nolatlon_keeper, 'case1_site', '128.4.4.1')";
+            ($nolatlon_keeper, 'case1_site', '')";
         if (!pdo_query($insert_query)) {
             $this->fail('pdo_query returned false');
             $retval = 1;
@@ -425,7 +425,7 @@ class UpgradeTestCase extends KWWebTestCase
             INSERT INTO $table_name
             (id, name, ip)
             VALUES
-            ($nolatlon_dupe, 'case1_site', '128.4.4.1')";
+            ($nolatlon_dupe, 'case1_site', '')";
         if (!pdo_query($insert_query)) {
             $this->fail('pdo_query returned false');
             $retval = 1;
@@ -439,7 +439,7 @@ class UpgradeTestCase extends KWWebTestCase
             INSERT INTO $table_name
             (id, name, ip, latitude, longitude)
             VALUES
-            ($latlon_dupe1, 'case2_site', '129.5.5.2', '40.70', '-74.00')";
+            ($latlon_dupe1, 'case2_site', '', '40.70', '-74.00')";
         if (!pdo_query($insert_query)) {
             $this->fail('pdo_query returned false');
             $retval = 1;
@@ -450,7 +450,7 @@ class UpgradeTestCase extends KWWebTestCase
             INSERT INTO $table_name
             (id, name, ip, latitude, longitude)
             VALUES
-            ($latlon_keeper, 'case2_site', '129.5.5.2', '40.71', '-73.97')";
+            ($latlon_keeper, 'case2_site', '', '40.71', '-73.97')";
         if (!pdo_query($insert_query)) {
             $this->fail('pdo_query returned false');
             $retval = 1;
@@ -461,7 +461,7 @@ class UpgradeTestCase extends KWWebTestCase
             INSERT INTO $table_name
             (id, name, ip)
             VALUES
-            ($latlon_dupe2, 'case2_site', '129.5.5.2')";
+            ($latlon_dupe2, 'case2_site', '')";
         if (!pdo_query($insert_query)) {
             $this->fail('pdo_query returned false');
             $retval = 1;


### PR DESCRIPTION
Force each separate site record to have a unique name. Previously we enforced a unique combination of name and ip address. The motivation to change this constraint was the fact that cloud services often change their ip addresses. This was causing us to accumulate many records that differed only by ip address, not by name.

Because such builds were considered to come from different sites, we lost the ability to easily track how build & test results changed from one build to the next.