### PR TITLE
Fix display of viewBuildGroup.php

### DIFF
--- a/app/Http/Controllers/CDash.php
+++ b/app/Http/Controllers/CDash.php
@@ -345,6 +345,11 @@ class CDash extends Controller
         $name = '';
         $path = $this->getPath();
         $file = pathinfo(substr($path, strrpos($path, '/')), PATHINFO_FILENAME);
+
+        // Special case: viewBuildGroup.php shares a controller with index.php.
+        if ($file === 'viewBuildGroup') {
+            $file = 'index';
+        }
         $controller_path = config('cdash.file.path.js.controllers');
         $controller = "{$controller_path}/{$file}.js";
         if (is_readable($controller)) {


### PR DESCRIPTION
This page was inadvertently broken during our move to Laravel because
the name of its AngularJS controller (index) does not match the name
of the page (viewBuildGroup).