### PR TITLE
Fix undefined variables

### DIFF
--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -206,7 +206,7 @@ class Timeline extends Index
         $buildgroup->SetName($groupname);
         if (!$buildgroup->Exists()) {
             $error_msg =
-                "BuildGroup '$groupname' does not exist for project '$project->Name'";
+                "BuildGroup '$groupname' does not exist for project '" . $this->project->Name . "'";
             json_error_response(['error' => $error_msg], 404);
             return[];
         }

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -1276,7 +1276,7 @@ class Build
             if ($existing_diff_row) {
                 \DB::table('configureerrordiff')
                     ->where('buildid', $this->Id)
-                    ->update(['difference' => $warniningdiff]);
+                    ->update(['difference' => $warningdiff]);
             } else {
                 \DB::table('configureerrordiff')->insertOrIgnore([
                     ['buildid' => $this->Id, 'difference' => $warningdiff],

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -294,7 +294,6 @@ function get_p4_repository_commits($root, $branch, $dates): array
             $describe_lines = explode("\n", $raw_output);
 
             $commit = array();
-            $comment = '';
 
             // Parse the changelist description and add each file modified to the
             // commits list
@@ -328,7 +327,7 @@ function get_p4_repository_commits($root, $branch, $dates): array
                 elseif (preg_match('/^\\.\\.\\. (.*)#[0-9]+ ([^ ]+)$/', $dline, $matches)) {
                     $commit['filename'] = $matches[1];
                     $commit['directory'] = remove_directory_from_filename($commit['filename']);
-                    $commits[$directory . '/' . $filename . ';' . $commit['revision']] = $commit;
+                    $commits[$commit['directory'] . '/' . $commit['filename'] . ';' . $commit['revision']] = $commit;
                 } // Anything else that begins with a tab is a comment line
                 elseif (strlen($dline) > 0 && $dline[0] == "\t") {
                     $commit['comment'] = $commit['comment'] . trim(substr($dline, 1)) . "\n";

--- a/app/cdash/public/api/v1/overview.php
+++ b/app/cdash/public/api/v1/overview.php
@@ -571,7 +571,7 @@ foreach ($dynamic_analysis_types as $checker) {
         $group_response['name_clean'] =
             sanitize_string($build_group['name']);
 
-        $chart_data = get_DA_chart_data($build_group['name'], $checker, $date_range, $dynamic_analysis_data);
+        $chart_data = get_DA_chart_data($build_group['name'], $checker, $date_range, $dynamic_analysis_data, $beginning_timestamp);
         $group_response['chart'] = $chart_data;
 
         $value = get_current_DA_value($build_group['name'], $checker, $date_range, $dynamic_analysis_data);
@@ -786,7 +786,7 @@ function get_recent_coverage_values($build_group_name, $coverage_category, $date
 }
 
 // Get line chart data for dynamic analysis
-function get_DA_chart_data($group_name, $checker, $date_range, $dynamic_analysis_data)
+function get_DA_chart_data($group_name, $checker, $date_range, $dynamic_analysis_data, $beginning_timestamp)
 {
     $chart_data = array();
 
@@ -796,7 +796,6 @@ function get_DA_chart_data($group_name, $checker, $date_range, $dynamic_analysis
             continue;
         }
 
-        // TODO: (williamjallen) $beginning_timestamp is undefined here. Fix it.
         $chart_date = get_date_from_index($i, $beginning_timestamp);
         $chart_data[] =
             array($chart_date, $dynamic_analysis_data[$i][$group_name][$checker]);

--- a/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
@@ -121,6 +121,7 @@ class BuildRelationshipTest extends CDashTestCase
 
         $this->mock_build1->method('Exists')->willReturn(true);
         $this->mock_build2->method('Exists')->willReturn(true);
+        $error_msg = null;
         $this->relationship->Save($error_msg);
         $this->assertEquals('', $error_msg);
     }

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -104,7 +104,8 @@ class BuildDetailsTestCase extends KWWebTestCase
     // This will be specific to a test xml
     public function testViewTestReturnsProperFormat()
     {
-        if (!$this->submission('BuildDetails', $this->testDataDir . '/' . 'Insight_Experimental_Test.xml')) {
+        $testDataFile = $this->testDataDir . '/' . 'Insight_Experimental_Test.xml';
+        if (!$this->submission('BuildDetails', $testDataFile)) {
             $this->fail('Failed to submit ' . $testDataFile);
             return 1;
         }
@@ -127,7 +128,8 @@ class BuildDetailsTestCase extends KWWebTestCase
 
     public function testViewTestReturnsProperFormatForParentBuilds()
     {
-        if (!$this->submission('BuildDetails', $this->testDataDir . '/' . 'Insight_Experimental_Test_Subbuild.xml')) {
+        $testDataFile = $this->testDataDir . '/' . 'Insight_Experimental_Test_Subbuild.xml';
+        if (!$this->submission('BuildDetails', $testDataFile)) {
             $this->fail('Failed to submit ' . $testDataFile);
             return 1;
         }

--- a/app/cdash/tests/test_longbuildname.php
+++ b/app/cdash/tests/test_longbuildname.php
@@ -4,6 +4,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 use CDash\Database;
 use CDash\Model\BuildConfigure;
 use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
 
 class LongBuildNameTestCase extends KWWebTestCase
 {
@@ -38,15 +39,16 @@ class LongBuildNameTestCase extends KWWebTestCase
 
         // Submit our testing data.
         $test_dir = dirname(__FILE__) . '/data/LongBuildName/';
-        if (!$this->submission('LongBuildName', "{$test_dir}/Configure.xml")) {
-            $this->fail("Failed to submit {$file}");
+        $filename = "{$test_dir}/Configure.xml";
+        if (!$this->submission('LongBuildName', $filename)) {
+            $this->fail("Failed to submit {$filename}");
         }
 
         // No errors in the log.
         $this->assertTrue($this->checkLog($this->logfilename) !== false);
 
         // The build exists.
-        $results = \DB::select(
+        $results = DB::select(
             DB::raw("SELECT id FROM build WHERE projectid = :projectid"),
             [':projectid' => $this->project->Id]
         );
@@ -56,6 +58,6 @@ class LongBuildNameTestCase extends KWWebTestCase
         $configure = new BuildConfigure();
         $configure->BuildId = $results[0]->id;
         $log = $configure->GetConfigureForBuild()['log'];
-        $this->assertTrue(strpos($log, 'This is my config output') !== false);
+        $this->assertTrue(str_contains($log, 'This is my config output'));
     }
 }

--- a/app/cdash/tests/test_multiplelabelsfortests.php
+++ b/app/cdash/tests/test_multiplelabelsfortests.php
@@ -39,8 +39,9 @@ class MultipleLabelsForTestsTestCase extends KWWebTestCase
 
         // Submit our testing data.
         $test_dir = dirname(__FILE__) . '/data/MultipleLabelsForTests/';
-        if (!$this->submission('MultipleLabelsForTests', "{$test_dir}/Test.xml")) {
-            $this->fail("Failed to submit {$file}");
+        $filename = "{$test_dir}/Test.xml";
+        if (!$this->submission('MultipleLabelsForTests', $filename)) {
+            $this->fail("Failed to submit {$filename}");
         }
 
         // No errors in the log.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2509,11 +2509,6 @@ parameters:
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
-			message: "#^Undefined variable\\: \\$project$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/Timeline.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Models\\\\BuildNote\\:\\:\\$note\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewNotes.php
@@ -4246,11 +4241,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Uuid has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Undefined variable\\: \\$warniningdiff$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -13233,16 +13223,6 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Undefined variable\\: \\$directory$#"
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
-			message: "#^Undefined variable\\: \\$filename$#"
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
 			message: "#^Variable \\$commit might not be defined\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
@@ -17480,6 +17460,11 @@ parameters:
 			path: app/cdash/public/api/v1/overview.php
 
 		-
+			message: "#^Function CDash\\\\Api\\\\v1\\\\Overview\\\\get_DA_chart_data\\(\\) has parameter \\$beginning_timestamp with no type specified\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/overview.php
+
+		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\Overview\\\\get_DA_chart_data\\(\\) has parameter \\$checker with no type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/overview.php
@@ -17721,11 +17706,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float given\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/overview.php
-
-		-
-			message: "#^Undefined variable\\: \\$beginning_timestamp$#"
 			count: 1
 			path: app/cdash/public/api/v1/overview.php
 
@@ -21577,11 +21557,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
 
 		-
-			message: "#^Undefined variable\\: \\$error_msg$#"
-			count: 2
-			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
-
-		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 2
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
@@ -24785,11 +24760,6 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
-			message: "#^Undefined variable\\: \\$testDataFile$#"
-			count: 2
-			path: app/cdash/tests/test_builddetails.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_builderrordiff.php
@@ -26654,11 +26624,6 @@ parameters:
 			path: app/cdash/tests/test_longbuildname.php
 
 		-
-			message: "#^Undefined variable\\: \\$file$#"
-			count: 1
-			path: app/cdash/tests/test_longbuildname.php
-
-		-
 			message: "#^Method LotsOfSubProjectsTestCase\\:\\:testLotsOfSubProjects\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_lotsofsubprojects.php
@@ -26934,11 +26899,6 @@ parameters:
 
 		-
 			message: "#^Property MultipleLabelsForTestsTestCase\\:\\:\\$project has no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_multiplelabelsfortests.php
-
-		-
-			message: "#^Undefined variable\\: \\$file$#"
 			count: 1
 			path: app/cdash/tests/test_multiplelabelsfortests.php
 


### PR DESCRIPTION
This PR fixes most of the undefined variables flagged by PHPStan.  Most of these are on code paths which are not frequently travelled, or in places where errors may go unnoticed.

The one remaining undefined variable (excluding false positives) flagged by PHPStan will be resolved once https://github.com/Kitware/CDash/pull/1351 is merged.