### PR TITLE
Remove "nav-link" class from Register button

### DIFF
--- a/resources/views/cdash/header.blade.php
+++ b/resources/views/cdash/header.blade.php
@@ -2,7 +2,7 @@
     <div id="headertop">
         <div id="topmenu">
             <a href="viewProjects.php">All Dashboards</a>
-            <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+            <a href="{{ route('register') }}">{{ __('Register') }}</a>
         </div>
     </div>
     <div id="headerbottom">


### PR DESCRIPTION
To ensure that all buttons on the login screen stay in the menu bar, remove the `nav-link` class from the Register button to take away the block display.

With the class: 
![image](https://user-images.githubusercontent.com/542106/229847007-fd531eff-6df1-45fd-80b0-ad3ad5ab6f4f.png)

Without the class:
![image](https://user-images.githubusercontent.com/542106/229847041-53f48f4e-b531-4410-a08a-87d2f9e41b0f.png)
