### PR TITLE
Remove 'use' statements that don't do anything

### DIFF
--- a/tests/case/CDash/DatabaseTest.php
+++ b/tests/case/CDash/DatabaseTest.php
@@ -4,7 +4,6 @@ use CDash\Database;
 use CDash\Config;
 use CDash\Log;
 use CDash\Test\Log as TestLog;
-use PDO;
 
 class DatabaseTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/test_timestatus.php
+++ b/tests/test_timestatus.php
@@ -10,7 +10,6 @@ require_once 'include/pdo.php';
 use CDash\Database;
 use CDash\Test\UseCase\TestUseCase;
 use CDash\Model\Project;
-use PDO;
 
 class TimeStatusTestCase extends KWWebTestCase
 {


### PR DESCRIPTION
'use PDO' outside of a namespace doesn't do anything.
Removing it silences the following warning:

PHP Warning:  The use statement with non-compound name 'PDO' has no effect