### PR TITLE
Fix extra measurement graphs on test details page

### DIFF
--- a/app/cdash/public/api/v1/testGraph.php
+++ b/app/cdash/public/api/v1/testGraph.php
@@ -92,8 +92,8 @@ switch ($type) {
         ];
         $extra_fields = 'tm.value';
         $extra_joins = 'JOIN testmeasurement tm ON (b2t.outputid = tm.outputid)';
-        $extra_where = 'AND tm.name = :measurementname';
-        $params[':measurementname'] = $measurement_name;
+        $extra_wheres = 'AND tm.name = :measurementname';
+        $query_params[':measurementname'] = $measurement_name;
         break;
 }
 

--- a/app/cdash/tests/data/TestMeasurements/Test.xml
+++ b/app/cdash/tests/data/TestMeasurements/Test.xml
@@ -63,6 +63,9 @@
 				<NamedMeasurement type="numeric/double" name="Processors">
 					<Value>3</Value>
 				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="I/O Wait Time">
+					<Value>4.2</Value>
+				</NamedMeasurement>
 				<NamedMeasurement type="text/string" name="Completion Status">
 					<Value>Completed</Value>
 				</NamedMeasurement>

--- a/app/cdash/tests/data/TestMeasurements/Test_subproj.xml
+++ b/app/cdash/tests/data/TestMeasurements/Test_subproj.xml
@@ -55,6 +55,9 @@
                                 <NamedMeasurement type="numeric/double" name="Processors">
                                     <Value>2</Value>
                                 </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="I/O Wait Time">
+                                    <Value>4.2</Value>
+                                </NamedMeasurement>
                                 <NamedMeasurement type="text/string" name="Fail Reason">
                                         <Value>Required regular expression not found.Regex=[Test!
 ]</Value>
@@ -92,6 +95,9 @@
                                 <NamedMeasurement type="numeric/double" name="Processors">
                                     <Value>3</Value>
                                 </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="I/O Wait Time">
+                                    <Value>5.3</Value>
+                                </NamedMeasurement>
                                 <NamedMeasurement type="text/string" name="Fail Reason">
                                         <Value>Required regular expression not found.Regex=[Test!
 ]</Value>
@@ -122,6 +128,9 @@
                                 </NamedMeasurement>
                                 <NamedMeasurement type="numeric/double" name="Processors">
                                     <Value>4</Value>
+                                </NamedMeasurement>
+                                <NamedMeasurement type="numeric/double" name="I/O Wait Time">
+                                    <Value>6.4</Value>
                                 </NamedMeasurement>
                                 <NamedMeasurement type="text/string" name="Completion Status">
                                         <Value>Completed</Value>


### PR DESCRIPTION
All of a test's extra measurements were inadvertently getting shown on the same chart, rather than being displayed individually.