### PR TITLE
Improve support for redundant tests

### DIFF
--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -85,8 +85,8 @@ class TestDetails extends BuildApi
                 'SELECT * FROM build2test b2t
                 JOIN test t ON t.id = b2t.testid
                 JOIN testoutput ON testoutput.id = b2t.outputid
-                WHERE b2t.testid = :testid AND b2t.buildid = :buildid');
-        $this->db->execute($stmt, [':testid' => $this->testid, ':buildid' => $this->build->Id]);
+                WHERE b2t.id = :buildtestid');
+        $this->db->execute($stmt, [':buildtestid' => $this->buildtest->id]);
         $testRow = $stmt->fetch();
         $testName = $testRow['name'];
         $outputid = $testRow['outputid'];

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -240,6 +240,7 @@ add_php_test(starttimefromnotes)
 add_php_test(querytestsfilterlabels)
 add_php_test(lotsofsubprojects)
 add_php_test(querytestsrevisionfilter)
+add_php_test(redundanttests)
 
 add_subdirectory(ctest)
 

--- a/app/cdash/tests/data/RedundantTests/Test.xml
+++ b/app/cdash/tests/data/RedundantTests/Test.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="redundant_tests"
+	BuildStamp="20211201-1538-Experimental"
+	Name="hesperides"
+	>
+	<Testing>
+		<StartDateTime>Dec 01 10:38 EST</StartDateTime>
+		<StartTestTime>1638373091</StartTestTime>
+		<TestList>
+			<Test>./test1</Test>
+			<Test>./test1</Test>
+		</TestList>
+		<Test Status="passed">
+			<Name>test1</Name>
+			<Path>.</Path>
+			<FullName>./test1</FullName>
+			<FullCommandLine>/tmp/bin/test1</FullCommandLine>
+			<Results>
+				<NamedMeasurement type="numeric/double" name="Execution Time">
+					<Value>0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Completed</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value>/tmp/bin/test1</Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value>this is a test
+</Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<Test Status="failed">
+			<Name>test1</Name>
+			<Path>.</Path>
+			<FullName>./test1</FullName>
+			<FullCommandLine>/tmp/bin/test1</FullCommandLine>
+			<Results>
+				<NamedMeasurement type="numeric/double" name="Execution Time">
+					<Value>0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Completed</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value>/tmp/bin/test1</Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value>this is the same test but with different output
+</Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<EndDateTime>Dec 01 10:38 EST</EndDateTime>
+		<EndTestTime>1638373091</EndTestTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Testing>
+</Site>

--- a/app/cdash/tests/test_redundanttests.php
+++ b/app/cdash/tests/test_redundanttests.php
@@ -1,0 +1,74 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+use CDash\Database;
+use CDash\Model\Project;
+
+class RedundantTestsTestCase extends KWWebTestCase
+{
+    private $project;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->project = null;
+        $this->deleteLog($this->logfilename);
+    }
+
+    public function __destruct()
+    {
+        // Delete project & build created by this test.
+        if ($this->project) {
+            remove_project_builds($this->project->Id);
+            $this->project->Delete();
+        }
+    }
+
+    public function testRedundantTests()
+    {
+        // Create test project.
+        $this->login();
+        $this->project = new Project();
+        $this->project->Id = $this->createProject([
+            'Name' => 'RedundantTests',
+        ]);
+        $this->project->Fill();
+
+        // Submit our testing data.
+        if (!$this->submission('RedundantTests', dirname(__FILE__) . '/data/RedundantTests/Test.xml')) {
+            $this->fail('Failed to submit');
+        }
+
+        // No errors in the log.
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+
+        // Verify one build.
+        $results = \DB::select(
+            DB::raw('SELECT id FROM build WHERE projectid = :projectid'),
+            [':projectid' => $this->project->Id]
+        );
+        $this->assertTrue(1 === count($results));
+        $buildid = $results[0]->id;
+
+        // Verify two tests.
+        $results = \DB::select(
+            DB::raw('SELECT id FROM build2test WHERE buildid = :buildid'),
+            [':buildid' => $buildid]
+        );
+        $this->assertTrue(2 === count($results));
+
+        $buildtestid1 = $results[0]->id;
+        $buildtestid2 = $results[1]->id;
+
+        // Verify expected output from API.
+        $this->get("{$this->url}/api/v1/testDetails.php?buildtestid={$buildtestid1}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual("this is a test\n", $jsonobj['test']['output']);
+
+        $this->get("{$this->url}/api/v1/testDetails.php?buildtestid={$buildtestid2}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $this->assertEqual("this is the same test but with different output\n", $jsonobj['test']['output']);
+    }
+}


### PR DESCRIPTION
This commit fixes a bug on the 'test details' page.

It would occur when a build had two separate tests with the same name.
In that case, 'test details' would show the output from the 1st test, even
if you were attempting to look at the results from the second one.