### PR TITLE
Add migration to add user::email_verified_at column

### DIFF
--- a/database/migrations/2021_07_20_093407_email_verified.php
+++ b/database/migrations/2021_07_20_093407_email_verified.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EmailVerified extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasColumn('user', 'email_verified_at')) {
+            Schema::table('user', function (Blueprint $table) {
+                $table->timestamp('email_verified_at')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasColumn('user', 'email_verified_at')) {
+            Schema::table('user', function (Blueprint $table) {
+                $table->dropColumn('email_verified_at');
+            });
+        }
+    }
+}


### PR DESCRIPTION
This column was missing from some older installations of CDash,
causing HTTP 500 errors when a new user attempted to register.