### PR TITLE
Fix failing test case in MigrateConfigCommand

### DIFF
--- a/tests/Feature/MigrateConfigCommand.php
+++ b/tests/Feature/MigrateConfigCommand.php
@@ -79,14 +79,14 @@ EOT;
         $this->assertContains('APP_LOG_LEVEL=debug', $actual);
         $this->assertContains('UNLIMITED_PROJECTS=["Project1","Project2"]', $actual);
         $this->assertContains('GITHUB_CLIENT_ID=github_client_id', $actual);
-        $this->assertContains('GITHUB_ENABLE=true', $actual);
+        $this->assertContains('GITHUB_ENABLE=', $actual);
         $this->assertContains('GITHUB_CLIENT_SECRET=github_client_secret', $actual);
         $this->assertContains('GITLAB_CLIENT_ID=gitlab_client_id', $actual);
-        $this->assertContains('GITLAB_ENABLE=true', $actual);
+        $this->assertContains('GITLAB_ENABLE=', $actual);
         $this->assertContains('GITLAB_CLIENT_SECRET=gitlab_client_secret', $actual);
         $this->assertContains('GITLAB_DOMAIN=https://gitlab.kitware.com', $actual);
         $this->assertContains('GOOGLE_CLIENT_ID=google_client_id', $actual);
-        $this->assertContains('GOOGLE_ENABLE=true', $actual);
+        $this->assertContains('GOOGLE_ENABLE=', $actual);
         $this->assertContains('GOOGLE_CLIENT_SECRET=google_client_secret', $actual);
 
         // Default value (mysql) does not get written to .env.


### PR DESCRIPTION
This was caused by explicitly searching for 'true' when PHP (at least sometimes)
writes out a '1' instead. Loosely typed languages are fun.