### PR TITLE
Fix ordering of header menu items

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -862,7 +862,6 @@ div#headertop {
   font-size:20px;
   font-weight:700;
   height:100%;
-  order: 2;
 }
 
 #headername .projectname {
@@ -874,7 +873,7 @@ div#headertop {
   float:right;
   height:100%;
   padding-right:30px;
-  order: 4;
+  margin-left: auto;
 }
 
 #headermenu #navigation {
@@ -969,7 +968,6 @@ div#headertop {
 #header .projectnav {
   margin:0 auto;
   padding: 19px;
-  order: 3;
 }
 
 #header .projectnav .projectnav_controls {


### PR DESCRIPTION
The menu on some administrative pages is left-aligned, while it is supposed to be right-aligned.  This is due to the CSS `order` property being poorly used, similar to https://github.com/Kitware/CDash/pull/1318.