### PR TITLE
Fix Build History table on buildSummary.php

### DIFF
--- a/public/api/v1/getPreviousBuilds.php
+++ b/public/api/v1/getPreviousBuilds.php
@@ -49,7 +49,7 @@ $stmt = $pdo->prepare(
      WHERE siteid=:siteid AND b.type=:type AND name=:name AND
      projectid=:projectid AND b.starttime<=:starttime
      $subproj_criteria
-     ORDER BY starttime ASC LIMIT 50");
+     ORDER BY starttime DESC LIMIT 50");
 
 $stmt->bindParam(':siteid', $build->SiteId);
 $stmt->bindParam(':type', $build->Type);

--- a/public/js/controllers/buildSummary.js
+++ b/public/js/controllers/buildSummary.js
@@ -122,7 +122,6 @@ CDash.controller('BuildSummaryController',
           history_build['starttime'] = build['starttime'];
           $scope.cdash.buildhistory.push(history_build);
         }
-        $scope.cdash.buildhistory.reverse();
         $scope.graphLoaded = true;
         if (graphType) {
           // Render the graph that triggered this call.


### PR DESCRIPTION
It was mistakenly showing the 50 oldest builds in the series, not
the 50 most recent ones.