### PR TITLE
Always do npm "dev" builds

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -107,7 +107,7 @@ else                                                                       \
                   --optimize-autoloader                                    \
  && echo "LOG_CHANNEL=stderr" >> .env                                      \
  && npm install                                                            \
- && npm run prod;                                                          \
+ && npm run dev;                                                           \
 fi
 
 RUN cp app/cdash/php.ini /usr/local/etc/php/conf.d/cdash.ini


### PR DESCRIPTION
We were seeing angularjs errors due to production minification.
For now, run npm dev instead of npm prod.