### PR TITLE
Set submit time when submit.php initializes the build

### DIFF
--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -314,6 +314,7 @@ class Build
                 projectid,
                 starttime,
                 endtime,
+                submittime,
                 siteid,
                 name,
                 stamp,
@@ -337,6 +338,7 @@ class Build
         $this->Type = $build_array['type'];
         $this->StartTime = $build_array['starttime'];
         $this->EndTime = $build_array['endtime'];
+        $this->SubmitTime = $build_array['submittime'];
         $this->SiteId = $build_array['siteid'];
         $this->ProjectId = $build_array['projectid'];
         $this->SetParentId($build_array['parentid']);

--- a/public/api/v1/addBuild.php
+++ b/public/api/v1/addBuild.php
@@ -48,6 +48,8 @@ $build->Name = get_param('name');
 $build->SetStamp(get_param('stamp'));
 $build->ProjectId = $project->Id;
 $build->SiteId = $site->Id;
+$build->StartTime = gmdate(FMT_DATETIME);
+$build->SubmitTime = $build->StartTime;
 $subProjectName = get_param('subProjectName', false);
 if ($subProjectName) {
     $build->SubProjectName = $subProjectName;

--- a/public/submit.php
+++ b/public/submit.php
@@ -120,6 +120,7 @@ if (isset($_GET['build']) && isset($_GET['site']) && isset($_GET['stamp'])) {
     $build->ProjectId = $projectid;
     $build->SetStamp(pdo_real_escape_string($_GET['stamp']));
     $build->StartTime = gmdate(FMT_DATETIME);
+    $build->SubmitTime = $build->StartTime;
 
     if (isset($_GET['subproject'])) {
         $build->SubProjectName = pdo_real_escape_string($_GET['subproject']);

--- a/tests/test_submission_assign_buildid.php
+++ b/tests/test_submission_assign_buildid.php
@@ -8,6 +8,7 @@ class SubmissionAssignBuildIdTestCase extends KWWebTestCase
 {
     public function testSubmissionAssignBuildId()
     {
+        $begin_test_time = time();
         $file_to_submit = dirname(__FILE__) .  '/data/AssignBuildId/Configure.xml';
         $buildid = $this->submission_assign_buildid(
                 $file_to_submit, 'InsightExample', 'assign_buildid',
@@ -24,6 +25,9 @@ class SubmissionAssignBuildIdTestCase extends KWWebTestCase
 
         $build->FillFromId($buildid);
         $this->assertEqual('assign_buildid', $build->Name);
+        $this->assertTrue(strtotime($build->SubmitTime) >= $begin_test_time);
+        $this->assertEqual('2018-09-18 14:27:07', $build->StartTime);
+        $this->assertEqual('2018-09-18 14:27:08', $build->EndTime);
 
         remove_build($buildid);
     }


### PR DESCRIPTION
We recently updated submit.php to assign a buildid if a few extra
parameters are passed (2a27b4e).

This commit fixes a bug where such builds never had their submit time
properly set. It also updates the related addBuild.php endpoint to
make sure start time and submit time are properly set.