### PR TITLE
Allow configuration of allowable token scopes

### DIFF
--- a/app/cdash/public/api/v1/user.php
+++ b/app/cdash/public/api/v1/user.php
@@ -97,6 +97,8 @@ foreach ($project_rows as $project_row) {
 $response['projects'] = $projects_response;
 
 $response['authtokens'] = AuthTokenService::getTokensForUser($userid);
+$response['allow_full_access_tokens'] = config('cdash.allow_full_access_tokens') === true;
+$response['allow_submit_only_tokens'] = config('cdash.allow_submit_only_tokens') === true;
 
 // Find all the public projects that this user is not subscribed to.
 $stmt = $PDO->prepare(

--- a/app/cdash/public/js/controllers/user.js
+++ b/app/cdash/public/js/controllers/user.js
@@ -9,24 +9,24 @@ CDash.controller('UserController', function UserController($scope, $http, $timeo
                  || $scope.cdash.tokenscope === 'submit_only' ? -1 : $scope.cdash.tokenscope
     };
     $http.post('/api/authtokens/create', parameters)
-    .then(function success(s) {
-      const authtoken = s.data.token;
-      authtoken.copied = false;
-      authtoken.raw_token = s.data.raw_token;
+      .then(function success(s) {
+        const authtoken = s.data.token;
+        authtoken.copied = false;
+        authtoken.raw_token = s.data.raw_token;
 
-      $scope.cdash.projects.forEach(project => {
-        if (project.id === authtoken.projectid) {
-          authtoken.projectname = project.name;
-        }
+        $scope.cdash.projects.forEach(project => {
+          if (project.id === authtoken.projectid) {
+            authtoken.projectname = project.name;
+          }
+        });
+
+        // A terrible hack to format the date the same way the DB returns them on initial page load
+        authtoken.expires = authtoken.expires.replace('T', ' ');
+
+        $scope.cdash.authtokens.push(authtoken);
+      }, function error(e) {
+        $scope.cdash.message = e.data.error;
       });
-
-      // A terrible hack to format the date the same way the DB returns them on initial page load
-      authtoken.expires = authtoken.expires.replace('T', ' ');
-
-      $scope.cdash.authtokens.push(authtoken);
-    }, function error(e) {
-      $scope.cdash.message = e.data.error;
-    });
   };
 
   $scope.copyTokenSuccess = function(token) {
@@ -57,4 +57,19 @@ CDash.controller('UserController', function UserController($scope, $http, $timeo
       $scope.cdash.message = e.data.error;
     });
   };
+
+  $scope.finishSetup = function() {
+    if ($scope.cdash.allow_full_access_tokens) {
+      $scope.cdash.tokenscope = 'full_access';
+    }
+    else if ($scope.cdash.allow_submit_only_tokens) {
+      $scope.cdash.tokenscope = 'submit_only';
+    }
+    else if ($scope.cdash.projects.length > 0) {
+      $scope.cdash.tokenscope = $scope.cdash.projects[0].id.toString();
+    }
+    else {
+      $scope.cdash.tokenscope = '';
+    }
+  }
 });

--- a/app/cdash/public/js/services/apiLoader.js
+++ b/app/cdash/public/js/services/apiLoader.js
@@ -1,6 +1,6 @@
 // Encapsulate common code involved in loading our page data from the API.
 CDash.factory('apiLoader', function ($http, $rootScope, $window, renderTimer) {
-  var loadPageData = function(controllerScope, endpoint) {
+  const loadPageData = function(controllerScope, endpoint) {
     controllerScope.loading = true;
 
     $http({
@@ -8,7 +8,7 @@ CDash.factory('apiLoader', function ($http, $rootScope, $window, renderTimer) {
       method: 'GET',
       params: $rootScope.queryString
     }).then(function success(s) {
-      var cdash = s.data;
+      const cdash = s.data;
 
       // Check if we should display filters.
       if (cdash.filterdata && cdash.filterdata.showfilters == 1) {

--- a/app/cdash/public/views/user.html
+++ b/app/cdash/public/views/user.html
@@ -302,10 +302,11 @@
                        ng-model="cdash.tokendescription" />
               </td>
               <td align="center">
-                <select ng-model="cdash.tokenscope" class="form-select"
-                        ng-init="cdash.tokenscope = 'full_access'">
-                  <option selected="selected" value="full_access">Full Access</option>
-                  <option value="submit_only">All Projects (Submit Only)</option>
+                <select ng-model="cdash.tokenscope" class="form-select">
+                  <option selected="selected" value="full_access" ng-if="cdash.allow_full_access_tokens">
+                    Full Access
+                  </option>
+                  <option value="submit_only" ng-if="cdash.allow_submit_only_tokens">All Projects (Submit Only)</option>
                   <option ng-repeat="project in ::cdash.projects" value="{{::project.id}}">{{::project.name}} (Submit Only)</option>
                 </select>
               </td>

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -76,6 +76,10 @@ return [
     'show_last_submission' => env('SHOW_LAST_SUBMISSION', true),
     'slow_page_time' => env('SLOW_PAGE_TIME', 10),
     'token_duration' => env('TOKEN_DURATION', 15811200),
+    // Specify whether users are allowed to create "full access" authentication tokens
+    'allow_full_access_tokens' => env('ALLOW_FULL_ACCESS_TOKENS', true),
+    // Specify whether users are allowed to create "submit only" tokens which are valid for all projects
+    'allow_submit_only_tokens' => env('ALLOW_SUBMIT_ONLY_TOKENS', true),
     'unlimited_projects' => $unlimited_projects,
     'use_compression' => env('USE_COMPRESSION', true),
     'use_vcs_api' => env('USE_VCS_API', true),


### PR DESCRIPTION
This PR adds two new configuration settings which allow system administrators to allow or disallow full-access and submit-only authentication tokens which may be used to submit to any project.