### PR TITLE
Update Docker base image to latest Debian

### DIFF
--- a/docker/common.docker
+++ b/docker/common.docker
@@ -1,4 +1,4 @@
-FROM php:8.1-apache-buster
+FROM php:8.1-apache-bullseye
 LABEL MAINTAINER="Kitware, Inc. <cdash@public.kitware.com>"
 
 ARG CDASH_DB_HOST=localhost


### PR DESCRIPTION
The [base image](https://hub.docker.com/layers/library/php/8.1-apache-buster/images/sha256-8af25037ef2d776145f18fcfe4fc76627ce80793d300cf49334307475ce30a5a?context=explore) we currently use for Docker installs is not based on the latest version of Debian and has a large number of security vulnerabilities listed.  The [latest version](https://hub.docker.com/layers/library/php/8.1-apache-bullseye/images/sha256-2723799df278efb7c49a134e278c5e6c9549b3a2c7bdcecc442974509eb57380?context=explore) of Debian has significantly fewer vulnerabilities.

This PR serves as a temporary patch while we investigate potentially switching away from Debian altogether.