### PR TITLE
Improvements to CDash's GitHub Checks

### DIFF
--- a/app/Lib/Repository/GitHub.php
+++ b/app/Lib/Repository/GitHub.php
@@ -220,14 +220,75 @@ class GitHub implements RepositoryInterface
     {
         $stmt = $this->db->prepare('
             SELECT b.id, b.name, b.builderrors, b.configureerrors, b.testfailed,
-                   b.done, bp.properties
+                   b.done, b.starttime, bp.properties
             FROM build b
             JOIN build2update b2u ON b2u.buildid = b.id
             JOIN buildupdate bu ON bu.id = b2u.updateid
             LEFT JOIN buildproperties bp ON bp.buildid = b.id
             WHERE bu.revision = :sha');
         $this->db->execute($stmt, [':sha' => $head_sha]);
-        return $stmt;
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $this->dedupeAndSortBuildRows($rows);
+        return $rows;
+    }
+
+    /**
+     * Include only one row per build name: the one with the most recent start time.
+     * Also sort the rows by the build name (in alphabetical order).
+     */
+    public function dedupeAndSortBuildRows($rows)
+    {
+        // Gather up all the rows that have non-unique build names.
+        $build_names = [];
+        foreach ($rows as $row) {
+            $build_name = $row['name'];
+            if (!array_key_exists($build_name, $build_names)) {
+                $build_names[$build_name] = [];
+            }
+            $build_names[$build_name][] = $row;
+        }
+        $build_names = array_filter($build_names, function ($k, $v) {
+            return count($k) > 1;
+        }, ARRAY_FILTER_USE_BOTH);
+
+        // Find the ids of all the older builds that should not be included
+        // in our report.
+        $buildids_to_remove = [];
+        foreach ($build_names as $name => $builds) {
+            // Find the newest build with this name.
+            // This is the one we will include in the report.
+            $newest_starttime = -1;
+            $buildid_to_keep = -1;
+            foreach ($builds as $build) {
+                $starttime = strtotime($build['starttime']);
+                if ($starttime > $newest_starttime) {
+                    $newest_starttime = $starttime;
+                    $buildid_to_keep = $build['id'];
+                }
+            }
+            // Record all the old builds that should not be included.
+            foreach ($builds as $build) {
+                if ($build['id'] !== $buildid_to_keep) {
+                    $buildids_to_remove[] = $build['id'];
+                }
+            }
+        }
+
+        // Make a new array of rows that only contains the builds that will be
+        // included in our report.
+        $output_rows = [];
+        foreach ($rows as $row) {
+            if (!in_array($row['id'], $buildids_to_remove)) {
+                $output_rows[] = $row;
+            }
+        }
+
+        // Alphabetize this array by build name.
+        usort($output_rows, function ($a, $b) {
+            return strcmp($a['name'], $b['name']);
+        });
+
+        return $output_rows;
     }
 
     /**

--- a/app/Lib/Repository/GitHub.php
+++ b/app/Lib/Repository/GitHub.php
@@ -32,39 +32,6 @@ use CDash\Model\Project;
 require_once 'include/log.php';
 
 /**
- * Class Checks
- * TODO: upstream this to KnpLabs/php-github-api
- **/
-class Checks extends \Github\Api\AbstractApi
-{
-    use \Github\Api\AcceptHeaderTrait;
-
-    public function configure()
-    {
-        // TODO: this isn't working yet (manually added this header below).
-        // Maybe it will once we move it into php-github-api.
-        $this->acceptHeaderValue = 'application/vnd.github.antiope-preview+json';
-
-        return $this;
-    }
-
-    // https://developer.github.com/v3/checks/runs/#create-a-check-run
-    public function create($username, $repository, array $params = [])
-    {
-        if (!isset($params['name'], $params['head_sha'])) {
-            throw new \Github\Exception\MissingArgumentException(['name', 'head_sha']);
-        }
-        return $this->post('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs', $params);
-    }
-
-    // https://developer.github.com/v3/checks/runs/#update-a-check-run
-    public function update($username, $repository, $checkRunId, array $params = [])
-    {
-        return $this->patch('/repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/check-runs/'.rawurlencode($checkRunId), $params);
-    }
-}
-
-/**
  * Class GitHub
  * @package CDash\Lib\Repository
  */
@@ -231,7 +198,7 @@ class GitHub implements RepositoryInterface
         $payload = $this->generateCheckPayloadFromBuildRows($build_rows, $head_sha);
 
         if (!$this->check) {
-            $this->check = new Checks($this->apiClient);
+            $this->check = new \Github\Api\Repository\Checks($this->apiClient);
         }
         try {
             $this->check->create($this->owner, $this->repo, $payload);

--- a/app/Lib/Repository/GitHub.php
+++ b/app/Lib/Repository/GitHub.php
@@ -367,7 +367,7 @@ class GitHub implements RepositoryInterface
                 } else {
                     $params['conclusion'] = 'success';
                     $output['title'] = 'Success';
-                    $summary = 'All builds completed successfully';
+                    $summary = 'All builds completed successfully :shipit:';
                 }
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "aws/aws-sdk-php": "^3.57",
     "doctrine/dbal": "^2.5",
     "iron-io/iron_mq": "~2.0",
-    "knplabs/github-api": "^2.11",
+    "knplabs/github-api": "dev-master#8c26dc85",
     "php-http/guzzle6-adapter": "^1.1",
     "lcobucci/jwt": "3.2.0",
     "jenssegers/blade": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1bb1afe5083ac086555e24aead93c29",
+    "content-hash": "00c619441fd600c2fc84e7f857fb0591",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1433,16 +1433,16 @@
         },
         {
             "name": "knplabs/github-api",
-            "version": "2.11.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
-                "reference": "7e67b4ccf9ef62fbd6321a314c61d3202c07b855"
+                "reference": "8c26dc85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/7e67b4ccf9ef62fbd6321a314c61d3202c07b855",
-                "reference": "7e67b4ccf9ef62fbd6321a314c61d3202c07b855",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/8c26dc85",
+                "reference": "8c26dc85",
                 "shasum": ""
             },
             "require": {
@@ -1465,7 +1465,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.11.x-dev"
+                    "dev-master": "2.12.x-dev"
                 }
             },
             "autoload": {
@@ -1496,7 +1496,7 @@
                 "gist",
                 "github"
             ],
-            "time": "2019-01-28T19:31:35+00:00"
+            "time": "2019-04-23 20:21:16"
         },
         {
             "name": "lcobucci/jwt",
@@ -5336,7 +5336,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "bernard/bernard": 15
+        "bernard/bernard": 15,
+        "knplabs/github-api": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -241,6 +241,30 @@ class GitHubTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testDedupeAndSortBuildRows()
+    {
+        $this->project->expects($this->once())
+            ->method('GetRepositories')
+            ->willReturn([]);
+        $sut = new GitHub($this->project);
+
+        $rows = [
+            ['id' => 1, 'name' => 'c', 'starttime' => '2019-05-01 18:08:35'],
+            ['id' => 2, 'name' => 'a', 'starttime' => '2019-05-01 18:08:36'],
+            ['id' => 3, 'name' => 'a', 'starttime' => '2019-05-01 18:08:37'],
+            ['id' => 4, 'name' => 'a', 'starttime' => '2019-05-01 18:08:38'],
+            ['id' => 5, 'name' => 'b', 'starttime' => '2019-05-01 18:08:39'],
+            ['id' => 6, 'name' => 'b', 'starttime' => '2019-05-01 18:08:40'],
+        ];
+        $actual = $sut->dedupeAndSortBuildRows($rows);
+        $expected = [
+            ['id' => 4, 'name' => 'a', 'starttime' => '2019-05-01 18:08:38'],
+            ['id' => 6, 'name' => 'b', 'starttime' => '2019-05-01 18:08:40'],
+            ['id' => 1, 'name' => 'c', 'starttime' => '2019-05-01 18:08:35']
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
     private function setupAuthentication()
     {
         $github_url = 'https://github.com/Foo/Bar';

--- a/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -191,7 +191,7 @@ class GitHubTest extends PHPUnit_Framework_TestCase
         $expected['status'] = 'completed';
         $expected['conclusion'] = 'success';
         $expected['output']['title'] = 'Success';
-        $expected['output']['summary'] = "[All builds completed successfully]($index_url)";
+        $expected['output']['summary'] = "[All builds completed successfully :shipit:]($index_url)";
         $expected['output']['text'] = "$table_header\n[a]($this->baseUrl/buildSummary.php?buildid=99995) | :white_check_mark: | [success]($this->baseUrl/buildSummary.php?buildid=99995)";
         $build_rows[0]['done'] = 1;
         $actual = $sut->generateCheckPayloadFromBuildRows($build_rows, 'zzz');

--- a/xml_handlers/done_handler.php
+++ b/xml_handlers/done_handler.php
@@ -68,7 +68,9 @@ class DoneHandler extends AbstractHandler
             // Should we re-run any checks that were previously marked
             // as pending?
             if ($this->PendingSubmissions->Recheck) {
-                $update = $this->Build->GetBuildUpdate();
+                $update = new BuildUpdate();
+                $update->BuildId = $this->Build->Id;
+                $update->FillFromBuildId();
                 Repository::createOrUpdateCheck($update->Revision);
             }
 


### PR DESCRIPTION
* Use newly upstreamed php-github-api Checks class
* Only show the most recent result (per build name) in the check
* Display build's in alphabetical order
* Display the "ship it" squirrel on successful checks