### PR TITLE
Remove extra table cell on buildgroup header

### DIFF
--- a/public/views/partials/buildgroup.html
+++ b/public/views/partials/buildgroup.html
@@ -36,7 +36,6 @@
         <span class="glyphicon" ng-class="buildgroup.orderByFields.indexOf('-buildname') != -1 ? 'glyphicon-chevron-down' : (buildgroup.orderByFields.indexOf('buildname') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
       <td ng-if="::cdash.showorder" align="center" width="5%" class="timeheader botl"></td>
-      <td ng-if="::cdash.childview != 1 && cdash.displaylabels == 1" align="center" width="5%" class="timeheader botl"></td>
     </tr>
 
     <tr class="table-heading">


### PR DESCRIPTION
This cell is only conditionally displayed when we have labels enabled, so we must not have caught it as part of our UI refresh.