### PR TITLE
Fix `editSite.php` DB query typo

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -272,7 +272,7 @@ class SiteController extends AbstractController
                                  FROM site2user
                                  WHERE siteid=? AND userid=?
                              ', [$siteid, intval($userid)]);
-                if (count($user2site['c']) === 0) {
+                if (intval($user2site['c']) === 0) {
                     $xml .= add_XML_value('claimed', '0');
                 } else {
                     $xml .= add_XML_value('claimed', '1');


### PR DESCRIPTION
`editSite.php` is currently broken due to an oversight when creating https://github.com/Kitware/CDash/pull/1332.

Instead of counting the number of rows queried in PHP, https://github.com/Kitware/CDash/pull/1332 used SQL to count the number of rows instead.

This PR will create merge conflicts with https://github.com/Kitware/CDash/pull/1351, which should be resolved by simply re-copying this file into the new controller.