### PR TITLE
Standardize prepared text UI

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -508,7 +508,6 @@ textarea {
 .compiler-output {
   font-size: 14px;
   font-family: Courier New, Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono, monospace;
-  border: 1px inset #ccc;
   overflow-x:scroll;
   max-height:350px;
 }


### PR DESCRIPTION
`viewBuildError.php` currently applies custom styles which conflict with the standard Bootstrap `<pre>` tag styling.  This results in ugly (and inconsistent) black borders around prepared text.

Before:
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/16820599/235493821-3e78ac63-63a2-4162-ae48-2d6a38cd05a4.png">

After:
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/16820599/235493902-725014fc-9da5-49b9-995a-6b7b6a83c65e.png">
