### PR TITLE
New config option: USE_VCS_API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,9 @@ MIX_APP_URL="${APP_URL}"
 # Should CDash compress test and coverage results in the database?
 #USE_COMPRESSION=true
 
+# Whether or not this CDash instance should attempt to communicate with
+# VCS (eg. GitHub) API endpoints.
+#USE_VCS_API=true
 
 # logging.php
 #LOG_CHANNEL=stack

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -117,6 +117,10 @@ class GitHub implements RepositoryInterface
 
     public function authenticate($required = true)
     {
+        if (!config('cdash.use_vcs_api')) {
+            return false;
+        }
+
         if (!$this->apiClient) {
             $this->initializeApiClient();
         }
@@ -488,6 +492,11 @@ class GitHub implements RepositoryInterface
         $stmt = $this->db->prepare(
                 'UPDATE buildupdate SET priorrevision = ? WHERE id = ?');
         $this->db->execute($stmt, [$base, $update->UpdateId]);
+
+        // Return early if we are configured to not use the GitHub API.
+        if (!config('cdash.use_vcs_api')) {
+            return;
+        }
 
         // Attempt to authenticate with the GitHub API.
         // We do not check the return value of authenticate() here because

--- a/app/cdash/include/repository.php
+++ b/app/cdash/include/repository.php
@@ -737,7 +737,7 @@ function post_pull_request_comment($projectid, $pull_request, $comment, $cdash_u
         return;
     }
 
-    if (!config('cdash.notify_pull_request')) {
+    if (!config('cdash.notify_pull_request') || !config('cdash.use_vcs_api')) {
         if (config('app.debug')) {
             \Log::info('pull request commenting is disabled');
         }

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -71,5 +71,5 @@ return [
     'token_duration' => env('TOKEN_DURATION', 15811200),
     'unlimited_projects' => $unlimited_projects,
     'use_compression' => env('USE_COMPRESSION', true),
-
+    'use_vcs_api' => env('USE_VCS_API', true),
 ];


### PR DESCRIPTION
Allow CDash instance administrators to control whether or not their installation of CDash will attempt to communicate with Version Control API endpoints (eg. api.github.com).