### PR TITLE
Use buffers when decompressing dynamic analysis logs

### DIFF
--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -149,14 +149,28 @@ class DynamicAnalysis
             $idvalue = qnum($this->Id) . ',';
         }
 
+        $max_log_length = 1024 * 1024;
+
         // Handle log decoding/decompression
         if (strtolower($this->LogEncoding) == 'base64') {
             $this->Log = str_replace(array("\r\n", "\n", "\r"), '', $this->Log);
             $this->Log = base64_decode($this->Log);
         }
         if (strtolower($this->LogCompression) == 'gzip') {
-            $this->Log = gzuncompress($this->Log);
+            // Avoid memory exhaustion errors by buffering data as we
+            // decompress the gzipped log.
+            $uncompressed_log = '';
+            $inflate_context = inflate_init(ZLIB_ENCODING_DEFLATE);
+            foreach (str_split($this->Log, 1024) as $chunk) {
+                $uncompressed_log = inflate_add($inflate_context, $chunk, ZLIB_NO_FLUSH);
+                if (strlen($uncompressed_log) >= $max_log_length) {
+                    break;
+                }
+            }
+            $uncompressed_log .= inflate_add($inflate_context, NULL, ZLIB_FINISH);
+            $this->Log = $uncompressed_log;
         }
+
         if ($this->Log === false) {
             add_log('Unable to decompress dynamic analysis log',
                 'DynamicAnalysis::Insert', LOG_ERR, 0, $this->BuildId, ModelType::DYNAMICANALYSIS, $this->Id);
@@ -164,9 +178,9 @@ class DynamicAnalysis
         }
 
         // Only store 1MB of log.
-        if (strlen($this->Log) > 1024 * 1024) {
+        if (strlen($this->Log) > $max_log_length) {
             $truncated_msg = "\n(truncated)\n";
-            $keep_length = (1024 * 1024) - strlen($truncated_msg);
+            $keep_length = $max_log_length - strlen($truncated_msg);
             $this->Log = substr($this->Log, 0, $keep_length);
             $this->Log .= $truncated_msg;
         }
@@ -198,6 +212,9 @@ class DynamicAnalysis
                 $defect->Insert();
             }
         }
+
+        // Log won't be re-used, clear it here to save memory.
+        $this->Log = '';
 
         // Add the labels
         $this->InsertLabelAssociations();


### PR DESCRIPTION
Avoid memory exhaustion errors when decompressing lots of data.

Also clear the Log member variable after it's been inserted into the database.
Otherwise we can also run out of memory when inserting lots of dynamic analysis
results for a single build.