### PR TITLE
Do not send out email notifications for notrun tests

### DIFF
--- a/app/cdash/include/Messaging/Topic/TestFailureTopic.php
+++ b/app/cdash/include/Messaging/Topic/TestFailureTopic.php
@@ -49,9 +49,7 @@ class TestFailureTopic extends Topic implements Decoratable, Fixable, Labelable
         $subscribe = false;
         $this->diff = $build->GetDiffWithPreviousBuild();
         if ($this->diff) {
-            $subscribe = $this->diff['TestFailure']['failed']['new'] > 0
-                || $this->diff['TestFailure']['passed']['broken'] > 0
-                || $this->diff['TestFailure']['notrun']['new'] > 0;
+            $subscribe = $this->diff['TestFailure']['failed']['new'] > 0;
         }
 
         return $subscribe;
@@ -126,16 +124,7 @@ class TestFailureTopic extends Topic implements Decoratable, Fixable, Labelable
      */
     public function itemHasTopicSubject(Build $build, $item)
     {
-        if ($item->IsFailed()) {
-            return true;
-        }
-
-        if ($item->IsNotRun()) {
-            if ($item->Details !== Test::DISABLED) {
-                return true;
-            }
-        }
-        return false;
+        return $item->IsFailed();
     }
 
     /**

--- a/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
@@ -43,7 +43,7 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $diff = $this->createNew('testnotrunpositive');
         $this->assertEquals(1, $diff['testnotrunpositive']);
         $build = $this->createMockBuildWithDiff($diff);
-        $this->assertTrue($sut->subscribesToBuild($build));
+        $this->assertFalse($sut->subscribesToBuild($build));
     }
 
     public function testItemHasTopicSubject()
@@ -64,7 +64,7 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
 
         $buildTest->Status = Test::NOTRUN;
 
-        $this->assertTrue($sut->itemHasTopicSubject($build, $test));
+        $this->assertFalse($sut->itemHasTopicSubject($build, $test));
 
         $test->Details = Test::DISABLED;
 
@@ -116,10 +116,11 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $sut->setTopicData($build);
 
         $collection = $sut->getTopicCollection();
-        $this->assertEquals(2, $sut->getTopicCount());
+        $this->assertEquals(1, $sut->getTopicCount());
 
         $this->assertTrue($collection->has('Failed'));
-        $this->assertTrue($collection->has('NotRun'));
+        $this->assertFalse($collection->has('NotRun'));
+        $this->assertFalse($collection->has('Passed'));
     }
 
     public function testGetTopicName()
@@ -207,13 +208,13 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $test2->AddLabel($labelForTwo);
         $test2->SetBuildTest($buildTestTwo);
 
-        // Create a test that is not run and has a label that we're searching for
+        // Create a test that has failed and has a label that we're searching for
         $labelFor3 = new Label();
         $labelFor3->Text = 'Three';
         $test3 = new Test();
         $test3->Name = 'TestThree';
         $buildTestThree = new BuildTest();
-        $buildTestThree->Status = Test::NOTRUN;
+        $buildTestThree->Status = Test::FAILED;
         $test3->AddLabel($labelFor3);
         $test3->SetBuildTest($buildTestThree);
 
@@ -287,7 +288,7 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $collection = $sut->getLabelsFromBuild($build);
 
         $this->assertTrue($collection->has($labelForTwo->Text));
-        $this->assertTrue($collection->has($labelFor3->Text));
+        $this->assertFalse($collection->has($labelFor3->Text));
     }
 
     public function testIsSubscribedToBy()

--- a/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+++ b/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -168,7 +168,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
             ->createSubproject('MyProductionCode')
             ->createSubproject('MyThirdPartyDependency')
             ->createSubproject('EmptySubproject')
-            ->createTestNotRun('thirdparty', ['MyThirdPartyDependency'])
+            ->createTestFailed('thirdparty', ['MyThirdPartyDependency'])
             ->createTestFailed('experimentalFail1', ['MyExperimentalFeature'])
             ->createTestFailed('experimentalFail2', ['MyExperimentalFeature'])
             ->createTestFailed('experimentalFail3', ['MyExperimentalFeature'])

--- a/app/cdash/tests/data/DisabledTests/Test.xml
+++ b/app/cdash/tests/data/DisabledTests/Test.xml
@@ -27,13 +27,13 @@
 		<StartDateTime>Feb 13 10:17 EST</StartDateTime>
 		<StartTestTime>1486999078</StartTestTime>
 		<TestList>
-			<Test>./ThisTestWillNotRun</Test>
+			<Test>./ThisTestFails</Test>
 			<Test>./ThisTestIsDisabled</Test>
 		</TestList>
-		<Test Status="notrun">
-			<Name>ThisTestWillNotRun</Name>
+		<Test Status="failed">
+			<Name>ThisTestFails</Name>
 			<Path>.</Path>
-			<FullName>./ThisTestWillNotRun</FullName>
+			<FullName>./ThisTestFails</FullName>
 			<FullCommandLine></FullCommandLine>
 			<Results>
 				<NamedMeasurement type="text/string" name="Completion Status">

--- a/app/cdash/tests/test_disabledtests.php
+++ b/app/cdash/tests/test_disabledtests.php
@@ -38,16 +38,16 @@ class DisabledTestsTestCase extends KWWebTestCase
         $this->get("$this->url/api/v1/viewTest.php?buildid=$buildid");
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
-        if ($jsonobj['numNotRun'] !== 2) {
-            $this->fail("Did not find 2 'Not Run' tests when expected");
+        if ($jsonobj['numFailed'] !== 1) {
+            $this->fail("Did not find 1 'Failed' tests when expected");
+        }
+        if ($jsonobj['numNotRun'] !== 1) {
+            $this->fail("Did not find 1 'NotRun' tests when expected");
         }
 
         $verified_disabled = false;
         $verified_missingexe = false;
         foreach ($jsonobj['tests'] as $test) {
-            if ($test['status'] !== 'Not Run') {
-                $this->fail("Test has a status other than 'Not Run'");
-            }
             if ($test['details'] === 'Disabled') {
                 $verified_disabled = true;
             }
@@ -64,8 +64,8 @@ class DisabledTestsTestCase extends KWWebTestCase
 
         // Verify email was sent for the missing exe but not for the disabled test.
         $log_contents = file_get_contents($this->logfilename);
-        if (strpos($log_contents, 'ThisTestWillNotRun') === false) {
-            $this->fail("No email sent for test 'ThisTestWillNotRun'");
+        if (strpos($log_contents, 'ThisTestFails') === false) {
+            $this->fail("No email sent for test 'ThisTestFails'");
         }
         if (strpos($log_contents, 'ThisTestIsDisabled') !== false) {
             $this->fail("Erroneous email sent for test 'ThisTestIsDisabled'");

--- a/app/cdash/tests/test_timeoutsandmissingtests.php
+++ b/app/cdash/tests/test_timeoutsandmissingtests.php
@@ -18,8 +18,8 @@ class TimeoutsAndMissingTestsTestCase extends KWWebTestCase
     private function getLastBuildId()
     {
         $sql = "
-          SELECT id 
-          FROM build 
+          SELECT id
+          FROM build
           WHERE name='{$this->buildName}'
           ORDER BY starttime DESC
           LIMIT 1
@@ -41,27 +41,22 @@ class TimeoutsAndMissingTestsTestCase extends KWWebTestCase
         $url = Config::getInstance()->getBaseUrl();
         $expected = [
             'simpletest@localhost',
-            'FAILED (t=3, m=3): EmailProjectExample - Win32-MSVC2009 - Nightly',
-            'A submission to CDash for the project EmailProjectExample has failing tests and missing tests.',
+            'FAILED (m=3): EmailProjectExample - Win32-MSVC2009 - Nightly',
+            'A submission to CDash for the project EmailProjectExample has missing tests.',
             "Details on the submission can be found at {$url}/buildSummary.php?buildid=",
             'Project: EmailProjectExample',
             'Site: Dash20.kitware',
             'Build Name: Win32-MSVC2009',
             'Build Time: 2009-02-26 10:04:00',
             'Type: Nightly',
-            'Total Failing Tests: 3',
             'Total Missing Tests: 3',
-            '*Failing Tests*',
-            "curl | Completed | ({$url}/testDetails.php?test=",
-            "StringActionsTest | Completed (OTHER_FAULT) | ({$url}/testDetails.php?test=",
-            "MathActionsTest | Completed (OTHER_FAULT) | ({$url}/testDetails.php?test=",
             '*Missing Tests*',
             "DashboardSendTest ({$url}/viewTest.php?buildid=",
             "Parser1Test1 ({$url}/viewTest.php?buildid=",
             "SystemInfoTest ({$url}/viewTest.php?buildid=",
             '-CDash on',
         ];
-        if ($this->assertLogContains($expected, 26)) {
+        if ($this->assertLogContains($expected, 20)) {
             $this->pass('Passed');
         }
     }


### PR DESCRIPTION
Redefine the notification topic to strictly deal with failing tests.