### PR TITLE
Fix duplicate line output

### DIFF
--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -298,7 +298,7 @@ class GCovTarHandler extends NonSaxHandler
                 $sourceLine = rtrim($fields[2]);
                 
                 //check for duplicate line output
-                if($lineNumber <= $last_lineNumber){
+                if($lineNumber <= $last_lineNumber) {
                     $file->next();
                     continue;
                 }

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -280,7 +280,8 @@ class GCovTarHandler extends NonSaxHandler
 
         $coverageFile->FullPath = trim($path);
         $lineNumber = 0;
-
+        
+        $last_lineNumber = 0;
         // The lack of rewind is intentional.
         while (!$file->eof()) {
             $gcovLine = $file->current();
@@ -295,7 +296,13 @@ class GCovTarHandler extends NonSaxHandler
                 $timesHit = trim($fields[0]);
                 $lineNumber = trim($fields[1]);
                 $sourceLine = rtrim($fields[2]);
-
+                
+                //check for duplicate line output
+                if($lineNumber <= $last_lineNumber){
+                    $file->next();
+                    continue;
+                }
+                
                 if ($lineNumber > 0) {
                     $coverageFile->File .= $sourceLine;
                     // cannot be <br/> for backward compatibility.
@@ -313,6 +320,8 @@ class GCovTarHandler extends NonSaxHandler
                     $timesHit = 0;
                 }
 
+                //save last inserted line number
+                $last_lineNumber = $lineNumber;
                 $coverageFileLog->AddLine($lineNumber - 1, $timesHit);
                 $file->next();
             }

--- a/xml_handlers/GcovTar_handler.php
+++ b/xml_handlers/GcovTar_handler.php
@@ -298,7 +298,7 @@ class GCovTarHandler extends NonSaxHandler
                 $sourceLine = rtrim($fields[2]);
                 
                 //check for duplicate line output
-                if($lineNumber <= $last_lineNumber) {
+                if ($lineNumber <= $last_lineNumber) {
                     $file->next();
                     continue;
                 }


### PR DESCRIPTION
CDash with enabled branch coverage produces multiple versions of output for some lines(e.g.destructors).

**For example:**
```
392*:   37:Something::~Something()
-:   38:{
392*:   39:}
------------------
_ZN12SomethingD0Ev:
#####:   37:Something::~Something()
 -:   38:{
#####:   39:}
------------------
_ZN12SomethingD2Ev:
392:   37:Something::~Something()
-:   38:{      
392:   39:}
```

**Shown as:**
![3krat](https://user-images.githubusercontent.com/47740276/53818938-3f710c00-3f69-11e9-9a06-78a247eb7416.PNG)

Fix this by ensuring that duplicate lines in per-instance gcov output are
correctly ignored. Only the initial occurrence of each line will be processed.

