### PR TITLE
Add padding to build summary table

### DIFF
--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -1066,4 +1066,7 @@ export default {
 </script>
 
 <style scoped>
+.dart th, .dart td {
+  padding: 3px 7px;
+}
 </style>


### PR DESCRIPTION
The first table on the build summary page sticks out from the rest of the CDash UI like a sore thumb because it doesn't have any padding.  The contents look cramped.  This PR adds a bit of padding to the table to make it consistent with other tables throughout the CDash UI.  The solution used here is a bit of a hack but this page as a whole desperately needs a UI overhaul to better use the available space and we can re-visit the table UI as part of a future refactor.

Before:
<img width="171" alt="image" src="https://user-images.githubusercontent.com/16820599/235375402-f682a9a5-b679-4417-ae90-5381bf89536f.png">

After:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/16820599/235375378-1269e161-4db2-4dbf-a3ea-291838593b22.png">
