### PR TITLE
Remove "Choose" option from admin dropdowns

### DIFF
--- a/app/cdash/public/manageBanner.xsl
+++ b/app/cdash/public/manageBanner.xsl
@@ -42,12 +42,7 @@
     <form name="form1" method="post">
     <xsl:attribute name="action">manageBanner.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>
     <select onchange="location = 'manageBanner.php?projectid='+this.options[this.selectedIndex].value;" name="projectSelection">
-        <option>
-        <xsl:attribute name="value">-1</xsl:attribute>
-        Choose...
-        </option>
-
-        <xsl:for-each select="cdash/availableproject">
+      <xsl:for-each select="cdash/availableproject">
         <option>
         <xsl:attribute name="value"><xsl:value-of select="id"/></xsl:attribute>
         <xsl:if test="selected=1">

--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -47,7 +47,6 @@
     <form name="form1" method="post">
     <xsl:attribute name="action">subscribeProject.php?projectid=<xsl:value-of select="cdash/project/id"/></xsl:attribute>
     <select onchange="location='subscribeProject.php?projectid='+this.options[this.selectedIndex].value;" name="projectSelection">
-        <option value="0">Choose project</option>
         <xsl:for-each select="cdash/availableproject">
         <option>
         <xsl:attribute name="value"><xsl:value-of select="id"/></xsl:attribute>

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -38,9 +38,6 @@
               name="projectSelection"
               @change="switchProject()"
             >
-              <option value="-1">
-                Choose...
-              </option>
               <option
                 v-for="proj in cdash.availableprojects"
                 :value="proj.id"


### PR DESCRIPTION
Currently, if you navigate to the edit project page and select the default "Choose..." option in the project selector, a 404 error will result because there is no project with an ID of -1.  Given that this option currently does nothing productive, I have removed it entirely.  If there are no projects available, there will simply be no projects to be selected.