### PR TITLE
Selectively prefer <Time> XML element in Notes.xml

### DIFF
--- a/app/cdash/include/ctestparserutils.php
+++ b/app/cdash/include/ctestparserutils.php
@@ -53,62 +53,6 @@ function extract_date_from_buildstamp($buildstamp)
     return substr($buildstamp, 0, strpos($buildstamp, '-', strpos($buildstamp, '-') + 1));
 }
 
-/** Return timestamp from string
- *  \WARNING this function needs improvement */
-function str_to_time($str, $stamp)
-{
-    $str = str_replace('Eastern Standard Time', 'EST', $str);
-    $str = str_replace('Eastern Daylight Time', 'EDT', $str);
-
-    // For some reasons the Australian time is not recognized by php
-    // Actually an open bug in PHP 5.
-    $offset = 0; // no offset by default
-    if (strpos($str, 'AEDT') !== false) {
-        $str = str_replace('AEDT', 'UTC', $str);
-        $offset = 3600 * 11;
-    } // We had more custom dates
-    elseif (strpos($str, 'Paris, Madrid') !== false) {
-        $str = str_replace('Paris, Madrid', 'UTC', $str);
-        $offset = 3600 * 1;
-    } elseif (strpos($str, 'W. Europe Standard Time') !== false) {
-        $str = str_replace('W. Europe Standard Time', 'UTC', $str);
-        $offset = 3600 * 1;
-    }
-
-    // The year is always at the end of the string if it exists (from CTest)
-    $stampyear = substr($stamp, 0, 4);
-    $year = substr($str, strlen($str) - 4, 2);
-
-    if ($year != '19' && $year != '20') {
-        // No year is defined we add it
-        // find the hours
-        $pos = strpos($str, ':');
-        if ($pos !== false) {
-            $tempstr = $str;
-            $str = substr($tempstr, 0, $pos - 2);
-            $str .= $stampyear . ' ' . substr($tempstr, $pos - 2);
-        }
-    }
-
-    $strtotimefailed = 0;
-
-    if (strtotime($str) === false) {
-        $strtotimefailed = 1;
-    }
-
-    // If it's still failing we assume GMT and put the year at the end
-    if ($strtotimefailed) {
-        // find the hours
-        $pos = strpos($str, ':');
-        if ($pos !== false) {
-            $tempstr = $str;
-            $str = substr($tempstr, 0, $pos - 2);
-            $str .= substr($tempstr, $pos - 2, 5);
-        }
-    }
-    return strtotime($str) - $offset;
-}
-
 /** Add the difference between the numbers of errors and warnings
  *  for the previous and current build */
 function compute_error_difference($buildid, $previousbuildid, $warning)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -234,6 +234,7 @@ add_php_test(longbuildname)
 add_php_test(multiplelabelsfortests)
 add_php_test(subprojecttestfilters)
 add_php_test(dynamicanalysisdefectlongtype)
+add_php_test(starttimefromnotes)
 
 add_subdirectory(ctest)
 

--- a/app/cdash/tests/data/StartTimeFromNotes/Notes.xml
+++ b/app/cdash/tests/data/StartTimeFromNotes/Notes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
+<Site BuildName="note_starttime" BuildStamp="20210916-1919-Experimental" Name="hesperides" Generator="ctest-3.20.1">
+  <Notes>
+    <Note Name="my very own note">
+      <!-- This timestamp corresponds to: Sep 16 2021 15:19:46 PM EDT -->
+      <Time>1631819986</Time>
+      <!-- DateTime purposefully doesn't match the UNIX timestamp above. -->
+      <DateTime>Sep 13 15:19 EDT</DateTime>
+      <Text>this is
+my note
+</Text>
+    </Note>
+  </Notes>
+</Site>

--- a/app/cdash/tests/test_starttimefromnotes.php
+++ b/app/cdash/tests/test_starttimefromnotes.php
@@ -1,0 +1,74 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+use CDash\Database;
+use CDash\Model\Build;
+use CDash\Model\Project;
+
+class StartTimeFromNotesTestCase extends KWWebTestCase
+{
+    private $project;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->project = null;
+    }
+
+    public function __destruct()
+    {
+        // Delete project & build created by this test.
+        if ($this->project) {
+            remove_project_builds($this->project->Id);
+            $this->project->Delete();
+        }
+    }
+
+    public function testStartTimeFromNotes()
+    {
+        // Create test project.
+        $this->login();
+        $this->project = new Project();
+        $this->project->Id = $this->createProject([
+            'Name' => 'StartTimeFromNotes',
+            'NightlyTime' => '18:00:00 America/Denver'
+        ]);
+        $this->project->Fill();
+
+        // Submit our testing data.
+        $file = dirname(__FILE__) . '/data/StartTimeFromNotes/Notes.xml';
+        if (!$this->submission('StartTimeFromNotes', $file)) {
+            $this->fail("Failed to submit {$file}");
+        }
+
+        // No errors in the log.
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+
+        // The build exists.
+        $results = \DB::select(
+            DB::raw('SELECT id FROM build WHERE projectid = :projectid'),
+            [':projectid' => $this->project->Id]
+        );
+        $this->assertTrue(1 === count($results));
+
+        // Verify start time & testing day.
+        $build = new Build();
+        $build->Id = $results[0]->id;
+        $build->FillFromId($build->Id);
+        $this->assertEqual('2021-09-16', $build->GetDate());
+        $this->assertEqual('2021-09-16 19:19:46', $build->StartTime);
+
+        // Verify note was stored successfully.
+        $results = \DB::select(
+            DB::raw("
+                SELECT note.name, note.text FROM note
+                JOIN build2note ON (note.id = build2note.noteid)
+                JOIN build ON (build.id = build2note.buildid)
+                WHERE build.id = :buildid"),
+            [':buildid' => $build->Id]
+        );
+        $this->assertTrue(1 === count($results));
+        $this->assertEqual("my very own note", $results[0]->name);
+        $this->assertEqual("this is\nmy note\n", $results[0]->text);
+    }
+}

--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -25,9 +25,11 @@ use CDash\Model\SiteInformation;
 
 class NoteHandler extends AbstractHandler
 {
+    private $AdjustStartTime;
     private $BuildId;
     private $Note;
     private $Configure;
+    private $TimeStamp;
 
     /** Constructor */
     public function __construct($projectID)
@@ -36,6 +38,9 @@ class NoteHandler extends AbstractHandler
         $this->Build = new Build();
         $this->Site = new Site();
         $this->Configure = new BuildConfigure();
+
+        $this->AdjustStartTime = false;
+        $this->Timestamp = 0;
     }
 
     /** startElement function */
@@ -72,6 +77,7 @@ class NoteHandler extends AbstractHandler
             $this->Note = new BuildNote();
             $this->Note->Name =
                 isset($attributes['NAME']) ? $attributes['NAME'] : '';
+            $this->Timestamp = 0;
         }
     }
 
@@ -84,16 +90,20 @@ class NoteHandler extends AbstractHandler
             $this->Build->GetIdFromName($this->SubProjectName);
             $this->Build->RemoveIfDone();
 
+            $this->Note->Time = gmdate(FMT_DATETIME, $this->Timestamp);
+
             // If the build doesn't exist we add it.
             if ($this->Build->Id == 0) {
                 $this->Build->SetSubProject($this->SubProjectName);
 
-                // Since we only have precision in minutes (not seconds) here,
-                // set the start time at the end of the minute so it can be overridden
-                // by any more precise XML file received later.
-                $start_time = gmdate(FMT_DATETIME, strtotime($this->Note->Time) + 59);
-                $this->Build->StartTime = $start_time;
-
+                $build_start_timestamp = $this->Timestamp;
+                if ($this->AdjustStartTime) {
+                    // Since we only have precision in minutes (not seconds) here,
+                    // set the start time at the end of the minute so it can be overridden
+                    // by any more precise XML file received later.
+                    $build_start_timestamp = $this->Timestamp + 59;
+                }
+                $this->Build->StartTime = gmdate(FMT_DATETIME, $build_start_timestamp);
                 $this->Build->EndTime = $this->Note->Time;
                 $this->Build->SubmitTime = gmdate(FMT_DATETIME);
                 $this->Build->InsertErrors = false;
@@ -118,12 +128,79 @@ class NoteHandler extends AbstractHandler
         if ($parent == 'NOTE') {
             switch ($element) {
                 case 'DATETIME':
-                    $this->Note->Time = gmdate(FMT_DATETIME, str_to_time($data, $this->Build->GetStamp()));
+                    // Only use the <DateTime> element when <Time> is unsuitable.
+                    if ($this->Timestamp === 0) {
+                        $this->Timestamp =
+                            $this->getTimestampFromDateTimeElement($data, $this->Build->GetStamp());
+                        $this->AdjustStartTime = true;
+                    }
+                    break;
+                case 'TIME':
+                    // Prefer the <Time> element if it wasn't specified in
+                    // scientific notation (CTest v3.11.0 or newer).
+                    if (strpos($data, 'e+') === false) {
+                        $this->Timestamp = $data;
+                        $this->AdjustStartTime = false;
+                    }
                     break;
                 case 'TEXT':
                     $this->Note->Text .= $data;
                     break;
             }
         }
+    }
+
+    private function getTimestampFromDateTimeElement($str, $stamp)
+    {
+        $str = str_replace('Eastern Standard Time', 'EST', $str);
+        $str = str_replace('Eastern Daylight Time', 'EDT', $str);
+
+        // For some reasons the Australian time is not recognized by php
+        // Actually an open bug in PHP 5.
+        $offset = 0; // no offset by default
+        if (strpos($str, 'AEDT') !== false) {
+            $str = str_replace('AEDT', 'UTC', $str);
+            $offset = 3600 * 11;
+        } // We had more custom dates
+        elseif (strpos($str, 'Paris, Madrid') !== false) {
+            $str = str_replace('Paris, Madrid', 'UTC', $str);
+            $offset = 3600 * 1;
+        } elseif (strpos($str, 'W. Europe Standard Time') !== false) {
+            $str = str_replace('W. Europe Standard Time', 'UTC', $str);
+            $offset = 3600 * 1;
+        }
+
+        // The year is always at the end of the string if it exists (from CTest)
+        $stampyear = substr($stamp, 0, 4);
+        $year = substr($str, strlen($str) - 4, 2);
+
+        if ($year != '19' && $year != '20') {
+            // No year is defined we add it
+            // find the hours
+            $pos = strpos($str, ':');
+            if ($pos !== false) {
+                $tempstr = $str;
+                $str = substr($tempstr, 0, $pos - 2);
+                $str .= $stampyear . ' ' . substr($tempstr, $pos - 2);
+            }
+        }
+
+        $strtotimefailed = 0;
+
+        if (strtotime($str) === false) {
+            $strtotimefailed = 1;
+        }
+
+        // If it's still failing we assume GMT and put the year at the end
+        if ($strtotimefailed) {
+            // find the hours
+            $pos = strpos($str, ':');
+            if ($pos !== false) {
+                $tempstr = $str;
+                $str = substr($tempstr, 0, $pos - 2);
+                $str .= substr($tempstr, $pos - 2, 5);
+            }
+        }
+        return strtotime($str) - $offset;
     }
 }


### PR DESCRIPTION
Since CTest v3.11, the `<Time>` XML element in Notes.xml contains an
unambiguous UNIX timestamp. If found, we now prefer this value over
the human-readable date/time string found in `<DateTime>`.

This commit also moves/renames
`ctestparserutils::str_to_time()`
to
`notes_handler::getTimestampFromDateTimeElement()`
since this is the last place this function is being used.