### PR TITLE
refactor docker shell scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY backup /var/www/cdash/backup
 COPY include /var/www/cdash/include
 COPY bootstrap /var/www/cdash/bootstrap
 COPY composer.json /var/www/cdash/composer.json
+COPY scripts/bash /bash-lib
 
 RUN cd /var/www/cdash                                                      \
  && composer install --no-interaction --no-progress --prefer-dist --no-dev \
@@ -56,3 +57,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5m \
   CMD ["curl", "-f", "http://localhost/viewProjects.php"]
 
 ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
+CMD ["serve"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,297 +1,143 @@
 #!/bin/bash
 
-declare -a __exit_callbacks
-onexit() {
-    __exit_callbacks[${#__exit_callbacks[@]}]="$@"
-}
+export BASH_LIB=/bash-lib
+source "$BASH_LIB/cdash.bash"
+source "$BASH_LIB/debug.bash"
+source "$BASH_LIB/misc.bash"
+source "$BASH_LIB/on_exit.bash"
+source "$BASH_LIB/tmp_dir.bash"
+source "$BASH_LIB/web.bash"
 
-do_exit() {
-    if [ -z "$exit_code" ] ; then
-        exit_code="$1"
-        local n
-        n=${#__exit_callbacks[@]}
-        for ((; n--; )) ; do
-            eval "${__exit_callbacks[$n]}"
-        done
-    fi
-}
+do_configure() {
+    local_service_setup
+    (
+        cdash_session "$CDASH_ROOT_ADMIN_EMAIL" \
+                "$CDASH_ROOT_ADMIN_PASS"        \
+                "$CDASH_ROOT_ADMIN_NEW_PASS"
 
-EXEC() {
-    do_exit 0
-    exec "$@"
-}
-
-trap "do_exit 1; exit $exit_code" INT TERM QUIT
-trap "do_exit 0; exit $exit_code" EXIT
-
-onexit 'if [ -n "$tmpdir" -a -d "$tmpdir" ] ; then rm -r "$tmpdir" ; fi'
-
-ensure_tmp() {
-    if [ -z "$tmpdir" ] ; then
-        tmpdir="$( mktemp -d )"
-    fi
-}
-
-# poor man's CDash client
-mksession() {
-    local result
-    ensure_tmp
-    mkdir -p "$tmpdir/sessions"
-    until mkdir "$result" 2> /dev/null ; do
-        result="$tmpdir/sessions/$RANDOM"
-    done
-    echo "$result"
-}
-
-ajax() {
-    local method
-    local session
-    local route
-    local curl_args
-    local arg
-
-    method="$1" ; shift
-    session="$1" ; shift
-    route="$1" ; shift
-
-    if [ "$method" '=' 'POST' ] ; then
-        for arg in "$@" ; do
-            curl_args="$curl_args --form '$arg'"
-        done
-    fi
-
-    local oldcookies
-    local newcookies
-
-    oldcookies="$session/cookies.txt"
-    newcookies="$session/cookies.tmp"
-
-    if [ "$session" '!=' '-' ] ; then
-        if [ -f "$oldcookies" ] ; then
-            curl_args="$curl_args --cookie '$oldcookies'"
-        fi
-        curl_args="$curl_args --cookie-jar '$newcookies'"
-    fi
-
-    local port="$PORT"
-    if [ -n "$port" ] ; then
-        port=":$port"
-    fi
-
-    curl_args="$curl_args 'http://localhost${port}/$route"
-
-    if [ "$method" '=' 'GET' ] ; then
-        arg="$1" ; shift
-        if [ -n "$arg" ] ; then
-            curl_args="${curl_args}?$arg"
-        fi
-
-        for arg in "$@" ; do
-            curl_args="${curl_args}&$arg"
-        done
-    fi
-
-    curl_args="${curl_args}'"
-
-    eval "curl $curl_args" 2>&-
-
-    if [ "$session" '!=' '-' ] ; then
-        if [ -f "$newcookies" ] ; then
-            mv "$newcookies" "$oldcookies"
-        fi
-    fi
-
-    sleep 0.2
-}
-
-get() {
-    ajax GET "$@"
-}
-
-post() {
-    ajax POST "$@"
-}
-
-user_prefix="__user"
-user_set() {
-    email="$1" ; shift
-    key="$1" ; shift
-    value="$1" ; shift
-    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
-    eval "${user_prefix}_${email_hash}_${key}=\"${value}\""
-}
-
-user_get() {
-    email="$1" ; shift
-    key="$1" ; shift
-    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
-    eval "echo \"\$${user_prefix}_${email_hash}_${key}\""
-}
-
-DEBUG() {
-    if [ -n "$DEBUG" ] ; then
-        echo -n "DEBUG:: "
-        echo "$@"
-    fi
-}
-
-if [ -z "$CDASH_ROOT_ADMIN_PASS" ] ; then
-    cat << ____EOF
-error: This container requires the CDASH_ROOT_ADMIN_PASS
-       environment variable to be defined.
-____EOF
-    exit 1
-fi 1>&2
-
-local_config_file="/var/www/cdash/config/config.local.php"
-
-(
-    echo '<?php'
-    if [ '!' -z ${CDASH_CONFIG+x} ] ; then
-        echo "$CDASH_CONFIG"
-    fi
-) > "$local_config_file"
-
-PORT="$(( (RANDOM % 20000) + 10000 ))"
-sed -i 's/^Listen [0-9][0-9]*/Listen '"$PORT"'/g' /etc/apache2/ports.conf
-sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:'"$PORT"'>/g' \
-    /etc/apache2/sites-enabled/000-default.conf
-echo "\$CDASH_FULL_EMAIL_WHEN_ADDING_USER = '1';" >> "$local_config_file"
-
-/usr/sbin/apache2ctl -D FOREGROUND &
-apache_pid="$!"
-onexit '
-if [ -n "$apache_pid" ] ; then
-    /usr/sbin/apache2ctl graceful-stop
-    wait
-fi'
-
-sleep 10
-
-if [ -z "$CDASH_ROOT_ADMIN_EMAIL" ] ; then
-    CDASH_ROOT_ADMIN_EMAIL="root@docker.container"
-fi
-
-# ENSURE ROOT ADMIN USER
-final_root_pass="$CDASH_ROOT_ADMIN_PASS"
-if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
-    final_root_pass="$CDASH_ROOT_ADMIN_NEW_PASS"
-fi
-
-post - install.php admin_email="$CDASH_ROOT_ADMIN_EMAIL" \
-                   admin_password="$final_root_pass"     \
-                   Submit=Install &> /dev/null
-
-if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
-    root_session="$( mksession )"
-    post "$root_session" user.php login="$CDASH_ROOT_ADMIN_EMAIL" \
-                                  passwd="$final_root_pass"       \
-                                  sent='Login >>'                 \
-        | grep 'Wrong email or password'                          \
-        | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
-
-    if [ "$?" '!=' '0' -a \
-         "$CDASH_ROOT_ADMIN_PASS" '!=' "$final_root_pass" ] ; then
-
-        # login failure
-        post "$root_session" user.php login="$CDASH_ROOT_ADMIN_EMAIL" \
-                                      passwd="$CDASH_ROOT_ADMIN_PASS" \
-                                      sent='Login >>'                 \
-            | grep 'Wrong email or password'                          \
-            | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
-
-        if [ "$?" '=' '0' ] ; then
-            post "$root_session" editUser.php      \
-                oldpasswd="$CDASH_ROOT_ADMIN_PASS" \
-                passwd="$final_root_pass"          \
-                passwd2="$final_root_pass"         \
-                updatepassword='Update Password' &> /dev/null
-        else
+        if [ "$?" '!=' '0' ] ; then
             echo "Warning: could not log in as the root admin user:" \
                  "Wrong email or password" >&2
-            root_login_failed=1
+            return 1
         fi
-    fi
-fi
 
-if [ "$root_login_failed" '!=' '1' ] ; then
-    declare -a users_list
-    if [ '!' -z ${CDASH_STATIC_USERS+x} ] ; then
-        ensure_tmp
-        mkfifo "$tmpdir/fifo"
-        eval "exec 3<>$tmpdir/fifo"
-        unlink "$tmpdir/fifo"
+        if cdash_password_index 1 ; then
+            cdash_change_password            \
+                "$CDASH_ROOT_ADMIN_PASS"     \
+                "$CDASH_ROOT_ADMIN_NEW_PASS"
+        fi
 
-        echo "$CDASH_STATIC_USERS" >&3
-        echo EOF >&3
+        declare -a users_list
+        if [ '!' -z ${CDASH_STATIC_USERS+x} ] ; then
+            tmp_dir tmpdir
+            mkfifo "$tmpdir/fifo"
+            eval "exec 3<>$tmpdir/fifo"
+            unlink "$tmpdir/fifo"
 
-        oldifs="$IFS"
-        IFS=$'\n'
+            echo "$CDASH_STATIC_USERS" >&3
+            echo EOF >&3
 
-        while read -u 3 line ; do
-            processed_line="$( echo "$line" |
-                     sed $'s/\t\t*/ /g' | sed 's/  */ /g' | sed 's/#.*//g')"
+            oldifs="$IFS"
+            IFS=$'\n'
 
-            if [ "$processed_line" '=' 'EOF' ] ; then
-                break
-            fi
+            while read -u 3 line ; do
+                processed_line="$( echo "$line" |
+                         sed $'s/\t\t*/ /g' |
+                         sed 's/  */ /g' | sed 's/#.*//g')"
 
-            if [ -z "$( echo "$processed_line" | sed $'s/[ \t]*//g' )" ] ; then
-                DEBUG "SKIPPING LINE"
-                DEBUG "[$line]"
-                continue
-            fi
+                if [ "$processed_line" '=' 'EOF' ] ; then
+                    break
+                fi
 
-            eval "entry=($processed_line)"
-            _disp=
-            _email=
-            _pass=
-            _newpass=
+                if [ -z "$( echo "$processed_line" | sed $'s/[ \t]*//g' )" ]
+                then
+                    debug "SKIPPING LINE"
+                    debug "[$line]"
+                    continue
+                fi
 
-            if [ "${entry[0]}" '=' 'USER'   -o \
-                 "${entry[0]}" '=' 'ADMIN'  -o \
-                 "${entry[0]}" '=' 'DELETE' ] ; then
+                eval "entry=($processed_line)"
+                _disp=
+                _email=
+                _pass=
+                _newpass=
 
-                # explicit user entry line
-                _disp="${entry[0]}"
-                _email="${entry[1]}"
-                _pass="${entry[2]}"
-                _newpass="${entry[3]}"
-                parsed_user=1
+                if [ "${entry[0]}" '=' 'USER'   -o \
+                     "${entry[0]}" '=' 'ADMIN'  -o \
+                     "${entry[0]}" '=' 'DELETE' ] ; then
 
-            elif [ "${entry[0]}" '!=' "${entry[0]/@*}" ] ; then
-                # implicit user entry line
-                _disp=USER
-                _email="${entry[0]}"
-                _pass="${entry[1]}"
-                _newpass="${entry[2]}"
-                parsed_user=1
+                    # explicit user entry line
+                    _disp="${entry[0]}"
+                    _email="${entry[1]}"
+                    _pass="${entry[2]}"
+                    _newpass="${entry[3]}"
+                    parsed_user=1
 
-            elif [ "${entry[0]}" '=' 'INFO' ] ; then
-                # explicit user info line
-                first="${entry[1]}"
-                last="${entry[2]}"
-                institution="${entry[3]}"
-                parsed_user=0
+                elif [ "${entry[0]}" '!=' "${entry[0]/@*}" ] ; then
+                    # implicit user entry line
+                    _disp=USER
+                    _email="${entry[0]}"
+                    _pass="${entry[1]}"
+                    _newpass="${entry[2]}"
+                    parsed_user=1
 
-            else
-                # implicit user info line
-                first="${entry[0]}"
-                last="${entry[1]}"
-                institution="${entry[2]}"
-                parsed_user=0
-            fi
+                elif [ "${entry[0]}" '=' 'INFO' ] ; then
+                    # explicit user info line
+                    first="${entry[1]}"
+                    last="${entry[2]}"
+                    institution="${entry[3]}"
+                    parsed_user=0
+
+                else
+                    # implicit user info line
+                    first="${entry[0]}"
+                    last="${entry[1]}"
+                    institution="${entry[2]}"
+                    parsed_user=0
+                fi
+
+                if [ -n "$email" ] ; then
+                    user_set "$email" disp "$disp"
+                    user_set "$email" pass "$pass"
+                    user_set "$email" newpass "$newpass"
+
+                    if [ "$parsed_user" '=' '0' ] ; then
+                        user_set "$email" first "$first"
+                        user_set "$email" last "$last"
+                        user_set "$email" institution "$institution"
+                    fi
+
+                    if [ "$( user_get "$email" listed )" '!=' 1 ] ; then
+                        users_list[${#users_list[@]}]="$email"
+                        user_set "$email" listed 1
+                    fi
+                fi
+
+                email="$_email"
+                disp="$_disp"
+                pass="$_pass"
+                newpass="$_newpass"
+
+                if debug ; then
+                    if [ "$parsed_user" '=' '0' ] ; then
+                        debug "PARSED USER INFO"
+                        debug "  First Name:  |$first|"
+                        debug "  Last Name:   |$last|"
+                        debug "  Institution: |$institution|"
+                    else
+                        debug "PARSED USER ENTRY"
+                        debug "  email:        |$email|"
+                        debug "  disposition:  |$disp|"
+                        debug "  password:     |$pass|"
+                        debug "  new password: |$newpass|"
+                    fi
+                fi
+            done
 
             if [ -n "$email" ] ; then
                 user_set "$email" disp "$disp"
                 user_set "$email" pass "$pass"
                 user_set "$email" newpass "$newpass"
-
-                if [ "$parsed_user" '=' '0' ] ; then
-                    user_set "$email" first "$first"
-                    user_set "$email" last "$last"
-                    user_set "$email" institution "$institution"
-                fi
 
                 if [ "$( user_get "$email" listed )" '!=' 1 ] ; then
                     users_list[${#users_list[@]}]="$email"
@@ -299,46 +145,49 @@ if [ "$root_login_failed" '!=' '1' ] ; then
                 fi
             fi
 
-            email="$_email"
-            disp="$_disp"
-            pass="$_pass"
-            newpass="$_newpass"
-
-            if [ -n "$DEBUG" ] ; then
-                if [ "$parsed_user" '=' '0' ] ; then
-                    DEBUG "PARSED USER INFO"
-                    DEBUG "  First Name:  |$first|"
-                    DEBUG "  Last Name:   |$last|"
-                    DEBUG "  Institution: |$institution|"
-                else
-                    DEBUG "PARSED USER ENTRY"
-                    DEBUG "  email:        |$email|"
-                    DEBUG "  disposition:  |$disp|"
-                    DEBUG "  password:     |$pass|"
-                    DEBUG "  new password: |$newpass|"
-                fi
-            fi
-        done
-
-        if [ -n "$email" ] ; then
-            user_set "$email" disp "$disp"
-            user_set "$email" pass "$pass"
-            user_set "$email" newpass "$newpass"
-
-            if [ "$( user_get "$email" listed )" '!=' 1 ] ; then
-                users_list[${#users_list[@]}]="$email"
-                user_set "$email" listed 1
-            fi
+            exec 3<&-
+            IFS="$oldifs"
         fi
 
-        exec 3<&-
-        IFS="$oldifs"
-    fi
+        debug "BEGIN DUMP OF USER TABLE"
+        if debug ; then
+            for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
+                email="${users_list[$i]}"
 
-    DEBUG "BEGIN DUMP OF USER TABLE"
-    if [ -n "$DEBUG" ] ; then
+                for tuple in "disp" "pass" "newpass" "first:NONE" \
+                             "last:NONE" "institution:NONE" ; do
+                    fragment="${tuple/:*}"
+                    tuple="${tuple:$(( ${#fragment} + 1 ))}"
+                    param="$fragment"
+                    fragment="${tuple/:*}"
+                    tuple="${tuple:$(( ${#fragment} + 1 ))}"
+                    default="$fragment"
+
+                    value="$( user_get "$email" "$param" )"
+                    if [ -z "$value" -a -n "$default" ] ; then
+                        value="$default"
+                    fi
+                    eval "${param}=\"$value\""
+                done
+                debug "$i:"
+                debug "  $email"
+                debug "  disposition: $disp"
+                debug "  password: $pass"
+                debug "  new pass: $newpass"
+                debug "  First Name: $first"
+                debug "  Last Name: $last"
+                debug "  Institution: $institution"
+            done
+        fi
+
         for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
             email="${users_list[$i]}"
+            if [ "$email" '=' 'root' ] ; then
+                echo 'Warning: refusing to modify the root admin account!' \
+                     "Use the CDASH_ROOT_ADMIN_NEW_PASS environment variable" \
+                     "to update the root account password." >&2
+                continue
+            fi
 
             for tuple in "disp" "pass" "newpass" "first:NONE" \
                          "last:NONE" "institution:NONE" ; do
@@ -355,204 +204,258 @@ if [ "$root_login_failed" '!=' '1' ] ; then
                 fi
                 eval "${param}=\"$value\""
             done
-            DEBUG "$i:"
-            DEBUG "  $email"
-            DEBUG "  disposition: $disp"
-            DEBUG "  password: $pass"
-            DEBUG "  new pass: $newpass"
-            DEBUG "  First Name: $first"
-            DEBUG "  Last Name: $last"
-            DEBUG "  Institution: $institution"
-        done
-    fi
 
-    for (( i=0; i < ${#users_list[@]} ; ++i )) ; do
-        email="${users_list[$i]}"
-        if [ "$email" '=' 'root' ] ; then
-            echo 'Warning: refusing to modify the root admin account!' \
-                 "Use the CDASH_ROOT_ADMIN_NEW_PASS environment variable" \
-                 "to update the root account password." >&2
-            continue
-        fi
+            user_id="$( cdash_find_user "$email" )"
 
-        if [ -z "$root_session" ] ; then
-            root_session="$( mksession )"
+            if [ "$disp" '=' 'DELETE' ] ; then
+                # REMOVE USER
+                debug "REMOVING USER: $email"
+                if [ -n "$user_id" ] ; then
+                    cdash_remove_user "$user_id"
+                else
+                    echo "Warning: could not remove user" \
+                         "$email: user not found" >&2
+                fi
 
-            # LOGIN AS ROOT ADMIN USER
-            post "$root_session" user.php           \
-                    login="$CDASH_ROOT_ADMIN_EMAIL" \
-                    passwd="$final_root_pass"       \
-                    sent='Login >>'                 \
-                | grep 'Wrong email or password'    \
-                | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
-
-            if [ "$?" '!=' '0' ] ; then
-                echo "Warning: could not log in as the root admin user:" \
-                     "Wrong email or password" >&2
-                break
-            fi
-        fi
-
-        for tuple in "disp" "pass" "newpass" "first:NONE" \
-                     "last:NONE" "institution:NONE" ; do
-            fragment="${tuple/:*}"
-            tuple="${tuple:$(( ${#fragment} + 1 ))}"
-            param="$fragment"
-            fragment="${tuple/:*}"
-            tuple="${tuple:$(( ${#fragment} + 1 ))}"
-            default="$fragment"
-
-            value="$( user_get "$email" "$param" )"
-            if [ -z "$value" -a -n "$default" ] ; then
-                value="$default"
-            fi
-            eval "${param}=\"$value\""
-        done
-
-        ids=($(                                                    \
-            get "$root_session" ajax/findusers.php search="$email" \
-                | grep '<input'                                    \
-                | grep 'name="userid"'                             \
-                | grep 'type="hidden"'                             \
-                | sed 's/..*value="\([0-9][0-9]*\)"..*/\1/g'))
-
-        user_id="${ids[0]}"
-
-        if [ "$disp" '=' 'DELETE' ] ; then
-            # REMOVE USER
-            DEBUG "REMOVING USER: $email"
-            if [ -n "$user_id" ] ; then
-                post "$root_session" manageUsers.php          \
-                                     userid="$user_id"        \
-                                     removeuser="remove user" &> /dev/null
-            else
-                echo "Warning: could not remove user" \
-                     "$email: user not found" >&2
-            fi
-
-            continue
-        fi
-
-        final_pass="$pass"
-        if [ -n "$newpass" ] ; then
-            final_pass="$newpass"
-        fi
-
-        login_pass="$pass"
-
-        if [ -z "$user_id" ] ; then
-            login_pass="$final_pass"
-
-            # CREATE USER
-            DEBUG "CREATING USER: $email"
-            post "$root_session" manageUsers.php             \
-                                  fname="$first"             \
-                                  lname="$last"              \
-                                  email="$email"             \
-                                  passwd="$final_pass"       \
-                                  passwd2="$final_pass"      \
-                                  institution="$institution" \
-                                  adduser='Add user >>' &> /dev/null
-
-            ids=($(                                                    \
-                get "$root_session" ajax/findusers.php search="$email" \
-                    | grep '<input'                                    \
-                    | grep 'name="userid"'                             \
-                    | grep 'type="hidden"'                             \
-                    | sed 's/..*value="\([0-9][0-9]*\)"..*/\1/g'))
-
-            user_id="${ids[0]}"
-
-            if [ -z "$user_id" ] ; then
-                echo "Warning: unable to create user account" \
-                     "$email: unknown error" >&2
                 continue
             fi
-         fi
 
-         if [ "$disp" '=' 'ADMIN' ] ; then
-             DEBUG "PROMOTING USER: $email"
-             post "$root_session" manageUsers.php        \
-                                  userid="$user_id"      \
-                                  makeadmin="make admin" &> /dev/null
-         fi
-
-         if [ "$disp" '=' 'USER' ] ; then
-             DEBUG "DEMOTING USER: $email"
-             post "$root_session" manageUsers.php                   \
-                                  userid="$user_id"                 \
-                                  makenormaluser="make normal user" \
-                                  &> /dev/null
-         fi
-
-        user_session="$( mksession )"
-
-        # LOGIN AS NORMAL USER
-        login_success=0
-        DEBUG "LOGGING IN AS USER: $email"
-        post "$user_session" user.php login="$email"        \
-                                      passwd="$login_pass"  \
-                                      sent='Login >>'       \
-            | grep 'Wrong email or password'                \
-            | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
-
-        if [ "$?" '=' '0' ] ; then # login success
-            login_success=1
-        elif [ "$login_pass" '!=' "$newpass" ] ; then # login failure
-            login_pass="$newpass"
-            DEBUG "LOGGING IN (FALLBACK) AS USER: $email"
-            post "$user_session" user.php login="$email"        \
-                                          passwd="$login_pass"  \
-                                          sent='Login >>'       \
-                | grep 'Wrong email or password'                \
-                | ( read X ; DEBUG "|$X|" ; [ -z "$X" ] )
-
-            if [ "$?" '=' '0' ] ; then
-                login_success=1
+            final_pass="$pass"
+            if [ -n "$newpass" ] ; then
+                final_pass="$newpass"
             fi
-        fi
 
-        if [ "$login_success" '=' '0' ] ; then
-            echo "Warning: could not log in as user" \
-                 "$email: Wrong email or password" >&2
-            continue
-        fi
+            login_pass="$pass"
 
-        DEBUG "UPDATING USER PROFILE: $email"
-        post "$user_session" editUser.php fname="$first"                 \
-                                          lname="$last"                  \
-                                          email="$email"                 \
-                                          institution="$institution"     \
-                                          updateprofile='Update Profile' \
-                                          &> /dev/null
+            if [ -z "$user_id" ] ; then
+                login_pass="$final_pass"
 
-        if [ -n "$newpass" -a "$login_pass" '!=' "$newpass" ] ; then
-            # update user's password
-            DEBUG "UPDATING USER PASSWORD: $email"
-            post "$user_session" editUser.php    \
-                oldpasswd="$login_pass"          \
-                passwd="$newpass"                \
-                passwd2="$newpass"               \
-                updatepassword='Update Password' &> /dev/null
-        fi
+                # CREATE USER
+                debug "CREATING USER: $email"
+                user_id="$(                       \
+                    cdash_add_user                \
+                        "$first" "$last" "$email" \
+                        "$final_pass" "$institution" )"
 
-        get "$user_session" user.php logout=1 &> /dev/null
-    done
+                if [ -z "$user_id" ] ; then
+                    echo "Warning: unable to create user account" \
+                         "$email: unknown error" >&2
+                    continue
+                fi
+            fi
 
-    get "$root_session" user.php logout=1 &> /dev/null
+            if [ "$disp" '=' 'ADMIN' ] ; then
+                debug "PROMOTING USER: $email"
+                cdash_promote_user "$user_id"
+            fi
+
+            if [ "$disp" '=' 'USER' ] ; then
+                debug "DEMOTING USER: $email"
+                cdash_demote_user "$user_id"
+            fi
+
+            (
+                # LOGIN AS NORMAL USER
+                debug "LOGGING IN AS USER: $email"
+                cdash_session "$email" "$login_pass" "$newpass"
+                login_success=$?
+
+                if [ "$login_success" '!=' '0' ] ; then
+                    echo "Warning: could not log in as user" \
+                         "$email: Wrong email or password" >&2
+                    continue
+                fi
+
+                debug "UPDATING USER PROFILE: $email"
+                cdash_update_profile "$first" "$last" "$email" "$institution"
+
+                if cdash_password_index 1 ; then
+                    # update user's password
+                    debug "UPDATING USER PASSWORD: $email"
+                    cdash_change_password "$login_pass" "$newpass"
+                fi
+            )
+        done
+    )
+}
+
+do_install() {
+    local_service_setup
+
+    # ENSURE ROOT ADMIN USER
+    root_pass="$CDASH_ROOT_ADMIN_PASS"
+    if [ -n "$CDASH_ROOT_ADMIN_NEW_PASS" ] ; then
+        root_pass="$CDASH_ROOT_ADMIN_NEW_PASS"
+    fi
+
+    session="$( web_make_session )"
+    cdash_install "$session" "$CDASH_ROOT_ADMIN_EMAIL" \
+        "$root_pass"
+}
+
+do_install=0
+do_upgrade=0
+do_configure=0
+do_fix_build_groups=0
+do_check_builds_for_wrong_date=0
+do_delete_builds_with_wrong_date=0
+do_compute_timing=0
+do_update_stats=0
+do_compress=0
+do_cleanup=0
+do_serve=0
+
+timing_days=4
+stat_days=4
+
+local_service_needed=0
+
+args_provided=0
+
+while [ -n "$*" ] ; do
+    args_provided=1
+
+    case "$1" in
+        install)
+            do_install=1
+            local_service_needed=1
+            ;;
+        upgrade)
+            do_upgrade=1
+            local_service_needed=1
+            ;;
+        configure)
+            do_configure=1
+            local_service_needed=1
+            ;;
+        fix-build-groups)
+            do_fix_build_groups=1
+            local_service_needed=1
+            ;;
+        check-builds-for-wrong-date)
+            do_check_builds_for_wrong_date=1
+            local_service_needed=1
+            ;;
+        delete-builds-with-wrong-date)
+            do_delete_builds_with_wrong_date=1
+            local_service_needed=1
+            ;;
+        compute-timing*)
+            frag="$1"
+            frag="${frag:14}"
+            if [ -z "$frag" ] ||
+               [ "${frag::1}" '=' ':' -a -n "${frag:2}" ]
+            then
+                timing_days=4
+                if [ -n "$frag" ] ; then
+                    timing_days="${frag:2}"
+                fi
+
+                do_compute_timing=1
+                local_service_needed=1
+            fi
+            ;;
+        update-stats*)
+            frag="$1"
+            frag="${frag:12}"
+            if [ -z "$frag" ] ||
+               [ "${frag::1}" '=' ':' -a -n "${frag:2}" ]
+            then
+                stat_days=4
+                if [ -n "$frag" ] ; then
+                    stat_days="${frag:2}"
+                fi
+
+                do_update_stats=1
+                local_service_needed=1
+            fi
+            ;;
+        compress)
+            do_compress=1
+            local_service_needed=1
+            ;;
+        cleanup)
+            do_cleanup=1
+            local_service_needed=1
+            ;;
+        serve)
+            do_serve=1
+            ;;
+    esac
+    shift
+done
+
+if [ "$args_provided" '=' '0' ] ; then
+    do_serve=1
 fi
 
-/usr/sbin/apache2ctl graceful-stop
-unset apache_pid
-wait
-sleep 10
+if missing_root_admin_pass ; then
+    exit 1
+fi
 
-sed -i 's/^Listen [0-9][0-9]*/Listen 80/g' /etc/apache2/ports.conf
-sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:80>/g' \
-    /etc/apache2/sites-enabled/000-default.conf
-tmp="$( mktemp )"
-head -n -1 "$local_config_file" > "$tmp"
-cat "$tmp" > "$local_config_file"
-rm "$tmp"
+setup_local_config
 
-EXEC /usr/sbin/apache2ctl -D FOREGROUND
+if [ -z "$CDASH_ROOT_ADMIN_EMAIL" ] ; then
+    CDASH_ROOT_ADMIN_EMAIL="root@docker.container"
+fi
+
+if [ "$local_service_needed" '=' '1' ] ; then
+    local_service_setup
+fi
+
+if [ "$do_install" '=' '1' ] ; then
+    do_install
+fi
+
+if [ "$local_service_needed" '=' '1' ] ; then
+    cdash_session "$CDASH_ROOT_ADMIN_EMAIL" \
+            "$CDASH_ROOT_ADMIN_PASS"        \
+            "$CDASH_ROOT_ADMIN_NEW_PASS"
+fi
+
+if [ "$do_upgrade" '=' '1' ] ; then
+    cdash_upgrade
+fi
+
+if [ "$do_configure" '=' '1' ] ; then
+    do_configure
+fi
+
+if [ "$do_fix_build_groups" '=' '1' ] ; then
+    cdash_fix_build_groups
+fi
+
+if [ "$do_check_builds_for_wrong_date" '=' '1' ] ; then
+    cdash_check_builds_with_wrong_date
+fi
+
+if [ "$do_delete_builds_with_wrong_date" '=' '1' ] ; then
+    cdash_delete_builds_with_wrong_date
+fi
+
+if [ "$do_compute_timing" '=' '1' ] ; then
+    cdash_compute_test_timing "$timing_days"
+fi
+
+if [ "$do_update_stats" '=' '1' ] ; then
+    cdash_update_statistics "$stat_days"
+fi
+
+if [ "$do_compress" '=' '1' ] ; then
+    cdash_compress_test_output
+fi
+
+if [ "$do_cleanup" '=' '1' ] ; then
+    cdash_cleanup_database
+fi
+
+if [ "$local_service_needed" '=' '1' ] ; then
+    local_service_teardown
+fi
+
+if [ "$do_serve" '!=' '1' ] ; then
+    exit
+fi
+
+# serve
+exec /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -293,6 +293,69 @@ do_install() {
         "$root_pass"
 }
 
+usage() {
+    echo "Usage: $0 [OPTIONS]... [COMMANDS]..."
+    echo "Run various CDash operations."
+    echo ""
+
+    echo "OPTIONS"
+    echo ""
+    echo "  -v, --verbose enable more verbose logging"
+    echo "  -h, --help    display this help and exit"
+    echo ""
+
+    echo "COMMANDS"
+    echo ""
+
+    echo "  install"
+    echo "      run CDash's initial install process (install.php)."
+    echo ""
+
+    echo "  upgrade"
+    echo "      upgrade database schema"
+    echo ""
+
+    echo "  configure"
+    echo "      update local configuration and manage static users"
+    echo ""
+
+    echo "  fix-build-groups"
+    echo "      fix build groups based on build rules"
+    echo ""
+
+    echo "  check-builds-for-wrong-date"
+    echo "      check CDash for builds with wrong start dates"
+    echo ""
+
+    echo "  delete-builds-with-wrong-date"
+    echo "      delete CDash builds with wrong start dates"
+    echo ""
+
+    echo "  compute-timing[:N]"
+    echo "      compute test timing for the last N days (default: 4)"
+    echo ""
+
+    echo "  update-stats[:N]"
+    echo "      compute updated statistics for last N days (default: 4)"
+    echo ""
+
+    echo "  compress"
+    echo "      compress test output"
+    echo ""
+
+    echo "  cleanup"
+    echo "      run CDash's database cleanup process"
+    echo ""
+
+    echo "  serve"
+    echo "      serve web traffic (default operation)"
+    echo ""
+
+    echo "  help"
+    echo "      display this help and exit"
+    echo ""
+}
+
 do_install=0
 do_upgrade=0
 do_configure=0
@@ -380,6 +443,24 @@ while [ -n "$*" ] ; do
             ;;
         serve)
             do_serve=1
+            ;;
+        -v)
+            export DEBUG=1
+            ;;
+        --verbose)
+            export DEBUG=1
+            ;;
+        -h)
+            usage
+            exit
+            ;;
+        --help)
+            usage
+            exit
+            ;;
+        help)
+            usage
+            exit
             ;;
     esac
     shift

--- a/scripts/bash/cdash.bash
+++ b/scripts/bash/cdash.bash
@@ -1,0 +1,291 @@
+if [ -z "$__bash_lib_cdash" ] ; then
+__bash_lib_cdash=1
+
+
+source "$BASH_LIB/debug.bash"
+source "$BASH_LIB/on_exit.bash"
+source "$BASH_LIB/web.bash"
+
+
+__cdash_session_host=
+__cdash_session=
+__cdash_password_index=
+
+# poor man's CDash web client
+cdash_set_host() {
+    __cdash_session_host="$1"
+}
+
+cdash_session() {
+    local login
+    local pass
+    local result
+    local counter
+
+    login="$1" ; shift
+
+    __cdash_session="$( web_make_session )"
+
+    result=1
+    counter=-1
+
+    while [ -n "$*" ] ; do
+        counter="$(( counter + 1 ))"
+        pass="$1" ; shift
+
+        web_post        "${__cdash_session}"               \
+                        "${__cdash_session_host}/user.php" \
+                login="$login"                             \
+                passwd="$pass"                             \
+                sent='Login >>'                            \
+            | grep 'Wrong email or password'               \
+            | ( read X ; debug "|$X|" ; [ -z "$X" ] )
+
+        if [ "$?" '=' '0' ] ; then
+            __cdash_password_index="$counter"
+            on_exit __cdash_logout
+            return
+        fi
+    done
+
+    __cdash_password_index="-1"
+    return $result
+}
+
+cdash_password_index() {
+    [ "${__cdash_password_index}" '=' "$1" ]
+    return $?
+}
+
+__cdash_logout() {
+    web_get     "${__cdash_session}"               \
+                "${__cdash_session_host}/user.php" \
+            logout=1 &> /dev/null
+    return $?
+}
+
+cdash_change_password() {
+    local old_pass
+    local new_pass
+
+    old_pass="$1" ; shift
+    new_pass="$1"
+
+    web_post    "${__cdash_session}"                   \
+                "${__cdash_session_host}/editUser.php" \
+        oldpasswd="$old_pass"                          \
+        passwd="$new_pass"                             \
+        passwd2="$new_pass"                            \
+        updatepassword='Update Password' &> /dev/null
+
+    return $?
+}
+
+cdash_update_profile() {
+    local first_name
+    local last_name
+    local email
+    local institution
+
+    first_name="$1" ; shift
+    last_name="$1" ; shift
+    email="$1" ; shift
+    institution="$1"
+
+    web_post    "${__cdash_session}"                   \
+                "${__cdash_session_host}/editUser.php" \
+        fname="$first_name"                            \
+        lname="$last_name"                             \
+        email="$email"                                 \
+        institution="$institution"                     \
+        updateprofile='Update Profile' &> /dev/null
+
+    return $?
+}
+
+cdash_remove_user() {
+    local user_id
+
+    user_id="$1" ; shift
+
+    web_post    "${__cdash_session}"                      \
+                "${__cdash_session_host}/manageUsers.php" \
+        userid="$user_id"                                 \
+        removeuser="remove user" &> /dev/null
+}
+
+cdash_find_user() {
+    local email
+
+    email="$1" ; shift
+
+    ids=($(                                                      \
+        web_get     "${__cdash_session}"                         \
+                    "${__cdash_session_host}/ajax/findusers.php" \
+            search="$email"                                      \
+        | grep '<input'                                          \
+        | grep 'name="userid"'                                   \
+        | grep 'type="hidden"'                                   \
+        | sed 's/..*value="\([0-9][0-9]*\)"..*/\1/g'))
+
+    echo "${ids[0]}"
+    [ -n "${ids[0]}" ]
+    return $?
+}
+
+cdash_add_user() {
+    local first_name
+    local last_name
+    local email
+    local pass
+    local institution
+    local ids
+
+    first_name="$1" ; shift
+    last_name="$1" ; shift
+    email="$1" ; shift
+    pass="$1" ; shift
+    institution="$1"
+
+    web_post    "${__cdash_session}"                      \
+                "${__cdash_session_host}/manageUsers.php" \
+        fname="$first_name"                               \
+        lname="$last_name"                                \
+        email="$email"                                    \
+        passwd="$pass"                                    \
+        passwd2="$pass"                                   \
+        institution="$institution"                        \
+        adduser='Add user >>' &> /dev/null
+
+    cdash_find_user "$email"
+    return $?
+}
+
+cdash_promote_user() {
+    local user_id
+
+    user_id="$1" ; shift
+
+    web_post    "${__cdash_session}"                      \
+                "${__cdash_session_host}/manageUsers.php" \
+        userid="$user_id"                                 \
+        makeadmin="make admin" &> /dev/null
+
+    return $?
+}
+
+cdash_demote_user() {
+    local user_id
+
+    user_id="$1" ; shift
+
+    web_post    "${__cdash_session}"                      \
+                "${__cdash_session_host}/manageUsers.php" \
+        userid="$user_id"                                 \
+        makenormaluser="make normal user" &> /dev/null
+
+    return $?
+}
+
+cdash_install() {
+    local session
+    local admin_email
+    local admin_pass
+
+    session="$1" ; shift
+    admin_email="$1" ; shift
+    admin_pass="$1" ; shift
+
+    web_post    "${session}"                          \
+                "${__cdash_session_host}/install.php" \
+        admin_email="$admin_email"                    \
+        admin_password="$admin_pass"                  \
+        Submit=Install &> /dev/null
+
+    return $?
+}
+
+cdash_upgrade() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        Upgrade="Upgrade CDash" &> /dev/null
+
+    return $?
+}
+
+cdash_fix_build_groups() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        FixBuildBasedOnRule="Fix build groups" &> /dev/null
+
+    return $?
+}
+
+cdash_check_builds_for_wrong_date() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        CheckBuildsWrongDate="Check builds" &> /dev/null
+
+    return $?
+}
+
+cdash_delete_builds_with_wrong_date() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        DeleteBuildsWrongDate="Delete builds" &> /dev/null
+
+    return $?
+}
+
+cdash_compute_test_timing() {
+    local num_days
+
+    num_days="$1" ; shift
+
+    if [ -z "$num_days" ] ; then
+        num_days=4
+    fi
+
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        TestTimingDays="$num_days"                    \
+        ComputeTestTiming="Compute test timing" &> /dev/null
+
+    return $?
+}
+
+cdash_update_statistics() {
+    local num_days
+
+    num_days="$1" ; shift
+
+    if [ -z "$num_days" ] ; then
+        num_days=4
+    fi
+
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        UpdateStatisticsDays="$num_days"              \
+        ComputeUpdateStatistics="Compute update statistics" &> /dev/null
+
+    return $?
+}
+
+cdash_compress_test_output() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        CompressTestOutput="Compress test output" &> /dev/null
+
+    return $?
+}
+
+cdash_cleanup_database() {
+    web_post    "${__cdash_session}"                  \
+                "${__cdash_session_host}/upgrade.php" \
+        Cleanup="Cleanup database" &> /dev/null
+
+    return $?
+}
+
+
+fi # __bash_lib_cdash

--- a/scripts/bash/debug.bash
+++ b/scripts/bash/debug.bash
@@ -1,0 +1,18 @@
+if [ -z "$__bash_lib_debug" ] ; then
+__bash_lib_debug=1
+
+
+debug() {
+    if [ -z "$*" ] ; then
+        [ -n "$DEBUG" ]
+        return $?
+    fi
+
+    if debug ; then
+        echo -n "DEBUG:: "
+        echo "$@"
+    fi
+}
+
+
+fi # __bash_lib_debug

--- a/scripts/bash/misc.bash
+++ b/scripts/bash/misc.bash
@@ -1,0 +1,95 @@
+if [ -z "$__bash_lib_misc" ] ; then
+__bash_lib_misc=1
+
+
+source "$BASH_LIB/cdash.bash"
+source "$BASH_LIB/on_exit.bash"
+
+
+__local_config_file="/var/www/cdash/config/config.local.php"
+
+missing_root_admin_pass() {
+    if [ -z "$CDASH_ROOT_ADMIN_PASS" ] ; then
+        echo "error: This container requires the CDASH_ROOT_ADMIN_PASS"
+        echo "       environment variable to be defined."
+        return
+    fi >&2
+    return 1
+}
+
+__local_service_setup=0
+__apache_pid=
+local_service_setup() {
+    if [ "$__local_service_setup" '=' '1' ] ; then
+        return
+    fi
+
+    PORT="$(( (RANDOM % 20000) + 10000 ))"
+    sed -i 's/^Listen [0-9][0-9]*/Listen '"$PORT"'/g' /etc/apache2/ports.conf
+    sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:'"$PORT"'>/g' \
+        /etc/apache2/sites-enabled/000-default.conf
+    echo "\$CDASH_FULL_EMAIL_WHEN_ADDING_USER = '1';" >> "$__local_config_file"
+
+    /usr/sbin/apache2ctl -D FOREGROUND &
+    __apache_pid="$!"
+
+    on_exit local_service_teardown
+    __local_service_setup=1
+
+    cdash_set_host "http://localhost:$PORT"
+
+    sleep 2
+}
+
+setup_local_config() {
+    (
+        echo '<?php'
+        if [ '!' -z ${CDASH_CONFIG+x} ] ; then
+            echo "$CDASH_CONFIG"
+        fi
+    ) > "$__local_config_file"
+}
+
+local_service_teardown() {
+    if [ "$__local_service_setup" '=' '0' ] ; then
+        return
+    fi
+
+    if [ -n "$__apache_pid" ] ; then
+        /usr/sbin/apache2ctl graceful-stop
+        wait $__apache_pid
+        __apache_pid=
+        sleep 2
+    fi
+
+    sed -i 's/^Listen [0-9][0-9]*/Listen 80/g' /etc/apache2/ports.conf
+    sed -i 's/^<VirtualHost \*:[0-9][0-9]*>/<VirtualHost \*:80>/g' \
+        /etc/apache2/sites-enabled/000-default.conf
+    tmp="$( mktemp )"
+    head -n -1 "$__local_config_file" > "$tmp"
+    cat "$tmp" > "$__local_config_file"
+    rm "$tmp"
+
+    cdash_set_host ""
+
+    __local_service_setup=0
+}
+
+__user_prefix="__user"
+user_set() {
+    email="$1" ; shift
+    key="$1" ; shift
+    value="$1" ; shift
+    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
+    eval "${__user_prefix}_${email_hash}_${key}=\"${value}\""
+}
+
+user_get() {
+    email="$1" ; shift
+    key="$1" ; shift
+    email_hash="$( echo "$email" | sha1sum | cut -d\  -f 1 )"
+    eval "echo \"\$${__user_prefix}_${email_hash}_${key}\""
+}
+
+
+fi # __bash_lib_misc

--- a/scripts/bash/on_exit.bash
+++ b/scripts/bash/on_exit.bash
@@ -1,0 +1,37 @@
+if [ -z "$__bash_lib_on_exit" ] ; then
+__bash_lib_on_exit=1
+
+
+declare -a __exit_callbacks
+
+on_exit() {
+    __exit_callbacks[${#__exit_callbacks[@]}]="$@"
+}
+
+__exit_wrapper() {
+    if [ -z "$exit_code" ] ; then
+        exit_code="$1"
+        if [ -z "$exit_code" ] ; then
+            exit_code=0
+        fi
+        local n
+        n=${#__exit_callbacks[@]}
+        for ((; n--; )) ; do
+            eval "${__exit_callbacks[$n]}"
+        done
+    fi
+}
+
+__exec_wrapper() {
+    __exit_wrapper 0
+    \exec "$@"
+}
+
+trap "__exit_wrapper 1; \\exit $exit_code" INT TERM QUIT
+trap "__exit_wrapper 0; \\exit $exit_code" EXIT
+
+alias exit='__exit_wrapper ; exit'
+alias exec=__exec_wrapper
+
+
+fi # __bash_lib_on_exit

--- a/scripts/bash/tmp_dir.bash
+++ b/scripts/bash/tmp_dir.bash
@@ -1,0 +1,43 @@
+if [ -z "$__bash_lib_tmp_dir" ] ; then
+__bash_lib_tmp_dir=1
+
+
+source "$BASH_LIB/on_exit.bash"
+
+
+declare -a __tmp_dirs
+
+__clean_tmp_dirs() {
+    local n
+    n=${#__tmp_dirs[@]}
+    for ((; n--; )) ; do
+        rm -rf "${__tmp_dirs[$n]}"
+    done
+}
+
+tmp_dir() {
+    local n
+    n=${#__tmp_dirs[@]}
+
+    if [ "$n" '=' '0' ] ; then
+        on_exit __clean_tmp_dirs
+    fi
+
+    var="$1" ; shift
+
+    if [ -n "$var" -a -n "${!var}" ] ; then
+        return
+    fi
+
+    tmpdir="$( mktemp -d )"
+    __tmp_dirs[${#tmp_dirs[@]}]="$tmpdir"
+
+    if [ -n "$var" ] ; then
+        eval "$var=\"$tmpdir\""
+    else
+        echo "$tmpdir"
+    fi
+}
+
+
+fi # __bash_lib_tmp_dir

--- a/scripts/bash/web.bash
+++ b/scripts/bash/web.bash
@@ -1,0 +1,88 @@
+if [ -z "$__bash_lib_web" ] ; then
+__bash_lib_web=1
+
+
+source "$BASH_LIB/tmp_dir.bash"
+
+
+__sessions_dir=
+__sessions_counter=0
+
+# poor man's web client (using curl)
+web_make_session() {
+    local result
+    tmp_dir __sessions_dir
+    mkdir -p "$__sessions_dir/sessions"
+    until mkdir "$result" 2> /dev/null ; do
+        result="$__sessions_dir/sessions/$__sessions_counter"
+        __sessions_counter="$(( __sessions_counter + 1 ))"
+    done
+    echo "$result"
+}
+
+web_ajax() {
+    local method
+    local session
+    local url
+    local curl_args
+    local arg
+
+    method="$1" ; shift
+    session="$1" ; shift
+    url="$1" ; shift
+
+    if [ "$method" '=' 'POST' ] ; then
+        for arg in "$@" ; do
+            curl_args="$curl_args --form '$arg'"
+        done
+    fi
+
+    local oldcookies
+    local newcookies
+
+    oldcookies="$session/cookies.txt"
+    newcookies="$session/cookies.tmp"
+
+    if [ "$session" '!=' '-' ] ; then
+        if [ -f "$oldcookies" ] ; then
+            curl_args="$curl_args --cookie '$oldcookies'"
+        fi
+        curl_args="$curl_args --cookie-jar '$newcookies'"
+    fi
+
+    curl_args="$curl_args '${url}"
+
+    if [ "$method" '=' 'GET' ] ; then
+        arg="$1" ; shift
+        if [ -n "$arg" ] ; then
+            curl_args="${curl_args}?$arg"
+        fi
+
+        for arg in "$@" ; do
+            curl_args="${curl_args}&$arg"
+        done
+    fi
+
+    curl_args="${curl_args}'"
+
+    eval "curl $curl_args" 2>&-
+
+    if [ "$session" '!=' '-' ] ; then
+        if [ -f "$newcookies" ] ; then
+            mv "$newcookies" "$oldcookies"
+        fi
+    fi
+
+    sleep 0.2
+}
+
+web_get() {
+    web_ajax GET "$@"
+}
+
+web_post() {
+    web_ajax POST "$@"
+}
+
+
+fi # __bash_lib_web


### PR DESCRIPTION
Reworks the docker entrypoint so that its various operations are now separated.

The container can now be run with any number of the following operations as command-line arguments (where `N` stands for "number of days"):

```
install
upgrade
configure
fix-build-groups
check-builds-for-wrong-date
delete-builds-with-wrong-date
compute-timing:N
update-stats:N
compress
serve
```

The above list is also the order in which the operations are performed, if specified on the command line.

### Demo:

Build and run main services.  `docker-compose up -d --build`

Browse to `localhost:8080`, notice that the `install` procedure has not yet been performed.  By default, the container only serves traffic, now (`docker run ... serve`).

Run a one-shot container that runs the install process, sets up the predefined users, and upgrades the schema (if such an upgrade is available).

```docker-compose run --rm cdash install configure upgrade```

After the container completes, browsing `localhost:8080` should show that the database has been properly initialized.

