### PR TITLE
Delete `redirect_to_https()` function

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1659,23 +1659,6 @@ function begin_XML_for_XSLT(): string
     return $xml;
 }
 
-function redirect_to_https()
-{
-    $config = Config::getInstance();
-
-    if ($config->get('CDASH_USE_HTTPS') &&
-        (!isset($_SERVER['HTTPS']) || !$_SERVER['HTTPS'])) {
-        // if request is not secure, redirect to secure url if available
-        $url = 'https://' . $_SERVER['HTTP_HOST']
-            . $_SERVER['REQUEST_URI'];
-
-        $https_check = @fsockopen($_SERVER['HTTP_HOST']);
-        if ($https_check) {
-            return redirect($url);
-        }
-    }
-}
-
 function begin_JSON_response(): array
 {
     $response = array();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13170,11 +13170,6 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			message: "#^Function redirect_to_https\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			message: "#^Function remove_build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/common.php


### PR DESCRIPTION
#1351 removed the last remaining reference to the function `redirect_to_https()`, and it is now possible to remove the function itself.