### PR TITLE
Skip over dates with no results

### DIFF
--- a/app/Controller/Api/ResultsApi.php
+++ b/app/Controller/Api/ResultsApi.php
@@ -16,6 +16,7 @@
 namespace CDash\Controller\Api;
 
 use CDash\Database;
+use CDash\Model\Build;
 use CDash\Model\Project;
 
 /**
@@ -119,6 +120,17 @@ class ResultsApi extends ProjectApi
             }
         } elseif (isset($_REQUEST['date'])) {
             $this->date = $_REQUEST['date'];
+        } else {
+            // No date specified. Look up the most recent date with results.
+            $stmt = $this->db->prepare('
+                SELECT starttime FROM build
+                WHERE projectid = :projectid
+                ORDER BY starttime DESC LIMIT 1');
+            $this->db->execute($stmt, [':projectid' => $this->project->Id]);
+            $starttime = $stmt->fetchColumn();
+            if ($starttime) {
+                $this->date = Build::GetTestingDate($starttime, strtotime($this->project->NightlyTime));
+            }
         }
 
         if ($this->beginDate == self::BEGIN_EPOCH) {

--- a/app/Controller/Api/TestOverview.php
+++ b/app/Controller/Api/TestOverview.php
@@ -77,7 +77,7 @@ class TestOverview extends ResultsApi
         if (date(FMT_DATE, $this->currentStartTime) != date(FMT_DATE)) {
             $menu['next'] = 'testOverview.php?project=' . urlencode($this->project->Name) . "&date={$this->nextDate}$group_link";
         } else {
-            $menu['nonext'] = '1';
+            $menu['next'] = false;
         }
         $today = date(FMT_DATE);
         $menu['current'] = 'testOverview.php?project=' . urlencode($this->project->Name) . "&date=$today$group_link";

--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -2443,7 +2443,12 @@ class Build
             get_dates($build_date, $this->NightlyStartTime);
 
         $beginning_timestamp = $currentstarttime;
-        $end_timestamp = $currentstarttime + 3600 * 24;
+
+        $datetime = new \DateTime();
+        $datetime->setTimeStamp($beginning_timestamp);
+        $datetime->add(new \DateInterval('P1D'));
+        $end_timestamp = $datetime->getTimestamp();
+
         $this->BeginningOfDay = gmdate(FMT_DATETIME, $beginning_timestamp);
         $this->EndOfDay = gmdate(FMT_DATETIME, $end_timestamp);
 

--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -2438,20 +2438,13 @@ class Build
             return true;
         }
 
+        $project = new Project();
+        $project->Id = $this->ProjectId;
+        $project->Fill();
+
         $build_date = $this->GetDate();
-        list($previousdate, $currentstarttime, $nextdate) =
-            get_dates($build_date, $this->NightlyStartTime);
-
-        $beginning_timestamp = $currentstarttime;
-
-        $datetime = new \DateTime();
-        $datetime->setTimeStamp($beginning_timestamp);
-        $datetime->add(new \DateInterval('P1D'));
-        $end_timestamp = $datetime->getTimestamp();
-
-        $this->BeginningOfDay = gmdate(FMT_DATETIME, $beginning_timestamp);
-        $this->EndOfDay = gmdate(FMT_DATETIME, $end_timestamp);
-
+        list($this->BeginningOfDay, $this->EndOfDay) =
+            $project->ComputeTestingDayBounds($build_date);
         return true;
     }
 

--- a/app/Model/Project.php
+++ b/app/Model/Project.php
@@ -1690,4 +1690,23 @@ class Project
         }
         return true;
     }
+
+    /**
+     * Return the beginning and the end of the specified testing day
+     * in DATETIME format.
+     */
+    public function ComputeTestingDayBounds($date)
+    {
+        list($unused, $beginning_timestamp) =
+            get_dates($date, $this->NightlyTime);
+
+        $datetime = new \DateTime();
+        $datetime->setTimeStamp($beginning_timestamp);
+        $datetime->add(new \DateInterval('P1D'));
+        $end_timestamp = $datetime->getTimestamp();
+
+        $beginningOfDay = gmdate(FMT_DATETIME, $beginning_timestamp);
+        $endOfDay = gmdate(FMT_DATETIME, $end_timestamp);
+        return [$beginningOfDay, $endOfDay];
+    }
 }

--- a/public/api/v1/buildSummary.php
+++ b/public/api/v1/buildSummary.php
@@ -64,7 +64,7 @@ if ($previous_buildid > 0) {
     $previous_build->FillFromId($previous_build->Id);
     $lastsubmitdate = date(FMT_DATETIMETZ, strtotime($previous_build->StartTime . ' UTC'));
 } else {
-    $menu['noprevious'] = '1';
+    $menu['previous'] = false;
     $lastsubmitdate = 0;
 }
 
@@ -73,7 +73,7 @@ $menu['current'] = "buildSummary.php?buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu['next'] = "buildSummary.php?buildid=$next_buildid";
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 
 $response['menu'] = $menu;

--- a/public/api/v1/compareCoverage.php
+++ b/public/api/v1/compareCoverage.php
@@ -82,7 +82,7 @@ $menu['current'] = "$page_id?project=$projectname_encoded&date=$today";
 if (has_next_date($date, $currentstarttime)) {
     $menu['next'] = "$page_id?project=$projectname_encoded&date=$nextdate";
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 $response['menu'] = $menu;
 

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -229,7 +229,7 @@ if (!function_exists('echo_main_dashboard_JSON')) {
             if ($previous_buildid > 0) {
                 $response['menu']['previous'] = "$base_url&parentid=$previous_buildid";
             } else {
-                $response['menu']['noprevious'] = '1';
+                $response['menu']['previous'] = false;
             }
 
             $response['menu']['current'] = "$base_url&parentid=$current_buildid";
@@ -237,21 +237,23 @@ if (!function_exists('echo_main_dashboard_JSON')) {
             if ($next_buildid > 0) {
                 $response['menu']['next'] = "$base_url&parentid=$next_buildid";
             } else {
-                $response['menu']['nonext'] = '1';
+                $response['menu']['next'] = false;
             }
         } else {
             if (!has_next_date($date, $currentstarttime)) {
-                $response['menu']['nonext'] = 1;
+                $response['menu']['next'] = false;
             }
             if (isset($_GET['buildgroup'])) {
                 $page_id = 'viewBuildGroup.php';
                 $buildgroup = $_GET['buildgroup'];
                 $base_url = "viewBuildGroup.php?project={$projectname_encoded}&buildgroup=$buildgroup";
-                $response['menu']['previous'] = "$base_url&date=" . $response['previousdate'];
-                $response['menu']['current'] = "$base_url";
-                if (!array_key_exists('nonext', $response['menu'])) {
-                    $response['menu']['next'] = "$base_url&date=" . $response['nextdate'];
-                }
+            } else {
+                $base_url = "index.php?project={$projectname_encoded}";
+            }
+            $response['menu']['previous'] = "$base_url&date=" . $response['previousdate'];
+            $response['menu']['current'] = "$base_url";
+            if (! (isset($response['menu']['next']) && $response['menu']['next'] === false)) {
+                $response['menu']['next'] = "$base_url&date=" . $response['nextdate'];
             }
         }
         $response['childview'] = $controller->childView;
@@ -268,8 +270,13 @@ if (!function_exists('echo_main_dashboard_JSON')) {
 
             if ($subprojectid) {
                 $controller->setSubProjectId($subprojectid);
-                // Add an extra URL argument for the menu
-                $response['extraurl'] = '&subproject=' . urlencode($subproject_name);
+                // Add an extra URL argument to menu navigation items.
+                $extraurl = '&subproject=' . urlencode($subproject_name);
+                foreach (['previous', 'next', 'current'] as $item) {
+                    if ($response['menu'][$item]) {
+                        $response['menu'][$item] .= $extraurl;
+                    }
+                }
                 $response['subprojectname'] = $subproject_name;
 
                 $subproject_response = array();

--- a/public/api/v1/manageMeasurements.php
+++ b/public/api/v1/manageMeasurements.php
@@ -118,8 +118,7 @@ function rest_get($projectid)
     // Menu
     $menu_response = [];
     $menu_response['back'] = 'user.php';
-    $menu_response['noprevious'] =  1;
-    $menu_response['nonext'] = 1;
+    $menu_response['hidenav'] =  true;
     $response['menu'] = $menu_response;
 
     // Get any measurements associated with this project's tests.

--- a/public/api/v1/queryTests.php
+++ b/public/api/v1/queryTests.php
@@ -83,7 +83,7 @@ if (isset($_GET['parentid'])) {
     if ($previous_buildid > 0) {
         $menu['previous'] = "$base_url&parentid=$previous_buildid" . $limit_param;
     } else {
-        $menu['noprevious'] = '1';
+        $menu['previous'] = false;
     }
 
     $menu['current'] = "$base_url&parentid=$current_buildid" . $limit_param;
@@ -91,7 +91,7 @@ if (isset($_GET['parentid'])) {
     if ($next_buildid > 0) {
         $menu['next'] = "$base_url&parentid=$next_buildid" . $limit_param;
     } else {
-        $menu['nonext'] = '1';
+        $menu['next'] = false;
     }
 } else {
     if ($date == '') {
@@ -108,7 +108,7 @@ if (isset($_GET['parentid'])) {
     if (has_next_date($date, $currentstarttime)) {
         $menu['next'] = $base_url . '&date=' . $nextdate . $limit_param;
     } else {
-        $menu['nonext'] = '1';
+        $menu['next'] = false;
     }
 }
 

--- a/public/api/v1/testDetails.php
+++ b/public/api/v1/testDetails.php
@@ -146,7 +146,7 @@ if ($previous_buildid > 0) {
         $menu['previous'] = "testDetails.php?test=$previous_testid&build=$previous_buildid$extra_url";
     }
 } else {
-    $menu['noprevious'] = '1';
+    $menu['previous'] = false;
 }
 
 // Current build
@@ -160,7 +160,7 @@ if ($next_buildid > 0) {
         $menu['next'] = "testDetails.php?test=$next_testid&build=$next_buildid$extra_url";
     }
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 
 $response['menu'] = $menu;

--- a/public/api/v1/testSummary.php
+++ b/public/api/v1/testSummary.php
@@ -85,7 +85,7 @@ $menu['current'] = "testSummary.php?project=$projectid&name=$testName&date=" . d
 if ($date != '' && date(FMT_DATE, $currentstarttime) != date(FMT_DATE)) {
     $menu['next'] = "testSummary.php?project=$projectid&name=$testName&date=$nextdate";
 } else {
-    $menu['nonext'] = 1;
+    $menu['next'] = false;
 }
 $response['menu'] = $menu;
 

--- a/public/api/v1/viewBuildError.php
+++ b/public/api/v1/viewBuildError.php
@@ -95,7 +95,7 @@ $next_buildid = $build->GetNextBuildId();
 if ($previous_buildid > 0) {
     $menu['previous'] = "viewBuildError.php?type=$type&buildid=$previous_buildid";
 } else {
-    $menu['noprevious'] = 1;
+    $menu['previous'] = false;
 }
 
 $menu['current'] = "viewBuildError.php?type=$type&buildid=$current_buildid";
@@ -103,7 +103,7 @@ $menu['current'] = "viewBuildError.php?type=$type&buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu['next'] = "viewBuildError.php?type=$type&buildid=$next_buildid";
 } else {
-    $menu['nonext'] = 1;
+    $menu['next'] = false;
 }
 
 $response['menu'] = $menu;

--- a/public/api/v1/viewConfigure.php
+++ b/public/api/v1/viewConfigure.php
@@ -53,7 +53,7 @@ $current_buildid = $build->GetCurrentBuildId();
 if ($previous_buildid > 0) {
     $menu_response['previous'] = "viewConfigure.php?buildid=$previous_buildid";
 } else {
-    $menu_response['noprevious'] = 1;
+    $menu_response['previous'] = false;
 }
 
 $menu_response['current'] = "viewConfigure.php?buildid=$current_buildid";
@@ -61,7 +61,7 @@ $menu_response['current'] = "viewConfigure.php?buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu_response['next'] = "viewConfigure.php?buildid=$next_buildid";
 } else {
-    $menu_response['nonext'] = 1;
+    $menu_response['next'] = false;
 }
 $response['menu'] = $menu_response;
 

--- a/public/api/v1/viewDynamicAnalysis.php
+++ b/public/api/v1/viewDynamicAnalysis.php
@@ -58,7 +58,7 @@ $previousbuildid = get_previous_buildid_dynamicanalysis($build->ProjectId, $buil
 if ($previousbuildid > 0) {
     $menu['previous'] = "viewDynamicAnalysis.php?buildid=$previousbuildid";
 } else {
-    $menu['noprevious'] = '1';
+    $menu['previous'] = false;
 }
 
 $currentbuildid = get_last_buildid_dynamicanalysis($build->ProjectId, $build->SiteId, $build->Type, $build->Name, $build->StartTime);
@@ -68,7 +68,7 @@ $nextbuildid = get_next_buildid_dynamicanalysis($build->ProjectId, $build->SiteI
 if ($nextbuildid > 0) {
     $menu['next'] = "viewDynamicAnalysis.php?buildid=$nextbuildid";
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 $response['menu'] = $menu;
 

--- a/public/api/v1/viewDynamicAnalysisFile.php
+++ b/public/api/v1/viewDynamicAnalysisFile.php
@@ -82,7 +82,7 @@ $previous_id = $DA->GetPreviousId($build);
 if ($previous_id > 0) {
     $menu_response['previous'] = "viewDynamicAnalysisFile.php?id=$previous_id";
 } else {
-    $menu_response['noprevious'] = '1';
+    $menu_response['previous'] = false;
 }
 $current_id = $DA->GetLastId($build);
 $menu_response['current'] = "viewDynamicAnalysisFile.php?id=$current_id";
@@ -90,7 +90,7 @@ $next_id = $DA->GetNextId($build);
 if ($next_id > 0) {
     $menu_response['next'] = "viewDynamicAnalysisFile.php?id=$next_id";
 } else {
-    $menu_response['nonext'] = '1';
+    $menu_response['next'] = false;
 }
 $response['menu'] = $menu_response;
 

--- a/public/api/v1/viewNotes.php
+++ b/public/api/v1/viewNotes.php
@@ -55,7 +55,7 @@ $next_buildid = $build->GetNextBuildId();
 if ($previous_buildid > 0) {
     $menu['previous'] = "viewNotes.php?buildid=$previous_buildid";
 } else {
-    $menu['noprevious'] = '1';
+    $menu['previous'] = false;
 }
 
 $menu['current'] = "viewNotes.php?buildid=$current_buildid";
@@ -63,7 +63,7 @@ $menu['current'] = "viewNotes.php?buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu['next'] = "viewNotes.php?buildid=$next_buildid";
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 
 $response['menu'] = $menu;

--- a/public/api/v1/viewSubProjects.php
+++ b/public/api/v1/viewSubProjects.php
@@ -103,7 +103,7 @@ function echo_subprojects_dashboard_JSON($project_instance, $date)
     $menu_response['previous'] = "viewSubProjects.php?project=$projectname_encoded&date=$previousdate";
     $menu_response['current'] = "viewSubProjects.php?project=$projectname_encoded";
     if (!has_next_date($date, $currentstarttime)) {
-        $menu_response['nonext'] = 1;
+        $menu_response['next'] = false;
     } else {
         $menu_response['next'] = "viewSubProjects.php?project=$projectname_encoded&date=$nextdate";
     }

--- a/public/api/v1/viewTest.php
+++ b/public/api/v1/viewTest.php
@@ -170,7 +170,7 @@ if ($previous_buildid > 0) {
         $previous_buildids_str = implode(', ', $previous_buildids);
     }
 } else {
-    $menu['noprevious'] = '1';
+    $menu['previous'] = false;
 }
 $response['previous_builds'] = $previous_buildids_str;
 
@@ -179,7 +179,7 @@ $menu['current'] = "viewTest.php?buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu['next'] = 'viewTest.php?buildid=' . $next_buildid . $extraquery;
 } else {
-    $menu['nonext'] = '1';
+    $menu['next'] = false;
 }
 
 $response['menu'] = $menu;

--- a/public/api/v1/viewUpdate.php
+++ b/public/api/v1/viewUpdate.php
@@ -51,7 +51,7 @@ $next_buildid = $build->GetNextBuildId();
 if ($previous_buildid > 0) {
     $menu_response['previous'] = "viewUpdate.php?buildid=$previous_buildid";
 } else {
-    $menu_response['noprevious'] = '1';
+    $menu_response['previous'] = false;
 }
 
 $menu_response['current'] = "viewUpdate.php?buildid=$current_buildid";
@@ -59,7 +59,7 @@ $menu_response['current'] = "viewUpdate.php?buildid=$current_buildid";
 if ($next_buildid > 0) {
     $menu_response['next'] = "viewUpdate.php?buildid=$next_buildid";
 } else {
-    $menu_response['nonext'] = '1';
+    $menu_response['next'] = false;
 }
 $response['menu'] = $menu_response;
 

--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -28,9 +28,9 @@
       <span ng-if="cdash.subheadername" id="subheadername">{{::cdash.subprojectname}}</span>
     </div>
 
-    <div class="projectnav clearfix">
+    <div ng-if="!cdash.hidenav" class="projectnav clearfix">
       <ul class="projectnav_controls clearfix">
-        <li class="btnprev" ng-if="!cdash.hidenav">
+        <li class="btnprev">
           <a ng-if="cdash.menu.previous"
              ng-href="{{::cdash.menu.previous}}{{::cdash.filterurl}}">Prev</a>
           <a ng-if="!cdash.menu.previous && !cdash.menu.noprevious"
@@ -38,7 +38,7 @@
             Prev
           </a>
         </li>
-        <li class="btncurr" ng-if="!cdash.hidenav">
+        <li class="btncurr">
           <a ng-if="cdash.menu.current"
              ng-href="{{::cdash.menu.current}}{{::cdash.filterurl}}">
             Current
@@ -48,7 +48,7 @@
             Current
           </a>
         </li>
-        <li class="btnnext" ng-if="!cdash.menu.nonext && !cdash.hidenav">
+        <li class="btnnext" ng-if="!cdash.menu.nonext">
           <a ng-if="cdash.menu.next"
              ng-href="{{::cdash.menu.next}}{{::cdash.filterurl}}">
             Next

--- a/public/views/partials/header.html
+++ b/public/views/partials/header.html
@@ -33,28 +33,16 @@
         <li class="btnprev">
           <a ng-if="cdash.menu.previous"
              ng-href="{{::cdash.menu.previous}}{{::cdash.filterurl}}">Prev</a>
-          <a ng-if="!cdash.menu.previous && !cdash.menu.noprevious"
-             ng-href="index.php?project={{::cdash.projectname_encoded}}&date={{::cdash.previousdate}}{{::cdash.extraurl}}{{::cdash.filterurl}}">
-            Prev
-          </a>
         </li>
         <li class="btncurr">
           <a ng-if="cdash.menu.current"
              ng-href="{{::cdash.menu.current}}{{::cdash.filterurl}}">
             Current
           </a>
-          <a ng-if="!cdash.menu.current"
-             ng-href="index.php?project={{::cdash.projectname_encoded}}{{::cdash.extraurl}}{{::cdash.filterurl}}">
-            Current
-          </a>
         </li>
-        <li class="btnnext" ng-if="!cdash.menu.nonext">
+        <li class="btnnext">
           <a ng-if="cdash.menu.next"
              ng-href="{{::cdash.menu.next}}{{::cdash.filterurl}}">
-            Next
-          </a>
-          <a ng-if="!cdash.menu.next"
-             ng-href="index.php?project={{::cdash.projectname_encoded}}&date={{::cdash.nextdate}}{{::cdash.extraurl}}{{::cdash.filterurl}}">
             Next
           </a>
         </li>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ add_php_test(changeid)
 add_php_test(updateonlyuserstats)
 add_php_test(expiredbuildrules)
 add_php_test(filterblocks)
+add_php_test(indexnextprevious)
 
 if(CDASH_GITHUB_USERNAME AND CDASH_GITHUB_PASSWORD)
   add_php_test(github_PR_comment)

--- a/tests/data/BuildDetails/InsightExperimentalExample_Expected.json
+++ b/tests/data/BuildDetails/InsightExperimentalExample_Expected.json
@@ -29,9 +29,9 @@
     "previous_builds": "",
     "menu": {
         "back": "index.php?project=SubProjectExample&date=2009-02-23",
-        "noprevious": 1,
+        "previous": false,
         "current": "viewTest.php?buildid=221",
-        "nonext": 1
+        "next": false
     },
     "build": {
         "displaylabels": 0,

--- a/tests/test_expectedandmissing.php
+++ b/tests/test_expectedandmissing.php
@@ -54,8 +54,8 @@ class ExpectedAndMissingTestCase extends KWWebTestCase
             $this->fail("Error marking $buildname as expected");
         }
 
-        // Verify that our API lists this build even though it hasn't submitted today.
-        $this->get($this->url . "/api/v1/index.php?project=$projectname");
+        // Verify that our API lists this build even though it hasn't submitted on this day.
+        $this->get($this->url . "/api/v1/index.php?project=$projectname&date=2019-04-18");
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $buildgroup = array_pop($jsonobj['buildgroups']);

--- a/tests/test_indexnextprevious.php
+++ b/tests/test_indexnextprevious.php
@@ -1,0 +1,82 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+require_once 'include/common.php';
+
+use CDash\Model\Build;
+use CDash\Model\Project;
+use CDash\Model\Site;
+
+class IndexNextPreviousTestCase extends KWWebTestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testIndexNextPrevious()
+    {
+        $projectname = 'NextPreviousProject';
+        // Cleanup from previous runs.
+        $project = new Project();
+        $project->Id = get_project_id($projectname);
+        if ($project->Id >= 0) {
+            remove_project_builds($project->Id);
+            $project->Delete();
+        }
+
+        // Make a separate project for this test.
+        $project->Id = $this->createProject(['Name' => $projectname]);
+
+        // Make some builds.
+        $first_date = '2016-10-10';
+        $second_date = '2017-10-10';
+        $third_date = '2018-10-10';
+        $build_rows = [
+            [$first_date, 1476079800, 'Experimental'],
+            [$second_date, 1507637400, 'Nightly'],
+            [$third_date, 1539195000, 'Experimental']
+        ];
+        foreach ($build_rows as $build_row) {
+            $date = str_replace('-', '', $build_row[0]);
+            $timestamp = $build_row[1];
+            $group = $build_row[2];
+            $build = new Build();
+            $build->Name = 'next-previous-build';
+            $build->ProjectId = $project->Id;
+            $site = new Site();
+            $site->Id = 1;
+            $build->SiteId = $site->Id;
+            $stamp = "$date-1410-$group";
+            $build->SetStamp($stamp);
+            $build->StartTime = gmdate(FMT_DATETIME, $timestamp);
+            $this->assertTrue($build->AddBuild());
+            $this->assertTrue($build->Id > 0);
+        }
+
+        // Verify next/previous links point to day with builds.
+        $this->get($this->url . "/api/v1/index.php?project=$projectname&date=$first_date");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertFalse($jsonobj['menu']['previous']);
+        $this->assertEqual($jsonobj['menu']['next'], "index.php?project=NextPreviousProject&date=$second_date");
+
+        $this->get($this->url . "/api/v1/index.php?project=$projectname&date=$second_date");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual($jsonobj['menu']['previous'], "index.php?project=NextPreviousProject&date=$first_date");
+        $this->assertEqual($jsonobj['menu']['next'], "index.php?project=NextPreviousProject&date=$third_date");
+
+        $this->get($this->url . "/api/v1/index.php?project=$projectname&date=$third_date");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual($jsonobj['menu']['previous'], "index.php?project=NextPreviousProject&date=$second_date");
+        $this->assertFalse($jsonobj['menu']['next']);
+
+        // Verify viewBuildGroup only finds days with builds in that group.
+        $this->get($this->url . "/api/v1/index.php?project=$projectname&buildgroup=Experimental&date=$third_date");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual($jsonobj['menu']['previous'], "viewBuildGroup.php?project=NextPreviousProject&buildgroup=Experimental&date=$first_date");
+        $this->assertFalse($jsonobj['menu']['next']);
+    }
+}

--- a/tests/test_projectwebpage.php
+++ b/tests/test_projectwebpage.php
@@ -121,7 +121,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
         $this->login();
 
         // Find buildid for coverage.
-        $content = $this->connect($this->url . '/api/v1/index.php?project=InsightExample&date=20090223');
+        $content = $this->connect($this->url . '/api/v1/index.php?project=InsightExample');
         $jsonobj = json_decode($content, true);
         if (count($jsonobj['coverages']) < 1) {
             $this->fail('No coverage build found when expected');
@@ -203,7 +203,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
 
     public function testProjectExperimentalLinkMachineName()
     {
-        $content = $this->connect($this->url . '/api/v1/index.php?project=BatchmakeExample&date=20090223');
+        $content = $this->connect($this->url . '/api/v1/index.php?project=BatchmakeExample');
         $jsonobj = json_decode($content, true);
         if (count($jsonobj['buildgroups']) < 1) {
             $this->fail('No build found when expected');
@@ -224,7 +224,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
 
     public function testProjectExperimentalLinkBuildSummary()
     {
-        $content = $this->connect($this->url . '/api/v1/index.php?project=BatchmakeExample&date=20090223');
+        $content = $this->connect($this->url . '/api/v1/index.php?project=BatchmakeExample');
         $jsonobj = json_decode($content, true);
         if (count($jsonobj['buildgroups']) < 1) {
             $this->fail('No build found when expected');


### PR DESCRIPTION
Avoid generating links to "blank pages" -- pages for dates when no results occurred.

When a user navigates to index.php with no date specified, display the most recent date with results (rather than unconditionally linking to the current day).

Also update next/previous links on index.php so they always point to dates with results (skipping over empty dates).