### PR TITLE
Fix image comparison

### DIFF
--- a/app/cdash/public/js/je_compare.js
+++ b/app/cdash/public/js/je_compare.js
@@ -290,7 +290,7 @@
 
               // required for webkit-based browser as images arrive later 
               if(!imgs[0].complete) {
-                img0.load(function(){
+                img0.on("load", function(){
                             var im, parent, l, w, h;
                             im=$(this);
                             parent=im.parent();


### PR DESCRIPTION
Without touching the package versions listed in package.json, the image comparison is broken in CDash.  
The issue seems to come from a bad use of the jQuery method load in the je_compare plugin.  
http://api.jquery.com/load-event/