### PR TITLE
Encapsulate where the queue name gets set for Bernard

### DIFF
--- a/app/Middleware/Queue/SubmissionService.php
+++ b/app/Middleware/Queue/SubmissionService.php
@@ -83,7 +83,13 @@ class SubmissionService
             );
             throw new \Exception($message);
         }
-        $name = isset($parameters['queue_name']) ? $parameters['queue_name'] : self::NAME;
+
+        if (array_key_exists('queue_name', $parameters)) {
+            $name = $parameters['queue_name'];
+        } else {
+            $queue_config = Config::getInstance()->load('queue');
+            $name = $queue_config['ctest_submission_queue'];
+        }
         return new PlainMessage($name, $parameters);
     }
 

--- a/include/do_submit.php
+++ b/include/do_submit.php
@@ -335,15 +335,12 @@ function do_submit_queue($filehandle, $projectid, $buildid = null, $expected_md5
         $ip = $_SERVER['REMOTE_ADDR'];
     }
 
-    $queue_config = $config->load('queue');
-    $queue_name = $queue_config['ctest_submission_queue'];
     $message = SubmissionService::createMessage([
         'file'          => $destinationFilename,
         'project'       => $projectid,
         'md5'           => $expected_md5,
         'checksum'      => true,
-        'ip'            => $ip,
-        'queue_name'    => $queue_name
+        'ip'            => $ip
     ]);
     $queue->produce($message);
 


### PR DESCRIPTION
Use the same code path for XML and non-XML submissions.

Also more gracefully handle the (hopefully rare) situation where we attempt to decrement a `pending_submissions` record below zero.