### PR TITLE
Remove ValidatePostSize check from CDash

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,7 +15,6 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \App\Http\Middleware\CheckForMaintenanceMode::class,
-        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,


### PR DESCRIPTION
This Middleware check breaks submissions larger than post_max_size.