### PR TITLE
Added support for ldap over TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,22 @@ FROM php:7.0-apache
 
 LABEL maintainer="Kitware, Inc. <cdash@public.kitware.com>"
 
-RUN apt-get update                                                             \
- && apt-get install -y gnupg                                                   \
- && curl -sL https://deb.nodesource.com/setup_6.x | bash                       \
- && apt-get install -y git libbz2-dev libfreetype6-dev libjpeg62-turbo-dev     \
-    libmcrypt-dev libpng-dev libpq-dev libxslt-dev libxss1 nodejs unzip wget   \
-    zip                                                                        \
- && docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql               \
- && docker-php-ext-configure gd --with-freetype-dir=/usr/include/              \
-                                --with-jpeg-dir=/usr/include/                  \
- && docker-php-ext-install -j$(nproc) bcmath bz2 gd pdo_mysql pdo_pgsql xsl    \
- && wget -q -O checksum https://composer.github.io/installer.sha384sum         \
- && wget -q -O composer-setup.php https://getcomposer.org/installer            \
- && sha384sum -c checksum                                                      \
- && php composer-setup.php --install-dir=/usr/local/bin --filename=composer    \
- && php -r "unlink('composer-setup.php');"                                     \
+RUN apt-get update                                                               \
+ && apt-get install -y gnupg                                                     \
+ && curl -sL https://deb.nodesource.com/setup_6.x | bash                         \
+ && apt-get install -y git libbz2-dev libfreetype6-dev libjpeg62-turbo-dev       \
+    libmcrypt-dev libpng-dev libpq-dev libxslt-dev libxss1 nodejs unzip wget     \
+    zip libldap2-dev                                                             \
+ && docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql                 \
+ && docker-php-ext-configure gd --with-freetype-dir=/usr/include/                \
+                                --with-jpeg-dir=/usr/include/                    \
+ && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/            \
+ && docker-php-ext-install -j$(nproc) bcmath bz2 gd pdo_mysql pdo_pgsql xsl ldap \
+ && wget -q -O checksum https://composer.github.io/installer.sha384sum           \
+ && wget -q -O composer-setup.php https://getcomposer.org/installer              \
+ && sha384sum -c checksum                                                        \
+ && php composer-setup.php --install-dir=/usr/local/bin --filename=composer      \
+ && php -r "unlink('composer-setup.php');"                                       \
  && composer self-update --no-interaction
 
 RUN mkdir -p /var/www/cdash

--- a/include/login_functions.php
+++ b/include/login_functions.php
@@ -163,7 +163,7 @@ function ldapAuthenticate($email, $password, $SessionCachePolicy, $rememberme)
     // Bind as the LDAP user if authenticated ldap is enabled
     if ($config->get('CDASH_LDAP_AUTHENTICATED')) {
         if ($config->get('CDASH_LDAP_STARTTLS')) {
-           ldap_start_tls($ldap);
+            ldap_start_tls($ldap);
         }
         ldap_bind(
             $ldap,

--- a/include/login_functions.php
+++ b/include/login_functions.php
@@ -162,6 +162,9 @@ function ldapAuthenticate($email, $password, $SessionCachePolicy, $rememberme)
 
     // Bind as the LDAP user if authenticated ldap is enabled
     if ($config->get('CDASH_LDAP_AUTHENTICATED')) {
+        if ($config->get('CDASH_LDAP_STARTTLS')) {
+           ldap_start_tls($ldap);
+        }
         ldap_bind(
             $ldap,
             $config->get('CDASH_LDAP_BIND_DN'),


### PR DESCRIPTION
ldap over TLS is not supported by default, with this PR can be set from config file (or docker-compose file) using the variable CDASH_LDAP_STARTTLS
