### PR TITLE
Add padding around viewSite page content

### DIFF
--- a/app/cdash/public/viewSite.xsl
+++ b/app/cdash/public/viewSite.xsl
@@ -31,154 +31,154 @@
 </xsl:otherwise>
 </xsl:choose>
 
-<br/>
-
 <!-- Site manager -->
-<xsl:if test="cdash/user/sitemanager=1">
-<a><xsl:attribute name="href">editSite.php?siteid=<xsl:value-of select="cdash/site/id"/></xsl:attribute>
-<xsl:if test="cdash/user/siteclaimed=0">Are you maintaining this site? [claim this site]</xsl:if><xsl:if test="cdash/user/siteclaimed=1">[edit site description]</xsl:if></a>
-<br/>
-</xsl:if>
-
-<!-- Main -->
-<xsl:if test="cdash/site/outoforder=1">
-   <br/><span style="color:red"><b>This site has been marked as temporarly out of order by its maintainer.</b></span>
-   <br/>
- </xsl:if>
-
-<xsl:if test="cdash/site/processorclockfrequency='0Hz'">
-  No system information available at this time.
-</xsl:if>
-<xsl:if test="cdash/site/processorclockfrequency!='0Hz'">
-<br/><b>Processor Speed: </b> <xsl:value-of select="cdash/site/processorclockfrequency"/>
-<xsl:if test="string-length(cdash/site/processorvendor)>0">
-<br/><b>Processor Vendor: </b> <xsl:value-of select="cdash/site/processorvendor"/>
-<xsl:if test="string-length(cdash/site/processorvendorid)>0">
-  (<xsl:value-of select="cdash/site/processorvendorid"/>)
-</xsl:if>
-</xsl:if>
-<xsl:if test="string-length(cdash/site/numberlogicalcpus)>0">
-  <br/><b>Number of CPUs: </b> <xsl:value-of select="cdash/site/numberlogicalcpus"/>
-</xsl:if>
-<xsl:if test="string-length(cdash/site/numberphysicalcpus)>0">
-<br/><b>Number of Cores: </b> <xsl:value-of select="cdash/site/numberphysicalcpus"/>
-</xsl:if>
-<xsl:if test="string-length(cdash/site/totalphysicalmemory)>0">
-<br/><b>Total Physical Memory: </b> <xsl:value-of select="cdash/site/totalphysicalmemory"/>
-</xsl:if>
-
-</xsl:if>
-<xsl:if test="string-length(cdash/site/description)>0">
-  <br/><b>Description: </b> <xsl:value-of select="cdash/site/description"/><br/>
-</xsl:if>
-<br/>
-
-
-<!-- Display the claimers -->
-<xsl:if test="count(cdash/claimer)>0">
-<b>Claimed by: </b>
-<xsl:for-each select="cdash/claimer">
-  <xsl:value-of select="firstname"/><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text><xsl:value-of select="lastname"/>
-  <xsl:if test="email">
-  <a>
-  <xsl:attribute name="href">mailto:<xsl:value-of select="email"/></xsl:attribute>
-  <img src="img/mail.png" border="0"/>
-  </a>
+<div id="main_content">
+  <xsl:if test="cdash/user/sitemanager=1">
+  <a><xsl:attribute name="href">editSite.php?siteid=<xsl:value-of select="cdash/site/id"/></xsl:attribute>
+  <xsl:if test="cdash/user/siteclaimed=0">Are you maintaining this site? [claim this site]</xsl:if><xsl:if test="cdash/user/siteclaimed=1">[edit site description]</xsl:if></a>
+  <br/>
   </xsl:if>
-</xsl:for-each>
-<br/><br/>
-</xsl:if>
 
-<!-- Display the map -->
-<xsl:if test="string-length(cdash/googlemapkey)>0">
-  <xsl:if test="string-length(cdash/site/ip)>0">
-    <b>IP address: </b><xsl:value-of select="cdash/site/ip"/><br/>
-    <b>Map:</b><br/>
-    <script type="text/javascript">
-        <xsl:attribute name="src">http://maps.google.com/maps?file=api&amp;v=2&amp;key=<xsl:value-of select="cdash/dashboard/googlemapkey"/></xsl:attribute>
-     </script>
-      <xsl:text disable-output-escaping="yes">
-      &lt;script type="text/javascript"&gt;
-        // Creates a marker whose info window displays the letter corresponding
-        // to the given index.
-        function createMarker(point,title)
-          {
-          var marker = new GMarker(point);
-          GEvent.addListener(marker, "click", function()
+  <!-- Main -->
+  <xsl:if test="cdash/site/outoforder=1">
+     <br/><span style="color:red"><b>This site has been marked as temporarly out of order by its maintainer.</b></span>
+     <br/>
+   </xsl:if>
+
+  <xsl:if test="cdash/site/processorclockfrequency='0Hz'">
+    No system information available at this time.
+  </xsl:if>
+  <xsl:if test="cdash/site/processorclockfrequency!='0Hz'">
+  <br/><b>Processor Speed: </b> <xsl:value-of select="cdash/site/processorclockfrequency"/>
+  <xsl:if test="string-length(cdash/site/processorvendor)>0">
+  <br/><b>Processor Vendor: </b> <xsl:value-of select="cdash/site/processorvendor"/>
+  <xsl:if test="string-length(cdash/site/processorvendorid)>0">
+    (<xsl:value-of select="cdash/site/processorvendorid"/>)
+  </xsl:if>
+  </xsl:if>
+  <xsl:if test="string-length(cdash/site/numberlogicalcpus)>0">
+    <br/><b>Number of CPUs: </b> <xsl:value-of select="cdash/site/numberlogicalcpus"/>
+  </xsl:if>
+  <xsl:if test="string-length(cdash/site/numberphysicalcpus)>0">
+  <br/><b>Number of Cores: </b> <xsl:value-of select="cdash/site/numberphysicalcpus"/>
+  </xsl:if>
+  <xsl:if test="string-length(cdash/site/totalphysicalmemory)>0">
+  <br/><b>Total Physical Memory: </b> <xsl:value-of select="cdash/site/totalphysicalmemory"/>
+  </xsl:if>
+
+  </xsl:if>
+  <xsl:if test="string-length(cdash/site/description)>0">
+    <br/><b>Description: </b> <xsl:value-of select="cdash/site/description"/><br/>
+  </xsl:if>
+  <br/>
+
+
+  <!-- Display the claimers -->
+  <xsl:if test="count(cdash/claimer)>0">
+  <b>Claimed by: </b>
+  <xsl:for-each select="cdash/claimer">
+    <xsl:value-of select="firstname"/><xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text><xsl:value-of select="lastname"/>
+    <xsl:if test="email">
+    <a>
+    <xsl:attribute name="href">mailto:<xsl:value-of select="email"/></xsl:attribute>
+    <img src="img/mail.png" border="0"/>
+    </a>
+    </xsl:if>
+  </xsl:for-each>
+  <br/><br/>
+  </xsl:if>
+
+  <!-- Display the map -->
+  <xsl:if test="string-length(cdash/googlemapkey)>0">
+    <xsl:if test="string-length(cdash/site/ip)>0">
+      <b>IP address: </b><xsl:value-of select="cdash/site/ip"/><br/>
+      <b>Map:</b><br/>
+      <script type="text/javascript">
+          <xsl:attribute name="src">http://maps.google.com/maps?file=api&amp;v=2&amp;key=<xsl:value-of select="cdash/dashboard/googlemapkey"/></xsl:attribute>
+       </script>
+        <xsl:text disable-output-escaping="yes">
+        &lt;script type="text/javascript"&gt;
+          // Creates a marker whose info window displays the letter corresponding
+          // to the given index.
+          function createMarker(point,title)
             {
-            marker.openInfoWindowHtml(title);
-            });
-          return marker;
-        }
+            var marker = new GMarker(point);
+            GEvent.addListener(marker, "click", function()
+              {
+              marker.openInfoWindowHtml(title);
+              });
+            return marker;
+          }
 
-      function load() {
-        if (GBrowserIsCompatible()) {
-          var map = new GMap2(document.getElementById("map"));
-      </xsl:text>
-      <xsl:if test="string-length(cdash/site/latitude)>0">
-          map.setCenter(new GLatLng(<xsl:value-of select="cdash/site/latitude"/>,<xsl:value-of select="cdash/site/longitude"/>),5);
-          map.addControl(new GLargeMapControl());
-          var point = new GLatLng(<xsl:value-of select="cdash/site/latitude"/>,<xsl:value-of select="cdash/site/longitude"/>);
-          map.addOverlay(createMarker(point,'<xsl:value-of select="cdash/site/name"/>'));
-      </xsl:if>
-      <!-- if no geolocation found -->
-      <xsl:if test="string-length(cdash/site/latitude)=0">
-       map.setCenter(new GLatLng(0,0),1);
-      </xsl:if>
-      <xsl:text disable-output-escaping="yes">
+        function load() {
+          if (GBrowserIsCompatible()) {
+            var map = new GMap2(document.getElementById("map"));
+        </xsl:text>
+        <xsl:if test="string-length(cdash/site/latitude)>0">
+            map.setCenter(new GLatLng(<xsl:value-of select="cdash/site/latitude"/>,<xsl:value-of select="cdash/site/longitude"/>),5);
+            map.addControl(new GLargeMapControl());
+            var point = new GLatLng(<xsl:value-of select="cdash/site/latitude"/>,<xsl:value-of select="cdash/site/longitude"/>);
+            map.addOverlay(createMarker(point,'<xsl:value-of select="cdash/site/name"/>'));
+        </xsl:if>
+        <!-- if no geolocation found -->
+        <xsl:if test="string-length(cdash/site/latitude)=0">
+         map.setCenter(new GLatLng(0,0),1);
+        </xsl:if>
+        <xsl:text disable-output-escaping="yes">
+          }
         }
-      }
-      &lt;/script&gt;
-      </xsl:text>
-     <body onload="load()" onunload="GUnload()">
-    <center><div id="map" style="width: 700px; height: 400px"></div></center>
-    </body>
+        &lt;/script&gt;
+        </xsl:text>
+       <body onload="load()" onunload="GUnload()">
+      <center><div id="map" style="width: 700px; height: 400px"></div></center>
+      </body>
+    </xsl:if>
   </xsl:if>
-</xsl:if>
-<br/>
+  <br/>
 
-<!-- Projects -->
-<b>This site belongs to the following projects:</b><br/>
-<xsl:for-each select="cdash/project">
-<a>
-<xsl:attribute name="href">index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
-<xsl:value-of select="name"/>
-</a>
-(<xsl:value-of select="submittime"/>)<br/>
-</xsl:for-each>
-<br/>
+  <!-- Projects -->
+  <b>This site belongs to the following projects:</b><br/>
+  <xsl:for-each select="cdash/project">
+  <a>
+  <xsl:attribute name="href">index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
+  <xsl:value-of select="name"/>
+  </a>
+  (<xsl:value-of select="submittime"/>)<br/>
+  </xsl:for-each>
+  <br/>
 
-<!-- Timing per project -->
-<b>Time spent per project (computed from average data over one week):</b><br/><br/>
+  <!-- Timing per project -->
+  <b>Time spent per project (computed from average data over one week):</b><br/><br/>
 
-<center><div id="placeholder" style="width:900px;height:300px"></div></center>
-<script id="source" language="javascript" type="text/javascript">
-$(function () {
-    $.plot($("#placeholder"), [
+  <center><div id="placeholder" style="width:900px;height:300px"></div></center>
+  <script id="source" language="javascript" type="text/javascript">
+  $(function () {
+      $.plot($("#placeholder"), [
 
-<xsl:for-each select="cdash/siteload/build">
- { label: "<xsl:value-of select="project"/> - <xsl:value-of select="name"/> (<xsl:value-of select="type"/>)",  data: <xsl:value-of select="time"/>},
-</xsl:for-each>
- { label: "Non-CDash",  data: <xsl:value-of select="cdash/siteload/idle"/>}
-  ],
-  {
-   series: {
-      pie: {
-        show: true,
-        radius: 1,
-        label: {
+  <xsl:for-each select="cdash/siteload/build">
+   { label: "<xsl:value-of select="project"/> - <xsl:value-of select="name"/> (<xsl:value-of select="type"/>)",  data: <xsl:value-of select="time"/>},
+  </xsl:for-each>
+   { label: "Non-CDash",  data: <xsl:value-of select="cdash/siteload/idle"/>}
+    ],
+    {
+     series: {
+        pie: {
           show: true,
-          radius: 3/4,
-          formatter: function(label, series){
-            return '<div style="font-size:8pt;text-align:center;padding:2px;color:white;">'+label+'<br/>'+Math.round(series.percent)+'%</div>';
-          },
-          background: { opacity: 0.5 }
+          radius: 1,
+          label: {
+            show: true,
+            radius: 3/4,
+            formatter: function(label, series){
+              return '<div style="font-size:8pt;text-align:center;padding:2px;color:white;">'+label+'<br/>'+Math.round(series.percent)+'%</div>';
+            },
+            background: { opacity: 0.5 }
+          }
         }
-      }
-    },
-  })
-});
-</script>
+      },
+    })
+  });
+  </script>
+</div>
 
 <!-- FOOTER -->
 <br/>

--- a/app/cdash/public/views/viewProjects.html
+++ b/app/cdash/public/views/viewProjects.html
@@ -20,77 +20,78 @@
         </div>
       </div>
     </div>
+    <div id="main_content">
+      <br/>
+      <p ng-show="cdash.upgradewarning" style="color:red">
+        <b>
+          The current database schema doesn't match the version of CDash
+          you are running, upgrade your database structure in the
+          <a href="upgrade.php">
+            Administration/CDash maintenance panel of CDash
+          </a>
+        </b>
+      </p>
 
-    <br/>
-    <p ng-show="cdash.upgradewarning" style="color:red">
-      <b>
-        The current database schema doesn't match the version of CDash
-        you are running, upgrade your database structure in the
-        <a href="upgrade.php">
-          Administration/CDash maintenance panel of CDash
-        </a>
-      </b>
-    </p>
+      <h1 ng-if="cdash.projects.length == 0"
+         class="text-info text-center">
+          No Projects Found
+      </h1>
 
-    <h1 ng-if="cdash.projects.length == 0"
-       class="text-info text-center">
-        No Projects Found
-    </h1>
+      <!-- Main table -->
+      <table ng-if="cdash.projects.length > 0"
+             border="0" cellpadding="4" cellspacing="0" width="100%" id="indexTable" class="tabb">
+        <thead>
+          <tr class="table-heading1">
+            <td colspan="6" align="left" class="nob"><h3>Dashboards</h3></td>
+          </tr>
 
-    <!-- Main table -->
-    <table ng-if="cdash.projects.length > 0"
-           border="0" cellpadding="4" cellspacing="0" width="100%" id="indexTable" class="tabb">
-      <thead>
-        <tr class="table-heading1">
-          <td colspan="6" align="left" class="nob"><h3>Dashboards</h3></td>
+          <tr class="table-heading">
+            <th align="center" id="sort_0" width="10%"><b>Project</b></th>
+            <td align="center" width="65%"><b>Description</b></td>
+            <th align="center" class="nob"  id="sort_2" width="13%"><b>Last activity</b></th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr ng-repeat="project in cdash.projects" ng-class-odd="'odd'" ng-class-even="'even'">
+            <td align="center" >
+              <a ng-href="{{project.link}}">
+                {{project.name}}
+              </a>
+            </td>
+            <td align="left">{{project.description}}</td>
+            <td align="center" class="nob">
+              <span class="sorttime" style="display:none">
+                {{project.lastbuilddatefull}}
+              </span>
+              <a class="builddateelapsed" ng-alt="{{project.lastbuild}}" ng-href="{{project.link}}&date={{project.lastbuilddate}}">
+                {{project.lastbuild_elapsed}}
+              </a>
+              <img src="img/cleardot.gif" ng-class="'activity-level-{{project.activity}}'"/>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table ng-if="cdash.projects.length > 0"
+             width="100%" cellspacing="0" cellpadding="0">
+        <tr>
+          <td height="1" colspan="14" align="left" bgcolor="#888888"></td>
         </tr>
-
-        <tr class="table-heading">
-          <th align="center" id="sort_0" width="10%"><b>Project</b></th>
-          <td align="center" width="65%"><b>Description</b></td>
-          <th align="center" class="nob"  id="sort_2" width="13%"><b>Last activity</b></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr ng-repeat="project in cdash.projects" ng-class-odd="'odd'" ng-class-even="'even'">
-          <td align="center" >
-            <a ng-href="{{project.link}}">
-              {{project.name}}
-            </a>
+        <tr>
+          <td height="1" colspan="14" align="right">
+            <div ng-if="cdash.showoldtoggle" id="showold">
+              <a ng-show="!cdash.allprojects" href="viewProjects.php?allprojects=1">
+                Show all {{cdash.nprojects}} projects
+              </a>
+              <a ng-show="cdash.allprojects" href="viewProjects.php">
+                Hide old projects
+              </a>
+            </div>
           </td>
-          <td align="left">{{project.description}}</td>
-          <td align="center" class="nob">
-            <span class="sorttime" style="display:none">
-              {{project.lastbuilddatefull}}
-            </span>
-            <a class="builddateelapsed" ng-alt="{{project.lastbuild}}" ng-href="{{project.link}}&date={{project.lastbuilddate}}">
-              {{project.lastbuild_elapsed}}
-            </a>
-            <img src="img/cleardot.gif" ng-class="'activity-level-{{project.activity}}'"/>
-          </td>
         </tr>
-      </tbody>
-    </table>
-
-    <table ng-if="cdash.projects.length > 0"
-           width="100%" cellspacing="0" cellpadding="0">
-      <tr>
-        <td height="1" colspan="14" align="left" bgcolor="#888888"></td>
-      </tr>
-      <tr>
-        <td height="1" colspan="14" align="right">
-          <div ng-if="cdash.showoldtoggle" id="showold">
-            <a ng-show="!cdash.allprojects" href="viewProjects.php?allprojects=1">
-              Show all {{cdash.nprojects}} projects
-            </a>
-            <a ng-show="cdash.allprojects" href="viewProjects.php">
-              Hide old projects
-            </a>
-          </div>
-        </td>
-      </tr>
-    </table>
+      </table>
+    </div>
 
     <!-- FOOTER -->
     <ng-include src="'build/views/partials/footer_@@version.html'"></ng-include>


### PR DESCRIPTION
The main page content of most CDash pages is wrapped in a `<div>` with the ID `#main_content`, which is styled to provide a small amount of padding around the edges of the page.

This PR adds a wrapper `<div>` around the main content of the `viewSite` page to make it match the rest of the CDash interface.

The same changes have been made to the `viewProjects` page as well.

Before:
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/16820599/222542525-e9f761fa-1228-4133-b1dc-a08293852915.png">

After:
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/16820599/222542368-840a167b-1eac-44da-a8a2-852637b6b1b2.png">
