### PR TITLE
Restore missing build information

### DIFF
--- a/public/api/v1/addBuild.php
+++ b/public/api/v1/addBuild.php
@@ -52,7 +52,7 @@ $build->StartTime = gmdate(FMT_DATETIME);
 $build->SubmitTime = $build->StartTime;
 $subProjectName = get_param('subProjectName', false);
 if ($subProjectName) {
-    $build->SubProjectName = $subProjectName;
+    $build->SetSubProject($subProjectName);
 }
 
 // Call AddBuild() to create the build or get the ID of an existing build.

--- a/public/submit.php
+++ b/public/submit.php
@@ -123,7 +123,7 @@ if (isset($_GET['build']) && isset($_GET['site']) && isset($_GET['stamp'])) {
     $build->SubmitTime = $build->StartTime;
 
     if (isset($_GET['subproject'])) {
-        $build->SubProjectName = pdo_real_escape_string($_GET['subproject']);
+        $build->SetSubProject(pdo_real_escape_string($_GET['subproject']));
     }
 
     $site = $service->create(Site::class);

--- a/tests/data/AssignBuildId/Configure.xml
+++ b/tests/data/AssignBuildId/Configure.xml
@@ -2,6 +2,13 @@
 <Site BuildName="assign_buildid"
 	BuildStamp="20180918-0100-Nightly"
 	Name="localhost"
+	Generator="ctest-3.13.0"
+	CompilerName="gcc"
+	CompilerVersion="5.5.0"
+	OSName="Linux"
+	OSRelease="4.4.0"
+	OSVersion="#166"
+	OSPlatform="x86_64"
 	>
 	<Configure>
 		<StartConfigureTime>1537280827</StartConfigureTime>

--- a/tests/test_submission_assign_buildid.php
+++ b/tests/test_submission_assign_buildid.php
@@ -3,6 +3,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'include/common.php';
 
 use CDash\Model\Build;
+use CDash\Model\BuildInformation;
 
 class SubmissionAssignBuildIdTestCase extends KWWebTestCase
 {
@@ -28,6 +29,18 @@ class SubmissionAssignBuildIdTestCase extends KWWebTestCase
         $this->assertTrue(strtotime($build->SubmitTime) >= $begin_test_time);
         $this->assertEqual('2018-09-18 14:27:07', $build->StartTime);
         $this->assertEqual('2018-09-18 14:27:08', $build->EndTime);
+        $this->assertEqual('ctest-3.13.0', $build->Generator);
+
+        // Make sure a buildinformation row was created too.
+        $buildinformation = new BuildInformation();
+        $buildinformation->BuildId = $buildid;
+        $buildinformation->Fill();
+        $this->assertEqual('Linux', $buildinformation->OSName);
+        $this->assertEqual('x86_64', $buildinformation->OSPlatform);
+        $this->assertEqual('4.4.0', $buildinformation->OSRelease);
+        $this->assertEqual('#166', $buildinformation->OSVersion);
+        $this->assertEqual('gcc', $buildinformation->CompilerName);
+        $this->assertEqual('5.5.0', $buildinformation->CompilerVersion);
 
         remove_build($buildid);
     }


### PR DESCRIPTION
Our changes to assign buildids up front inadvertently caused us to lose some information about builds (OS name and version).

This PR also avoids an SQL exception when removing a build that does not have any tests.