### PR TITLE
Fix setup on CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           command: |
             wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+            sudo sed -i '/jessie-updates/d' /etc/apt/sources.list
             sudo apt-get update
             sudo apt-get -y install google-chrome-stable
       - run:


### PR DESCRIPTION
Fix 404 for jessie-updates when running `apt-get update`.