### PR TITLE
Append 'UTC' to input of Project::GetTestingDay()

### DIFF
--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1832,7 +1832,7 @@ class Project
         // If the build was started after the nightly start time
         // then it should appear on the dashboard results for the
         // subsequent day.
-        $build_datetime = new \DateTime($date);
+        $build_datetime = new \DateTime($date . ' UTC');
         $build_start_timestamp = $build_datetime->getTimestamp();
         $nightly_start_timestamp = strtotime($this->NightlyTime);
 

--- a/app/cdash/tests/case/CDash/NightlyTimeTest.php
+++ b/app/cdash/tests/case/CDash/NightlyTimeTest.php
@@ -84,14 +84,32 @@ class NightlyTimeTest extends TestCase
     {
         date_default_timezone_set('America/New_York');
         $this->Project->NightlyTime = '01:00:00 America/New_York';
+        $utc_time = new \DateTimeZone('UTC');
 
         // DST 2019 in New York began at 2:00 AM on Sunday, March 10
-        $this->validateTestingDay('2019-03-10 00:59:59', '2019-03-09');
-        $this->validateTestingDay('2019-03-10 01:00:01', '2019-03-10');
+        $datetime = new \DateTime('2019-03-10 00:59:59');
+        $datetime->setTimezone($utc_time);
+        $this->validateTestingDay($datetime->format('Y-m-d H:i:s'), '2019-03-09');
+
+        $datetime = new \DateTime('2019-03-10 01:00:01');
+        $datetime->setTimezone($utc_time);
+        $this->validateTestingDay($datetime->format('Y-m-d H:i:s'), '2019-03-10');
 
         // DST 2018 in New York ended at 2:00 AM on Sunday, November 4
-        $this->validateTestingDay('2018-11-04 00:59:59', '2018-11-03');
-        $this->validateTestingDay('2019-11-04 01:00:01', '2019-11-04');
+        $datetime = new \DateTime('2018-11-04 00:59:59');
+        $datetime->setTimezone($utc_time);
+        $this->validateTestingDay($datetime->format('Y-m-d H:i:s'), '2018-11-03');
+
+        $datetime = new \DateTime('2018-11-04 01:00:01');
+        $datetime->setTimezone($utc_time);
+        $this->validateTestingDay($datetime->format('Y-m-d H:i:s'), '2018-11-04');
+    }
+
+    public function testUTCInput()
+    {
+        date_default_timezone_set('America/Denver');
+        $this->Project->NightlyTime = '04:01:00 UTC';
+        $this->validateTestingDay('2019-09-26 04:00:59 UTC', '2019-09-25');
     }
 
     private function validateTestingDay($starttime, $expected)

--- a/app/cdash/tests/test_buildgetdate.php
+++ b/app/cdash/tests/test_buildgetdate.php
@@ -28,7 +28,7 @@ class BuildGetDateTestCase extends KWWebTestCase
         $original_nightlytime = $row['nightlytime'];
         // Test the case where the project's start time is in the evening.
         pdo_query("UPDATE project SET nightlytime = '20:00:00' WHERE id=1");
-        $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 19:59:59'));
+        $build->StartTime = gmdate('Y-m-d H:i:s', strtotime('2009-02-23 19:59:59'));
 
         $expected_date = '2009-02-23';
         $date = $build->GetDate();
@@ -37,7 +37,7 @@ class BuildGetDateTestCase extends KWWebTestCase
             $retval = 1;
         }
 
-        $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 20:00:00'));
+        $build->StartTime = gmdate('Y-m-d H:i:s', strtotime('2009-02-23 20:00:00'));
 
         $expected_date = '2009-02-24';
         $build->NightlyStartTime = false;
@@ -49,7 +49,7 @@ class BuildGetDateTestCase extends KWWebTestCase
 
         // Test the case where the project's start time is in the morning.
         pdo_query("UPDATE project SET nightlytime = '09:00:00' WHERE id=1");
-        $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 08:59:59'));
+        $build->StartTime = gmdate('Y-m-d H:i:s', strtotime('2009-02-23 08:59:59'));
         $expected_date = '2009-02-22';
         $build->NightlyStartTime = false;
         $date = $build->GetDate();
@@ -58,7 +58,7 @@ class BuildGetDateTestCase extends KWWebTestCase
             $retval = 1;
         }
 
-        $build->StartTime = date('Y-m-d H:i:s', strtotime('2009-02-23 09:00:00'));
+        $build->StartTime = gmdate('Y-m-d H:i:s', strtotime('2009-02-23 09:00:00'));
         $expected_date = '2009-02-23';
         $build->NightlyStartTime= false;
         $date = $build->GetDate();


### PR DESCRIPTION
The input to this function is always a timestamp from the database,
which is stored in UTC format. So we need to explicitly tell PHP
what timezone this date string is from so that it can convert it
to the correct UNIX timestamp value. This is a bug fix for servers
that are configured to locally use a non-UTC timezone.