### PR TITLE
Improve parsing of Bazel build errors and warnings

### DIFF
--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -359,7 +359,7 @@ class BazelJSONTestCase extends KWWebTestCase
         $row = $stmt->fetch();
 
         $answer_key = [
-            'builderrors' => 4,
+            'builderrors' => 8,
             'buildwarnings' => 0,
             'testfailed' => 0,
             'testpassed' => 0,
@@ -427,7 +427,7 @@ class BazelJSONTestCase extends KWWebTestCase
         $row = $stmt->fetch();
 
         $answer_key = [
-            'builderrors' => 3,
+            'builderrors' => 1,
             'buildwarnings' => 0,
             'testfailed' => 0,
             'testpassed' => 0
@@ -446,12 +446,6 @@ class BazelJSONTestCase extends KWWebTestCase
         $errors = $jsonobj['errors'];
         if ($errors[0]["logline"] != 1) {
             $this->fail("Expected error at line 1, found at line ".$errors[0]["logline"]);
-        }
-        if ($errors[1]["logline"] != 3) {
-            $this->fail("Expected error at line 3, found at line ".$errors[1]["logline"]);
-        }
-        if ($errors[2]["logline"] != 6) {
-            $this->fail("Expected error at line 6, found at line ".$errors[2]["logline"]);
         }
 
         // Cleanup.

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -26,13 +26,13 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
         $answer_key = [
             'builderrors' => 1,
-            'buildwarnings' => 2,
+            'buildwarnings' => 1,
             'testfailed' => 1,
             'testpassed' => 1,
             'configureerrors' => 0,
@@ -108,7 +108,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -173,14 +173,17 @@ class BazelJSONTestCase extends KWWebTestCase
 
         // Validate the parent build.
         $stmt = $this->PDO->query(
-                "SELECT builderrors, buildwarnings, testfailed, testpassed
+                "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $parentid");
         $row = $stmt->fetch();
         $answer_key = [
             'builderrors' => 0,
             'buildwarnings' => 2,
             'testfailed' => 1,
-            'testpassed' => 1
+            'testpassed' => 1,
+            'configureerrors' => 0,
+            'configurewarnings' => 0
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -193,6 +196,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the children builds.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings,
                         sp.name
                 FROM build b
                 JOIN subproject2build sp2b ON sp2b.buildid = b.id
@@ -207,7 +211,9 @@ class BazelJSONTestCase extends KWWebTestCase
                         'builderrors' => 0,
                         'buildwarnings' => 1,
                         'testfailed' => 0,
-                        'testpassed' => 1
+                        'testpassed' => 1,
+                        'configureerrors' => 0,
+                        'configurewarnings' => 0
                     ];
                     break;
                 case 'subproj2':
@@ -215,7 +221,9 @@ class BazelJSONTestCase extends KWWebTestCase
                         'builderrors' => 0,
                         'buildwarnings' => 1,
                         'testfailed' => 1,
-                        'testpassed' => 0
+                        'testpassed' => 0,
+                        'configureerrors' => 0,
+                        'configurewarnings' => 0
                     ];
                     break;
                 default:
@@ -247,7 +255,8 @@ class BazelJSONTestCase extends KWWebTestCase
 
         // Validate the build.
         $stmt = $this->PDO->query(
-                "SELECT builderrors, buildwarnings, testfailed, testpassed
+                "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -255,7 +264,9 @@ class BazelJSONTestCase extends KWWebTestCase
             'builderrors' => 0,
             'buildwarnings' => 0,
             'testfailed' => 1,
-            'testpassed' => 1
+            'testpassed' => 1,
+            'configureerrors' => 0,
+            'configurewarnings' => 0
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -300,7 +311,8 @@ class BazelJSONTestCase extends KWWebTestCase
 
         // Validate the build.
         $stmt = $this->PDO->query(
-                "SELECT builderrors, buildwarnings, testfailed, testpassed
+                "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -308,7 +320,9 @@ class BazelJSONTestCase extends KWWebTestCase
             'builderrors' => 0,
             'buildwarnings' => 1,
             'testfailed' => 1,
-            'testpassed' => 18
+            'testpassed' => 18,
+            'configureerrors' => 0,
+            'configurewarnings' => 1
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -354,7 +368,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -389,7 +403,8 @@ class BazelJSONTestCase extends KWWebTestCase
 
         // Validate the build.
         $stmt = $this->PDO->query(
-                "SELECT builderrors, buildwarnings, testfailed, testpassed
+                "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -397,7 +412,9 @@ class BazelJSONTestCase extends KWWebTestCase
             'builderrors' => 0,
             'buildwarnings' => 0,
             'testfailed' => 1,
-            'testpassed' => 0
+            'testpassed' => 0,
+            'configureerrors' => 0,
+            'configurewarnings' => 0
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -422,7 +439,8 @@ class BazelJSONTestCase extends KWWebTestCase
 
         // Validate the build.
         $stmt = $this->PDO->query(
-                "SELECT builderrors, buildwarnings, testfailed, testpassed
+                "SELECT builderrors, buildwarnings, testfailed, testpassed,
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -430,7 +448,9 @@ class BazelJSONTestCase extends KWWebTestCase
             'builderrors' => 1,
             'buildwarnings' => 0,
             'testfailed' => 0,
-            'testpassed' => 0
+            'testpassed' => 0,
+            'configureerrors' => 0,
+            'configurewarnings' => 0
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -465,7 +485,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -521,7 +541,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 
@@ -617,7 +637,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Validate the build.
         $stmt = $this->PDO->query(
                 "SELECT builderrors, buildwarnings, testfailed, testpassed,
-                configureerrors, configurewarnings
+                        configureerrors, configurewarnings
                 FROM build WHERE id = $buildid");
         $row = $stmt->fetch();
 

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -313,7 +313,7 @@ class BazelJSONHandler extends NonSaxHandler
                     // searching for configure and build warnings and errors.
                     $stderr = $json_array[$message_id]['stderr'];
                     $warning_pattern = '/(.*?) warning: (.*?)$/i';
-                    $error_pattern = '/(.*?)error: (.*?)$/i';
+                    $error_pattern = '/(.*?)ERROR: (.*?)$/';
 
                     // The first two phases of a Bazel build, Loading and
                     // Analysis, will be treated as the 'Configure' step by
@@ -382,11 +382,7 @@ class BazelJSONHandler extends NonSaxHandler
                         } else {
                             // Done with configure, parsing build errors and warnings
                             $record_error = false;
-                            if (!is_null($build_error) && $type === 0 && empty($build_error->PostContext)) {
-                                // Assume all errors have at list one line of
-                                // context *AND* that the first line of context
-                                // may match the error pattern
-                            } elseif (preg_match($warning_pattern, $line, $matches) === 1
+                            if (preg_match($warning_pattern, $line, $matches) === 1
                                   && count($matches) === 3) {
                                 // This line contains a warning.
                                 $record_error = true;

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -311,16 +311,21 @@ class BazelJSONHandler extends NonSaxHandler
                 if (array_key_exists('stderr', $json_array[$message_id])) {
                     // Parse through stderr line-by-line,
                     // searching for configure and build warnings and errors.
-                    $stderr = $json_array[$message_id]['stderr'];
-                    $warning_pattern = '/(.*?) warning: (.*?)$/i';
-                    $error_pattern = '/(.*?)ERROR: (.*?)$/';
 
                     // The first two phases of a Bazel build, Loading and
                     // Analysis, will be treated as the 'Configure' step by
                     // CDash. The final phase, Execution, will be treated as
                     // the 'Build' step by CDash.
+
+                    $stderr = $json_array[$message_id]['stderr'];
+
+                    $info_pattern = '/(.*?)INFO: (.*?)$/';
+                    $linking_pattern = '/(.*?)____From Linking (.*?)$/';
+                    $error_pattern = '/(.*?)ERROR: (.*?)$/';
+                    $warning_pattern = '/(.*?)warning: (.*?)$/';
+
                     $configure_error_pattern = '/\s*ERROR: (.*?)BUILD/';
-                    $analysis_warning_pattern = '/\s*WARNING: errors encountered while analyzing target \'(.*?)\': it will not be built.*?$/';
+                    $analysis_warning_pattern = '/\s*WARNING: (.*?)$/';
                     // Look for the report printed at the end of the analysis phase.
                     $analysis_report_pattern = '/(.*?)Found (.*?)target(.*?)/';
 
@@ -328,7 +333,8 @@ class BazelJSONHandler extends NonSaxHandler
                     $lines = explode("\n", $stderr);
                     $build_error = null;
                     $subproject_name = '';
-
+                    $warning_text = '';
+                    $check_for_warning = false;
 
                     foreach ($lines as $line) {
                         // Remove ANSI color codes.
@@ -382,11 +388,41 @@ class BazelJSONHandler extends NonSaxHandler
                         } else {
                             // Done with configure, parsing build errors and warnings
                             $record_error = false;
-                            if (preg_match($warning_pattern, $line, $matches) === 1
+
+                            if ($check_for_warning) {
+                                if (preg_match($warning_pattern, $line, $matches) === 1
+                                      && count($matches) === 3) {
+                                    // This line is part of a warning message
+                                    $record_error = true;
+                                    $type = 1;
+                                } else {
+                                    $warning_text = '';
+                                }
+                                $check_for_warning = false;
+                            }
+
+                            if (!empty($warning_text)) {
+                                // This line is part of a warning message
+                            } elseif (preg_match($info_pattern, $line, $matches) === 1
                                   && count($matches) === 3) {
-                                // This line contains a warning.
-                                $record_error = true;
-                                $type = 1;
+                                // This line might be the start of a warning message
+                                // Some warnings are structured:
+                                // INFO: ....
+                                // ... warning: ...
+                                // ...
+                                // ... warning: ...
+                                // ...
+                                // <n> warnings generated.
+                                $check_for_warning = true;
+                                $warning_text = $line;
+                            } elseif (preg_match($linking_pattern, $line, $matches) === 1
+                                  && count($matches) === 3) {
+                                // This line might be the start of a warning message
+                                // Some warnings are structed:
+                                // ____From Linking <...>:
+                                // clang: warning: ...
+                                $check_for_warning = true;
+                                $warning_text = $line;
                             } elseif (preg_match($error_pattern, $line, $matches) === 1
                                   && count($matches) === 3) {
                                 // This line contains an error.
@@ -402,6 +438,7 @@ class BazelJSONHandler extends NonSaxHandler
                                     $subproject_name = '';
                                     $build_error = null;
                                 }
+
                                 $build_error = new BuildError();
                                 $build_error->Type = $type;
                                 $build_error->LogLine = $log_line_number;
@@ -433,7 +470,13 @@ class BazelJSONHandler extends NonSaxHandler
                                     $source_line_number = 0;
                                 }
 
-                                $build_error->Text = $line;
+                                if (empty($warning_text)) {
+                                    $build_error->Text = $line;
+                                } else {
+                                    $build_error->Text = $warning_text;
+                                    $warning_text = '';
+                                    $build_error->PostContext .= "$line\n";
+                                }
                                 $build_error->SourceFile = $source_file;
                                 $build_error->SourceLine = $source_line_number;
 


### PR DESCRIPTION
Otherwise, compiler errors that caused the Bazel error are incorrectly
broken out separate errors.