### PR TITLE
Don't run PHP style fixer before running test suite

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,6 +6,8 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('node_modules')
     ->exclude('storage')
     ->exclude('vendor')
+    ->exclude('_build')
+    ->notPath('app/cdash/tests/config.test.local.php')
     ->in(__DIR__)
 ;
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,12 +78,6 @@ endif()
 
 find_program(PHP_EXE NAMES php PATHS c:/xampp/php /xampp/php)
 
-# Run PHP style fixer.
-execute_process(
-  COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
 if(CDASH_USE_SELENIUM)
   find_program(PHPUNIT_EXE NAMES phpunit PATHS c:/xampp/php /xampp/php vendor/bin)
 endif(CDASH_USE_SELENIUM)


### PR DESCRIPTION
We currently run the PHP style fixer during the CMake configure step, which fixes most of the code before we re-run the fixer again during the testing process to catch style issues.  This means that there are potentially style issues in the codebase which are not caught by our test suite because they are automatically fixed before the test suite is run.

This PR removes the "fix" step from the CMake configure process.  To automatically fix changes locally, it is now necessary to run `vendor/bin/php-cs-fixer fix` manually.

In the future, we may want to investigate using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) instead of [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) since the former provides more helpful errors.

I believe that this fixes https://github.com/Kitware/CDash/issues/1309.