### PR TITLE
Move header image to left side

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -849,7 +849,6 @@ div#headertop {
   float:left;
   height: 60px;
   padding-left:30px;
-  order: 1;
 }
 
 #headerlogo #projectlogo {


### PR DESCRIPTION
Most CDash pages have a header with an image on the left and a small amount of text on the right.  Some pages have this flipped, such that the image is on the right and the text is on the left.  This visual inconsistency is poor UI design.

To resolve this issue, I removed the `order` CSS property.  Since this property was set to 1, it is possible that a developer set it to 1 sometime in the past under the assumption that 1 is the leftmost value possible.  In fact, 0 is the leftmost value for this property, which is why the image was displayed out of order.


Before:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/16820599/222550250-e2a2d878-7f27-48fe-bfd7-3ee00c78c1b2.png">

After:
<img width="519" alt="image" src="https://user-images.githubusercontent.com/16820599/222550077-4f12a615-8faf-42cd-9a52-4f3b76adf78c.png">
