### PR TITLE
Fix potential deadlock when updating userstatistics table

### DIFF
--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -1650,7 +1650,7 @@ class Build
                     nfixedtests=nfixedtests+:nfixedtests,
                     nfailedtests=nfailedtests+:nfailedtests
                     WHERE userid=:userid AND projectid=:projectid AND
-                    checkindate>=:checkindate');
+                    checkindate=:checkindate');
             $stmt->bindParam(':totalbuilds', $totalbuilds);
             $stmt->bindParam(':nfixedwarnings', $nfixedwarnings);
             $stmt->bindParam(':nfailedwarnings', $nfailedwarnings);


### PR DESCRIPTION
We were locking a single row but then attempt to update potentially
more than one. So if two different process obtained locks on different
rows and then tried to update each other it would result in an SQL deadlock.