### PR TITLE
Align top menu items with page content

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -480,11 +480,8 @@ div#datetime {
 }
 
 div#topmenu {
-  position: relative;
-  float: left;
   width: 100%;
-  top: 4px;
-  left: 6px;
+  line-height: 25px;
 }
 
 div#topmenu a {
@@ -818,7 +815,7 @@ div#headertop {
   background-image: none;
   color: #CCCCCC !important;
   min-height:25px;
-  padding:0 30px;
+  padding:0 2em;
   width:100%;
 }
 
@@ -848,7 +845,7 @@ div#headertop {
 #headerlogo {
   float:left;
   height: 60px;
-  padding-left:30px;
+  padding-left:2em;
 }
 
 #headerlogo #projectlogo {


### PR DESCRIPTION
Various components of the top menu are currently misaligned.  In particular, the menu item background overflows the menu bar when the hover action is triggered.  The items are also not horizontally aligned with the edges of the remaining page content.

This PR is a quick patch to improve the top menu UI.  It would be good to fully refactor the underlying CSS to be more robust at some point.