### PR TITLE
Move footer to bottom of page

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -12,6 +12,15 @@ body {
  font-size: 14px;
  font-weight: normal;
  color: #000000;
+ min-height: 100vh;
+ display: flex;
+ flex-direction: column;
+}
+
+#app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .argument {

--- a/app/cdash/public/footer.xsl
+++ b/app/cdash/public/footer.xsl
@@ -4,7 +4,7 @@
    doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 
 <xsl:template name="footer">
-
+<div style="flex:1;"></div>
 <div id="footer" class="clearfix">
   <div id="kitwarelogo">
       <a href="http://www.kitware.com"><img src="img/kitware_logo_footer.svg" border="0" alt="logo" /></a>

--- a/app/cdash/public/views/partials/footer.html
+++ b/app/cdash/public/views/partials/footer.html
@@ -25,6 +25,11 @@
     </span>
   </div>
 </div>
+<script>
+  // Insert a dummy element before the footer, which will push the footer to the bottom of the page
+  // This has to be the child of the parent "include" element and cannot be done with CSS (at least currently).
+  $( '<div style="flex:1;"></div>' ).insertBefore($("#footer").parent());
+</script>
 
 <!-- Google Analytics -->
 <script type="text/ng-template" id="google-analytics-snippet">

--- a/resources/views/build/page-footer.blade.php
+++ b/resources/views/build/page-footer.blade.php
@@ -2,6 +2,7 @@
 use CDash\Config;
 $version = Config::getVersion();
 @endphp
+<div style="flex:1;"></div>
 <page-footer
     version="{{ $version }}"
     cdash-logo="{{ asset('img/cdash.png?rev=2019-05-08') }}"


### PR DESCRIPTION
For pages with a minimal amount of content, the page footer is displayed in the middle of the page.  This contributes to a low quality user experience across the platform as a whole.  This PR moves the footer to the bottom of the page such that the footer can be pushed down the page if the page has a lot of content, but the footer can never be placed higher than the bottom of the user's browser window.

Before:
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/16820599/221390078-84a287a0-e9aa-41fb-9712-14fbbc37a4f5.png">

After:
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/16820599/221390043-b395d032-8d84-4d37-a226-5a1bc5aee706.png">
