### PR TITLE
Add environment flag for disabling registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,9 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # Whether or not "normal" username+password authentication is enabled
 # USERNAME_PASSWORD_AUTHENTICATION_ENABLED=true
 
+# Whether or not "normal" username+password registration form submission is enabled
+# USER_REGISTRATION_FORM_ENABLED=true
+
 
 # ldap.php
 #LDAP_HOSTS=

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -47,6 +47,9 @@ class RegisterController extends AbstractController
 
     public function showRegistrationForm(Request $request)
     {
+        if (config('auth.user_registration_form_enabled') === false) {
+            return response("Registration via form is disabled", 404);
+        }
         // We can route a user here with our form pre-populated
         $params = [
             'title' => 'Register',
@@ -125,6 +128,9 @@ class RegisterController extends AbstractController
      */
     public function register(Request $request)
     {
+        if (config('auth.user_registration_form_enabled') === false) {
+            return response("Registration via form is disabled", 404);
+        }
         try {
             $this->validator($request->all())->validate();
         } catch (ValidationException $e) {

--- a/app/cdash/app/Controller/Api/ViewProjects.php
+++ b/app/cdash/app/Controller/Api/ViewProjects.php
@@ -130,6 +130,7 @@ class ViewProjects extends \CDash\Controller\Api
         }
         $response['projects'] = $projects_response;
 
+        $response['enable_registration'] = config("auth.user_registration_form_enabled");
         $this->pageTimer->end($response);
         return $response;
     }

--- a/config/auth.php
+++ b/config/auth.php
@@ -3,6 +3,8 @@
 return [
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),
+    // Whether or not "normal" username+password authentication is enabled
+    'user_registration_form_enabled' => env('USER_REGISTRATION_FORM_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -2,6 +2,7 @@
     if (isset($project)) {
         $logoid = getLogoID(intval($project->Id));
     }
+$hideRegistration = config('auth.user_registration_form_enabled') === false;
 @endphp
 
 <div id="header">
@@ -17,7 +18,9 @@
                     <a href="/logout">Logout</a>
                 @else
                     <a href="/login">Login</a>
-                    <a href="{{ route('register') }}">{{ __('Register') }}</a>
+                    @if(!$hideRegistration)
+                      <a href="{{ route('register') }}">{{ __('Register') }}</a>
+                    @endif
                 @endif
             </span>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,13 +11,20 @@
 |
 */
 
+use App\Http\Controllers\Auth\RegisterController;
+
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 
-Auth::routes(['verify' => true]);
+$routeList = array('verify' => true);
+
+if(config('auth.user_registration_form_enabled') === false) {
+    $routeList['register'] =  false;
+}
+Auth::routes($routeList);
 
 Route::get('/install.php', 'AdminController@install');
 Route::post('/install.php', 'AdminController@install');

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -20,6 +20,8 @@ class LoginAndRegistration extends TestCase
     protected static string $email = 'logintest@user.com';
     protected static string $password = '54321';
 
+    protected static string $blockedEmail = 'disabledRegistration@user.com';
+
     protected function setUp() : void
     {
         parent::setUp();
@@ -247,5 +249,35 @@ class LoginAndRegistration extends TestCase
         $user->delete();
 
         Mockery::close();
+    }
+
+    public function testRegisterUserWhenDisabled() : void
+    {
+        // Create a user by sending proper data
+
+        config(['auth.user_registration_form_enabled' => false]);
+        $post_data = [
+            'fname' => 'Test',
+            'lname' => 'User',
+            'email' => LoginAndRegistration::$blockedEmail,
+            'password' => LoginAndRegistration::$password,
+            'password_confirmation' => LoginAndRegistration::$password,
+            'institution' => 'home',
+            'sent' => 'Register',
+            'url' => 'catchbot',
+        ];
+        $this->post(route('register'), $post_data);
+
+        // Verify that nothing was added to the database
+        $this->assertDatabaseMissing('user', ['email' => LoginAndRegistration::$blockedEmail]);
+    }
+
+    public function testDisabledRegistrationForm() : void
+    {
+        // Disable username+password authentication and verify that the
+        // form is no longer displayed.
+        config(['auth.user_registration_form_enabled' => false]);
+        $response = $this->get('/register');
+        $response->assertStatus(404);
     }
 }


### PR DESCRIPTION
Add an environment variable which will disable the showing of the registration link, form, and acceptance of the JSON in the API.

The `manageUsers` and `manageProjectRoles` pages will still allow an administrator to register a user.