### PR TITLE
Filter out passed tests from queryTests.php by default

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1680,6 +1680,7 @@ function begin_JSON_response()
     }
     $user_response['id'] = $userid;
     $response['user'] = $user_response;
+    $response['querytestfilters'] = '&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed';
     return $response;
 }
 

--- a/app/cdash/public/js/controllers/index.js
+++ b/app/cdash/public/js/controllers/index.js
@@ -212,6 +212,7 @@ CDash.filter("showEmptyBuildsLast", function () {
     $scope.cdash.extrafilterurl = '';
     if ($scope.cdash.sharelabelfilters) {
       $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
+      $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
     }
 
     // Read simple/advanced view cookie setting.

--- a/app/cdash/public/js/controllers/queryTests.js
+++ b/app/cdash/public/js/controllers/queryTests.js
@@ -37,6 +37,9 @@ CDash.controller('QueryTestsController',
 
       // Check for label filters
       $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
+      if ($scope.cdash.extrafilterurl) {
+        $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
+      }
       $scope.cdash.builds = $filter('orderBy')($scope.cdash.builds, $scope.orderByFields);
       $scope.pageChanged();
     };

--- a/app/cdash/public/js/controllers/viewTest.js
+++ b/app/cdash/public/js/controllers/viewTest.js
@@ -40,6 +40,9 @@ CDash.controller('ViewTestController',
     $scope.finishSetup = function() {
       // Check for label filters
       $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
+      if ($scope.cdash.extrafilterurl) {
+        $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
+      }
       $scope.cdash.tests = $filter('orderBy')($scope.cdash.tests, $scope.orderByFields);
       $scope.setPage(1);
     };

--- a/app/cdash/public/views/partials/header.html
+++ b/app/cdash/public/views/partials/header.html
@@ -72,7 +72,7 @@
               </a>
             </li>
             <li>
-              <a ng-if="cdash.parentid <= 0"
+              <a ng-if="!cdash.parentid || cdash.parentid <= 0"
                  ng-href="queryTests.php?project={{::cdash.projectname_encoded}}&date={{::cdash.date}}{{::cdash.extraurl}}{{::cdash.extrafilterurl}}">
                 Tests Query
               </a>

--- a/app/cdash/public/views/partials/header.html
+++ b/app/cdash/public/views/partials/header.html
@@ -73,7 +73,7 @@
             </li>
             <li>
               <a ng-if="!cdash.parentid || cdash.parentid <= 0"
-                 ng-href="queryTests.php?project={{::cdash.projectname_encoded}}&date={{::cdash.date}}{{::cdash.extraurl}}{{::cdash.extrafilterurl}}">
+                 ng-href="queryTests.php?project={{::cdash.projectname_encoded}}&date={{::cdash.date}}{{::cdash.extraurl}}{{::cdash.querytestfilters}}">
                 Tests Query
               </a>
               <a ng-if="cdash.parentid > 0"

--- a/app/cdash/tests/js/e2e_tests/queryTests.js
+++ b/app/cdash/tests/js/e2e_tests/queryTests.js
@@ -37,4 +37,12 @@ describe("queryTests", function() {
     // filter_test("time", "41", "0", 5);
   });
 
+  it("check default filters", function() {
+      browser.get('index.php?project=InsightExample');
+      browser.actions().mouseMove(element(by.linkText('Dashboard'))).perform();
+      var link = element(by.linkText('Tests Query'));
+      expect(link.getAttribute('href')).toContain('queryTests.php?project=InsightExample');
+      expect(link.getAttribute('href')).toContain('&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed');
+  });
+
 });

--- a/app/cdash/tests/js/e2e_tests/viewTest.js
+++ b/app/cdash/tests/js/e2e_tests/viewTest.js
@@ -5,6 +5,13 @@ describe("viewTest", function() {
     expect(browser.getPageSource()).toContain("kwsys.testHashSTL");
   });
 
+  it("shows link to queryTests.php", function() {
+    browser.get('viewTest.php?buildid=1');
+    browser.actions().mouseMove(element(by.linkText('Dashboard'))).perform();
+    var link = element(by.linkText('Tests Query'));
+    expect(link.getAttribute('href')).toContain('&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed');
+  });
+
   describe("Missing Tests", function() {
 
     beforeEach(async function() {

--- a/resources/js/components/page-header/HeaderMenu.vue
+++ b/resources/js/components/page-header/HeaderMenu.vue
@@ -157,6 +157,12 @@ export default {
 
   mounted() {
     this.$root.$on('api-loaded', cdash => {
+      this.handleApiResponse(cdash);
+    });
+  },
+
+  methods: {
+    handleApiResponse: function (cdash) {
       var extraurl = '';
       if (cdash.extraurl) {
         extraurl = cdash.extraurl;
@@ -223,9 +229,8 @@ export default {
         this.subProjectSettingsUrl = `${this.$baseURL}/manageSubProject.php?projectid=${cdash.projectid}`;
         this.overviewSettingsUrl = `${this.$baseURL}/manageOverview.php?projectid=${cdash.projectid}`;
       }
-    });
+    },
   },
-
 }
 </script>
 

--- a/resources/js/components/page-header/HeaderMenu.vue
+++ b/resources/js/components/page-header/HeaderMenu.vue
@@ -164,6 +164,7 @@ export default {
       var extrafilterurl = '';
       if (cdash.extrafilterurl) {
         extrafilterurl = cdash.extrafilterurl;
+        cdash.querytestfilters = extrafilterurl;
       }
 
       if (cdash.menu.back) {
@@ -190,9 +191,9 @@ export default {
       this.testsUrl = `${this.$baseURL}/testOverview.php?project=${cdash.projectname_encoded}&date=${cdash.date}${extraurl}`;
 
       if (cdash.parentid > 0) {
-        this.testQueryUrl = `${this.$baseURL}/queryTests.php?project=${cdash.projectname_encoded}&parentid=${cdash.parentid}${extraurl}${extrafilterurl}`;
+        this.testQueryUrl = `${this.$baseURL}/queryTests.php?project=${cdash.projectname_encoded}&parentid=${cdash.parentid}${extraurl}${cdash.querytestfilters}`;
       } else {
-        this.testQueryUrl = `${this.$baseURL}/queryTests.php?project=${cdash.projectname_encoded}&date=${cdash.date}${extraurl}${extrafilterurl}`;
+        this.testQueryUrl = `${this.$baseURL}/queryTests.php?project=${cdash.projectname_encoded}&date=${cdash.date}${extraurl}${cdash.querytestfilters}`;
       }
 
       this.statisticsUrl = `${this.$baseURL}/userStatistics.php?project=${cdash.projectname_encoded}&date=${cdash.date}`;

--- a/tests/Spec/page-header/header-menu.spec.js
+++ b/tests/Spec/page-header/header-menu.spec.js
@@ -1,23 +1,16 @@
-import {mount, config} from "@vue/test-utils";
+import {mount, config, createWrapper} from "@vue/test-utils";
 config.mocks['$baseURL'] = 'http://localhost';
 import HeaderMenu from "../../../resources/js/components/page-header/HeaderMenu.vue";
+
 import expect from 'expect';
 import moment from "moment";
 
 let component;
 const today = moment().format('YYYY-MM-DD');
-const bugUrl = 'https://github.com/project/project/issues';
-const docUrl = 'https://github.com/project/project/wiki';
-const homeUrl = 'https://www.project.tld/';
-const vcsUrl = 'https://github.com/project/project';
-
-const indexUrl = `http://localhost/index.php?project=CDash&date=${today}`;
-const overviewUrl = `http://localhost/overview.php?project=CDash&date=${today}`;
-const buildsUrl = `http://localhost/buildOverview.php?project=CDash&date=${today}`;
-const testQueryUrl = `http://localhost/queryTests.php?project=CDash&date=${today}`;
-const statisticsUrl = `http://localhost/userStatistics.php?project=CDash&date=${today}`;
-const sitesUrl = `http://localhost/viewMap.php?project=CDash&date=${today}`;
-const subscribeUrl = 'http://localhost/subscribeProject.php?projectid=111';
+const bugUrl = "https://github.com/project/project/issues";
+const docUrl = "https://github.com/project/project/wiki";
+const homeUrl = "https://www.project.tld/";
+const vcsUrl = "https://github.com/project/project";
 
 const verifyLink = (url, text) => {
   const selector = `a[href='${url}']`;
@@ -28,53 +21,56 @@ const verifyLink = (url, text) => {
 };
 
 beforeEach(() => {
-  component = mount(HeaderMenu, {
-    data () {
-      return {
-        bugUrl: bugUrl,
-        docUrl: docUrl,
-        homeUrl: homeUrl,
-        vcsUrl: vcsUrl,
-        indexUrl: indexUrl,
-        overviewUrl: overviewUrl,
-        buildsUrl: buildsUrl,
-        testQueryUrl: testQueryUrl,
-        statisticsUrl: statisticsUrl,
-        sitesUrl: sitesUrl,
-        subscribeUrl: subscribeUrl,
-        hasProject: true,
-        showNav: true,
-        showSubscribe: true,
-      }
-    },
-    propsData: {
-      date: today,
-    },
-  });
+  component = mount(HeaderMenu);
+  var apiData = {
+    "bugtracker": bugUrl,
+    "date": today,
+    "documentation": docUrl,
+    "home": homeUrl,
+    "menu": {},
+    "projectid": 111,
+    "projectname_encoded": "TestProject",
+    "querytestfilters": "&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed",
+    "user": {"id": null},
+    "vcs": vcsUrl,
+  };
+  component.vm.handleApiResponse(apiData);
 });
 
 test('HeaderMenu has a "Dashboard" link', () => {
-  verifyLink(indexUrl, 'Dashboard');
+  var expected = `http://localhost/index.php?project=TestProject&date=${today}`;
+  expect(component.vm.indexUrl).toBe(expected);
+  verifyLink(expected, 'Dashboard');
 });
 
 test('HeaderMenu has an "Overview" link', () => {
-  verifyLink(overviewUrl, 'Overview');
+  var expected = `http://localhost/overview.php?project=TestProject&date=${today}`;
+  expect(component.vm.overviewUrl).toBe(expected);
+  verifyLink(expected, 'Overview');
 });
 
 test('HeaderMenu has a "Builds" link', () => {
-  verifyLink(buildsUrl, 'Builds');
+  var expected = `http://localhost/buildOverview.php?project=TestProject&date=${today}`;
+  expect(component.vm.buildsUrl).toBe(expected);
+  verifyLink(expected, 'Builds');
 });
 
 test('HeaderMenu has a "Tests Query" link', () => {
-  verifyLink(testQueryUrl, 'Tests Query');
+  var expected = "http://localhost/queryTests.php?project=TestProject&date=2022-08-19&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed";
+  expect(component.vm.testQueryUrl).toBe(expected);
+  verifyLink(expected, 'Tests Query');
 });
 
 test('HeaderMenu has a "Statistics" link', () => {
-  verifyLink(statisticsUrl, 'Statistics');
+  var expected = `http://localhost/userStatistics.php?project=TestProject&date=${today}`;
+  expect(component.vm.statisticsUrl).toBe(expected);
+  verifyLink(expected, 'Statistics');
 });
 
 test('HeaderMenu has a "Sites" link', () => {
-  verifyLink(sitesUrl, 'Sites');
+  var expected = `http://localhost/viewMap.php?project=TestProject&date=${today}`;
+  expect(component.vm.sitesUrl).toBe(expected);
+  verifyLink(expected, 'Sites');
 });
 
 test('HeaderMenu has a "Project" link', () => {
@@ -84,21 +80,27 @@ test('HeaderMenu has a "Project" link', () => {
 });
 
 test('HeaderMenu has a "Home" link', () => {
+  expect(component.vm.homeUrl).toBe(homeUrl);
   verifyLink(homeUrl, 'Home');
 });
 
 test('HeaderMenu has a "Documentation" link', () => {
+  expect(component.vm.docUrl).toBe(docUrl);
   verifyLink(docUrl, 'Documentation');
 });
 
 test('HeaderMenu has a "Repository" link', () => {
+  expect(component.vm.vcsUrl).toBe(vcsUrl);
   verifyLink(vcsUrl, 'Repository');
 });
 
 test('HeaderMenu has a "Bug Tracker" link', () => {
+  expect(component.vm.bugUrl).toBe(bugUrl);
   verifyLink(bugUrl, 'Bug Tracker');
 });
 
 test('HeaderMenu has a "Subscribe" link', () => {
-  verifyLink(subscribeUrl, 'Subscribe');
+  var expected = "http://localhost/subscribeProject.php?projectid=111";
+  expect(component.vm.subscribeUrl).toBe(expected);
+  verifyLink(component.vm.subscribeUrl, 'Subscribe');
 });


### PR DESCRIPTION
Some projects have lots of tests, loading them all by default is expensive and unnecessary.