### PR TITLE
Fix unsafe:javascript Calendar link

### DIFF
--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -85,7 +85,7 @@
              uib-tooltip="Go back up one level in the hierarchy of results">Up</a>
         </li>
         <li ng-if="::cdash.showcalendar">
-          <a id="cal" href="javascript:;" ng-click="toggleCalendar()">Calendar</a>
+          <a id="cal" href="" ng-click="toggleCalendar()">Calendar</a>
           <span id="date_now" style="display:none;">{{::cdash.date}}</span>
         </li>
         <li ng-if="::!cdash.hidenav">


### PR DESCRIPTION
Some users of our Docker images are reporting that the Calendar link is getting rendered by AngularJS as `href="unsafe:javascript:;"`. Convert it to a blank href instead to keep web browsers happy.