### PR TITLE
Bug fix for configureerrordiff

### DIFF
--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -1294,7 +1294,7 @@ class Build
                     $duplicate_sql");
         }
 
-        $stmt->bindValue(':buildid', $previousbuildid);
+        $stmt->bindValue(':buildid', $this->Id);
         $stmt->bindValue(':difference', $warningdiff);
         if (!pdo_execute($stmt)) {
             $this->PDO->rollBack();

--- a/tests/data/ConfigureWarnings/1.xml
+++ b/tests/data/ConfigureWarnings/1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_configure_diffs"
+	BuildStamp="20190117-1833-Experimental"
+	Name="elysium"
+	>
+	<Configure>
+		<StartDateTime>Jan 17 11:33 MST</StartDateTime>
+		<StartConfigureTime>1547750015</StartConfigureTime>
+		<ConfigureCommand>"/usr/bin/cmake"</ConfigureCommand>
+		<Log>-- Configuring done
+-- Generating done
+</Log>
+		<ConfigureStatus>0</ConfigureStatus>
+		<EndDateTime>Jan 17 11:33 MST</EndDateTime>
+		<EndConfigureTime>1547750016</EndConfigureTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Configure>
+</Site>

--- a/tests/data/ConfigureWarnings/2.xml
+++ b/tests/data/ConfigureWarnings/2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_configure_diffs"
+	BuildStamp="20190117-1834-Experimental"
+	Name="elysium"
+	>
+	<Configure>
+		<StartDateTime>Jan 17 11:34 MST</StartDateTime>
+		<StartConfigureTime>1547750075</StartConfigureTime>
+		<ConfigureCommand>"/usr/bin/cmake"</ConfigureCommand>
+		<Log>-- WARNING: here
+-- Configuring done
+-- Generating done
+</Log>
+		<ConfigureStatus>0</ConfigureStatus>
+		<EndDateTime>Jan 17 11:34 MST</EndDateTime>
+		<EndConfigureTime>1547750076</EndConfigureTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Configure>
+</Site>


### PR DESCRIPTION
The difference was getting associated with the previous build when it should be associated with the current build.