### PR TITLE
Fix Undefined Index on viewTest.php

### DIFF
--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -120,7 +120,7 @@ class BuildTest extends Model
             $marshaledData['new'] = '1';
         }
 
-        if ($projectshowtesttime) {
+        if ($projectshowtesttime && array_key_exists('timestatus', $data)) {
             if ($data['timestatus'] == 0) {
                 $marshaledData['timestatus'] = 'Passed';
                 $marshaledData['timestatusclass'] = 'normal';


### PR DESCRIPTION
This bug would occur when loading viewTest.php for a build with missing tests that belongs to a project with timestatus checking enabled.