### PR TITLE
Fix broken `buildnote.php`

### DIFF
--- a/app/cdash/public/views/partials/build.html
+++ b/app/cdash/public/views/partials/build.html
@@ -77,7 +77,7 @@
     <!-- Display the note icon -->
     <a name="Build Notes" id="buildnote_{{::build.id}}"
        ng-if="::build.buildnotes > 0"
-       ng-href="ajax/buildnote.php?buildid={{::build.id}}&width=350&link=build%2F{{::build.id}}">
+       ng-href="ajax/buildnote.php?buildid={{::build.id}}">
       <img src="img/note.png" alt="note" class="icon"></img>
     </a>
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16421,16 +16421,6 @@ parameters:
 			path: app/cdash/public/ajax/buildinfogroup.php
 
 		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\:\\:\\$firstname\\.$#"
-			count: 1
-			path: app/cdash/public/ajax/buildnote.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\:\\:\\$lastname\\.$#"
-			count: 1
-			path: app/cdash/public/ajax/buildnote.php
-
-		-
 			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#


### PR DESCRIPTION
The AJAX endpoint which allows access to build note data is currently completely broken.  The primary way this page is accessed is the icon on the administrative dashboard boxed in red below:
![image](https://user-images.githubusercontent.com/16820599/235376378-4d7a811b-1e2f-4535-b477-41f1cce83fbc.png)

In addition to fixing the broken functionality, access controls which only allow administrators to access this endpoint were implemented.  It was not clear what the intended access level was, but the only (legitimate) way to access this page is through the administrator UI.
