### PR TITLE
Fix behavior of SubProjects include filter in child view

### DIFF
--- a/app/Controller/Api/Index.php
+++ b/app/Controller/Api/Index.php
@@ -777,7 +777,7 @@ class Index extends ResultsApi
         $compilation_response = array();
 
         if ($build_array['countbuilderrors'] >= 0) {
-            if ($this->includeSubProjects) {
+            if ($this->includeSubProjects && $this->childView != 1) {
                 $nerrors = $selected_build_errors;
                 $nwarnings = $selected_build_warnings;
                 $buildduration = $selected_build_duration;
@@ -822,7 +822,7 @@ class Index extends ResultsApi
             $build_response['hasconfigure'] = true;
             $configure_response = array();
 
-            if ($this->includeSubProjects) {
+            if ($this->includeSubProjects && $this->childView != 1) {
                 $nconfigureerrors = $selected_configure_errors;
                 $nconfigurewarnings = $selected_configure_warnings;
                 $configureduration = $selected_configure_duration;
@@ -860,7 +860,7 @@ class Index extends ResultsApi
             $this->buildgroupsResponse[$i]['hastestdata'] = true;
             $test_response = array();
 
-            if ($this->includeSubProjects) {
+            if ($this->includeSubProjects && $this->childView != 1) {
                 $nnotrun = $selected_tests_not_run;
                 $nfail = $selected_tests_failed;
                 $npass = $selected_tests_passed;

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -148,7 +148,6 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
     private function setEmailPreference($status, $chars)
     {
         $pdo = get_link_identifier()->getPdo();
-        $success = false;
 
         $sql = "
             SELECT
@@ -172,7 +171,9 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             AND projectid = {$this->projectId}
         ";
 
-        $success = (bool) $pdo->exec($sql);
+        if (!$pdo->exec($sql)) {
+            $this->fail("Query failed: $sql");
+        }
 
         $sql = "
             UPDATE project
@@ -180,7 +181,9 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             WHERE id = {$this->projectId}
         ";
 
-        return (bool) $pdo->exec($sql) && $success;
+        if (!$pdo->exec($sql)) {
+            $this->fail("Query failed: $sql");
+        }
     }
 
     private function restoreEmailPreference()
@@ -199,7 +202,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             // the non-type testing here is intentional, throw exception if return value is
             // either false or zero (0).
             if ($pdo->exec($sql) == false) {
-                throw new Exception('Failed to restore email summary');
+                $this->fail('Failed to restore email summary');
             }
             $this->summaryEmail = null;
         }
@@ -214,7 +217,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             // the non-type testing here is intentional, throw exception if return value is
             // either false or zero (0).
             if ($pdo->exec($sql) == false) {
-                throw new Exception('Failed to restore project\'s emailmaxchars');
+                $this->fail('Failed to restore project\'s emailmaxchars');
             }
             $this->emailMaxChars = null;
         }
@@ -228,379 +231,374 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         $pdo = get_link_identifier()->getPdo();
         $parentid = null;
 
-        try {
-            $success = true;
-            $subprojects = array("MyThirdPartyDependency", "MyExperimentalFeature", "MyProductionCode", "EmptySubproject");
+        $subprojects = array("MyThirdPartyDependency", "MyExperimentalFeature", "MyProductionCode", "EmptySubproject");
 
-            //
-            $this->get($this->url . "/api/v1/index.php?project=SubProjectExample&date=2016-07-28");
-            $content = $this->getBrowser()->getContent();
-            $jsonobj = json_decode($content, true);
+        //
+        $this->get($this->url . "/api/v1/index.php?project=SubProjectExample&date=2016-07-28");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
 
-            $buildgroup = array_pop($jsonobj['buildgroups']);
-            $builds = $buildgroup['builds'];
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $builds = $buildgroup['builds'];
 
-            // Check number of parent builds
-            $num_builds = count($builds);
-            if ($num_builds !== 1) {
-                throw new Exception("Expected 1 parent build, found {$num_builds}");
+        // Check number of parent builds
+        $num_builds = count($builds);
+        if ($num_builds !== 1) {
+            $this->fail("Expected 1 parent build, found {$num_builds}");
+        }
+
+        // Get parent id
+        $parentid = $builds[0]['id'];
+        if (empty($parentid) || $parentid < 1) {
+            $this->fail("No parentid found when expected");
+        }
+
+        // Check number of children builds
+        $num_children = $builds[0]['numchildren'];
+        if ($num_children != 4) {
+            $this->fail("Expected 4 children, found {$num_children}");
+        }
+
+        // Check configure
+        $numconfigureerror = $buildgroup['numconfigureerror'];
+        if ($numconfigureerror != 1) {
+            $this->fail("Expected 1 configure error, found {$numconfigureerror}");
+        }
+
+        $numconfigurewarning = $buildgroup['numconfigurewarning'];
+        if ($numconfigurewarning != 1) {
+            $this->fail("Expected 1 configure warnings, found {$numconfigurewarning}");
+        }
+
+        // Check builds
+        $numbuilderror = $buildgroup['numbuilderror'];
+        if ($numbuilderror != 2) {
+            $this->fail("Expected 2 build errors, found {$numbuilderror}");
+        }
+
+        $numbuildwarning = $buildgroup['numbuildwarning'];
+        if ($numbuildwarning != 2) {
+            $this->fail("Expected 2 build warnings, found {$numbuildwarning}");
+        }
+
+        // Check tests
+        $numtestpass = $buildgroup['numtestpass'];
+        if ($numtestpass != 1) {
+            $this->fail("Expected 1 test to pass, found {$numtestpass}");
+        }
+
+        $numtestfail = $buildgroup['numtestfail'];
+        if ($numtestfail != 5) {
+            $this->fail("Expected 5 tests to fail, found {$numtestfail}");
+        }
+
+        $numtestnotrun = $buildgroup['numtestnotrun'];
+        if ($numtestnotrun != 1) {
+            $this->fail("Expected 1 test not run, found {$numtestnotrun}");
+        }
+
+        // Check coverage
+        $numcoverages = count($jsonobj['coverages']);
+        if ($numcoverages != 1) {
+            $this->fail("Expected 1 coverage build, found {$numcoverages}");
+        }
+        $cov = $jsonobj['coverages'][0];
+        $percent = $cov['percentage'];
+        if ($percent != 70) {
+            $this->fail("Expected 70% coverage, found {$percent}");
+        }
+        $loctested = $cov['loctested'];
+        if ($loctested != 14) {
+            $this->fail("Expected 14 LOC tested, found {$loctested}");
+        }
+        $locuntested = $cov['locuntested'];
+        if ($locuntested != 6) {
+            $this->fail("Expected 6 LOC untested, found {$locuntested}");
+        }
+
+        // Check dynamic analysis.
+        $numdynamicanalyses = count($jsonobj['dynamicanalyses']);
+        if ($numdynamicanalyses != 1) {
+            $this->fail("Expected 1 DA build, found {$numdynamicanalyses}");
+        }
+        $DA = $jsonobj['dynamicanalyses'][0];
+        $defectcount = $DA['defectcount'];
+        if ($defectcount != 3) {
+            $this->fail("Expected 3 DA defects, found {$defectcount}");
+        }
+
+        // View parent build
+        $this->get("{$this->url}/api/v1/index.php?project=SubProjectExample&parentid={$parentid}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+
+        $num_children = $jsonobj['numchildren'];
+        if ($num_children != 4) {
+            $this->fail("Expected 4 subprojects, found {$num_children}");
+        }
+
+        if ($jsonobj['parenthasnotes'] !== true) {
+            $this->fail("parenthasnotes not set to true when expected");
+        }
+
+        $num_uploaded_files = $jsonobj['uploadfilecount'];
+        if ($num_uploaded_files  !== 1) {
+            $this->fail("Expected 1 uploaded file, found $num_uploaded_files");
+        }
+
+        $numcoverages = count($jsonobj['coverages']);
+        if ($numcoverages != 2) {
+            $this->fail("Expected 2 subproject coverages, found {$numcoverages}");
+        }
+
+        $numdynamicanalyses = count($jsonobj['dynamicanalyses']);
+        if ($numdynamicanalyses != 3) {
+            $this->fail("Expected 3 subproject dynamic analyses, found {$numdynamicanalyses}");
+        }
+
+        if ($jsonobj['updateduration'] !== false) {
+            $this->fail("Expected updateduration to be false, found {$jsonobj['updateduration']}");
+        }
+        if ($jsonobj['configureduration'] != '1s') {
+            $this->fail("Expected configureduration to be 1s, found {$jsonobj['configureduration']}");
+        }
+        if ($jsonobj['buildduration'] != '5s') {
+            $this->fail("Expected buildduration to be 5s, found {$jsonobj['buildduration']}");
+        }
+        if ($jsonobj['testduration'] != '4s') {
+            $this->fail("Expected testduration to be 4s, found {$jsonobj['testduration']}");
+        }
+
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $builds = $buildgroup['builds'];
+
+        foreach ($builds as $build) {
+            $label = $build['label'];
+            $index = array_search($label, $subprojects);
+            if ($index === false) {
+                $this->fail("Invalid label ($label)!");
+            }
+            $index += 1;
+            if ($build['position'] !== $index) {
+                $this->fail("Expected {$index} but found ${build['position']} for {$label} position");
             }
 
-            // Get parent id
-            $parentid = $builds[0]['id'];
-            if (empty($parentid) || $parentid < 1) {
-                throw new Exception("No parentid found when expected");
+            // Adding tests to ensure that labels associated with subprojects and tests were saved
+            $sql = "
+                SELECT text
+                FROM label2test
+                     JOIN label
+                ON
+                  id=labelid
+                WHERE buildid=:buildid;
+            ";
+            $stmt = $pdo->prepare($sql);
+            $stmt->bindParam(':buildid', $build['id'], PDO::PARAM_INT);
+            $stmt->execute();
+            $rows = array_unique($stmt->fetchAll(PDO::FETCH_COLUMN, 'text'));
+
+            $count = count($rows);
+
+            $success = false;
+            switch ($label) {
+                case 'MyExperimentalFeature':
+                    $success = $count === 1 && in_array('MyExperimentalFeature', $rows);
+                    break;
+                case 'MyProductionCode':
+                    $success = $count === 1 && in_array('MyProductionCode', $rows);
+                    break;
+                case 'MyThirdPartyDependency':
+                    $success = $count === 1 && in_array('MyThirdPartyDependency', $rows);
+                    break;
+                case 'EmptySubproject':
+                    $success = $count === 0;
+                    break;
+                default:
+                    $success = false;
             }
 
-            // Check number of children builds
-            $num_children = $builds[0]['numchildren'];
-            if ($num_children != 4) {
-                throw new Exception("Expected 4 children, found {$num_children}");
+            if (!$success) {
+                $error_message = 'Unexpected label associations';
+                $error_message .= "\n{$build['label']}: count: {$count}: rows: " . implode(',', $rows);
+                $this->fail($error_message);
             }
+        }
 
-            // Check configure
-            $numconfigureerror = $buildgroup['numconfigureerror'];
-            if ($numconfigureerror != 1) {
-                throw new Exception("Expected 1 configure error, found {$numconfigureerror}");
+        // viewConfigure
+        $this->get("{$this->url}/viewConfigure.php?buildid={$parentid}");
+
+        $content = $this->getBrowser()->getContent();
+        if ($content == false) {
+            $this->fail("Error retrieving content from viewConfigure.php");
+        }
+
+        foreach ($subprojects as $subproject) {
+            $pattern = "#td style=\"vertical-align:top\">$subproject</td>#";
+            if (preg_match($pattern, $content) == 1) {
+                $this->fail('Subprojects should not be displayed on viewConfigure');
             }
+        }
 
-            $numconfigurewarning = $buildgroup['numconfigurewarning'];
-            if ($numconfigurewarning != 1) {
-                throw new Exception("Expected 1 configure warnings, found {$numconfigurewarning}");
+        // viewSubProjects
+        $this->get("{$this->url}/api/v1/viewSubProjects.php?project=SubProjectExample&date=2016-07-28");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+
+        if (!array_key_exists('project', $jsonobj)) {
+            $this->fail('No project found on viewSubProjects.php');
+        }
+
+        // Check top-level project results.
+        $project = $jsonobj['project'];
+        $project_expected = array(
+            'nbuilderror' => 1,
+            'nbuildwarning' => 1,
+            'nbuildpass' => 0,
+            'nconfigureerror' => 1,
+            'nconfigurewarning' => 1,
+            'nconfigurepass' => 0,
+            'ntestpass' => 1,
+            'ntestfail' => 5,       // Total number of tests failed
+            'ntestnotrun' => 1);
+        foreach ($project_expected as $key => $expected) {
+            $found = $project[$key];
+            if ($found !== $expected) {
+                $this->fail("Expected $key to be $expected, found $found");
             }
+        }
 
-            // Check builds
-            $numbuilderror = $buildgroup['numbuilderror'];
-            if ($numbuilderror != 2) {
-                throw new Exception("Expected 2 build errors, found {$numbuilderror}");
-            }
-
-            $numbuildwarning = $buildgroup['numbuildwarning'];
-            if ($numbuildwarning != 2) {
-                throw new Exception("Expected 2 build warnings, found {$numbuildwarning}");
-            }
-
-            // Check tests
-            $numtestpass = $buildgroup['numtestpass'];
-            if ($numtestpass != 1) {
-                throw new Exception("Expected 1 test to pass, found {$numtestpass}");
-            }
-
-            $numtestfail = $buildgroup['numtestfail'];
-            if ($numtestfail != 5) {
-                throw new Exception("Expected 5 tests to fail, found {$numtestfail}");
-            }
-
-            $numtestnotrun = $buildgroup['numtestnotrun'];
-            if ($numtestnotrun != 1) {
-                throw new Exception("Expected 1 test not run, found {$numtestnotrun}");
-            }
-
-            // Check coverage
-            $numcoverages = count($jsonobj['coverages']);
-            if ($numcoverages != 1) {
-                throw new Exception("Expected 1 coverage build, found {$numcoverages}");
-            }
-            $cov = $jsonobj['coverages'][0];
-            $percent = $cov['percentage'];
-            if ($percent != 70) {
-                throw new Exception("Expected 70% coverage, found {$percent}");
-            }
-            $loctested = $cov['loctested'];
-            if ($loctested != 14) {
-                throw new Exception("Expected 14 LOC tested, found {$loctested}");
-            }
-            $locuntested = $cov['locuntested'];
-            if ($locuntested != 6) {
-                throw new Exception("Expected 6 LOC untested, found {$locuntested}");
-            }
-
-            // Check dynamic analysis.
-            $numdynamicanalyses = count($jsonobj['dynamicanalyses']);
-            if ($numdynamicanalyses != 1) {
-                throw new Exception("Expected 1 DA build, found {$numdynamicanalyses}");
-            }
-            $DA = $jsonobj['dynamicanalyses'][0];
-            $defectcount = $DA['defectcount'];
-            if ($defectcount != 3) {
-                throw new Exception("Expected 3 DA defects, found {$defectcount}");
-            }
-
-            // View parent build
-            $this->get("{$this->url}/api/v1/index.php?project=SubProjectExample&parentid={$parentid}");
-            $content = $this->getBrowser()->getContent();
-            $jsonobj = json_decode($content, true);
-
-            $num_children = $jsonobj['numchildren'];
-            if ($num_children != 4) {
-                throw new Exception("Expected 4 subprojects, found {$num_children}");
-            }
-
-            if ($jsonobj['parenthasnotes'] !== true) {
-                throw new Exception("parenthasnotes not set to true when expected");
-            }
-
-            $num_uploaded_files = $jsonobj['uploadfilecount'];
-            if ($num_uploaded_files  !== 1) {
-                throw new Exception("Expected 1 uploaded file, found $num_uploaded_files");
-            }
-
-            $numcoverages = count($jsonobj['coverages']);
-            if ($numcoverages != 2) {
-                throw new Exception("Expected 2 subproject coverages, found {$numcoverages}");
-            }
-
-            $numdynamicanalyses = count($jsonobj['dynamicanalyses']);
-            if ($numdynamicanalyses != 3) {
-                throw new Exception("Expected 3 subproject dynamic analyses, found {$numdynamicanalyses}");
-            }
-
-            if ($jsonobj['updateduration'] !== false) {
-                throw new Exception("Expected updateduration to be false, found {$jsonobj['updateduration']}");
-            }
-            if ($jsonobj['configureduration'] != '1s') {
-                throw new Exception("Expected configureduration to be 1s, found {$jsonobj['configureduration']}");
-            }
-            if ($jsonobj['buildduration'] != '5s') {
-                throw new Exception("Expected buildduration to be 5s, found {$jsonobj['buildduration']}");
-            }
-            if ($jsonobj['testduration'] != '4s') {
-                throw new Exception("Expected testduration to be 4s, found {$jsonobj['testduration']}");
-            }
-
-            $buildgroup = array_pop($jsonobj['buildgroups']);
-            $builds = $buildgroup['builds'];
-
-            foreach ($builds as $build) {
-                $label = $build['label'];
-                $index = array_search($label, $subprojects);
-                if ($index === false) {
-                    throw new Exception("Invalid label ($label)!");
-                }
-                $index += 1;
-                if ($build['position'] !== $index) {
-                    throw new Exception("Expected {$index} but found ${build['position']} for {$label} position");
-                }
-
-                // Adding tests to ensure that labels associated with subprojects and tests were saved
-                $sql = "
-                    SELECT text
-                    FROM label2test
-                         JOIN label
-                    ON
-                      id=labelid
-                    WHERE buildid=:buildid;
-                ";
-                $stmt = $pdo->prepare($sql);
-                $stmt->bindParam(':buildid', $build['id'], PDO::PARAM_INT);
-                $stmt->execute();
-                $rows = array_unique($stmt->fetchAll(PDO::FETCH_COLUMN, 'text'));
-
-                $count = count($rows);
-
-                switch ($label) {
-                    case 'MyExperimentalFeature':
-                        $success = $count === 1 && in_array('MyExperimentalFeature', $rows);
-                        break;
-                    case 'MyProductionCode':
-                        $success = $count === 1 && in_array('MyProductionCode', $rows);
-                        break;
-                    case 'MyThirdPartyDependency':
-                        $success = $count === 1 && in_array('MyThirdPartyDependency', $rows);
-                        break;
-                    case 'EmptySubproject':
-                        $success = $count === 0;
-                        break;
-                    default:
-                        $success = false;
-                }
-
-                if (!$success) {
-                    $error_message = 'Unexpected label associations';
-                    $error_message .= "\n{$build['label']}: count: {$count}: rows: " . implode(',', $rows);
-                    throw new Exception($error_message);
-                }
-            }
-
-            // viewConfigure
-            $this->get("{$this->url}/viewConfigure.php?buildid={$parentid}");
-
-            $content = $this->getBrowser()->getContent();
-            if ($content == false) {
-                throw new Exception("Error retrieving content from viewConfigure.php");
-            }
-
-            foreach ($subprojects as $subproject) {
-                $pattern = "#td style=\"vertical-align:top\">$subproject</td>#";
-                if (preg_match($pattern, $content) == 1) {
-                    throw new Exception('Subprojects should not be displayed on viewConfigure');
-                }
-            }
-
-            // viewSubProjects
-            $this->get("{$this->url}/api/v1/viewSubProjects.php?project=SubProjectExample&date=2016-07-28");
-            $content = $this->getBrowser()->getContent();
-            $jsonobj = json_decode($content, true);
-
-            if (!array_key_exists('project', $jsonobj)) {
-                throw new Exception('No project found on viewSubProjects.php');
-            }
-
-            // Check top-level project results.
-            $project = $jsonobj['project'];
-            $project_expected = array(
+        // Check results for each individual SubProject.
+        $subprojects_expected = array(
+            'MyThirdPartyDependency' => array(
                 'nbuilderror' => 1,
+                'nbuildwarning' => 0,
+                'nbuildpass' => 0,
+                'nconfigureerror' => 1,
+                'nconfigurewarning' => 1,
+                'nconfigurepass' => 0,
+                'ntestpass' => 0,
+                'ntestfail' => 0,
+                'ntestnotrun' => 1),
+            'MyExperimentalFeature' => array(
+                'nbuilderror' => 0,
+                'nbuildwarning' => 1,
+                'nbuildpass' => 0,
+                'nconfigureerror' => 1,
+                'nconfigurewarning' => 1,
+                'nconfigurepass' => 0,
+                'ntestpass' => 0,
+                'ntestfail' => 5,
+                'ntestnotrun' => 0),
+            'MyProductionCode' => array(
+                'nbuilderror' => 0,
                 'nbuildwarning' => 1,
                 'nbuildpass' => 0,
                 'nconfigureerror' => 1,
                 'nconfigurewarning' => 1,
                 'nconfigurepass' => 0,
                 'ntestpass' => 1,
-                'ntestfail' => 5,       // Total number of tests failed
-                'ntestnotrun' => 1);
-            foreach ($project_expected as $key => $expected) {
-                $found = $project[$key];
+                'ntestfail' => 0,
+                'ntestnotrun' => 0));
+        foreach ($jsonobj['subprojects'] as $subproj) {
+            $subproj_name = $subproj['name'];
+            if (!array_key_exists($subproj_name, $subprojects_expected)) {
+                continue;
+            }
+            foreach ($subprojects_expected[$subproj_name] as $key => $expected) {
+                $found = $subproj[$key];
                 if ($found !== $expected) {
-                    throw new Exception("Expected $key to be $expected, found $found");
+                    $this->fail("Expected {$key} to be {$expected} for {$subproj_name}, found {$found}");
+                }
+            }
+        }
+
+        foreach ($builds as $build) {
+            // Verify that dynamic analysis data was correctly split across SubProjects.
+            $stmt = $pdo->query("SELECT numdefects FROM dynamicanalysissummary WHERE buildid = {$build['id']}");
+            $summary_total = $stmt->fetchColumn();
+            $this->get($this->url . "/api/v1/viewDynamicAnalysis.php?buildid={$build['id']}");
+            $content = $this->getBrowser()->getContent();
+            $jsonobj = json_decode($content, true);
+            $expected_defect_type = null;
+            switch ($build['label']) {
+                case 'MyExperimentalFeature':
+                    $expected_num_analyses = 1;
+                    $expected_num_defect_types = 1;
+                    $expected_num_defects = 1;
+                    $expected_defect_type = 'Invalid Pointer Write';
+                    $expected_proc_time = 0.01;
+                    break;
+                case 'MyProductionCode':
+                    $expected_num_analyses = 1;
+                    $expected_num_defect_types = 0;
+                    $expected_num_defects = 0;
+                    $expected_proc_time = 0.0;
+                    break;
+                case 'MyThirdPartyDependency':
+                    $expected_num_analyses = 1;
+                    $expected_num_defect_types = 1;
+                    $expected_num_defects = 2;
+                    $expected_defect_type = 'Memory Leak';
+                    $expected_proc_time = 0.0;
+                    break;
+                case 'EmptySubproject':
+                    $expected_num_analyses = 0;
+                    $expected_num_defect_types = 0;
+                    $expected_num_defects = 0;
+                    $expected_proc_time = 0.0;
+                    break;
+            }
+            $num_analyses = count($jsonobj['dynamicanalyses']);
+            if ($num_analyses != $expected_num_analyses) {
+                $this->fail("Expected {$expected_num_analyses} analyses for {$build['label']}, found {$num_analyses}");
+            }
+            if ($expected_num_analyses > 0) {
+                if ($summary_total != $expected_num_defects) {
+                    $this->fail("Expected {$expected_num_defects} defects for {$build['label']} but summary reports {$summary_total}");
+                }
+            }
+            $num_defect_types = count($jsonobj['defecttypes']);
+            if ($num_defect_types != $expected_num_defect_types) {
+                $this->fail("Expected {$expected_num_defect_types} type of defect for {$build['label']}, found {$num_defect_types}");
+            }
+            if ($expected_num_defects > 0) {
+                $num_defects = $jsonobj['dynamicanalyses'][0]['defects'][0];
+                if ($num_defects != $expected_num_defects) {
+                    $this->fail("Expected {$expected_num_defects} defects for {$build['label']}, found {$num_defects}");
+                }
+                $defect_type = $jsonobj['defecttypes'][0]['type'];
+                if ($expected_defect_type != $defect_type) {
+                    $this->fail("Expected type {$expected_defect_type} for {$build['label']}, found {$defect_type}");
                 }
             }
 
-            // Check results for each individual SubProject.
-            $subprojects_expected = array(
-                'MyThirdPartyDependency' => array(
-                    'nbuilderror' => 1,
-                    'nbuildwarning' => 0,
-                    'nbuildpass' => 0,
-                    'nconfigureerror' => 1,
-                    'nconfigurewarning' => 1,
-                    'nconfigurepass' => 0,
-                    'ntestpass' => 0,
-                    'ntestfail' => 0,
-                    'ntestnotrun' => 1),
-                'MyExperimentalFeature' => array(
-                    'nbuilderror' => 0,
-                    'nbuildwarning' => 1,
-                    'nbuildpass' => 0,
-                    'nconfigureerror' => 1,
-                    'nconfigurewarning' => 1,
-                    'nconfigurepass' => 0,
-                    'ntestpass' => 0,
-                    'ntestfail' => 5,
-                    'ntestnotrun' => 0),
-                'MyProductionCode' => array(
-                    'nbuilderror' => 0,
-                    'nbuildwarning' => 1,
-                    'nbuildpass' => 0,
-                    'nconfigureerror' => 1,
-                    'nconfigurewarning' => 1,
-                    'nconfigurepass' => 0,
-                    'ntestpass' => 1,
-                    'ntestfail' => 0,
-                    'ntestnotrun' => 0));
-            foreach ($jsonobj['subprojects'] as $subproj) {
-                $subproj_name = $subproj['name'];
-                if (!array_key_exists($subproj_name, $subprojects_expected)) {
-                    continue;
-                }
-                foreach ($subprojects_expected[$subproj_name] as $key => $expected) {
-                    $found = $subproj[$key];
-                    if ($found !== $expected) {
-                        throw new Exception("Expected {$key} to be {$expected} for {$subproj_name}, found {$found}");
-                    }
-                }
+            // Verify that test duration is calculated correctly.
+            $stmt = $pdo->query("SELECT time FROM buildtesttime WHERE buildid = {$build['id']}");
+            $found = $stmt->fetchColumn();
+            if ($found !== false && $found != $expected_proc_time) {
+                $this->fail("Expected $expected_proc_time but found $found for {$build['id']}'s test duration");
             }
+        }
 
-            foreach ($builds as $build) {
-                // Verify that dynamic analysis data was correctly split across SubProjects.
-                $stmt = $pdo->query("SELECT numdefects FROM dynamicanalysissummary WHERE buildid = {$build['id']}");
-                $summary_total = $stmt->fetchColumn();
-                $this->get($this->url . "/api/v1/viewDynamicAnalysis.php?buildid={$build['id']}");
-                $content = $this->getBrowser()->getContent();
-                $jsonobj = json_decode($content, true);
-                $expected_defect_type = null;
-                switch ($build['label']) {
-                    case 'MyExperimentalFeature':
-                        $expected_num_analyses = 1;
-                        $expected_num_defect_types = 1;
-                        $expected_num_defects = 1;
-                        $expected_defect_type = 'Invalid Pointer Write';
-                        $expected_proc_time = 0.01;
-                        break;
-                    case 'MyProductionCode':
-                        $expected_num_analyses = 1;
-                        $expected_num_defect_types = 0;
-                        $expected_num_defects = 0;
-                        $expected_proc_time = 0.0;
-                        break;
-                    case 'MyThirdPartyDependency':
-                        $expected_num_analyses = 1;
-                        $expected_num_defect_types = 1;
-                        $expected_num_defects = 2;
-                        $expected_defect_type = 'Memory Leak';
-                        $expected_proc_time = 0.0;
-                        break;
-                    case 'EmptySubproject':
-                        $expected_num_analyses = 0;
-                        $expected_num_defect_types = 0;
-                        $expected_num_defects = 0;
-                        $expected_proc_time = 0.0;
-                        break;
-                }
-                $num_analyses = count($jsonobj['dynamicanalyses']);
-                if ($num_analyses != $expected_num_analyses) {
-                    throw new Exception("Expected {$expected_num_analyses} analyses for {$build['label']}, found {$num_analyses}");
-                }
-                if ($expected_num_analyses > 0) {
-                    if ($summary_total != $expected_num_defects) {
-                        throw new Exception("Expected {$expected_num_defects} defects for {$build['label']} but summary reports {$summary_total}");
-                    }
-                }
-                $num_defect_types = count($jsonobj['defecttypes']);
-                if ($num_defect_types != $expected_num_defect_types) {
-                    throw new Exception("Expected {$expected_num_defect_types} type of defect for {$build['label']}, found {$num_defect_types}");
-                }
-                if ($expected_num_defects > 0) {
-                    $num_defects = $jsonobj['dynamicanalyses'][0]['defects'][0];
-                    if ($num_defects != $expected_num_defects) {
-                        throw new Exception("Expected {$expected_num_defects} defects for {$build['label']}, found {$num_defects}");
-                    }
-                    $defect_type = $jsonobj['defecttypes'][0]['type'];
-                    if ($expected_defect_type != $defect_type) {
-                        throw new Exception("Expected type {$expected_defect_type} for {$build['label']}, found {$defect_type}");
-                    }
-                }
+        // Verify that 'Back' links to the parent build.
+        $pages = [
+            'buildSummary.php',
+            'viewBuildError.php',
+            'viewDynamicAnalysis.php',
+            'viewNotes.php',
+            'viewTest.php'
+        ];
+        $child_buildid = $builds[0]['id'];
 
-                // Verify that test duration is calculated correctly.
-                $stmt = $pdo->query("SELECT time FROM buildtesttime WHERE buildid = {$build['id']}");
-                $found = $stmt->fetchColumn();
-                if ($found !== false && $found != $expected_proc_time) {
-                    throw new Exception("Expected $expected_proc_time but found $found for {$build['id']}'s test duration");
-                }
+        foreach ($pages as $page) {
+            $this->get("{$this->url}/api/v1/{$page}?buildid={$child_buildid}");
+            $content = $this->getBrowser()->getContent();
+            $jsonobj = json_decode($content, true);
+            $expected = "index.php?project=SubProjectExample&parentid={$parentid}";
+            $found = $jsonobj['menu']['back'];
+            if (strpos($found, $expected) === false) {
+                $this->fail("{$expected} not found in back link for {$page} ({$found})");
             }
-
-            // Verify that 'Back' links to the parent build.
-            $pages = [
-                'buildSummary.php',
-                'viewBuildError.php',
-                'viewDynamicAnalysis.php',
-                'viewNotes.php',
-                'viewTest.php'
-            ];
-            $child_buildid = $builds[0]['id'];
-
-            foreach ($pages as $page) {
-                $this->get("{$this->url}/api/v1/{$page}?buildid={$child_buildid}");
-                $content = $this->getBrowser()->getContent();
-                $jsonobj = json_decode($content, true);
-                $expected = "index.php?project=SubProjectExample&parentid={$parentid}";
-                $found = $jsonobj['menu']['back'];
-                if (strpos($found, $expected) === false) {
-                    throw new Exception("{$expected} not found in back link for {$page} ({$found})");
-                }
-            }
-        } catch (Exception $e) {
-            $success = false;
-            $error_message = $e->getMessage();
         }
 
         // Test changing subproject order.
@@ -618,22 +616,12 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             $label = $build['label'];
             $index = array_search($label, $new_order);
             if ($index === false) {
-                $success = false;
-                $error_message = "Invalid label ({$label})!";
+                $this->fail("Invalid label ({$label})!");
             }
             $index += 1;
             if ($build['position'] !== $index) {
-                $success = false;
-                $error_message = "Expected {$index} but found ${build['position']} for {$label} position";
+                $this->fail("Expected {$index} but found ${build['position']} for {$label} position");
             }
-        }
-
-        if ($success) {
-            $this->pass('Test passed');
-            return 0;
-        } else {
-            $this->fail($error_message);
-            return 1;
         }
     }
 }

--- a/tests/test_multiplesubprojects.php
+++ b/tests/test_multiplesubprojects.php
@@ -522,6 +522,35 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             }
         }
 
+        // Test include subprojects filter.
+        $this->get("{$this->url}/api/v1/index.php?project=SubProjectExample&parentid={$parentid}&filtercount=1&showfilters=1&field1=subprojects&compare1=93&value1=MyExperimentalFeature");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $num_children = $jsonobj['numchildren'];
+        if ($num_children != 1) {
+            $this->fail("Expected 1 subproject, found {$num_children}");
+        }
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $builds = $buildgroup['builds'];
+        $build = $builds[0];
+        $this->verifyBuild($expected_builds['MyExperimentalFeature'], $build, 'MyExperimentalFeature');
+
+        // Test exclude subprojects filter.
+        $this->get("{$this->url}/api/v1/index.php?project=SubProjectExample&parentid={$parentid}&filtercount=3&showfilters=1&filtercombine=and&field1=subprojects&compare1=92&value1=MyExperimentalFeature&field2=subprojects&compare2=92&value2=MyProductionCode&field3=subprojects&compare3=92&value3=EmptySubproject");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $num_children = $jsonobj['numchildren'];
+        if ($num_children != 1) {
+            $this->fail("Expected 1 subproject, found {$num_children}");
+        }
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $builds = $buildgroup['builds'];
+        $build = $builds[0];
+        $this->verifyBuild($expected_builds['MyThirdPartyDependency'], $build, 'MyThirdPartyDependency');
+
+
+
+
         // viewConfigure
         $this->get("{$this->url}/viewConfigure.php?buildid={$parentid}");
 


### PR DESCRIPTION
We only need to modify the number of build errors, passing tests, etc for parent builds. When viewing the list of child builds, each individual build will either be presented whole or completely removed from the list by these filters.