### PR TITLE
Fix bug where builds were not being assigned their generator

### DIFF
--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -1986,7 +1986,7 @@ class Build
 
         $stmt = $this->PDO->prepare('
             SELECT builderrors, buildwarnings, starttime, endtime,
-            submittime, log, command, parentid, changeid
+            submittime, log, command, generator, parentid, changeid
             FROM build WHERE id = ? FOR UPDATE');
         pdo_execute($stmt, [$buildid]);
         $build = $stmt->fetch();
@@ -2065,6 +2065,12 @@ class Build
         if ($this->PullRequest && $this->PullRequest != $build['changeid']) {
             $clauses[] = 'changeid = ?';
             $params[] = $this->PullRequest;
+        }
+
+        // Check if the build's generator has changed.
+        if ($this->Generator && $this->Generator != $build['generator']) {
+            $clauses[] = 'generator = ?';
+            $params[] = $this->Generator;
         }
 
         $num_clauses = count($clauses);

--- a/tests/data/BatchmakeNightlyExample/BatchMake_Nightly_Update.xml
+++ b/tests/data/BatchmakeNightlyExample/BatchMake_Nightly_Update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Update mode="Client" Generator="ctest-2.6-patch 0">
+<Update mode="Client" Generator="ctest2.6-patch 0">
   <Site>Dash20.kitware</Site>
   <BuildName>Win32-MSVC2009</BuildName>
   <BuildStamp>20090223-0100-Nightly</BuildStamp>

--- a/tests/data/GithubPR/UpdateBug_Test.xml
+++ b/tests/data/GithubPR/UpdateBug_Test.xml
@@ -2,6 +2,7 @@
 <Site BuildName="test_changeid"
 	BuildStamp="20190104-0100-Nightly"
 	Name="elysium"
+	Generator="ctest-3.14.0-rc1"
 	OSName="Linux"
 	Hostname="elysium"
 	ChangeId="555"

--- a/tests/test_changeid.php
+++ b/tests/test_changeid.php
@@ -35,11 +35,14 @@ class ChangeIdTestCase extends KWWebTestCase
 
         // Make sure the build has a changeid associated with it.
         $db = Database::getInstance();
-        $stmt = $db->prepare('SELECT changeid FROM build WHERE projectid = :projectid');
+        $stmt = $db->prepare('SELECT changeid, generator FROM build WHERE projectid = :projectid');
         $db->execute($stmt, [':projectid' => $this->ProjectId]);
-        $changeid = $stmt->fetchColumn();
-        if ($changeid != 555) {
+        $row = $stmt->fetch();
+        if ($row['changeid'] != 555) {
             $this->fail('Expected changeid not found');
+        }
+        if ($row['generator'] != 'ctest-3.14.0-rc1') {
+            $this->fail('Expected generator not found');
         }
         $this->deleteProject($this->ProjectId);
     }


### PR DESCRIPTION
The build is initially created without a generator and is updated
later to include this information.