### PR TITLE
Add descriptions to issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,6 @@
 ---
 name: Bug report
+description: Report an issue that you've experienced with CDash.
 labels: 'bug report'
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,6 @@
 ---
 name: Feature Request
+description: Propose an update that would enhance your CDash experience.
 labels: 'feature request'
 ---
 


### PR DESCRIPTION
The settings page for the issue templates reports that "About can't be blank".

![image](https://user-images.githubusercontent.com/542106/236224257-a5934183-baf4-46fa-891b-9dd9e31b02b6.png)


Add a description field to each template.