### PR TITLE
Enable and disable oauth2 providers with environment variables

### DIFF
--- a/app/Console/Commands/MigrateConfig.php
+++ b/app/Console/Commands/MigrateConfig.php
@@ -127,6 +127,9 @@ class MigrateConfig extends Command
                     if (array_key_exists('domain', $v)) {
                         $config["{$provider}_DOMAIN"] = $v['domain'];
                     }
+                    if (array_key_exists('clientId', $v) && array_key_exists('clientSecret', $v)) {
+                        $config["{$provider}_ENABLE"] = true;
+                    }
                 }
             }
 

--- a/config/oauth2.php
+++ b/config/oauth2.php
@@ -9,20 +9,20 @@ return [
         'clientId' => env('GITHUB_CLIENT_ID'),
         'clientSecret' => env('GITHUB_CLIENT_SECRET'),
         'className' => GitHub::class,
-        'enable' => false,
+        'enable' => env('GITHUB_ENABLE', false),
     ],
     'gitlab' => [
         'clientId' => env('GITLAB_CLIENT_ID'),
         'clientSecret' => env('GITLAB_CLIENT_SECRET'),
         'domain' => env('GITLAB_DOMAIN', 'https://gitlab.com'),
         'className' => GitLab::class,
-        'enable' => false,
+        'enable' => env('GITLAB_ENABLE', false),
     ],
     'google' => [
         'clientId' => env('GOOGLE_CLIENT_ID'),
         'clientSecret' => env('GOOGLE_CLIENT_SECRET'),
         'hostedDomain' => '*',
         'className' => Google::class,
-        'enable' => false,
+        'enable' => env('GOOGLE_ENABLE', false),
     ]
 ];

--- a/tests/Feature/MigrateConfigCommand.php
+++ b/tests/Feature/MigrateConfigCommand.php
@@ -78,11 +78,15 @@ EOT;
         $this->assertContains('APP_TIMEZONE=America/New_York', $actual);
         $this->assertContains('APP_LOG_LEVEL=debug', $actual);
         $this->assertContains('UNLIMITED_PROJECTS=["Project1","Project2"]', $actual);
+        $this->assertContains('GITHUB_CLIENT_ID=github_client_id', $actual);
+        $this->assertContains('GITHUB_ENABLE=true', $actual);
         $this->assertContains('GITHUB_CLIENT_SECRET=github_client_secret', $actual);
         $this->assertContains('GITLAB_CLIENT_ID=gitlab_client_id', $actual);
+        $this->assertContains('GITLAB_ENABLE=true', $actual);
         $this->assertContains('GITLAB_CLIENT_SECRET=gitlab_client_secret', $actual);
         $this->assertContains('GITLAB_DOMAIN=https://gitlab.kitware.com', $actual);
         $this->assertContains('GOOGLE_CLIENT_ID=google_client_id', $actual);
+        $this->assertContains('GOOGLE_ENABLE=true', $actual);
         $this->assertContains('GOOGLE_CLIENT_SECRET=google_client_secret', $actual);
 
         // Default value (mysql) does not get written to .env.


### PR DESCRIPTION
This PR adds environment variables to control whether an oauth2 provider is enabled.  See https://github.com/Kitware/CDash/issues/958#issuecomment-682574753