### PR TITLE
Improve support for wildcards in buildgroups

### DIFF
--- a/public/api/v1/manageBuildGroup.php
+++ b/public/api/v1/manageBuildGroup.php
@@ -174,6 +174,7 @@ foreach ($buildgroups as $buildgroup) {
             $match = $rule_array['buildname'];
             if (!empty($match)) {
                 $match = trim($match, '%');
+                $match = str_replace('%', '*', $match);
             }
             $rule['match'] = $match;
 
@@ -238,7 +239,8 @@ while ($wildcard_array = pdo_fetch_array($wildcards)) {
     $wildcard_response['buildtype'] = $wildcard_array['buildtype'];
 
     $match = $wildcard_array['buildname'];
-    $match = str_replace('%', '', $match);
+    $match = trim($match, '%');
+    $match = str_replace('%', '*', $match);
     $wildcard_response['match'] = $match;
 
     $wildcards_response[] = $wildcard_response;

--- a/public/views/manageBuildGroup.html
+++ b/public/views/manageBuildGroup.html
@@ -303,7 +303,7 @@
                 <label for="dynamicBuildNameMatch">whose build name contains:</label>
                 <input name="dynamicBuildNameMatch" type="text" ng-model="dynamicBuildNameMatch" size="12" class="form-control"/>
                 <p class="help-block">
-                  Leave blank to ignore this criterion.
+                  Leave blank to ignore this criterion. Use * to match one or more characters.
                 </p>
               </div>
 

--- a/tests/js/e2e_tests/manageBuildGroup.js
+++ b/tests/js/e2e_tests/manageBuildGroup.js
@@ -118,7 +118,7 @@ describe("manageBuildGroup", function() {
     element(by.name('parentBuildGroupSelection')).element(by.cssContainingText('option', 'Experimental')).click();
     var matchField = element(by.name('dynamicBuildNameMatch'));
     matchField.clear();
-    matchField.sendKeys('sameImage');
+    matchField.sendKeys('same*mage');
     element(by.buttonText('Add content to BuildGroup')).click();
     browser.waitForAngular();
 


### PR DESCRIPTION
When defining build groups, allow users to use wildcards to match one or more
characters in the build name.