### PR TITLE
Change how project names are validated

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -164,7 +164,7 @@ class ProcessSubmission implements ShouldQueue
         }
 
         // Special handling for "build metadata" files created while the DB was down.
-        if (strpos($filename, '_build-metadata_') !== false && strpos($filename, '.json') !== false) {
+        if (str_contains($filename, '_-_build-metadata_-_') && str_contains($filename, '.json')) {
             $handler = new UnparsedSubmissionProcessor();
             $handler->backupFileName = $this->filename;
             $handler->deserializeBuildMetadata($filehandle);

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1987,4 +1987,19 @@ class Project
         $endOfDay = gmdate(FMT_DATETIME, $end_timestamp);
         return [$beginningOfDay, $endOfDay];
     }
+
+    /**
+     * Returns a boolean indicating whether the specified string could be a valid project name
+     */
+    public static function validateProjectName(string $projectname): bool
+    {
+        if (preg_match('/^[a-zA-Z0-9\ +.\-_]+$/', $projectname) !== 1) {
+            return false;
+        }
+        if (str_contains($projectname, '_-_')) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -203,8 +203,12 @@ function get_project(&$response)
 function create_project(&$response, $user)
 {
     $Name = $_REQUEST['project']['Name'];
-    // Remove any potentially problematic characters.
-    $Name = preg_replace("/[^a-zA-Z0-9\s+-._]/", '', $Name);
+
+    if (!Project::validateProjectName($Name)) {
+        $response['error'] = 'Project name contains invalid characters or patterns.';
+        http_response_code(400);
+        return;
+    }
 
     // Make sure that a project with this name does not already exist.
     $Project = new Project();

--- a/app/cdash/public/submit.php
+++ b/app/cdash/public/submit.php
@@ -113,10 +113,10 @@ if (isset($_GET['buildid'])) {
 
 $projectname = $_GET['project'];
 
-if (str_contains($projectname, '..')) {
-    \Log::error("Project name contains invalid pattern '..': $projectname");
+if (!Project::validateProjectName($projectname)) {
+    \Log::error("Invalid project name: $projectname");
     $statusarray['status'] = 'ERROR';
-    $statusarray['message'] = "Project name contains invalid pattern '..'.";
+    $statusarray['message'] = "Invalid project name: $projectname";
     return displayReturnStatus($statusarray, Response::HTTP_BAD_REQUEST);
 }
 
@@ -133,7 +133,7 @@ $authtoken = AuthTokenService::getBearerToken();
 $authtoken_hash = $authtoken === null || $authtoken === '' ? '' : AuthTokenService::hashToken($authtoken);
 
 // Save the incoming file in the inbox directory.
-$filename = "{$projectname}_{$authtoken_hash}_" . \Illuminate\Support\Str::uuid()->toString() . "_{$expected_md5}_.xml";
+$filename = "{$projectname}_-_{$authtoken_hash}_-_" . \Illuminate\Support\Str::uuid()->toString() . "_-_{$expected_md5}.xml";
 $fp = request()->getContent(true);
 if (!Storage::put("inbox/{$filename}", $fp)) {
     \Log::error("Failed to save submission to inbox for $projectname (md5=$expected_md5)");

--- a/database/migrations/2023_04_16_204249_project_name_regex.php
+++ b/database/migrations/2023_04_16_204249_project_name_regex.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Doing the processing in PHP like this is a terrible hack, but is unfortunately the only
+        // reasonable way of doing this given that we have to support two different databases and
+        // have to allow only a limited number of characters.
+
+        // Wrap everything in a single transaction so if something goes wrong we can easily revert it
+        DB::transaction(function () {
+            $projects = DB::select('SELECT id, name FROM project');
+
+            foreach ($projects as $project) {
+                $new_name = preg_replace("/[^a-zA-Z0-9\ +.\-_]/", '_', $project->name);
+                $new_name = str_replace('_-_', '_', $new_name);
+                DB::table('project')
+                    ->where('id', $project->id)
+                    ->update(['name' => $new_name]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // This migration is a one-way street.  No way to revert here!
+    }
+};


### PR DESCRIPTION
The current regex we use to validate project names allows project names which may break CDash to be created.  This PR restricts the allowable characters in a project name to the upper- and lower-case letters, numbers, `-`, `+`, `_`, `.`, and the space character.  Filesystem paths have also been sanitized when submitting files to ensure that a handful of edge cases don't lead to CDash errors.

Explanation of regex changes:

1. `\s` -> `\ ` (accept only regular spaces; prohibit tabs, newlines,  and other forms of whitespace)
2. `-` -> `\-` (accept the `-` character instead of any character between `+` and `_`)

If any CDash instance currently has a project with a disallowed character in its name and attempts to run the migration in this PR, the disallowed characters will be converted to the underscore character.  This migration is irreversible.