### PR TITLE
Account for formatting issues in CDASH_CONFIG

### DIFF
--- a/docker/bash/misc.bash
+++ b/docker/bash/misc.bash
@@ -50,7 +50,8 @@ setup_local_config() {
         echo "DB_PASS="
 
         if [ '!' -z ${CDASH_CONFIG+x} ] ; then
-            echo "$CDASH_CONFIG"
+            # Drop old formatting for PHP values by removing "$" or ";"
+            sed 's/[$;]//g' <<< "$CDASH_CONFIG"
         fi
 
     ) >> "$__local_config_file"


### PR DESCRIPTION
In the event that an older system moves to the latest CDash docker-compose framework, try to replace the characters that were expected when the text was sent to `config.local.php` file with blanks to closer match the formatting used in the .env file that it now is a part of.

Fixes issue #1336