### PR TITLE
Fix login header text alignment

### DIFF
--- a/resources/views/cdash/header.blade.php
+++ b/resources/views/cdash/header.blade.php
@@ -12,7 +12,6 @@
             </a>
         </div>
         <div id="headername2">
-            CDash
-            <span id="subheadername">Login</span></div>
+            <span id="subheadername">CDash Login</span></div>
     </div>
 </div>


### PR DESCRIPTION
The header of the login page currently has text which looks like this:
<img width="505" alt="image" src="https://user-images.githubusercontent.com/16820599/227559709-b1141178-dd75-4640-874e-9470f89f1491.png">


This PR aligns the text properly:
<img width="517" alt="image" src="https://user-images.githubusercontent.com/16820599/227559480-777e054a-b775-4b3c-bd63-58384bfb53c2.png">
