### PR TITLE
add "Test Output" filter to queryTests.php

### DIFF
--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -28,9 +28,7 @@ class Index extends ResultsApi
     protected $includedSubProjects;
     protected $excludeSubProjects;
     protected $excludedSubProjects;
-    protected $filterSQL;
     protected $labelIds;
-    protected $limitSQL;
     protected $numSelectedSubProjects;
     protected $parentId;
     // This array is used to track if expected builds are found or not.
@@ -41,7 +39,6 @@ class Index extends ResultsApi
     public $buildgroupsResponse;
     public $buildStartTimes;
     public $childView;
-    public $filterdata;
     public $shareLabelFilters;
     public $siteResponse;
     public $updateType;
@@ -54,7 +51,6 @@ class Index extends ResultsApi
         $this->buildgroupsResponse = [];
         $this->buildStartTimes = [];
         $this->childView = 0;
-        $this->filterdata = [];
         $this->shareLabelFilters = false;
         $this->siteResponse = [];
         $this->updateType = '';
@@ -67,32 +63,11 @@ class Index extends ResultsApi
         $this->numSelectedSubProjects = 0;
         $this->selectedSubProjects = '';
 
-        $this->filterSQL = '';
         $this->labelIds = '';
-        $this->limitSQL = '';
         $this->parentId = false;
         $this->receivedBuilds = [];
         $this->subProjectId = false;
         $this->subProjectPositions = [];
-    }
-
-    public function getFilterData()
-    {
-        return $this->filterdata;
-    }
-
-    public function setFilterData(array $filterdata)
-    {
-        $this->filterdata = $filterdata;
-        $this->filterSQL = $this->filterdata['sql'];
-        if ($this->filterdata['limit'] > 0) {
-            $this->limitSQL = ' LIMIT ' . $this->filterdata['limit'];
-        }
-    }
-
-    public function getFilterSQL()
-    {
-        return $this->filterSQL;
     }
 
     public function setParentId($parentid)

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -1260,16 +1260,7 @@ class Index extends ResultsApi
     public function checkForSubProjectFilters()
     {
         $filter_on_labels = false;
-        $filters = [];
-        foreach ($this->filterdata['filters'] as $filter) {
-            if (array_key_exists('filters', $filter)) {
-                foreach ($filter['filters'] as $subfilter) {
-                    $filters[] = $subfilter;
-                }
-            } else {
-                $filters[] = $filter;
-            }
-        }
+        $filters = $this->flattenFilters();
         foreach ($filters as $filter) {
             if ($filter['field'] == 'subprojects') {
                 if ($filter['compare'] == 92) {

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -20,6 +20,7 @@ use CDash\Config;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Project;
+use CDash\Model\Test;
 
 require_once 'include/filterdataFunctions.php';
 
@@ -219,25 +220,7 @@ class QueryTests extends ResultsApi
         while ($row = $stmt->fetch()) {
 
             if ($this->filterOnTestOutput) {
-                // TODO: encapsulate this decode somewhere else
-                if ($config->get('CDASH_USE_COMPRESSION')) {
-                    if ($config->get('CDASH_DB_TYPE') == 'pgsql') {
-                        if (is_resource($row['output'])) {
-                            $row['output'] = base64_decode(stream_get_contents($row['output']));
-                        } else {
-                            $row['output'] = base64_decode($row['output']);
-                        }
-                    }
-                    @$uncompressedrow = gzuncompress($row['output']);
-                    if ($uncompressedrow !== false) {
-                        $test_output = $uncompressedrow;
-                    } else {
-                        $test_output = $row['output'];
-                    }
-                } else {
-                    $test_output = $row['output'];
-                }
-
+                $test_output = Test::DecompressOutput($row['output']);
                 // Make sure test output matches (or does not match) the
                 // specified filter values.
                 $skip = false;

--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -137,4 +137,20 @@ class ResultsApi extends ProjectApi
             $this->setDate($this->date);
         }
     }
+
+    // Return a flattened array of all filters and sub-filters.
+    public function flattenFilters()
+    {
+        $filters = [];
+        foreach ($this->filterdata['filters'] as $filter) {
+            if (array_key_exists('filters', $filter)) {
+                foreach ($filter['filters'] as $subfilter) {
+                    $filters[] = $subfilter;
+                }
+            } else {
+                $filters[] = $filter;
+            }
+        }
+        return $filters;
+    }
 }

--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -25,6 +25,10 @@ use CDash\Model\Project;
  **/
 class ResultsApi extends ProjectApi
 {
+    public $filterdata;
+
+    protected $filterSQL;
+    protected $limitSQL;
     protected $beginDate;
     protected $currentStartTime;
     protected $date;
@@ -37,10 +41,15 @@ class ResultsApi extends ProjectApi
     public function __construct(Database $db, Project $project)
     {
         parent::__construct($db, $project);
+
+        $this->filterdata = [];
+
         $this->beginDate = self::BEGIN_EPOCH;
         $this->currentStartTime = 0;
         $this->date = null;
         $this->endDate = self::BEGIN_EPOCH;
+        $this->filterSQL = '';
+        $this->limitSQL = '';
         $this->nextDate = '';
         $this->previousDate = '';
 
@@ -136,6 +145,25 @@ class ResultsApi extends ProjectApi
         if ($this->beginDate == self::BEGIN_EPOCH) {
             $this->setDate($this->date);
         }
+    }
+
+    public function getFilterData()
+    {
+        return $this->filterdata;
+    }
+
+    public function setFilterData(array $filterdata)
+    {
+        $this->filterdata = $filterdata;
+        $this->filterSQL = $this->filterdata['sql'];
+        if ($this->filterdata['limit'] > 0) {
+            $this->limitSQL = ' LIMIT ' . $this->filterdata['limit'];
+        }
+    }
+
+    public function getFilterSQL()
+    {
+        return $this->filterSQL;
     }
 
     // Return a flattened array of all filters and sub-filters.

--- a/app/cdash/app/Model/Test.php
+++ b/app/cdash/app/Model/Test.php
@@ -354,4 +354,29 @@ class Test
         $host_base = $config->getBaseUrl();
         return "{$host_base}/testDetails.php?test={$this->Id}&build={$this->BuildTest->BuildId}";
     }
+
+    /**
+     * Returns uncompressed test output.
+     *
+     * @return string
+     */
+    public static function DecompressOutput($output)
+    {
+        $config = \CDash\Config::getInstance();
+        if (!$config->get('CDASH_USE_COMPRESSION')) {
+            return $output;
+        }
+        if ($config->get('CDASH_DB_TYPE') == 'pgsql') {
+            if (is_resource($output)) {
+                $output = base64_decode(stream_get_contents($output));
+            } else {
+                $output = base64_decode($output);
+            }
+        }
+        @$uncompressedrow = gzuncompress($output);
+        if ($uncompressedrow !== false) {
+            $output = $uncompressedrow;
+        }
+        return $output;
+    }
 }

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -447,6 +447,12 @@ class QueryTestsPhpFilters extends DefaultFilters
             }
                 break;
 
+            case 'testoutput': {
+                // Handle via custom logic rather than a modified SQL query.
+                $sql_field = '';
+            }
+                break;
+
             case 'time': {
                 $sql_field = 'build2test.time';
             }

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -953,9 +953,12 @@ function get_sql_compare_and_value($compare, $value)
             break;
 
         case 92:
-        case 93: {
-            // Include or exclude a SubProject from the parent summary.
-            // This has to be handled via custom logic,
+        case 93:
+        case 94:
+        case 95:
+        case 96:
+        case 97: {
+            // These comparisons are handled via custom logic,
             // not just by tweaking the SQL query.
             $sql_compare = '';
             $sql_value = '';

--- a/app/cdash/public/api/v1/filterdata.php
+++ b/app/cdash/public/api/v1/filterdata.php
@@ -78,7 +78,7 @@ function getFiltersForPage($page_id)
         case 'queryTests.php':
             return [
                 'buildname', 'buildstarttime', 'details', 'groupname', 'label',
-                'site', 'status', 'testname', 'time'];
+                'site', 'status', 'testname', 'testoutput', 'time'];
             break;
 
         case 'viewCoverage.php':

--- a/app/cdash/public/api/v1/testDetails.php
+++ b/app/cdash/public/api/v1/testDetails.php
@@ -27,6 +27,7 @@ use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\Model\Site;
+use CDash\Model\Test;
 
 if (!function_exists('findTest')) {
     // Helper function
@@ -190,24 +191,7 @@ $test_response['test'] = $testName;
 $test_response['time'] = time_difference($testRow['time'], true, '', true);
 $test_response['command'] = $testRow['command'];
 $test_response['details'] = $testRow['details'];
-
-if ($config->get('CDASH_USE_COMPRESSION')) {
-    if ($config->get('CDASH_DB_TYPE') == 'pgsql') {
-        if (is_resource($testRow['output'])) {
-            $testRow['output'] = base64_decode(stream_get_contents($testRow['output']));
-        } else {
-            $testRow['output'] = base64_decode($testRow['output']);
-        }
-    }
-    @$uncompressedrow = gzuncompress($testRow['output']);
-    if ($uncompressedrow !== false) {
-        $test_response['output'] = utf8_for_xml($uncompressedrow);
-    } else {
-        $test_response['output'] = utf8_for_xml($testRow['output']);
-    }
-} else {
-    $test_response['output'] = utf8_for_xml($testRow['output']);
-}
+$test_response['output'] = utf8_for_xml(Test::DecompressOutput($testRow['output']));
 
 $test_response['summaryLink'] = $summaryLink;
 switch ($testRow['status']) {

--- a/app/cdash/public/js/controllers/filters.js
+++ b/app/cdash/public/js/controllers/filters.js
@@ -149,7 +149,7 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
     },
     "testoutput": {
       "text": "Test Output",
-      "type": "list",
+      "type": "search",
       "defaultvalue": "",
       "content": true
     },
@@ -227,6 +227,12 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
       {"value": 42, text: "is not"},
       {"value": 43, text: "is greater than"},
       {"value": 44, text: "is less than"}
+    ],
+    "search": [
+      {"value": 94, text: "exclude"},
+      {"value": 95, text: "include"},
+      {"value": 96, text: "exclude regex"},
+      {"value": 97, text: "include regex"},
     ],
     "string": [
       {"value": 63, text: "contains"},
@@ -344,14 +350,14 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
         s = s + "&" + prefix + "=block";
         s = s + "&" + prefix + "count=" + num_subfilters;
         for (var j = 1; j <= num_subfilters ; j++) {
-          s = s + "&" + prefix + "field" + j + "=" + escape($scope.filterdata.filters[i-1].filters[j-1].field);
-          s = s + "&" + prefix + "compare" + j + "=" + escape($scope.filterdata.filters[i-1].filters[j-1].compare);
-          s = s + "&" + prefix + "value" + j + "=" + escape($scope.filterdata.filters[i-1].filters[j-1].value);
+          s = s + "&" + prefix + "field" + j + "=" + encodeURIComponent($scope.filterdata.filters[i-1].filters[j-1].field);
+          s = s + "&" + prefix + "compare" + j + "=" + encodeURIComponent($scope.filterdata.filters[i-1].filters[j-1].compare);
+          s = s + "&" + prefix + "value" + j + "=" + encodeURIComponent($scope.filterdata.filters[i-1].filters[j-1].value);
         }
       } else {
-        s = s + "&field" + i + "=" + escape($scope.filterdata.filters[i-1].field);
-        s = s + "&compare" + i + "=" + escape($scope.filterdata.filters[i-1].compare);
-        s = s + "&value" + i + "=" + escape($scope.filterdata.filters[i-1].value);
+        s = s + "&field" + i + "=" + encodeURIComponent($scope.filterdata.filters[i-1].field);
+        s = s + "&compare" + i + "=" + encodeURIComponent($scope.filterdata.filters[i-1].compare);
+        s = s + "&value" + i + "=" + encodeURIComponent($scope.filterdata.filters[i-1].value);
       }
     }
 

--- a/app/cdash/public/js/controllers/filters.js
+++ b/app/cdash/public/js/controllers/filters.js
@@ -147,6 +147,12 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
       "type": "string",
       "defaultvalue": ""
     },
+    "testoutput": {
+      "text": "Test Output",
+      "type": "list",
+      "defaultvalue": "",
+      "content": true
+    },
     "testsduration": {
       "text": "Tests Duration",
       "type": "number",

--- a/app/cdash/public/js/controllers/queryTests.js
+++ b/app/cdash/public/js/controllers/queryTests.js
@@ -32,6 +32,9 @@ CDash.controller('QueryTestsController',
 
     apiLoader.loadPageData($scope, 'api/v1/queryTests.php');
     $scope.finishSetup = function() {
+      // Hide test output context by default.
+      $scope.cdash.showmatchingoutput = false;
+
       // Check for label filters
       $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
       $scope.cdash.builds = $filter('orderBy')($scope.cdash.builds, $scope.orderByFields);
@@ -65,4 +68,9 @@ CDash.controller('QueryTestsController',
       $.cookie("queryTests_num_per_page", $scope.pagination.numPerPage, { expires: 365 });
       $scope.pageChanged();
     };
+
+    $scope.toggleShowMatchingOutput = function() {
+      $scope.cdash.showmatchingoutput = !($scope.cdash.showmatchingoutput);
+    };
+
 });

--- a/app/cdash/public/views/queryTests.html
+++ b/app/cdash/public/views/queryTests.html
@@ -28,6 +28,11 @@
     <span ng-show="showfilters == 0">Show Filters</span>
     <span ng-show="showfilters != 0">Hide Filters</span>
   </a>
+  <a ng-if="::cdash.filterontestoutput"
+     ng-click="toggleShowMatchingOutput()">
+    <span ng-show="!cdash.showmatchingoutput">Show Matching Output</span>
+    <span ng-show="cdash.showmatchingoutput">Hide Matching Output</span>
+  </a>
 </div>
 <ng-include src="'build/views/partials/filterdataTemplate_@@version.html'"></ng-include>
 
@@ -104,7 +109,8 @@
       <span class="glyphicon" ng-class="orderByFields.indexOf('-nprocs') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('nprocs') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
     </th>
 
-    <th ng-if="::cdash.filterontestoutput">
+    <th ng-if="::cdash.filterontestoutput"
+        ng-show="cdash.showmatchingoutput">
       Matching Output
     </th>
   </tr>
@@ -153,7 +159,9 @@
       {{build.nprocs}}
     </td>
 
-    <td ng-if="::cdash.filterontestoutput">
+    <td ng-if="::cdash.filterontestoutput"
+        ng-show="cdash.showmatchingoutput"
+        class="animate-show">
       <pre ng-bind-html="build.matchingoutput | ctestNonXmlCharEscape | terminalColors | trustAsHtml"></pre>
     </td>
   </tr>

--- a/app/cdash/public/views/queryTests.html
+++ b/app/cdash/public/views/queryTests.html
@@ -91,7 +91,7 @@
       <span class="glyphicon" ng-class="orderByFields.indexOf('-details') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('details') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
     </th>
 
-    <th class="header nob"
+    <th class="header"
         ng-click="updateOrderByFields('buildstarttime', $event)">
       Build Time
       <span class="glyphicon" ng-class="orderByFields.indexOf('-buildstarttime') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('buildstarttime') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
@@ -102,6 +102,10 @@
         ng-click="updateOrderByFields('nprocs', $event)">
       Processors
       <span class="glyphicon" ng-class="orderByFields.indexOf('-nprocs') != -1 ? 'glyphicon-chevron-down' : (orderByFields.indexOf('nprocs') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
+    </th>
+
+    <th ng-if="::cdash.filterontestoutput">
+      Matching Output
     </th>
   </tr>
 </thead>
@@ -147,6 +151,10 @@
 
     <td ng-if="::cdash.hasprocessors">
       {{build.nprocs}}
+    </td>
+
+    <td ng-if="::cdash.filterontestoutput">
+      <pre ng-bind-html="build.matchingoutput | ctestNonXmlCharEscape | terminalColors | trustAsHtml"></pre>
     </td>
   </tr>
 

--- a/app/cdash/tests/test_querytests.php
+++ b/app/cdash/tests/test_querytests.php
@@ -31,15 +31,17 @@ class QueryTestsTestCase extends KWWebTestCase
         $expected_previous_url = 'queryTests.php?project=Trilinos&date=2011-07-21&limit=0';
         if ($previous_url != $expected_previous_url) {
             $this->fail("Expected previous url to be $expected_previous_url, found $previous_url");
-            return 1;
         }
         $next_url = $menu['next'];
         $expected_next_url = 'queryTests.php?project=Trilinos&date=2011-07-23&limit=0';
         if ($next_url != $expected_next_url) {
             $this->fail("Expected next url to be $expected_next_url, found $next_url");
-            return 1;
         }
 
-        $this->pass('Passed');
+        // Make sure the test output filters work as expected.
+        $this->get($this->url . '/api/v1/queryTests.php?project=Trilinos&date=2011-07-22&filtercount=2&showfilters=1&filtercombine=and&field1=testoutput&compare1=93&value1=analytic&field2=testoutput&compare2=92&value2=%5E2');
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual(count($jsonobj['builds']), 6);
     }
 }

--- a/app/cdash/tests/test_querytests.php
+++ b/app/cdash/tests/test_querytests.php
@@ -43,5 +43,8 @@ class QueryTestsTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $this->assertEqual(count($jsonobj['builds']), 6);
+        $this->assertTrue($jsonobj['filterontestoutput']);
+        $idx = strpos($jsonobj['builds'][0]['matchingoutput'], 'analytic');
+        $this->assertEqual($idx, 96);
     }
 }

--- a/app/cdash/tests/test_querytests.php
+++ b/app/cdash/tests/test_querytests.php
@@ -39,12 +39,17 @@ class QueryTestsTestCase extends KWWebTestCase
         }
 
         // Make sure the test output filters work as expected.
-        $this->get($this->url . '/api/v1/queryTests.php?project=Trilinos&date=2011-07-22&filtercount=2&showfilters=1&filtercombine=and&field1=testoutput&compare1=93&value1=analytic&field2=testoutput&compare2=92&value2=%5E2');
+        $this->get($this->url . '/api/v1/queryTests.php?project=Trilinos&date=2011-07-22&filtercount=2&showfilters=1&filtercombine=and&field1=testoutput&compare1=95&value1=analytic&field2=testoutput&compare2=94&value2=%5E2');
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $this->assertEqual(count($jsonobj['builds']), 6);
         $this->assertTrue($jsonobj['filterontestoutput']);
         $idx = strpos($jsonobj['builds'][0]['matchingoutput'], 'analytic');
         $this->assertEqual($idx, 96);
+
+        $this->get($this->url . '/api/v1/queryTests.php?project=Trilinos&date=2011-07-22&filtercount=2&showfilters=1&filtercombine=and&field1=testoutput&compare1=97&value1=der%5Biva%5D%2Btive&field2=testoutput&compare2=96&value2=Tay.*%3F%20series');
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual(count($jsonobj['builds']), 2);
     }
 }


### PR DESCRIPTION
Allow users to search for tests based on their output. We also add an option to show what test output matched the specified search criteria.