### PR TITLE
Fix SubProject filter propagation for the 'include' case

### DIFF
--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -1280,9 +1280,11 @@ class Index extends ResultsApi
             if ($this->includeSubProjects) {
                 $selected_subprojects = $this->includedSubProjects;
                 $compare = '61'; // string is equal
+                $combine = 'or';
             } elseif ($this->excludeSubProjects) {
                 $selected_subprojects = $this->excludedSubProjects;
                 $compare = '62'; // string is not equal
+                $combine = 'and';
             }
             if ($selected_subprojects) {
                 foreach ($selected_subprojects as $i => $subproject) {
@@ -1294,6 +1296,7 @@ class Index extends ResultsApi
                 $this->subProjectTestFilters = '&';
                 $this->subProjectTestFilters .= implode('&', $subproject_test_filters);
                 $this->subProjectTestFilters .= "&filtercount={$this->numSelectedSubProjects}";
+                $this->subProjectTestFilters .= "&filtercombine=$combine";
                 $this->subProjectTestFilters .= '&showfilters=1';
             }
         }

--- a/app/cdash/tests/test_subprojecttestfilters.php
+++ b/app/cdash/tests/test_subprojecttestfilters.php
@@ -24,7 +24,7 @@ class SubProjectTestFiltersTestCase extends KWWebTestCase
         $this->assertEqual(88, $build['test']['notrun']);
 
         // Verify filters to be passed to viewTest.php.
-        $expected = '&field1=subproject&compare1=62&value1=AztecOO&field2=subproject&compare2=62&value2=TrilinosFramework&filtercount=2&showfilters=1';
+        $expected = '&field1=subproject&compare1=62&value1=AztecOO&field2=subproject&compare2=62&value2=TrilinosFramework&filtercount=2&filtercombine=and&showfilters=1';
         $testfilters = $jsonobj['testfilters'];
         $this->assertEqual($expected, $testfilters);
 
@@ -46,5 +46,30 @@ class SubProjectTestFiltersTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $this->assertEqual('', $jsonobj['testfilters']);
+
+        // Verify that the "include SubProjects" filters works as expected.
+        $this->get($this->url . '/api/v1/index.php?project=Trilinos&filtercount=3&field1=subprojects&compare1=93&value1=Sacado&field2=subprojects&compare2=93&value2=TrilinosFramework&field3=site&compare3=61&value3=hut11.kitware');
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $this->assertEqual(1, count($buildgroup['builds']));
+        $build = $buildgroup['builds'][0];
+        $this->assertEqual(300, $build['test']['pass']);
+        $this->assertEqual(11, $build['test']['fail']);
+        $this->assertEqual(0, $build['test']['notrun']);
+        $expected = '&field1=subproject&compare1=61&value1=Sacado&field2=subproject&compare2=61&value2=TrilinosFramework&filtercount=2&filtercombine=or&showfilters=1';
+        $testfilters = $jsonobj['testfilters'];
+        $this->assertEqual($expected, $testfilters);
+        $this->get("{$this->url}/api/v1/viewTest.php?buildid={$build['id']}{$testfilters}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual(300, $jsonobj['numPassed']);
+        $this->assertEqual(11, $jsonobj['numFailed']);
+        $this->assertEqual(0, $jsonobj['numNotRun']);
+        foreach ($jsonobj['tests'] as $test) {
+            if ($test['subprojectname'] != 'TrilinosFramework' && $test['subprojectname'] != 'Sacado') {
+                $this->fail("Unexpected subprojectname on viewTest.php for include case: {$test['subprojectname']}");
+            }
+        }
     }
 }


### PR DESCRIPTION
In 2a58314 we added a feature to automatically propagate SubProject filters
from index.php to viewTest.php.

But this initial implementation did not work properly when using
'SubProject include' filters. This commit fixes that behavior and adds testing
for this case.