### PR TITLE
Increase size of testmeasurement::value

### DIFF
--- a/app/cdash/sql/mysql/cdash.sql
+++ b/app/cdash/sql/mysql/cdash.sql
@@ -715,7 +715,7 @@ CREATE TABLE `testmeasurement` (
   `outputid` bigint(20) NOT NULL,
   `name` varchar(70) NOT NULL,
   `type` varchar(70) NOT NULL,
-  `value` text NOT NULL,
+  `value` mediumtext NOT NULL,
   PRIMARY KEY  (`id`),
   KEY `outputid` (`outputid`)
 );

--- a/database/migrations/2020_06_22_085012_increase__test_measurement_value_size.php
+++ b/database/migrations/2020_06_22_085012_increase__test_measurement_value_size.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreaseTestMeasurementValueSize extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            // The blank comment is used to work around a limitation in
+            // doctrine/dbal. See:
+            // https://github.com/doctrine/dbal/issues/2566
+            $table->mediumText('value')->comment(' ')->change(); // up
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            $table->text('value')->comment('')->change(); // down
+        });
+    }
+}


### PR DESCRIPTION
This fixes an issue where we could only support ATTACHED_FILES
up to size 64 kb.