### PR TITLE
Remove all incorrect `@throws` annotations

### DIFF
--- a/app/Providers/OAuthServiceProvider.php
+++ b/app/Providers/OAuthServiceProvider.php
@@ -59,7 +59,6 @@ class OAuthServiceProvider extends ServiceProvider
      * This registers the correct oauth2 service provider for a given route.
      *
      * @return void
-     * @throws Exception
      */
     public function register()
     {

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -2234,7 +2234,6 @@ class Build
     /**
      * @param $message
      * @param $url
-     * @throws \Exception
      */
     private function NotifyPullRequest($message, $url)
     {

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1894,8 +1894,6 @@ class Project
      * Returns a SubscriberCollection; a collection of all users and their subscription preferences.
      *
      * @return SubscriberCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      */
     public function GetProjectSubscribers()
     {

--- a/app/cdash/app/Model/Repository.php
+++ b/app/cdash/app/Model/Repository.php
@@ -46,7 +46,6 @@ class Repository
 
     /**
      * @return array
-     * @throws \ReflectionException
      */
     public static function getViewers()
     {

--- a/app/cdash/app/Test/OAuthTestHelper.php
+++ b/app/cdash/app/Test/OAuthTestHelper.php
@@ -26,7 +26,6 @@ trait OAuthTestHelper
 
     /**
      * @return MockObject|OAuth2
-     * @throws ReflectionException
      */
     protected function getSut()
     {
@@ -59,7 +58,6 @@ trait OAuthTestHelper
     /**
      * @param array $methods
      * @return MockObject|AbstractProvider
-     * @throws ReflectionException
      */
     protected function getProvider(array $methods = [])
     {
@@ -92,7 +90,6 @@ trait OAuthTestHelper
 
     /**
      * @return MockObject|ResourceOwnerInterface
-     * @throws ReflectionException
      */
     protected function getResourceOwner()
     {

--- a/app/cdash/include/CDash/ServiceContainer.php
+++ b/app/cdash/include/CDash/ServiceContainer.php
@@ -44,8 +44,6 @@ class ServiceContainer extends Singleton
      *
      * @param $class_name
      * @return mixed
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      */
     public function create($class_name)
     {
@@ -57,8 +55,6 @@ class ServiceContainer extends Singleton
      *
      * @param $class_name
      * @return mixed
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      */
     public function get($class_name)
     {

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -175,8 +175,6 @@ function get_project_from_request()
  * Get project given request parameter, 'project'
  *
  * @return mixed|null
- * @throws \DI\DependencyException
- * @throws \DI\NotFoundException
  */
 function just_get_project_from_request()
 {

--- a/app/cdash/tests/case/CDash/Middleware/OAuth2/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Middleware/OAuth2/GitHubTest.php
@@ -33,7 +33,6 @@ class GitHubTest extends TestCase
     }
 
     /**
-     * @throws \ReflectionException
      * @throws IdentityProviderException
      */
     public function testGetEmail()

--- a/app/cdash/tests/case/CDash/Middleware/OAuth2Test.php
+++ b/app/cdash/tests/case/CDash/Middleware/OAuth2Test.php
@@ -12,7 +12,6 @@ class OAuth2Test extends TestCase
 
 
     /**
-     * @throws ReflectionException
      * @throws IdentityProviderException
      */
     public function testSetEmail()
@@ -28,7 +27,6 @@ class OAuth2Test extends TestCase
 
 
     /**
-     * @throws ReflectionException
      * @throws IdentityProviderException
      */
     public function testGetPrimaryEmail()

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -411,8 +411,6 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
 
     /**
      * @return BuildCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      * TODO: consider refactoring into abstract_handler asap
      */
     public function GetBuildCollection()

--- a/app/cdash/xml_handlers/configure_handler.php
+++ b/app/cdash/xml_handlers/configure_handler.php
@@ -336,8 +336,6 @@ class ConfigureHandler extends AbstractHandler implements ActionableBuildInterfa
 
     /**
      * @return BuildCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      * TODO: consider refactoring into abstract_handler asap
      */
     public function GetBuildCollection()

--- a/app/cdash/xml_handlers/dynamic_analysis_handler.php
+++ b/app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -329,8 +329,6 @@ class DynamicAnalysisHandler extends AbstractHandler implements ActionableBuildI
 
     /**
      * @return BuildCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      * TODO: consider refactoring into abstract_handler asap
      */
     public function GetBuildCollection()

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -392,8 +392,6 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
 
     /**
      * @return BuildCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      * TODO: consider refactoring into abstract_handler asap
      */
     public function GetBuildCollection()

--- a/app/cdash/xml_handlers/update_handler.php
+++ b/app/cdash/xml_handlers/update_handler.php
@@ -235,8 +235,6 @@ class UpdateHandler extends AbstractHandler implements ActionableBuildInterface,
 
     /**
      * @return BuildCollection
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
      */
     public function GetBuildCollection()
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,10 @@ parameters:
             - app/cdash/tests/selenium/cdash_selenium_test_case.php
             - app/cdash/include/Collection/Collection.php
 
+    exceptions:
+    		check:
+    			  tooWideThrowType: true
+
     treatPhpDocTypesAsCertain: false
 
     level: 6


### PR DESCRIPTION
PHPStan supports exception checking, and this PR is the first of several PRs to gradually turn on PHPStan's exception checking features.  The configuration option being enabled in this PR flags all incorrect PHPDoc `@throws` tags.