### PR TITLE
Ensure user has access to project before sending project data

### DIFF
--- a/app/cdash/public/ajax/buildinfogroup.php
+++ b/app/cdash/public/ajax/buildinfogroup.php
@@ -15,6 +15,7 @@
 =========================================================================*/
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 use CDash\Database;
 
@@ -35,6 +36,10 @@ $buildname = $build['name'];
 $siteid = intval($build['siteid']);
 $starttime = $build['starttime'];
 $projectid = intval($build['projectid']);
+
+if (!can_access_project($projectid)) {
+    return 'You do not have permission to view this project.';
+}
 
 $project = $db->executePreparedSingleRow('SELECT name FROM project WHERE id=?', [$projectid]);
 

--- a/app/cdash/public/ajax/expectedinfo.php
+++ b/app/cdash/public/ajax/expectedinfo.php
@@ -18,6 +18,7 @@ use CDash\Database;
 
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 $siteid = $_GET['siteid'];
 $buildname = htmlspecialchars($_GET['buildname']);
@@ -30,7 +31,7 @@ if (!isset($siteid) || !is_numeric($siteid)) {
     echo 'Not a valid siteid!';
     return;
 }
-if (!isset($projectid) || !is_numeric($projectid)) {
+if (!isset($projectid) || !is_numeric($projectid) || !can_access_project($projectid)) {
     echo 'Not a valid projectid!';
     return;
 }

--- a/app/cdash/public/ajax/finduserproject.php
+++ b/app/cdash/public/ajax/finduserproject.php
@@ -15,6 +15,7 @@
 =========================================================================*/
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 use CDash\Config;
 use CDash\Database;
@@ -22,7 +23,7 @@ use CDash\Database;
 $config = Config::getInstance();
 
 $projectid = $_GET['projectid'];
-if (!isset($projectid) || !is_numeric($projectid)) {
+if (!isset($projectid) || !is_numeric($projectid) || !can_access_project($projectid)) {
     echo 'Not a valid projectid!';
     return;
 }

--- a/app/cdash/public/ajax/getsubprojectdependencies.php
+++ b/app/cdash/public/ajax/getsubprojectdependencies.php
@@ -16,6 +16,7 @@
 
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 use CDash\Model\Project;
 use CDash\Model\SubProject;
@@ -33,7 +34,7 @@ if ($date != null) {
 
 $projectid = get_project_id($projectname);
 
-if ($projectid == 0) {
+if ($projectid == 0 || !can_access_project($projectid)) {
     echo 'Invalid project';
     return;
 }

--- a/app/cdash/public/ajax/getviewcoverage.php
+++ b/app/cdash/public/ajax/getviewcoverage.php
@@ -53,7 +53,7 @@ if ($policy !== true) {
 }
 
 $project = $db->executePreparedSingleRow('SELECT name, showcoveragecode FROM project WHERE id=?', [$projectid]);
-if (empty($project)) {
+if (empty($project) || !can_access_project($projectid)) {
     echo "This project doesn't exist.";
     exit();
 }

--- a/app/cdash/public/ajax/showcoveragegraph.php
+++ b/app/cdash/public/ajax/showcoveragegraph.php
@@ -15,6 +15,7 @@
 =========================================================================*/
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 use CDash\Database;
 
@@ -35,6 +36,10 @@ $buildname = $build['name'];
 $siteid = intval($build['siteid']);
 $starttime = $build['starttime'];
 $projectid = intval($build['projectid']);
+
+if (!can_access_project($projectid)) {
+    return 'You do not have permission to view this project.';
+}
 
 // Find the other builds
 $previousbuilds = $db->executePrepared('

--- a/app/cdash/public/ajax/showtestfailuregraph.php
+++ b/app/cdash/public/ajax/showtestfailuregraph.php
@@ -20,6 +20,7 @@ use CDash\Database;
 
 require_once 'include/pdo.php';
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 
 $projectid = $_GET['projectid'];
 $project = new Project();
@@ -33,7 +34,7 @@ $testname = htmlspecialchars($_GET['testname']);
 $starttime = $_GET['starttime'];
 @$zoomout = $_GET['zoomout'];
 
-if (!isset($projectid) || !is_numeric($projectid)) {
+if (!isset($projectid) || !is_numeric($projectid) || !can_access_project($projectid)) {
     echo 'Not a valid projectid!';
     return;
 }

--- a/app/cdash/public/api/v1/buildSummary.php
+++ b/app/cdash/public/api/v1/buildSummary.php
@@ -48,6 +48,11 @@ $service = ServiceContainer::getInstance();
 $project = $service->create(Project::class);
 $project->Id = $build->ProjectId;
 $project->Fill();
+if (!can_access_project($project->Id)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
 
 $date = TestingDay::get($project, $build->StartTime);
 

--- a/app/cdash/public/api/v1/createProject.php
+++ b/app/cdash/public/api/v1/createProject.php
@@ -17,6 +17,7 @@
 namespace CDash\Api\v1\CreateProject;
 
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 require_once 'include/pdo.php';
 
 use App\Services\PageTimer;
@@ -53,7 +54,7 @@ $projectid = null;
 if (isset($_GET['projectid'])) {
     // Make sure projectid is valid if one was specified.
     $Project->Id = $projectid = $_GET['projectid'];
-    if (!$Project->Exists()) {
+    if (!$Project->Exists() || !can_access_project($Project->Id)) {
         $response['error'] = 'This project does not exist.';
         echo json_encode($response);
         return;

--- a/app/cdash/public/api/v1/getbuildid.php
+++ b/app/cdash/public/api/v1/getbuildid.php
@@ -17,6 +17,7 @@
 namespace CDash\Api\v1\GetBuildID;
 
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 require_once 'include/pdo.php';
 
 use CDash\Database;
@@ -32,7 +33,7 @@ $projectid = get_project_id($project);
 $xml = '<?xml version="1.0" encoding="UTF-8"?>';
 $xml .= '<buildid>';
 
-if (!is_numeric($projectid)) {
+if (!is_numeric($projectid) || !can_access_project($projectid)) {
     $xml .= 'not found</buildid>';
     return response($xml, 404)->header('Content-Type', 'application/xml');
 }

--- a/app/cdash/public/api/v1/getuserid.php
+++ b/app/cdash/public/api/v1/getuserid.php
@@ -17,6 +17,7 @@
 namespace CDash\Api\v1\GetUserID;
 
 require_once 'include/common.php';
+require_once 'include/api_common.php';
 require_once 'include/pdo.php';
 
 use App\Models\User;
@@ -69,7 +70,7 @@ if (strlen($_GET['project']) == 0) {
 
 $project = new Project();
 $projectname = htmlspecialchars(pdo_real_escape_string($_GET['project']));
-if (!$project->FindByName($projectname)) {
+if (!$project->FindByName($projectname) || !can_access_project(get_project_id($projectname))) {
     $xml .= 'error<no-such-project/></userid>';
     return response($xml, 404)->header('Content-Type', 'application/xml');
 }

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -18,6 +18,7 @@ namespace CDash\Api\v1\ManageOverview;
 
 require_once 'include/pdo.php';
 include_once 'include/common.php';
+include_once 'include/api_common.php';
 
 use App\Services\PageTimer;
 use CDash\Database;
@@ -59,12 +60,12 @@ if (!$projectid_ok) {
 $Project = new Project();
 $Project->Id = $projectid;
 
-// Make sure the user has admin rights to this project.
-get_dashboard_JSON($Project->GetName(), null, $response);
-if ($response['user']['admin'] != 1) {
+if (!can_administrate_project($Project->Id)) {
     $response['error'] = "You don't have the permissions to access this page";
     return json_encode($response);
 }
+// Make sure the user has admin rights to this project.
+get_dashboard_JSON($Project->GetName(), null, $response);
 
 $db = Database::getInstance();
 

--- a/app/cdash/public/api/v1/manageSubProject.php
+++ b/app/cdash/public/api/v1/manageSubProject.php
@@ -18,6 +18,7 @@ namespace CDash\Api\v1\ManageSubProject;
 
 require_once 'include/pdo.php';
 include_once 'include/common.php';
+include_once 'include/api_common.php';
 
 use App\Services\PageTimer;
 use CDash\Model\Project;
@@ -45,6 +46,12 @@ $userid = $user->id;
 
 // List the available projects that this user has admin rights to.
 $projectid = intval($_GET['projectid'] ?? 0);
+
+if (!can_access_project($projectid)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
 
 $sql = 'SELECT id,name FROM project';
 $params = [];

--- a/app/cdash/public/api/v1/viewBuildError.php
+++ b/app/cdash/public/api/v1/viewBuildError.php
@@ -66,6 +66,12 @@ $project = $service->get(Project::class);
 $project->Id = $build->ProjectId;
 $project->Fill();
 
+if (!can_access_project($project->Id)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
+
 $response = begin_JSON_response();
 $response['title'] = "CDash : $project->Name";
 

--- a/app/cdash/public/api/v1/viewConfigure.php
+++ b/app/cdash/public/api/v1/viewConfigure.php
@@ -38,8 +38,14 @@ $project = new Project();
 $project->Id = $build->ProjectId;
 $project->Fill();
 
-$date = TestingDay::get($project, $build->StartTime);
 $response = begin_JSON_response();
+if (!can_access_project($project->Id)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
+
+$date = TestingDay::get($project, $build->StartTime);
 get_dashboard_JSON($project->Name, $date, $response);
 $response['title'] = "$project->Name : Configure";
 

--- a/app/cdash/public/api/v1/viewDynamicAnalysis.php
+++ b/app/cdash/public/api/v1/viewDynamicAnalysis.php
@@ -47,6 +47,12 @@ $defect_nice_names = array(
 $project = new Project();
 $project->Id = $build->ProjectId;
 $project->Fill();
+if (!can_access_project($project->Id)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
+
 $response['displaylabels'] = $project->DisplayLabels;
 
 $date = TestingDay::get($project, $build->StartTime);

--- a/app/cdash/public/api/v1/viewDynamicAnalysisFile.php
+++ b/app/cdash/public/api/v1/viewDynamicAnalysisFile.php
@@ -58,6 +58,11 @@ if (!can_access_project($build->ProjectId)) {
 $project = new Project();
 $project->Id = $build->ProjectId;
 $project->Fill();
+if (!can_access_project($project->Id)) {
+    $response['error'] = 'You do not have permission to view this project.';
+    echo json_encode($response);
+    return;
+}
 
 $date = TestingDay::get($project, $build->StartTime);
 $response = begin_JSON_response();


### PR DESCRIPTION
Fixes a problem where unauthorized users could access data about projects they could not view.