### PR TITLE
Fix issue template descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,10 @@
 ---
 name: Bug report
-description: Report an issue that you've experienced with CDash.
-labels: 'bug report'
+about: Report an issue that you've experienced with CDash.
+title: ''
+labels: bug report
+assignees: ''
+
 ---
 
 # Bug report

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,10 @@
 ---
 name: Feature Request
-description: Propose an update that would enhance your CDash experience.
-labels: 'feature request'
+about: Propose an update that would enhance your CDash experience.
+title: ''
+labels: feature request
+assignees: ''
+
 ---
 
 # Feature Request


### PR DESCRIPTION
Follows #1408.  GitHub requires several more fields for issue templates.