### PR TITLE
Add dependency update command for Artisan

### DIFF
--- a/app/Console/Commands/UpdateDependencies.php
+++ b/app/Console/Commands/UpdateDependencies.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class UpdateDependencies extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dependencies:update {--D|dev}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Attempt to update CDash\'s dependencies';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $composerArgs = "--no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader";
+        if ($this->option("dev"))
+        {
+            $composerArgs = "--no-interaction --no-progress --prefer-dist";
+        }
+
+        // Update PHP dependencies via composer
+        exec("composer update");
+        exec("composer install $composerArgs");
+
+        // Update JavaScript dependencies via npm
+        exec("npm update");
+        exec("npm install");
+
+        // Run laravel-mix to builds assets
+        exec("npm run dev");
+    }
+}

--- a/app/cdash/public/upgrade.php
+++ b/app/cdash/public/upgrade.php
@@ -50,6 +50,7 @@ $xml .= '<minversion>' . $version_array['major'] . '.' . $version_array['minor']
 
 @$Upgrade = $_POST['Upgrade'];
 @$Cleanup = $_POST['Cleanup'];
+@$Dependencies = $_POST['Dependencies'];
 
 if (!config('database.default')) {
     $db_type = 'mysql';
@@ -418,6 +419,12 @@ if ($ComputeUpdateStatistics) {
         $xml .= add_XML_value('alert', 'Wrong number of days.');
     }
 }
+
+if ($Dependencies) {
+    $returnVal = Artisan::call("dependencies:update");
+    $xml .= add_XML_value('alert', "The call to update CDash's dependencies was run. The call exited with value: $returnVal");
+}
+
 
 /* Cleanup the database */
 if ($Cleanup) {

--- a/app/cdash/public/upgrade.xsl
+++ b/app/cdash/public/upgrade.xsl
@@ -74,6 +74,10 @@
     <td><input type="submit" name="Cleanup" value="Cleanup database"/></td>
   </tr>
   <tr>
+    <td><div align="right">Attempt to update CDash dependencies:</div></td>
+    <td><input type="submit" name="Dependencies" value="Upgrade dependencies"/></td>
+  </tr>
+  <tr>
     <td><div align="right">Upgrade CDash: (this might take some time)</div></td>
     <td><div align="left"><input type="submit" name="Upgrade" value="Upgrade CDash"/></div></td>
   </tr>

--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -122,17 +122,17 @@ else                                                                       \
  && echo "LOG_CHANNEL=stderr" >> .env;                                     \
 fi
 
-# Install javascript dependencies
-RUN npm install
-
 # Generate Laravel application key
 RUN php artisan key:generate
 
 # Expose CDash config to Laravel
 RUN php artisan config:migrate
 
-# Run laravel-mix to builds assets
-RUN npm run dev
+RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                            \
+  php artisan dependencies:update -D;                                  \
+else                                                                   \
+  php artisan dependencies:update;                                     \
+fi
 
 COPY --chown=www-data:www-data docker/docker-entrypoint.sh /docker-entrypoint.sh
 COPY --chown=www-data:www-data docker/bash /bash-lib


### PR DESCRIPTION
Add a new Artisan command which executes composer and npm updates and installations.  This command should take an argument which toggles whether the development set of libraries is installed or not.

Add a button on the maintanence page which executes this call and updates a message when it finishes.