### PR TITLE
Add `never` return type for exit functions

### DIFF
--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -45,7 +45,6 @@ class TestGraph extends BuildTestApi
         $type = $_GET['type'];
         if (!in_array($type, $this->validTypes)) {
             json_error_response(['error' => 'Invalid type of graph requested.']);
-            return [];
         }
 
         $chart_data = [];

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -76,7 +76,6 @@ class Timeline extends Index
                 return $this->chartForBuildGroup();
             default:
                 json_error_response('Unexpected value for page');
-                break;
         }
     }
 
@@ -149,7 +148,6 @@ class Timeline extends Index
                 ORDER BY starttime");
         if (!pdo_execute($stmt, [':projectid' => $this->project->Id])) {
             json_error_response('Failed to load results');
-            return [];
         }
         $response = $this->getTimelineChartData($stmt);
         $response['colors'] = [
@@ -185,7 +183,6 @@ class Timeline extends Index
                 ORDER BY starttime");
         if (!pdo_execute($stmt, [':projectid' => $this->project->Id])) {
             json_error_response('Failed to load results');
-            return [];
         }
         $this->includeCleanBuilds = false;
         $response = $this->getTimelineChartData($stmt);
@@ -208,7 +205,6 @@ class Timeline extends Index
             $error_msg =
                 "BuildGroup '$groupname' does not exist for project '$project->Name'";
             json_error_response(['error' => $error_msg], 404);
-            return[];
         }
 
         $this->defectTypes = [
@@ -247,7 +243,6 @@ class Timeline extends Index
             ];
             if (!pdo_execute($stmt, $query_params)) {
                 json_error_response('Failed to load results');
-                return [];
             }
             $builds = [];
             while ($row = $stmt->fetch()) {

--- a/app/cdash/include/CDash/System.php
+++ b/app/cdash/include/CDash/System.php
@@ -158,11 +158,7 @@ class System
         header($string, $replace, $http_response_code);
     }
 
-    /**
-     * @param $exit_message
-     * @return void
-     */
-    public function system_exit($exit_message = '')
+    public function system_exit($exit_message = ''): never
     {
         exit($exit_message);
     }

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -69,7 +69,6 @@ function can_access_project($projectid)
         $response = ['requirelogin' => 1];
         json_error_response($response, 401);
     }
-    return false;
 }
 
 // Return true if this user has administrative access to this project.
@@ -81,14 +80,12 @@ function can_administrate_project($projectid)
     $project->Id = $projectid;
     if (!$project->Exists()) {
         json_error_response(['error' => 'Valid project ID required'], 404);
-        return false;
     }
 
     // Make sure the user is logged in.
     if (!Auth::check()) {
         $response = ['requirelogin' => 1];
         json_error_response($response, 401);
-        return false;
     }
 
     // Check if the user has the necessary permissions.
@@ -111,7 +108,6 @@ function get_param($name, $required = true)
     $value = isset($_REQUEST[$name]) ? $_REQUEST[$name] : null;
     if ($required && !$value) {
         json_error_response(['error' => "Valid $name required"]);
-        return null;
     }
     return pdo_real_escape_string($value);
 }
@@ -125,7 +121,6 @@ function get_int_param($name, $required = true)
 
     if ($required && !is_numeric($value)) {
         json_error_response(['error' => "Valid $name required"]);
-        return null;
     }
     return (int)$value;
 }
@@ -162,7 +157,6 @@ function just_get_project_from_request()
 {
     if (!isset($_REQUEST['project'])) {
         json_error_response(['error' => 'Valid project required']);
-        return null;
     }
     $projectname = $_REQUEST['project'];
     $projectid = get_project_id($projectname);
@@ -171,7 +165,6 @@ function just_get_project_from_request()
     $Project->Id = $projectid;
     if (!$Project->Exists()) {
         json_error_response(['error' => 'Project does not exist']);
-        return null;
     }
     return $Project;
 }
@@ -195,7 +188,6 @@ function get_request_build($required = true)
     if ($required && !$build->Exists()) {
         $response = ['error' => 'This build does not exist. Maybe it has been deleted.'];
         json_error_response($response, 400);
-        return null;
     }
 
     if ($id) {
@@ -211,9 +203,10 @@ function get_request_build($required = true)
  * @param $response
  * @param int $code
  */
-function json_error_response($response, $code = 400)
+function json_error_response($response, $code = 400): never
 {
     $service = ServiceContainer::getInstance();
+    /** @var System $system */
     $system = $service->get(System::class);
     http_response_code($code);
     echo json_encode($response);

--- a/app/cdash/public/api/v1/addUserNote.php
+++ b/app/cdash/public/api/v1/addUserNote.php
@@ -39,7 +39,6 @@ if (!isset($_REQUEST['AddNote']) || !isset($_REQUEST['Status']) ||
         strlen($_REQUEST['AddNote']) < 1 ||  strlen($_REQUEST['Status']) < 1) {
     $response['error'] = 'No note specified';
     json_error_response($response, 400);
-    return;
 }
 
 // Add the note.

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -58,7 +58,6 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_get')) {
         if (!array_key_exists('currenttime', $_REQUEST)) {
             $response['error'] = "currenttime not specified.";
             json_error_response($response);
-            return;
         }
         $currenttime = pdo_real_escape_numeric($_REQUEST['currenttime']);
         $currentUTCtime = gmdate(FMT_DATETIME, $currenttime);
@@ -110,7 +109,6 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_post')) {
             $response = array();
             $response['error'] = 'newgroupid not specified.';
             json_error_response($response);
-            return;
         }
 
         $newgroupid =
@@ -135,7 +133,6 @@ foreach ($required_params as $param) {
     if (!array_key_exists($param, $_REQUEST)) {
         $response['error'] = "$param not specified.";
         json_error_response($response);
-        return;
     }
 }
 $siteid = pdo_real_escape_numeric($_REQUEST['siteid']);
@@ -161,7 +158,6 @@ if ($method != 'GET') {
     if (!Auth::check()) {
         $response['error'] = 'No session found.';
         json_error_response($response, 401);
-        return;
     }
 
     $project = new Project();
@@ -171,7 +167,6 @@ if ($method != 'GET') {
     if (!ProjectPermissions::userCanEditProject($user, $project)) {
         $response['error'] = 'You do not have permission to access this page';
         json_error_response($response, 403);
-        return;
     }
 }
 

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -141,7 +141,6 @@ function get_repo_url_example()
     $functionname = "get_{$type}_diff_url";
     $example = $functionname($url, 'DIRECTORYNAME', 'FILENAME', 'REVISION');
     json_error_response(['example' => $example], 200);
-    return true;
 }
 
 /** Handle GET requests */

--- a/app/cdash/public/api/v1/relateBuilds.php
+++ b/app/cdash/public/api/v1/relateBuilds.php
@@ -60,11 +60,7 @@ if ($request_method == 'DELETE') {
     if (can_administrate_project($project->Id)) {
         if ($buildRelationship->Exists()) {
             if (!$buildRelationship->Delete($error_msg)) {
-                if ($error_msg) {
-                    json_error_response($error_msg, 400);
-                } else {
-                    json_error_response('Error deleting relationship', 500);
-                }
+                json_error_response('Error deleting relationship', 500);
             }
         }
         json_error_response('', 204);
@@ -89,11 +85,7 @@ if ($request_method == 'POST') {
         $exit_status = 201;
     }
     if (!$buildRelationship->Save($error_msg)) {
-        if ($error_msg) {
-            json_error_response(['error' => $error_msg], 400);
-        } else {
-            json_error_response(['error' => 'Error saving relationship'], 500);
-        }
+        json_error_response(['error' => 'Error saving relationship'], 500);
     }
     json_error_response($buildRelationship->marshal(), $exit_status);
 }

--- a/app/cdash/public/api/v1/testDetails.php
+++ b/app/cdash/public/api/v1/testDetails.php
@@ -39,7 +39,6 @@ if (!isset($buildtestid) || !is_numeric($buildtestid)) {
 $buildtest = BuildTest::where('id', '=', $buildtestid)->first();
 if ($buildtest === null) {
     json_error_response(['error' => 'test not found'], 404);
-    return;
 }
 
 

--- a/app/cdash/public/api/v1/testGraph.php
+++ b/app/cdash/public/api/v1/testGraph.php
@@ -34,7 +34,6 @@ if (is_null($build)) {
 $testid = pdo_real_escape_numeric($_GET['testid']);
 if (!isset($testid) || !is_numeric($testid)) {
     json_error_response(['error' => 'A valid test was not specified.']);
-    return;
 }
 
 $buildtest = BuildTest::where('buildid', '=', $build->Id)
@@ -42,7 +41,6 @@ $buildtest = BuildTest::where('buildid', '=', $build->Id)
     ->first();
 if ($buildtest === null) {
     json_error_response(['error' => 'test not found'], 404);
-    return;
 }
 
 $controller = new Controller($db, $buildtest);

--- a/app/cdash/public/submit.php
+++ b/app/cdash/public/submit.php
@@ -72,7 +72,6 @@ if (!function_exists('PHPErrorHandler')) {
                         LOG_ERR, $projectid, $GLOBALS['PHP_ERROR_BUILD_ID'],
                         $GLOBALS['PHP_ERROR_RESOURCE_TYPE'], $GLOBALS['PHP_ERROR_RESOURCE_ID']);
                     exit();  // stop the script
-                    break;
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "wiki": "http://public.kitware.com/Wiki/CDash"
   },
   "require": {
-    "php": "8.*",
+    "php": "^8.1",
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-json": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12592,16 +12592,6 @@ parameters:
 			path: app/cdash/include/api_common.php
 
 		-
-			message: "#^Function get_param\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: app/cdash/include/api_common.php
-
-		-
-			message: "#^Function json_error_response\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/api_common.php
-
-		-
 			message: "#^Function json_error_response\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/api_common.php
@@ -18496,11 +18486,6 @@ parameters:
 			path: app/cdash/public/api/v1/project.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 2
-			path: app/cdash/public/api/v1/relateBuilds.php
-
-		-
 			message: "#^Call to method RetryHandler\\:\\:increment\\(\\) with incorrect case\\: Increment$#"
 			count: 1
 			path: app/cdash/public/api/v1/requeueSubmissionFile.php
@@ -18968,11 +18953,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: app/cdash/public/submit.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/cdash/public/submit.php
 


### PR DESCRIPTION
PHP 8.1 added the `never` return type.  Since most modern PHP installations, including our default Docker environment, run at least 8.1, I have bumped PHP from 8+ to 8.1+, and added the `never` return type where appropriate.