### PR TITLE
Fail tests when errors occur

### DIFF
--- a/app/cdash/tests/kwtest/simpletest/exceptions.php
+++ b/app/cdash/tests/kwtest/simpletest/exceptions.php
@@ -39,7 +39,7 @@ class SimpleExceptionTrappingInvoker extends SimpleInvokerDecorator
         try {
             $has_thrown = false;
             parent::invoke($method);
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             $has_thrown = true;
             if (!$trap->isExpected($this->getTestCase(), $exception)) {
                 $this->getTestCase()->exception($exception);

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -551,7 +551,11 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             $stmt = $pdo->prepare($sql);
             $stmt->bindParam(':buildid', $build['id'], PDO::PARAM_INT);
             $stmt->execute();
-            $rows = array_unique($stmt->fetchAll(PDO::FETCH_COLUMN, 'text'));
+            $rows = [];
+            foreach ($stmt->fetchAll() as $row) {
+                $rows[] = $row['text'];
+            }
+            $rows = array_unique($rows);
 
             $count = count($rows);
 


### PR DESCRIPTION
Our current testing infrastructure tries to catch `Exception`s, which means that the tests continue to run even if some types of errors occur.  For example, [this](https://app.circleci.com/pipelines/github/Kitware/CDash/969/workflows/bb608c10-25bb-4384-b46a-efe7958ca409/jobs/4464?invite=true#step-104-3253) type error has gone unseen for some time, giving developers a false sense of security.  A real world example: https://github.com/Kitware/CDash/pull/1296 passed the tests, despite failing all of the tests in `test_authtoken.php`.  If I hadn't scrolled through the test log in detail, this PR could have easily been merged with the failing tests.

This PR changes the testing behavior to catch anything `Throwable`, not just the various types of `Exception`.  `Error`s such as the type error linked above, and the authtoken tests which were previously failing on https://github.com/Kitware/CDash/pull/1296, are now caught by the test suite.