### PR TITLE
Expicitly define 'Public' field for new projects

### DIFF
--- a/public/api/v1/createProject.php
+++ b/public/api/v1/createProject.php
@@ -146,6 +146,7 @@ if ($projectid > 0) {
 } else {
     // Initialize some variables for project creation.
     $project_response['AuthenticateSubmissions'] = $config->get('CDASH_DEFAULT_AUTHENTICATE_SUBMISSIONS');
+    $project_response['Public'] = 0;
     $project_response['AutoremoveMaxBuilds'] = 500;
     $project_response['AutoremoveTimeframe'] = 60;
     $project_response['CoverageThreshold'] = 70;


### PR DESCRIPTION
Depending on your SQL server settings, this value being undefined
could cause errors upon project creation.