### PR TITLE
Prevent multiple subprojects from being listed with the same order

### DIFF
--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -693,7 +693,7 @@ class Index extends ResultsApi
                 $this->subProjectPositions[] = $build_array['subprojectposition'];
             }
         } else {
-            $build_response['position'] = 0;
+            $build_response['position'] = -1;
         }
 
         // We maintain a list of distinct build start times when viewing
@@ -1269,13 +1269,20 @@ class Index extends ResultsApi
         }
     }
 
-    // Normalize subproject order so it's always 1 to N with no gaps.
+    // Normalize subproject order so it's always 1 to N with no gaps and no duplicates.
     public function normalizeSubProjectOrder()
     {
         sort($this->subProjectPositions);
         for ($i = 0; $i < count($this->buildgroupsResponse); $i++) {
             for ($j = 0; $j < count($this->buildgroupsResponse[$i]['builds']); $j++) {
-                $idx = array_search($this->buildgroupsResponse[$i]['builds'][$j]['position'], $this->subProjectPositions);
+                $position = $this->buildgroupsResponse[$i]['builds'][$j]['position'];
+                if ($position === -1) {
+                    // No SubProject position found for this build, stick it on the end of the list.
+                    $idx = count($this->subProjectPositions);
+                    $this->subProjectPositions[] = $idx;
+                } else {
+                    $idx = array_search($position, $this->subProjectPositions);
+                }
                 $this->buildgroupsResponse[$i]['builds'][$j]['position'] = $idx + 1;
             }
         }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -218,6 +218,7 @@ add_php_test(rehashpassword)
 add_php_test(consistenttestingday)
 add_php_test(numericupdate)
 add_php_test(attachedfiles)
+add_php_test(subprojectorder)
 
 add_subdirectory(ctest)
 

--- a/app/cdash/tests/test_subprojectorder.php
+++ b/app/cdash/tests/test_subprojectorder.php
@@ -1,0 +1,60 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+use CDash\Database;
+use CDash\Model\Project;
+
+class SubProjectOrderTestCase extends KWWebTestCase
+{
+    private $project;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->project = null;
+    }
+
+    public function __destruct()
+    {
+        // Delete project & build created by this test.
+        if ($this->project) {
+            remove_project_builds($this->project->Id);
+            $this->project->Delete();
+        }
+    }
+
+    public function testSubProjectOrder()
+    {
+        // Create test project.
+        $this->login();
+        $this->project = new Project();
+        $this->project->Id = $this->createProject([
+            'Name' => 'SubProjectOrder',
+        ]);
+        $this->project->Fill();
+
+        // Submit our testing data.
+        $test_data = dirname(__FILE__) . '/data/MultipleSubprojects/Build.xml';
+        if (!$this->submission('SubProjectOrder', $test_data)) {
+            $this->fail('failed to submit Build.xml');
+        }
+
+        // Get the parent build we created.
+        $db = Database::getInstance();
+        $stmt = $db->prepare(
+            'SELECT id FROM build
+            WHERE projectid = :projectid AND parentid = -1');
+        $db->execute($stmt, [':projectid' => $this->project->Id]);
+        $parent_buildid = $stmt->fetchColumn();
+
+        // Verify subproject order.
+        $this->get("{$this->url}/api/v1/index.php?project=SubProjectOrder&parentid={$parent_buildid}");
+        $content = $this->getBrowser()->getContent();
+        file_put_contents("/tmp/zackdebug.txt", $content);
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $this->assertTrue(1 === $buildgroup['builds'][0]['position']);
+        $this->assertTrue(2 === $buildgroup['builds'][1]['position']);
+        $this->assertTrue(3 === $buildgroup['builds'][2]['position']);
+    }
+}


### PR DESCRIPTION
De-duplicate subproject order on index.php when no explicit order was previously submitted to the database.