### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+labels: 'bug report'
+---
+
+# Bug report
+
+### Expected Behavior
+
+<!-- What did you expect to happen? -->
+
+### Actual Behavior
+
+<!-- What actually happened? -->
+
+### CDash Version
+
+<!-- What version of CDash are you using? -->
+
+### Additional Information
+
+<!--
+Add additional information here if necessary.  Helpful information includes:
+- How to reproduce the problem
+- Screenshots of a UI issue
+- Browser/OS information (if applicable)
+- Any other information which might help us track down the bug
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,8 @@
+---
+name: Feature Request
+labels: 'feature request'
+---
+
+# Feature Request
+
+### How can we make CDash better?


### PR DESCRIPTION
GitHub's issue templates help organize our issues by automatically tagging issues and encouraging all users to provide helpful information.  Our `SECURITY.md` will also show up automatically as a separate option when creating an issue.