### PR TITLE
Upgrade path for older dynamic build group rules

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -106,7 +106,7 @@ add_php_test(subproject)
 add_php_test(actualtrilinossubmission)
 add_php_test(summaryemail)
 
-# add_php_test(upgrade)
+add_php_test(upgrade)
 add_php_test(aggregatecoverage)
 add_php_test(banner)
 add_php_test(buildconfigure)

--- a/app/cdash/tests/js/e2e_tests/viewBuildError.js
+++ b/app/cdash/tests/js/e2e_tests/viewBuildError.js
@@ -21,12 +21,12 @@ describe("viewBuildError", function() {
   });
 
   it("displays build errors inline", function() {
-    browser.get('viewBuildError.php?buildid=69&type=0');
+    browser.get('viewBuildError.php?buildid=72&type=0');
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });
 
   it("displays build errors inline on parent builds", function() {
-    browser.get('viewBuildError.php?buildid=68&type=0');
+    browser.get('viewBuildError.php?buildid=71&type=0');
     expect(browser.getPageSource()).toContain("some-test-subproject");
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });


### PR DESCRIPTION
The format of these rules has changed slightly over time, so we add
an automatic upgrade converter to make them consistent.

This commit also re-enables the upgrade test, fixes it for postgres
builds, and makes the corresponding changes to hardcoded buildids
further down the testing dependency line.