### PR TITLE
Add dependency audit command

### DIFF
--- a/app/Console/Commands/AuditDependencies.php
+++ b/app/Console/Commands/AuditDependencies.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class AuditDependencies extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dependencies:audit';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Run security audit on CDash\'s dependencies';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Handle the running of the command.
+     *
+     * Print a header and then the output of each command.
+     * Laravel will pipe the output to a file if run by the scheduler
+     * or it will print to the console if run manually.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //  PHP auditing via composer
+        $output = null;
+        print("\n\nComposer Report:\n\n");
+        exec("HOME=" . base_path() . " composer audit --no-interaction -d" . base_path(), $output);
+        print(implode("\n", $output));
+
+        //  NPM audit too
+        print("\n\nNPM Report:\n\n");
+        $output = null;
+        exec("/usr/bin/npm audit", $output);
+        print(implode("\n", $output));
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,8 +24,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $cdash_directory_name = env('CDASH_DIRECTORY', 'cdash');
+        $cdash_app_dir = realpath(app_path($cdash_directory_name));
+        $output_filename = $cdash_app_dir . "/AuditReport.log";
+
+        $schedule->command('dependencies:audit')->everySixHours()->sendOutputTo($output_filename);
     }
 
     /**

--- a/app/cdash/public/upgrade.php
+++ b/app/cdash/public/upgrade.php
@@ -51,6 +51,10 @@ $xml .= '<minversion>' . $version_array['major'] . '.' . $version_array['minor']
 @$Upgrade = $_POST['Upgrade'];
 @$Cleanup = $_POST['Cleanup'];
 @$Dependencies = $_POST['Dependencies'];
+@$Audit = $_POST['Audit'];
+@$ClearAudit = $_POST['Clear'];
+
+$configFile = $config->get('CDASH_ROOT_DIR') . "/AuditReport.log";
 
 if (!config('database.default')) {
     $db_type = 'mysql';
@@ -424,6 +428,19 @@ if ($Dependencies) {
     $returnVal = Artisan::call("dependencies:update");
     $xml .= add_XML_value('alert', "The call to update CDash's dependencies was run. The call exited with value: $returnVal");
 }
+
+if ($Audit) {
+    if (!file_exists($configFile)) {
+        Artisan::call("schedule:test --name='dependencies:audit'");
+    }
+    $fileContents = file_get_contents($configFile);
+    $xml .= add_XML_value('audit', $fileContents);
+}
+
+if ($ClearAudit && file_exists($configFile)) {
+    unlink($configFile);
+}
+
 
 
 /* Cleanup the database */

--- a/app/cdash/public/upgrade.xsl
+++ b/app/cdash/public/upgrade.xsl
@@ -74,8 +74,11 @@
     <td><input type="submit" name="Cleanup" value="Cleanup database"/></td>
   </tr>
   <tr>
-    <td><div align="right">Attempt to update CDash dependencies:</div></td>
-    <td><input type="submit" name="Dependencies" value="Upgrade dependencies"/></td>
+    <td><div align="right">Manage CDash dependencies:</div></td>
+    <td><input type="submit" name="Audit" value="Display audit report"/>
+        <input type="submit" name="Clear" value="Clear current audit report"/>
+        <input type="submit" name="Dependencies" value="Upgrade dependencies"/>
+    </td>
   </tr>
   <tr>
     <td><div align="right">Upgrade CDash: (this might take some time)</div></td>
@@ -83,6 +86,14 @@
   </tr>
 </table>
 </form><br/>
+
+<xsl:if test="string-length(cdash/audit)>0">
+<b>Audit Report</b>
+<b>*****************</b>
+<pre><xsl:value-of select="cdash/audit"/></pre>
+<b>*****************</b>
+</xsl:if>
+<br/><br/>
 
 <div id="Upgrade-Tables-Status"></div>
 <div id="Upgrade-0-8-Status"></div>

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -180,4 +180,5 @@ if [ "$do_serve" '!=' '1' ] ; then
 fi
 
 # serve
+php artisan schedule:work &
 exec /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
Add a command which echoes the reports of `composer audit` and `npm audit` to the console.

Use Laravel's scheduler to run the task and pipe the output to a known file where the maintenance page will read it in for display. The task should run once a day at midnight and also be available for manual run.