### PR TITLE
Remove dead code from `Subscription.php`

### DIFF
--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1944,15 +1944,6 @@ class Project
         return $collection;
     }
 
-    /**
-     * Returns a self referencing URI of the current Project.
-     */
-    public function GetUrlForSelf(): string
-    {
-        $config = Config::getInstance();
-        return "{$config->getBaseUrl()}/viewProject?projectid={$this->Id}";
-    }
-
     // Modify the build error/warning filters for this project if necessary.
     public function UpdateBuildFilters(): bool
     {

--- a/app/cdash/docs/NOTIFICATIONS.md
+++ b/app/cdash/docs/NOTIFICATIONS.md
@@ -89,29 +89,6 @@ Each class implementing the SubscriptionBuilderInterface has its own criteria fo
 * Determine if the submission matches any of the criteria gathered from project, build group, and user settings.
 * Add the subscriptions with matching criteria to the SubscriptionCollection.
 
-### SubscriptionBuilder
-```php
-/**
- * @return SubscriptionCollection
- */
-public function build()
-{
-    ...
-    foreach ($subscribers as $subscriber) {
-        /** @var SubscriberInterface $subscriber */
-        if ($subscriber->hasBuildTopics($this->build)) {
-            $subscription = $factory->create();
-            $subscription
-                ->setSubscriber($subscriber)
-                ->setTopicCollection($subscriber->getTopics())
-                ->setProject($this->project);
-
-            $subscriptions->add($subscription);
-        }
-    }
-    return $subscriptions;
-}
-```
 ### Subscriber
 
 A subscriber is some entity that is able to subscribe to a submission via topics. Currently CDash has two implementations of a Subscriber; 1) a user; 2) a commit author. Users' topics are set by evaluating the preferences they've set through the CDash UI. Commit authors have a set of topics with which they are provided. Subscribers' topics are evaluated against an actionable submission to determine if the Subscriber is subscribed to any given submission. Example:

--- a/app/cdash/include/Messaging/Notification/NotificationDirector.php
+++ b/app/cdash/include/Messaging/Notification/NotificationDirector.php
@@ -13,6 +13,7 @@ class NotificationDirector
         $subscriptions = $builder->getSubscriptions();
         $notifications = $builder->getNotifications();
 
+        /* @var \CDash\Messaging\Subscription\Subscription $subscription */
         foreach ($subscriptions as $recipient => $subscription) {
             foreach ($subscription->getTopicTemplates() as $template) {
                 $notification = $builder->createNotification($subscription, $template);

--- a/app/cdash/include/Messaging/Subscription/Subscription.php
+++ b/app/cdash/include/Messaging/Subscription/Subscription.php
@@ -17,12 +17,6 @@ class Subscription implements SubscriptionInterface
     /** @var  SubscriberInterface $subscriber */
     private $subscriber;
 
-    /** @var  TopicCollection $topicCollection */
-    private $topicCollection;
-
-    /** @var  NotificationInterface $notification */
-    private $notification;
-
     /** @var  Project $project */
     private $project;
 
@@ -57,16 +51,6 @@ class Subscription implements SubscriptionInterface
     }
 
     /**
-     * @param TopicCollection $topicCollection
-     * @return Subscription
-     */
-    public function setTopicCollection(TopicCollection $topicCollection)
-    {
-        $this->topicCollection = $topicCollection;
-        return $this;
-    }
-
-    /**
      * @return SubscriberInterface
      */
     public function getSubscriber()
@@ -80,40 +64,6 @@ class Subscription implements SubscriptionInterface
     public function getTopicCollection()
     {
         return $this->subscriber->getTopics();
-    }
-
-    /**
-     * @return TopicCollection
-     */
-    public function getTopics()
-    {
-        return $this->getTopicCollection();
-    }
-
-    /**
-     * @param NotificationInterface $notification
-     * @return Subscription
-     */
-    public function setNotification(NotificationInterface $notification)
-    {
-        $this->notification = $notification;
-        return $this;
-    }
-
-    /**
-     * @return NotificationInterface;
-     */
-    public function getNotification()
-    {
-        return $this->notification;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSender()
-    {
-        return Config::getInstance()->get('CDASH_NOTIFICATION_SENDER');
     }
 
     /**
@@ -153,14 +103,6 @@ class Subscription implements SubscriptionInterface
     }
 
     /**
-     * @return Site
-     */
-    public function getSite()
-    {
-        return $this->site;
-    }
-
-    /**
      * @return int
      */
     public static function getMaxDisplayItems()
@@ -182,16 +124,6 @@ class Subscription implements SubscriptionInterface
     public function getProjectName()
     {
         return $this->project->GetName();
-    }
-
-    public function getProjectUrl()
-    {
-        return $this->project->GetUrlForSelf();
-    }
-
-    public function getSiteName()
-    {
-        return $this->site->GetName();
     }
 
     public function getTopicDescriptions($case = null)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10763,16 +10763,6 @@ parameters:
 			path: app/cdash/include/Messaging/Subscription/Subscription.php
 
 		-
-			message: "#^Method CDash\\\\Messaging\\\\Subscription\\\\Subscription\\:\\:getProjectUrl\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Subscription/Subscription.php
-
-		-
-			message: "#^Method CDash\\\\Messaging\\\\Subscription\\\\Subscription\\:\\:getSiteName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Subscription/Subscription.php
-
-		-
 			message: "#^Method CDash\\\\Messaging\\\\Subscription\\\\Subscription\\:\\:getTopicDescriptions\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Subscription/Subscription.php
@@ -10814,11 +10804,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Messaging\\\\Subscription\\\\Subscription\\:\\:\\$summary type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Subscription/Subscription.php
-
-		-
-			message: "#^Property CDash\\\\Messaging\\\\Subscription\\\\Subscription\\:\\:\\$topicCollection is never read, only written\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Subscription/Subscription.php
 

--- a/resources/views/email/fix.blade.php
+++ b/resources/views/email/fix.blade.php
@@ -1,5 +1,6 @@
 <?php
 $config = \CDash\Config::getInstance();
+/* @var \CDash\Messaging\Subscription\Subscription $subscription */
 $summary = $subscription->getBuildSummary();
 $collection = $subscription->getTopicCollection();
 $fixed = $collection->get('FixedTopic');

--- a/resources/views/email/issue.blade.php
+++ b/resources/views/email/issue.blade.php
@@ -4,6 +4,7 @@ use CDash\Messaging\Subscription\Subscription;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Config;
 
+/* @var \CDash\Messaging\Subscription\Subscription $subscription */
 $descriptions = $subscription->getTopicDescriptions(CASE_LOWER);
 $summary = $subscription->getBuildSummary();
 $config = Config::getInstance();

--- a/resources/views/email/issue/configure_errors.blade.php
+++ b/resources/views/email/issue/configure_errors.blade.php
@@ -1,6 +1,7 @@
 <?php
 use CDash\Messaging\Topic\Topic;
 
+/* @var \CDash\Messaging\Subscription\Subscription $subscription */
 $max = $subscription->getProject()->EmailMaxChars;
 $subscriber = $subscription->getSubscriber();
 $topics = $subscriber->getTopics();

--- a/resources/views/email/issue/subject.blade.php
+++ b/resources/views/email/issue/subject.blade.php
@@ -1,4 +1,5 @@
 <?php
+/* @var \CDash\Messaging\Subscription\Subscription $subscription */
 $summary = $subscription->getBuildSummary();
 $project = $subscription->getProjectName();
 $labels = $subscription->getSubscriber()->getLabels();


### PR DESCRIPTION
Cleans up a bit of dead code in `Subscription.php` and adds annotations to a few other files so IDEs and static analysis tools don't mark other functions as unused.