### PR TITLE
Don't show links to blank URLs in menu

### DIFF
--- a/app/cdash/public/views/partials/header.html
+++ b/app/cdash/public/views/partials/header.html
@@ -110,14 +110,15 @@
             <li>
               <a ng-href="{{::cdash.home}}">Home</a>
             </li>
-            <li>
+            <li ng-if="cdash.documentation.replace('https://', '').replace('http://', '').trim() !== ''">
               <a ng-href="{{::cdash.documentation}}">Documentation</a>
             </li>
-            <li>
+            <li ng-if="cdash.vcs.replace('https://', '').replace('http://', '').trim() !== ''">
               <a ng-href="{{::cdash.vcs}}">Repository</a>
             </li>
-            <li ng-class="::{endsubmenu: cdash.projectrole}">
-              <a ng-href="{{::cdash.bugtracker}}">Bug Tracker</a>
+            <li ng-if="cdash.bugtracker.replace('https://', '').replace('http://', '').trim() !== ''"
+                ng-class="::{endsubmenu: cdash.projectrole}">
+              <a ng-href="{{::cdash.bugtracker}}"> Bug Tracker</a>
             </li>
             <li ng-if="!cdash.projectrole" class="endsubmenu">
               <a ng-href="subscribeProject.php?projectid={{::cdash.projectid}}">Subscribe</a>


### PR DESCRIPTION
When viewing a project, a number of configurable menu items are added to the menu bar.  If these values aren't set, the menu item is still displayed, with a blank destination URL.

For example, the documentation menu item (Project > Documentation in the menu bar) is not set for the CDash project [here](https://open.cdash.org/index.php?project=CDash), and a blank entry is displayed.  This PR changes the behavior to hide menu items whose value hasn't been set configured, so the user only ever sees menu items which lead somewhere useful.