### PR TITLE
Show correct measurements for redundant tests

### DIFF
--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -115,6 +115,7 @@ class BuildTest extends Model
         $marshaledData = [
             'id' => $data['id'],
             'buildid' => $buildid,
+            'buildtestid' => $data['buildtestid'],
             'status' => $marshaledStatus[0],
             'statusclass' => $marshaledStatus[1],
             'name' => $data['name'],

--- a/app/cdash/tests/data/RedundantTests/Test.xml
+++ b/app/cdash/tests/data/RedundantTests/Test.xml
@@ -25,6 +25,9 @@
 				<NamedMeasurement type="text/string" name="Command Line">
 					<Value>/tmp/bin/test1</Value>
 				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="color">
+					<Value>purple</Value>
+				</NamedMeasurement>
 				<Measurement>
 					<Value>this is a test
 </Value>
@@ -45,6 +48,9 @@
 				</NamedMeasurement>
 				<NamedMeasurement type="text/string" name="Command Line">
 					<Value>/tmp/bin/test1</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="color">
+					<Value>orange</Value>
 				</NamedMeasurement>
 				<Measurement>
 					<Value>this is the same test but with different output


### PR DESCRIPTION
This commit fixes a bug where incorrect measurements would sometimes
be displayed on `viewTest.php` when a build contains more than one test
with the same name.