### PR TITLE
Various fixes & improvements to test displays

### DIFF
--- a/app/Models/TestLabel.php
+++ b/app/Models/TestLabel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestLabel extends Model
+{
+    protected $table = 'label2test';
+    protected $fillable = ['labelid', 'buildid', 'outputid'];
+
+    public $timestamps = false;
+}

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -450,6 +450,7 @@ function clean_backup_directory()
 
     foreach (glob("{$directory}/*") as $filename) {
         if (file_exists($filename) && is_file($filename) &&
+            substr($filename, -5) !== 'empty' &&
             time() - filemtime($filename) > $timeframe * 3600
         ) {
             cdash_unlink($filename);

--- a/app/cdash/public/api/v1/testDetails.php
+++ b/app/cdash/public/api/v1/testDetails.php
@@ -306,9 +306,15 @@ $stmt = $pdo->prepare(
 pdo_execute($stmt, [':outputid' => $outputid]);
 $fileid = 1;
 $test_response['environment'] = '';
+$preformatted_measurements = [];
+
 while ($row = $stmt->fetch()) {
     if ($row['name'] === 'Environment' && $row['type'] === 'text/string') {
         $test_response['environment'] = $row['value'];
+        continue;
+    } elseif ($row['type'] == 'text/preformatted') {
+        $preformatted_measurement = ['name' => $row['name'], 'value' => $row['value']];
+        $preformatted_measurements[] = $preformatted_measurement;
         continue;
     }
 
@@ -338,7 +344,12 @@ while ($row = $stmt->fetch()) {
     $measurement_response['value'] = $value;
     $measurements_response[] = $measurement_response;
 }
+
 $test_response['measurements'] = $measurements_response;
+usort($preformatted_measurements, function ($a, $b) {
+    return strcmp($a['name'], $b['name']);
+});
+$test_response['preformatted_measurements'] = $preformatted_measurements;
 $response['test'] = $test_response;
 $pageTimer->end($response);
 echo json_encode($response);

--- a/app/cdash/public/api/v1/testDetails.php
+++ b/app/cdash/public/api/v1/testDetails.php
@@ -189,6 +189,12 @@ $test_response['command'] = $testRow['command'];
 $test_response['details'] = $testRow['details'];
 $test_response['output'] = utf8_for_xml(TestOutput::DecompressOutput($testRow['output']));
 
+if ($project->DisplayLabels) {
+    $test_response['labels'] = $buildtest->getLabels()->keys()->implode(', ');
+} else {
+    $test_response['labels'] = '';
+}
+
 $test_response['summaryLink'] = $summaryLink;
 switch ($testRow['status']) {
     case 'passed':

--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -71,6 +71,15 @@ a:hover{
 .na { background-color : #cccccc; }
 .measurement { background-color : #b0c4de; }
 
+#test_measurement_table th {
+  padding: 4px;
+  margin-right: 4px;
+}
+#test_measurement_table td {
+  padding: 4px;
+  margin-left: 4px;
+}
+
 .table-heading {
  background-color : #c7d7e7; /* #c1c1c1 */
  font-size: 13px;

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -231,6 +231,7 @@ add_php_test(testimages)
 add_php_test(dynamicanalysislogs)
 add_php_test(namedmeasurements)
 add_php_test(longbuildname)
+add_php_test(multiplelabelsfortests)
 
 add_subdirectory(ctest)
 

--- a/app/cdash/tests/data/MultipleLabelsForTests/Test.xml
+++ b/app/cdash/tests/data/MultipleLabelsForTests/Test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_submit"
+	BuildStamp="20210405-1424-Experimental"
+	Name="hesperides"
+	Generator="ctest-3.20.0"
+	>
+	<Testing>
+		<StartDateTime>Apr 05 10:24 EDT</StartDateTime>
+		<StartTestTime>1617632667</StartTestTime>
+		<TestList>
+			<Test>./multi_labels</Test>
+		</TestList>
+		<Test Status="passed">
+			<Name>multi_labels</Name>
+			<Path>.</Path>
+			<FullName>./multi_labels</FullName>
+			<FullCommandLine>/tmp/bin/multi_labels</FullCommandLine>
+			<Results>
+				<NamedMeasurement type="numeric/double" name="Execution Time">
+					<Value>0.117901</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="Processors">
+					<Value>1</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Completed</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value>/tmp/bin/multi_labels</Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value></Value>
+				</Measurement>
+			</Results>
+			<Labels>
+				<Label>label1</Label>
+				<Label>label2</Label>
+				<Label>label3</Label>
+			</Labels>
+		</Test>
+		<EndDateTime>Apr 05 10:24 EDT</EndDateTime>
+		<EndTestTime>1617632668</EndTestTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Testing>
+</Site>

--- a/app/cdash/tests/data/OutputColor/Test_2.xml
+++ b/app/cdash/tests/data/OutputColor/Test_2.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="preformatted_test_measurement"
+	BuildStamp="20210409-1528-Experimental"
+	Name="hesperides"
+	Generator="ctest-3.20.1"
+	>
+	<Testing>
+		<StartDateTime>Apr 09 11:29 EDT</StartDateTime>
+		<StartTestTime>1617982140</StartTestTime>
+		<TestList>
+			<Test>./preformatted_color</Test>
+		</TestList>
+		<Test Status="passed">
+			<Name>preformatted_color</Name>
+			<Path>.</Path>
+			<FullName>./preformatted_color</FullName>
+			<FullCommandLine>/tmp/bin/preformatted_color</FullCommandLine>
+			<Results>
+				<NamedMeasurement type="numeric/double" name="Execution Time">
+					<Value>0.269173</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="Processors">
+					<Value>1</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Completed</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value>/tmp/bin/preformatted_color</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/preformatted" name="Color Output">
+					<Value>not bold[NON-XML-CHAR-0x1B][1m bold[NON-XML-CHAR-0x1B][0;0m not bold
+[NON-XML-CHAR-0x1B][32mHello world![NON-XML-CHAR-0x1B][0m
+[NON-XML-CHAR-0x1B][31mThis is test output[NON-XML-CHAR-0x1B][0m
+</Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value>regular output here
+</Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<EndDateTime>Apr 09 11:29 EDT</EndDateTime>
+		<EndTestTime>1617982140</EndTestTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Testing>
+</Site>

--- a/app/cdash/tests/test_multiplelabelsfortests.php
+++ b/app/cdash/tests/test_multiplelabelsfortests.php
@@ -1,0 +1,73 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+use CDash\Database;
+use App\Models\BuildTest;
+use CDash\Model\Project;
+
+class MultipleLabelsForTestsTestCase extends KWWebTestCase
+{
+    private $project;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->project = null;
+    }
+
+    public function __destruct()
+    {
+        // Delete project & build created by this test.
+        if ($this->project) {
+            remove_project_builds($this->project->Id);
+            $this->project->Delete();
+        }
+    }
+
+    public function testMultipleLabelsForTests()
+    {
+        // Create test project.
+        $this->login();
+        $this->project = new Project();
+        $this->project->Id = $this->createProject([
+            'Name' => 'MultipleLabelsForTests',
+            'DisplayLabels' => '1',
+        ]);
+        $this->project->Fill();
+
+        $this->deleteLog($this->logfilename);
+
+        // Submit our testing data.
+        $test_dir = dirname(__FILE__) . '/data/MultipleLabelsForTests/';
+        if (!$this->submission('MultipleLabelsForTests', "{$test_dir}/Test.xml")) {
+            $this->fail("Failed to submit {$file}");
+        }
+
+        // No errors in the log.
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+
+        // The build exists.
+        $results = \DB::select(
+            DB::raw("SELECT id FROM build WHERE projectid = :projectid"),
+            [':projectid' => $this->project->Id]
+        );
+        $this->assertTrue(1 === count($results));
+
+        // Verify that the test has multiple labels.
+        $buildid = $results[0]->id;
+        $buildtest = BuildTest::where('buildid', '=', $buildid)->first();
+        $this->assertTrue(3 === count($buildtest->getLabels()));
+
+        // Verify that these labels are correctly returned by the testDetails API.
+        $this->get("{$this->url}/api/v1/testDetails.php?buildtestid={$buildtest->id}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual('label1, label2, label3', $jsonobj['test']['labels']);
+
+        // Verify that these labels are correctly returned by the viewTests API.
+        $this->get("{$this->url}/api/v1/viewTest.php?buildid={$buildid}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertTrue(3 === count($jsonobj['tests'][0]['labels']));
+    }
+}

--- a/app/cdash/tests/test_outputcolor.php
+++ b/app/cdash/tests/test_outputcolor.php
@@ -46,33 +46,45 @@ class OutputColorTestCase extends KWWebTestCase
             return;
         }
 
-        $buildtestid_results = pdo_single_row_query(
-            "SELECT build2test.id FROM build2test
-            JOIN test ON (build2test.testid = test.id)
-            WHERE test.name = 'colortest_long'");
-        $buildtestid = $buildtestid_results['id'];
+        // No errors in the log.
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
 
-        // Get the output.
+        // Get test output.
+        $buildtestid = $this->getIdForTest('colortest_long');
         $content = $this->connect($this->url . "/api/v1/testDetails.php?buildtestid=$buildtestid");
         $json_content = json_decode($content, true);
         $output = $json_content['test']['output'];
 
+        // Check for expected escape sequences.
         if (strpos($output, "\x1B[32m") === false) {
             $this->fail('Could not find first escape sequence');
-            return;
         }
 
         if (strpos($output, "\x1B[91m") === false) {
             $this->fail('Could not find second escape sequence');
-            return;
         }
 
         if (strpos($output, "\x1B[0m") === false) {
             $this->fail('Could not find third escape sequence');
-            return;
         }
 
-        $this->assertTrue(true, 'All escape sequences found');
+        // Verify that color output works as expected for preformatted test measurements too.
+        $file = dirname(__FILE__) . '/data/OutputColor/Test_2.xml';
+        if (!$this->submission('OutputColor', $file)) {
+            $this->fail("Failed to submit $file");
+            return;
+        }
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+        $buildtestid = $this->getIdForTest('preformatted_color');
+        $content = $this->connect($this->url . "/api/v1/testDetails.php?buildtestid=$buildtestid");
+        $json_content = json_decode($content, true);
+        $this->assertEqual(1, count($json_content['test']['preformatted_measurements']));
+        $measurement = $json_content['test']['preformatted_measurements'][0];
+        $this->assertEqual('Color Output', $measurement['name']);
+        $expected = 'not bold[NON-XML-CHAR-0x1B][1m bold[NON-XML-CHAR-0x1B][0;0m not bold
+[NON-XML-CHAR-0x1B][32mHello world![NON-XML-CHAR-0x1B][0m
+[NON-XML-CHAR-0x1B][31mThis is test output[NON-XML-CHAR-0x1B][0m';
+        $this->assertEqual($expected, $measurement['value']);
 
         // Submit build data for later check in viewBuildErrors.
         $file = dirname(__FILE__) . '/data/OutputColor/Build.xml';
@@ -80,5 +92,17 @@ class OutputColorTestCase extends KWWebTestCase
             $this->fail("Failed to submit $file");
             return;
         }
+    }
+
+    private function getIdForTest($testname)
+    {
+        $buildtestid_results = \DB::select(
+            DB::raw(
+            "SELECT build2test.id FROM build2test
+            JOIN test ON (build2test.testid = test.id)
+            WHERE test.name = '$testname'")
+        );
+        $this->assertEqual(1, count($buildtestid_results));
+        return $buildtestid_results[0]->id;
     }
 }

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -36,6 +36,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
 
     private $TestMeasurement;
     private $Label;
+    private $Labels;
     private $Append;
 
     private $TestCreator;
@@ -133,6 +134,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
             $this->TestCreator->projectid = $this->projectid;
             $this->TestCreator->testStatus = $attributes['STATUS'];
             $this->TestSubProjectName = '';
+            $this->Labels = [];
         } elseif ($name == 'NAMEDMEASUREMENT' && array_key_exists('TYPE', $attributes)) {
             $this->TestMeasurement = $factory->create(TestMeasurement::class);
 
@@ -177,11 +179,9 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
             } elseif ($this->TestCreator->testStatus == 'notrun') {
                 $this->NumberTestsNotRun[$this->SubProjectName]++;
             }
-
-            if ($this->Label) {
-                $this->TestCreator->labels->push($this->Label);
+            if ($this->Labels) {
+                $this->TestCreator->labels = $this->Labels;
             }
-
             $this->TestCreator->create($build);
         } elseif ($name == 'LABEL' && $parent == 'LABELS') {
             if (!empty($this->TestSubProjectName)) {
@@ -306,6 +306,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
             }
             if (is_a($this->Label, Label::class)) {
                 $this->Label->SetText($data);
+                $this->Labels[] = $this->Label;
             }
         }
     }

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -76,6 +76,13 @@
           This test took longer to complete ({{ cdash.test.time }}) than the threshold allows ({{ cdash.test.threshold }}).
         </div>
       </div>
+
+      <div v-if="cdash.test.labels != ''">
+        <b>Labels: </b>
+        {{ cdash.test.labels }}
+        <br>
+      </div>
+
       <br>
 
       <!-- Display the measurements -->

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -79,7 +79,7 @@
       <br>
 
       <!-- Display the measurements -->
-      <table>
+      <table id="test_measurement_table">
         <tr v-if="cdash.test.compareimages">
           <th class="measurement">
             Interactive Image

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -225,6 +225,12 @@
         id="test_output"
         v-html="cdash.test.output"
       />
+
+      <div v-for="preformatted_measurement in cdash.test.preformatted_measurements">
+        <b>{{ preformatted_measurement.name }}</b>
+        <pre v-html="preformatted_measurement.value" />
+        <br>
+      </div>
     </div>
   </section>
 </template>
@@ -297,6 +303,11 @@ export default {
     postSetup: function(response) {
       this.cdash.test.output = TextMutator.ctestNonXmlCharEscape(this.cdash.test.output);
       this.cdash.test.output = TextMutator.terminalColors(this.cdash.test.output, true);
+
+      for (var i = 0; i < this.cdash.test.preformatted_measurements.length; i++) {
+        this.cdash.test.preformatted_measurements[i].value = TextMutator.ctestNonXmlCharEscape(this.cdash.test.preformatted_measurements[i].value);
+        this.cdash.test.preformatted_measurements[i].value = TextMutator.terminalColors(this.cdash.test.preformatted_measurements[i].value, true);
+      }
 
       this.queryParams = QueryParams.get();
       if (this.graphSelection) {

--- a/tests/Spec/test-details.spec.js
+++ b/tests/Spec/test-details.spec.js
@@ -69,6 +69,14 @@ describe('TestDetails', function() {
             value: '',
           },
         ],
+        preformatted_measurements: [
+          {
+            name: 'Custom Output',
+            type: 'test/preformatted',
+            value: `multiple
+lines`,
+          },
+        ],
       },
       user: {
         id: 1,
@@ -112,6 +120,9 @@ describe('TestDetails', function() {
     expect(html).toContain('my-test');
     expect(html).toContain('Completed (OTHER_FAULT)');
     expect(html).toContain('label1, label2, label3');
+    expect(html).toContain('Custom Output');
+    expect(html).toContain(`<pre>multiple
+lines</pre>`);
 
     // Verify colorized/escaped output.
     const test_output = component.find("#test_output");

--- a/tests/Spec/test-details.spec.js
+++ b/tests/Spec/test-details.spec.js
@@ -44,6 +44,7 @@ describe('TestDetails', function() {
         command: '/usr/bin/false',
         details: 'Completed (OTHER_FAULT)',
         environment: 'foo=bar',
+        labels: 'label1, label2, label3',
         output: "\u001b[32mHello world!\n\u001b[91m<script type=\"text\/javascript\">console.log(\"MALICIOUS JAVASCRIPT!!!\");<\/script>\n\u001b[0mGood bye world!\n",
         summaryLink: 'testSummary.php?project=1&name=my-test',
         status: 'Failed',
@@ -110,6 +111,7 @@ describe('TestDetails', function() {
     expect(html).toContain('my build');
     expect(html).toContain('my-test');
     expect(html).toContain('Completed (OTHER_FAULT)');
+    expect(html).toContain('label1, label2, label3');
 
     // Verify colorized/escaped output.
     const test_output = component.find("#test_output");


### PR DESCRIPTION
* Show more than the first label for a test on viewTest.php
* Show test labels on testDetails.php
* Extra padding between measurement name & value on testDetails.php
* Add support for 'preformatted' test measurements. These get rendered in a `<pre>` tag like test output does.