### PR TITLE
Implement "proc time" for parent builds

### DIFF
--- a/app/Controller/Api/Index.php
+++ b/app/Controller/Api/Index.php
@@ -252,7 +252,7 @@ class Index extends ResultsApi
     public function getIndexQuery($userupdatesql='')
     {
         return
-            "SELECT b.id,b.siteid,b.parentid,b.done,b.changeid,
+            "SELECT b.id,b.siteid,b.parentid,b.done,b.changeid,b.testduration,
             bu.status AS updatestatus,
             i.osname AS osname,
             bu.starttime AS updatestarttime,
@@ -266,7 +266,7 @@ class Index extends ResultsApi
             bw_diff.difference_positive AS countbuildwarningdiffp,
             bw_diff.difference_negative AS countbuildwarningdiffn,
             ce_diff.difference AS countconfigurewarningdiff,
-            btt.time AS testduration,
+            btt.time AS testtime,
             tnotrun_diff.difference_positive AS counttestsnotrundiffp,
             tnotrun_diff.difference_negative AS counttestsnotrundiffn,
             tfailed_diff.difference_positive AS counttestsfaileddiffp,
@@ -534,11 +534,10 @@ class Index extends ResultsApi
                     SELECT configureerrors, configurewarnings, configureduration,
                            builderrors, buildwarnings, buildduration,
                            b.starttime, b.endtime, testnotrun, testfailed, testpassed,
-                           btt.time AS testduration, sb.name
+                           testduration, sb.name
                                FROM build AS b
                                INNER JOIN subproject2build AS sb2b ON (b.id = sb2b.buildid)
                                INNER JOIN subproject AS sb ON (sb2b.subprojectid = sb.id)
-                               LEFT JOIN buildtesttime AS btt ON (b.id=btt.buildid)
                                WHERE b.parentid=$buildid
                                AND sb.name IN $this->selectedSubProjects";
                 $select_results = pdo_query($select_query);

--- a/app/Controller/Api/Index.php
+++ b/app/Controller/Api/Index.php
@@ -431,8 +431,7 @@ class Index extends ResultsApi
         }
 
         if (empty($build_row['testduration'])) {
-            $time_array = pdo_fetch_array(pdo_query("SELECT SUM(time) FROM build2test WHERE buildid='$buildid'"));
-            $build_row['testduration'] = round($time_array[0], 1);
+            $build_row['testduration'] = 0;
         } else {
             $build_row['testduration'] = round($build_row['testduration'], 1);
         }

--- a/app/Controller/Api/Index.php
+++ b/app/Controller/Api/Index.php
@@ -519,7 +519,7 @@ class Index extends ResultsApi
         $selected_tests_not_run = 0;
         $selected_tests_failed = 0;
         $selected_tests_passed = 0;
-        $selected_test_duration = 0;
+        $selected_proc_time = 0;
 
         if ($numchildren > 0) {
             $child_builds_hyperlink =
@@ -533,10 +533,11 @@ class Index extends ResultsApi
                     SELECT configureerrors, configurewarnings, configureduration,
                            builderrors, buildwarnings, buildduration,
                            b.starttime, b.endtime, testnotrun, testfailed, testpassed,
-                           testduration, sb.name
+                           testduration, sb.name, btt.time AS testtime
                                FROM build AS b
                                INNER JOIN subproject2build AS sb2b ON (b.id = sb2b.buildid)
                                INNER JOIN subproject AS sb ON (sb2b.subprojectid = sb.id)
+                               LEFT JOIN buildtesttime AS btt ON (btt.buildid = b.id)
                                WHERE b.parentid=$buildid
                                AND sb.name IN $this->selectedSubProjects";
                 $select_results = pdo_query($select_query);
@@ -559,8 +560,8 @@ class Index extends ResultsApi
                         max(0, $select_array['testfailed']);
                     $selected_tests_passed +=
                         max(0, $select_array['testpassed']);
-                    $selected_test_duration +=
-                        max(0, $select_array['testduration']);
+                    $selected_proc_time +=
+                        max(0, $select_array['testtime']);
                 }
             }
         } else {
@@ -863,7 +864,7 @@ class Index extends ResultsApi
                 $nnotrun = $selected_tests_not_run;
                 $nfail = $selected_tests_failed;
                 $npass = $selected_tests_passed;
-                $testduration = $selected_test_duration;
+                $proc_time = $selected_proc_time;
             } else {
                 $nnotrun = $build_array['counttestsnotrun'] -
                     $selected_tests_not_run;
@@ -871,8 +872,7 @@ class Index extends ResultsApi
                     $selected_tests_failed;
                 $npass = $build_array['counttestspassed'] -
                     $selected_tests_passed;
-                $testduration = $build_array['testduration'] -
-                    $selected_test_duration;
+                $proc_time = $build_array['testtime'] - $selected_proc_time;
             }
 
             if ($this->childView == 1 || (!$this->includeSubProjects && !$this->excludeSubProjects)) {
@@ -952,9 +952,13 @@ class Index extends ResultsApi
             $this->buildgroupsResponse[$i]['numtestfail'] += $nfail;
             $this->buildgroupsResponse[$i]['numtestpass'] += $npass;
 
+            $testduration = $build_array['testduration'];
             $test_response['time'] = time_difference($testduration, true);
             $test_response['timefull'] = $testduration;
             $this->buildgroupsResponse[$i]['testduration'] += $testduration;
+
+            $test_response['procTime'] = time_difference($proc_time, true);
+            $test_response['procTimeFull'] = $proc_time;
 
             $build_response['test'] = $test_response;
         }

--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -2374,6 +2374,11 @@ class Build
         return $this->UpdateDuration('build', $duration, $update_parent);
     }
 
+    public function UpdateTestDuration($duration, $update_parent=true)
+    {
+        return $this->UpdateDuration('test', $duration, $update_parent);
+    }
+
     // Return the dashboard date (in Y-m-d format) for this build.
     public function GetDate()
     {

--- a/app/Model/Build.php
+++ b/app/Model/Build.php
@@ -279,43 +279,84 @@ class Build
         return false;
     }
 
-    /** Update the total testing duration */
-    public function SaveTotalTestsTime($duration, $update_parent = true)
+    /**
+     * Record the total execution time of all the tests performed by this build.
+     **/
+    public function SaveTotalTestsTime($update_parent = true)
     {
-        if (!$this->Id || !is_numeric($this->Id)) {
+        if (!$this->Exists()) {
             return false;
         }
 
-        // Check if an entry already exists for this build.
-        $exists_stmt = $this->PDO->prepare(
-            'SELECT buildid FROM buildtesttime WHERE buildid = ?');
-        if (!pdo_execute($exists_stmt, [$this->Id])) {
+        // Calculate how much processor time was spent running this build's
+        // tests.
+        $total_proc_time = 0.0;
+        foreach ($this->TestCollection as $test) {
+            $exec_time = $test->GetExecutionTime();
+            $num_procs = 1.0;
+            foreach ($test->Measurements as $measurement) {
+                if ($measurement->Name == 'Processors') {
+                    $num_procs *= $measurement->Value;
+                    break;
+                }
+            }
+            $total_proc_time += ($exec_time * $num_procs);
+        }
+
+        if (!$this->UpdateBuildTestTime($total_proc_time)) {
             return false;
         }
-        if ($exists_stmt->fetchColumn() !== false) {
-            $stmt = $this->PDO->prepare(
-                'UPDATE buildtesttime SET time = time + ? WHERE buildid = ?');
-            $params = [$duration, $this->Id];
-        } else {
-            $stmt = $this->PDO->prepare(
-                'INSERT INTO buildtesttime (buildid, time) VALUES (?, ?)');
-            $params = [$this->Id, $duration];
-        }
-        if (!pdo_execute($stmt, $params)) {
-            return false;
-        }
+
 
         if (!$update_parent) {
             return true;
         }
-        // If this is a child build, add this duration
-        // to the parent's test duration sum.
+
+        // If this is a child build, add this exec time
+        // to the parent's value.
         $this->SetParentId($this->LookupParentBuildId());
         if ($this->ParentId > 0) {
             $parent = new Build();
             $parent->Id = $this->ParentId;
-            $parent->SaveTotalTestsTime($duration);
+            $parent->UpdateBuildTestTime($total_proc_time);
         }
+    }
+
+    /**
+     * Insert or update a record in the buildtesttime table.
+     **/
+    protected function UpdateBuildTestTime($test_exec_time)
+    {
+        // Check if an entry already exists for this build.
+        $this->PDO->beginTransaction();
+        $exists_stmt = $this->PDO->prepare(
+                'SELECT time FROM buildtesttime WHERE buildid = ?');
+        if (!pdo_execute($exists_stmt, [$this->Id])) {
+            $this->PDO->rollBack();
+            return false;
+        }
+
+        $existing_time = $exists_stmt->fetchColumn();
+        $query_params = [':buildid' => $this->Id];
+        if ($existing_time !== false) {
+            $stmt = $this->PDO->prepare(
+                    'UPDATE buildtesttime
+                    SET time = :time
+                    WHERE buildid = :buildid');
+            $query_params[':time'] = $test_exec_time + $existing_time;
+        } else {
+            $stmt = $this->PDO->prepare(
+                    'INSERT INTO buildtesttime (buildid, time)
+                    VALUES (:buildid, :time)');
+            $query_params[':time'] = $test_exec_time;
+        }
+        if (!pdo_execute($stmt, $query_params)) {
+            $this->PDO->rollBack();
+            return false;
+        }
+
+        $this->PDO->commit();
+        return true;
     }
 
     /** Update the end time */

--- a/include/common.php
+++ b/include/common.php
@@ -192,9 +192,14 @@ function time_difference($duration, $compact = false, $suffix = '', $displayms =
     $duration -= $hours * 3600;
     $mins = floor($duration / 60);
     $duration -= $mins * 60;
-    $secs = floor($duration);
-    $duration -= $secs;
-    $msecs = round($duration * 1000);
+    if ($displayms) {
+        $secs = floor($duration);
+        $duration -= $secs;
+        $msecs = round($duration * 1000);
+    } else {
+        $secs = round($duration);
+        $msecs = 0;
+    }
 
     $diff = '';
     if ($compact) {

--- a/include/filterdataFunctions.php
+++ b/include/filterdataFunctions.php
@@ -297,7 +297,7 @@ class IndexPhpFilters extends DefaultFilters
                 break;
 
             case 'testsduration': {
-                $sql_field = 'btt.time';
+                $sql_field = 'b.testduration';
             }
                 break;
 

--- a/public/api/v1/index.php
+++ b/public/api/v1/index.php
@@ -123,7 +123,6 @@ if (!function_exists('echo_main_dashboard_JSON')) {
             $banners[] = $text;
         }
         $response['banners'] = $banners;
-        $show_proc_time = false;
 
         // If parentid is set we need to lookup the date for this build
         // because it is not specified as a query string parameter.
@@ -168,17 +167,6 @@ if (!function_exists('echo_main_dashboard_JSON')) {
                 'SELECT COUNT(buildid) FROM build2uploadfile WHERE buildid = ?');
             pdo_execute($stmt, [$parentid]);
             $response['uploadfilecount'] = $stmt->fetchColumn();
-
-            // For parent builds, we support an additional advanced column called
-            // 'Proc Time'.  This is only shown if this project is setup to display
-            // an extra test measurement called 'Processors'.
-            $stmt = $PDO->prepare(
-                "SELECT id FROM measurement
-            WHERE projectid = ? and name = 'Processors'");
-            pdo_execute($stmt, [$projectid]);
-            if ($stmt->fetchColumn() !== false) {
-                $show_proc_time = true;
-            }
         } else {
             $controller->determineDateRange($response);
             $response['parentid'] = -1;
@@ -700,67 +688,18 @@ if (!function_exists('echo_main_dashboard_JSON')) {
             }
         }
 
-        // Compute 'Proc Time' here (if necessary).
-        $proc_time_verified = false;
-        if ($show_proc_time) {
-            $test_timing = [];
-            // Look up how long each test took for each build.
-            $stmt = $PDO->prepare(
-                'SELECT b2t.buildid, b2t.testid, b2t.time
-            FROM build2test b2t
-            JOIN build b on (b.id = b2t.buildid)
-            WHERE b.parentid = ?');
-            pdo_execute($stmt, [$parentid]);
-            while ($row = $stmt->fetch()) {
-                $buildid = $row['buildid'];
-                $testid = $row['testid'];
-                $test_duration = $row['time'];
-                if (!array_key_exists($buildid, $test_timing)) {
-                    $test_timing[$buildid] = [];
-                }
-                $test_timing[$buildid][$testid] = $test_duration;
-            }
-
-            // Multiply test duration by number of processors for any tests
-            // that have the 'Processor' measurement defined.
-            $stmt = $PDO->prepare(
-                "SELECT b2t.buildid, b2t.testid, tm.value
-            FROM build2test b2t
-            JOIN testmeasurement tm ON (b2t.testid = tm.testid)
-            JOIN build b ON (b.id = b2t.buildid)
-            WHERE b.parentid = ?
-            AND tm.name = 'Processors'");
-            pdo_execute($stmt, [$parentid]);
-            while ($row = $stmt->fetch()) {
-                $buildid = $row['buildid'];
-                $testid = $row['testid'];
-                $nprocs = $row['value'];
-                if (!is_numeric($nprocs)) {
-                    continue;
-                }
-                $proc_time_verified = true;
-                $test_timing[$buildid][$testid] *= $nprocs;
-            }
-
-            // Compute procTime = duration * nprocs and record it for each build.
-            // We assume only one buildgroup for subproject results.
-            foreach ($controller->buildgroupsResponse[0]['builds'] as $i => $build_response) {
-                $buildid = $build_response['id'];
-                if (!array_key_exists('test', $build_response)) {
-                    continue;
-                }
-                if (!array_key_exists($buildid, $test_timing)) {
-                    continue;
-                }
-
-                $proc_time = array_sum($test_timing[$buildid]);
-                $controller->buildgroupsResponse[0]['builds'][$i]['test']['procTime'] =
-                    time_difference($proc_time, true);
-                $controller->buildgroupsResponse[0]['builds'][$i]['test']['procTimeFull'] =
-                    $proc_time;
-            }
+        // We support an additional advanced column called 'Proc Time'.
+        // This is only shown if this project is setup to display
+        // an extra test measurement called 'Processors'.
+        $stmt = $PDO->prepare(
+                "SELECT id FROM measurement
+                WHERE projectid = ? and name = 'Processors'");
+        pdo_execute($stmt, [$projectid]);
+        if ($stmt->fetchColumn() !== false) {
+            $response['showProcTime'] = true;
+        } else {
+            $response['showProcTime'] = false;
         }
-        $response['showProcTime'] = $proc_time_verified;
 
         $response['buildgroups'] = $controller->buildgroupsResponse;
         $response['updatetype'] = $controller->updateType;
@@ -775,6 +714,5 @@ if (!function_exists('echo_main_dashboard_JSON')) {
         echo json_encode(cast_data_for_JSON($response));
     }
 }
-
 
 echo_main_dashboard_JSON($Project);

--- a/public/upgrade.php
+++ b/public/upgrade.php
@@ -832,6 +832,18 @@ if (isset($_GET['upgrade-2-8'])) {
     // Add a 'recheck' field to the pendingsubmission table.
     AddTableField('pending_submissions', 'recheck', 'tinyint(1)', 'smallint', '0');
 
+    // Migrate from buildtesttime.time to build.testduration
+    if (!pdo_query('SELECT testduration FROM build LIMIT 1')) {
+        // Add testduration column to build table.
+        AddTableField('build', 'testduration', 'int(11)', 'integer', '0');
+
+        // Migrate values from buildtesttime.time to build.testduration.
+        PopulateTestDuration();
+
+        // Change build.configureduration from float to int
+        ModifyTableField('build', 'configureduration', 'int(11)', 'integer', '0', true, false);
+    }
+
     // Set the database version
     setVersion();
 

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -31,7 +31,7 @@ CREATE TABLE `build` (
   `log` text NOT NULL DEFAULT '',
   `configureerrors` smallint(6) DEFAULT '-1',
   `configurewarnings` smallint(6) DEFAULT '-1',
-  `configureduration` float(7,2) NOT NULL default '0.00',
+  `configureduration` int(11) NOT NULL default '0',
   `builderrors` smallint(6) DEFAULT '-1',
   `buildwarnings` smallint(6) DEFAULT '-1',
   `buildduration` int(11) NOT NULL default '0',

--- a/sql/mysql/cdash.sql
+++ b/sql/mysql/cdash.sql
@@ -39,6 +39,7 @@ CREATE TABLE `build` (
   `testfailed` smallint(6) DEFAULT '-1',
   `testpassed` smallint(6) DEFAULT '-1',
   `testtimestatusfailed` smallint(6) DEFAULT '-1',
+  `testduration` int(11) NOT NULL default '0',
   `notified` tinyint(1) default '0',
   `done` tinyint(1) default '0',
   `uuid` varchar(36) NOT NULL,

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -25,6 +25,7 @@ CREATE TABLE "build" (
   "testfailed" smallint DEFAULT '-1',
   "testpassed" smallint DEFAULT '-1',
   "testtimestatusfailed" smallint DEFAULT '-1',
+  "testduration" integer DEFAULT '0' NOT NULL,
   "notified" smallint DEFAULT '0' NOT NULL,
   "done" smallint DEFAULT '0' NOT NULL,
   "uuid" character varying(36) NOT NULL,

--- a/sql/pgsql/cdash.sql
+++ b/sql/pgsql/cdash.sql
@@ -17,7 +17,7 @@ CREATE TABLE "build" (
   "log" text DEFAULT '' NOT NULL,
   "configureerrors" smallint DEFAULT '-1',
   "configurewarnings" smallint DEFAULT '-1',
-  "configureduration" numeric(7,2) DEFAULT '0.00' NOT NULL,
+  "configureduration" integer DEFAULT '0' NOT NULL,
   "builderrors" smallint DEFAULT '-1',
   "buildwarnings" smallint DEFAULT '-1',
   "buildduration" integer DEFAULT '0' NOT NULL,

--- a/tests/test_excludesubprojects.php
+++ b/tests/test_excludesubprojects.php
@@ -82,9 +82,15 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
             return 1;
         }
 
-        // Verify test duration of 44 seconds (normally 48).
-        if ($build['test']['timefull'] !== 44) {
-            $this->fail('Expected test duration to be 44, found ' . $build['test']['timefull']);
+        // Verify test duration of 48 seconds (unchanged).
+        if ($build['test']['timefull'] !== 48) {
+            $this->fail('Expected proc time to be 48, found ' . $build['test']['timefull']);
+            return 1;
+        }
+
+        // Verify proc time of 84.81 (normally 102.98).
+        if ($build['test']['procTimeFull'] !== 84.81) {
+            $this->fail('Expected proc time to be 84.81, found ' . $build['test']['procTimeFull']);
             return 1;
         }
 
@@ -188,9 +194,15 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
             return 1;
         }
 
-        // Verify test duration of 4 seconds (normally 48).
-        if ($build['test']['timefull'] !== 4) {
-            $this->fail('Expected test duration to be 4, found ' . $build['test']['timefull']);
+        // Verify test duration of 48 seconds (unchanged).
+        if ($build['test']['timefull'] !== 48) {
+            $this->fail('Expected test duration to be 48, found ' . $build['test']['timefull']);
+            return 1;
+        }
+
+        // Verify proc time of 18.17 (normally 102.98).
+        if ($build['test']['procTimeFull'] !== 18.17) {
+            $this->fail('Expected test duration to be 18.17, found ' . $build['test']['procTimeFull']);
             return 1;
         }
 
@@ -271,12 +283,6 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
                 'compare' => 42,
                 'value' => 35,
                 'exclude' => 'Sacado'
-            ),
-            array(
-                'filter' => 'testsduration',
-                'compare' => 41,
-                'value' => 48,
-                'exclude' => 'TrilinosFramework'
             ),
             array(
                 'filter' => 'testsfailed',

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -524,22 +524,26 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                         $expected_num_defect_types = 1;
                         $expected_num_defects = 1;
                         $expected_defect_type = 'Invalid Pointer Write';
+                        $expected_proc_time = 0.01;
                         break;
                     case 'MyProductionCode':
                         $expected_num_analyses = 1;
                         $expected_num_defect_types = 0;
                         $expected_num_defects = 0;
+                        $expected_proc_time = 0.0;
                         break;
                     case 'MyThirdPartyDependency':
                         $expected_num_analyses = 1;
                         $expected_num_defect_types = 1;
                         $expected_num_defects = 2;
                         $expected_defect_type = 'Memory Leak';
+                        $expected_proc_time = 0.0;
                         break;
                     case 'EmptySubproject':
                         $expected_num_analyses = 0;
                         $expected_num_defect_types = 0;
                         $expected_num_defects = 0;
+                        $expected_proc_time = 0.0;
                         break;
                 }
                 $num_analyses = count($jsonobj['dynamicanalyses']);
@@ -569,8 +573,8 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 // Verify that test duration is calculated correctly.
                 $stmt = $pdo->query("SELECT time FROM buildtesttime WHERE buildid = {$build['id']}");
                 $found = $stmt->fetchColumn();
-                if ($found !== false && $found != 4) {
-                    throw new Exception("Expected 4 but found $found for {$build['id']}'s test duration");
+                if ($found !== false && $found != $expected_proc_time) {
+                    throw new Exception("Expected $expected_proc_time but found $found for {$build['id']}'s test duration");
                 }
             }
 

--- a/xml_handlers/testing_handler.php
+++ b/xml_handlers/testing_handler.php
@@ -265,11 +265,11 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
                 if ($this->StartTimeStamp > 0 && $this->EndTimeStamp > 0) {
                     // Update test duration in the Build table.
                     $duration = $this->EndTimeStamp - $this->StartTimeStamp;
-                    $build->SaveTotalTestsTime($duration, !$all_at_once);
+                    $build->UpdateTestDuration($duration, !$all_at_once);
                     if ($all_at_once && !$parent_duration_set) {
                         $parent_build = $factory->create(Build::class);
                         $parent_build->Id = $build->GetParentId();
-                        $parent_build->SaveTotalTestsTime($duration, false);
+                        $parent_build->UpdateTestDuration($duration, false);
                         $parent_duration_set = true;
                     }
                 }

--- a/xml_handlers/testing_handler.php
+++ b/xml_handlers/testing_handler.php
@@ -273,6 +273,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
                         $parent_duration_set = true;
                     }
                 }
+                $build->SaveTotalTestsTime();
 
                 $config = \CDash\Config::getInstance();
                 if ($config->get('CDASH_ENABLE_FEED')) {

--- a/xml_handlers/testing_junit_handler.php
+++ b/xml_handlers/testing_junit_handler.php
@@ -290,7 +290,7 @@ class TestingJUnitHandler extends AbstractHandler
                 $this->NumberTestsFailed,
                 $this->NumberTestsNotRun);
 
-            $this->Build->SaveTotalTestsTime($this->TotalTestDuration);
+            $this->Build->UpdateTestDuration($this->TotalTestDuration);
             $this->Build->ComputeTestTiming();
         }
     }

--- a/xml_handlers/testing_nunit_handler.php
+++ b/xml_handlers/testing_nunit_handler.php
@@ -159,8 +159,6 @@ class TestingNUnitHandler extends AbstractHandler
             $this->Build->Information = $buildInformation;
             $this->Append = false;
         } elseif ($this->BuildAdded == false && $name == 'TEST-SUITE') {
-            $this->Build->SaveTotalTestsTime(0);
-
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $this->Build->ProjectId = $this->projectid;
             $this->Build->GetIdFromName($this->SubProjectName);


### PR DESCRIPTION
We now record two separate test time values per build.

* Wall clock time. This is how long was spent running all tests for a given build. This is stored in build.testduration.

* Execution time (aka proc time). This is multiplied by the number of processors used on a per-test basis. This is stored in buildtesttime.time.