### PR TITLE
cache CDash Docker image built on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,26 @@ jobs:
     machine: true
     steps:
       - checkout
+      - restore_cache:
+         keys:
+           - img-v1-{{checksum "docker/cdash.docker"}}
       - run:
           name: MySQL Build
           command: |
             set -x
             source ~/project/docker/commands.bash
             cdash_environment mysql
-            cdash_build_image
+            if [ -f "/home/circleci/circle-cache/cdash-image.tar.gz" ]; then
+              docker load -i /home/circleci/circle-cache/cdash-image.tar.gz
+            else
+              cdash_build_image
+              mkdir -p /home/circleci/circle-cache
+              docker save kitware/cdash:testing | gzip > /home/circleci/circle-cache/cdash-image.tar.gz
+            fi
+      - save_cache:
+          key: img-v1-{{checksum "docker/cdash.docker"}}
+          paths:
+            - /home/circleci/circle-cache/cdash-image.tar.gz
       - run:
           name: Spin Up MySQL Build
           command: |

--- a/docker/commands.bash
+++ b/docker/commands.bash
@@ -10,7 +10,7 @@ cdash_environment() {
 }
 
 cdash_build_image() {
-  docker-compose -f ./docker-compose.local.yml build --force-rm --no-cache cdash
+  docker-compose -f ./docker-compose.local.yml build --force-rm cdash
 }
 
 cdash_start_docker_services() {


### PR DESCRIPTION
Speed up CircleCI builds for PRs that are not modifying our Dockerfile.