### PR TITLE
Add files to introduce Helm installation capability 

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,12 @@
+name: CDash
+description: A Helm Chart to install a CDash instance.
+icon: https://www.cdash.org/wp-content/uploads/2019/05/CDash-logo-header.png
+version: 3.1.0
+apiVersion: v1
+keywords:
+  - CDash
+  - testing server
+  - open source
+sources:
+  - https://github.com/Kitware/CDash
+home: https://www.cdash.org/

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,1 @@
+This chart was created by Kompose

--- a/helm/templates/cdash-deployment.yaml
+++ b/helm/templates/cdash-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -c
+    kompose.version: 1.27.0 (b0ed6a2c9)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: cdash
+    app.kubernetes.io/name: cdash
+  name: cdash
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: cdash
+      app.kubernetes.io/name: cdash
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -c
+        kompose.version: 1.27.0 (b0ed6a2c9)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: cdash
+        app.kubernetes.io/name: cdash
+    spec:
+      containers:
+        - env:
+            - name: CDASH_ROOT_ADMIN_PASS
+              value: secret
+            - name: CDASH_STATIC_USERS
+              value: |
+                USER jdoe@acme.com jdoe_secret
+                  John Doe "ACME Inc."
+
+                ADMIN {{ .Values.adminEmail }} {{ .Values.adminSecret}}
+                  Admin User "Example Foundation"
+
+                donotreply@example.org oldsecret newsecret
+
+                strange.name@gmail.com strange_secret
+                INFO Str@nge N@me "Str@nge Rese@rch Gr0up LLC."
+
+                DELETE remove.this.user@example.org delete_secret
+          image: {{ .Values.dockerImage }}
+          name: cdash
+          ports:
+            - containerPort: 80
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/helm/templates/cdash-deployment.yaml
+++ b/helm/templates/cdash-deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - env:
             - name: CDASH_ROOT_ADMIN_PASS
               value: secret
+            - name: APP_URL
+              value: {{ .Values.applicationURL }}
             - name: CDASH_STATIC_USERS
               value: |
                 USER jdoe@acme.com jdoe_secret

--- a/helm/templates/cdash-service.yaml
+++ b/helm/templates/cdash-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -c
+    kompose.version: 1.27.0 (b0ed6a2c9)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: cdash
+  name: cdash
+spec:
+  type: LoadBalancer
+  selector:
+    app: cdash
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 80
+  selector:
+    io.kompose.service: cdash
+status:
+  loadBalancer: {}

--- a/helm/templates/mysql-deployment.yaml
+++ b/helm/templates/mysql-deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         io.kompose.service: mysql
     spec:
+      volumes:
+        - name: mysql-data-volume
+          persistentVolumeClaim:
+            claimName: mysql-data-volume
       containers:
         - env:
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
@@ -34,6 +38,9 @@ spec:
             - name: MYSQL_ROOT_PASSWORD
           image: mysql/mysql-server:5.7
           name: mysql
+          volumeMounts:
+          - mountPath: /var/lib/mysql
+            name: mysql-data-volume
           ports:
             - containerPort: 3306
           resources: {}

--- a/helm/templates/mysql-deployment.yaml
+++ b/helm/templates/mysql-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -c
+    kompose.version: 1.27.0 (b0ed6a2c9)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mysql
+  name: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mysql
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -c
+        kompose.version: 1.27.0 (b0ed6a2c9)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mysql
+    spec:
+      containers:
+        - env:
+            - name: MYSQL_ALLOW_EMPTY_PASSWORD
+              value: "yes"
+            - name: MYSQL_DATABASE
+              value: cdash
+            - name: MYSQL_ROOT_HOST
+              value: '%'
+            - name: MYSQL_ROOT_PASSWORD
+          image: mysql/mysql-server:5.7
+          name: mysql
+          ports:
+            - containerPort: 3306
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/helm/templates/mysql-service.yaml
+++ b/helm/templates/mysql-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -c
+    kompose.version: 1.27.0 (b0ed6a2c9)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mysql
+  name: mysql
+spec:
+  ports:
+    - name: "3306"
+      port: 3306
+      targetPort: 3306
+  selector:
+    io.kompose.service: mysql
+status:
+  loadBalancer: {}

--- a/helm/templates/mysql-volume-claim.yaml
+++ b/helm/templates/mysql-volume-claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-data-volume
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.requestedVolumeClaimSize }}

--- a/helm/templates/mysql-volume.yaml
+++ b/helm/templates/mysql-volume.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  creationTimestamp: null
+  name: mysql-data-volume
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.mysqlVolumeSize }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,3 +4,6 @@ dockerImage: kitware/cdash
 
 mysqlVolumeSize: 10Gi
 requestedVolumeClaimSize: 3Gi
+
+# Sets the base url for CDash, where redirects will attempt to resolve to.
+applicationURL: http://localhost

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,3 @@
+adminEmail: admin@example.org
+adminSecret: admin_secret
+dockerImage: kitware/cdash

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,3 +1,6 @@
 adminEmail: admin@example.org
 adminSecret: admin_secret
 dockerImage: kitware/cdash
+
+mysqlVolumeSize: 10Gi
+requestedVolumeClaimSize: 3Gi


### PR DESCRIPTION
Add the files and some updates needed to install the CDash and MySQL images used in the docker-compose system via Helm.

The first set of files were generated using the Kompose program and additional updates were added.  