### PR TITLE
Turn on PHPStan "bleeding edge"

### DIFF
--- a/app/Models/Ldap/User.php
+++ b/app/Models/Ldap/User.php
@@ -8,10 +8,8 @@ class User extends BaseModel
 {
     /**
      * Returns the model's GUID as is (not converted to binary).
-     *
-     * @return string|null
      */
-    public function getConvertedGuid()
+    public function getConvertedGuid(): string
     {
         return $this->getObjectGuid();
     }

--- a/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
+++ b/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
@@ -16,7 +16,6 @@
 namespace CDash\Messaging\Notification\Email;
 
 use CDash\Collection\BuildEmailCollection;
-use CDash\Config;
 use CDash\Messaging\FactoryInterface;
 use CDash\Collection\CollectionInterface;
 use CDash\Messaging\Notification\NotificationCollection;

--- a/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
+++ b/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
@@ -29,25 +29,16 @@ use CDash\Model\BuildEmail;
 
 class EmailBuilder extends SubscriptionNotificationBuilder
 {
-    /** @var string $templateDirectory */
-    private $templateDirectory;
-
-    /** @var string $cacheDirectory */
-    private $cacheDirectory;
-
     public function __construct(FactoryInterface $factory, CollectionInterface $collection)
     {
         parent::__construct($factory, $collection);
-        $this->templateDirectory = __DIR__ . '/Template';
-        $this->cacheDirectory = Config::getInstance()->get('CDASH_ROOT_DIR') . '/log';
     }
 
     /**
      * @param SubscriptionInterface $subscription
      * @param string $templateName
-     * @return EmailMessage|NotificationInterface|null
      */
-    public function createNotification(SubscriptionInterface $subscription, $templateName)
+    public function createNotification(SubscriptionInterface $subscription, $templateName): EmailMessage|NotificationInterface
     {
         $subject_template = "email.{$templateName}.subject";
         $template = "email.{$templateName}";

--- a/app/cdash/include/Messaging/Topic/FixedTopic.php
+++ b/app/cdash/include/Messaging/Topic/FixedTopic.php
@@ -42,7 +42,7 @@ class FixedTopic extends Topic
         }
     }
 
-    public function getTemplate()
+    public function getTemplate(): array
     {
         $templates = [];
         if ($this->topic->hasFixes()) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9682,16 +9682,6 @@ parameters:
 			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
 
 		-
-			message: "#^Property CDash\\\\Messaging\\\\Notification\\\\Email\\\\EmailBuilder\\:\\:\\$cacheDirectory is never read, only written\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
-
-		-
-			message: "#^Property CDash\\\\Messaging\\\\Notification\\\\Email\\\\EmailBuilder\\:\\:\\$templateDirectory is never read, only written\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
-
-		-
 			message: "#^Method CDash\\\\Messaging\\\\Notification\\\\Email\\\\EmailMessage\\:\\:setRecipient\\(\\) has parameter \\$recipient with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Notification/Email/EmailMessage.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27782,6 +27782,11 @@ parameters:
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
+			message: "#^Class DynamicAnalysisHandler has an uninitialized property \\$DynamicAnalysis\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 7
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,6 +17,16 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
 			message: "#^Method App\\\\Console\\\\Commands\\\\AutoRemoveBuilds\\:\\:handle\\(\\) should return mixed but return statement is missing\\.$#"
 			count: 1
 			path: app/Console/Commands/AutoRemoveBuilds.php
@@ -28,6 +38,16 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Console/Commands/MigrateConfig.php
 
@@ -80,6 +100,11 @@ parameters:
 			message: "#^PHPDoc type string of property App\\\\Console\\\\Commands\\\\RemoveUser\\:\\:\\$description is not the same as PHPDoc type string\\|null of overridden property Illuminate\\\\Console\\\\Command\\:\\:\\$description\\.$#"
 			count: 1
 			path: app/Console/Commands/RemoveUser.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
 
 		-
 			message: "#^Method App\\\\Console\\\\Commands\\\\SaveUser\\:\\:handle\\(\\) should return mixed but return statement is missing\\.$#"
@@ -140,6 +165,16 @@ parameters:
 			message: "#^Property App\\\\Exceptions\\\\Handler\\:\\:\\$dontReport type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Exceptions/Handler.php
+
+		-
+			message: "#^Class App\\\\Http\\\\Controllers\\\\AbstractBuildController has an uninitialized property \\$build\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractBuildController.php
+
+		-
+			message: "#^Class App\\\\Http\\\\Controllers\\\\AbstractProjectController has an uninitialized property \\$project\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractProjectController.php
 
 		-
 			message: "#^Call to an undefined static method App\\\\Models\\\\User\\:\\:PasswordHash\\(\\)\\.$#"
@@ -221,13 +256,43 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 11
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\AdminController\\:\\:removeBuilds\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\AdminController\\:\\:upgrade\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 11
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -312,6 +377,16 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:add_file\\(\\) has parameter \\$file with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
@@ -323,6 +398,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:apiBuildSummary\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:buildOverview\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
 
@@ -358,6 +438,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:summary\\(\\) has parameter \\$build_id with no type specified\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:viewFiles\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
 
@@ -482,8 +567,18 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
+			message: "#^Loose comparison using \\=\\= between 1 and 1 will always evaluate to true\\.$#"
 			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 12
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 62
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -494,6 +589,11 @@ parameters:
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:apiCompareCoverage_get_coverage\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:manageCoverage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -567,6 +667,11 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:viewCoverage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:viewCoverage\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 2
 			path: app/Http/Controllers/CoverageController.php
@@ -578,6 +683,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^PHPDoc tag @var with type App\\\\Models\\\\User is not subtype of type Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -640,6 +750,11 @@ parameters:
 			message: "#^Only booleans are allowed in a ternary operator condition, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/IndexController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageBannerController\\:\\:manageBanner\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageBannerController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:show\\(\\) has no return type specified\\.$#"
@@ -705,6 +820,16 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 8
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:register_user\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -735,14 +860,34 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:viewPage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, App\\\\Models\\\\User\\|null given\\.$#"
 			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 6
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
 			message: "#^Variable \\$project_array might not be defined\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageUsersController\\:\\:showPage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageUsersController\\:\\:showPage\\(\\) throws checked exception LogicException but it's missing from the PHPDoc @throws tag\\.$#"
@@ -768,6 +913,21 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\MapController\\:\\:viewMap\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
 			path: app/Http/Controllers/MapController.php
 
 		-
@@ -836,6 +996,11 @@ parameters:
 			path: app/Http/Controllers/OAuthController.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectController.php
+
+		-
 			message: "#^Access to an undefined property object\\:\\:\\$numdefects\\.$#"
 			count: 2
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -873,6 +1038,11 @@ parameters:
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$menu does not exist\\.$#"
 			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
@@ -1149,6 +1319,21 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 22
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:siteStatistics\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$description with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
@@ -1260,6 +1445,21 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the right side\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
@@ -1387,6 +1587,11 @@ parameters:
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\SubProjectController\\:\\:dependenciesGraph\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubProjectController.php
@@ -1397,6 +1602,11 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 3
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/Http/Controllers/SubmissionController.php
 
 		-
@@ -1421,6 +1631,21 @@ parameters:
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 8
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
 			message: """
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -1431,6 +1656,11 @@ parameters:
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
 			count: 3
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/Http/Controllers/TestController.php
 
 		-
@@ -1473,6 +1703,16 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\UserController\\:\\:ReportLastBuild\\(\\) has parameter \\$nightlytime with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/UserController.php
@@ -1489,7 +1729,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 3
+			count: 6
 			path: app/Http/Controllers/UserController.php
 
 		-
@@ -1567,7 +1807,17 @@ parameters:
 			path: app/Http/Middleware/Admin.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckDatabaseConnection.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Middleware\\\\CheckDirectoryPermissions\\:\\:handle\\(\\) throws checked exception UnexpectedValueException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckDirectoryPermissions.php
+
+		-
+			message: "#^PHPDoc tag @var with type DirectoryIterator is not subtype of native type RecursiveIteratorIterator\\<RecursiveDirectoryIterator\\>\\.$#"
 			count: 1
 			path: app/Http/Middleware/CheckDirectoryPermissions.php
 
@@ -1600,6 +1850,11 @@ parameters:
 			message: "#^Property App\\\\Http\\\\Middleware\\\\EncryptCookies\\:\\:\\$except type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Http/Middleware/EncryptCookies.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\User is not subtype of type App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Middleware/PasswordExpired.php
 
 		-
 			message: "#^PHPDoc type array of property App\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except is not the same as PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Foundation\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except\\.$#"
@@ -1649,6 +1904,11 @@ parameters:
 		-
 			message: "#^Instantiated class App\\\\Jobs\\\\GuzzleHttp\\\\Client not found\\.$#"
 			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/Jobs/ProcessSubmission.php
 
 		-
@@ -1807,8 +2067,18 @@ parameters:
 			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
 
 		-
+			message: "#^PHPDoc tag @var with type Illuminate\\\\Contracts\\\\Auth\\\\MustVerifyEmail is not subtype of type Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\.$#"
+			count: 1
+			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
+			path: app/Models/BuildTest.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/Models/BuildTest.php
 
 		-
@@ -1972,7 +2242,7 @@ parameters:
 			path: app/Models/User.php
 
 		-
-			message: "#^PHPDoc type array of property App\\\\Models\\\\User\\:\\:\\$hidden is not the same as PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$hidden\\.$#"
+			message: "#^PHPDoc type array of property App\\\\Models\\\\User\\:\\:\\$hidden is not the same as PHPDoc type list\\<string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$hidden\\.$#"
 			count: 1
 			path: app/Models/User.php
 
@@ -2013,6 +2283,11 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:save\\(\\)\\.$#"
+			count: 1
+			path: app/Providers/CDashDatabaseUserProvider.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Providers/CDashDatabaseUserProvider.php
 
@@ -2160,6 +2435,11 @@ parameters:
 			path: app/Services/NoteCreator.php
 
 		-
+			message: "#^Class App\\\\Services\\\\PageTimer has an uninitialized property \\$duration\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/Services/PageTimer.php
+
+		-
 			message: "#^Method App\\\\Services\\\\PageTimer\\:\\:end\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Services/PageTimer.php
@@ -2170,6 +2450,11 @@ parameters:
 			path: app/Services/PageTimer.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/Services/ProjectPermissions.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\:\\:\\$measurements\\.$#"
 			count: 1
 			path: app/Services/TestCreator.php
@@ -2177,6 +2462,11 @@ parameters:
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
 			count: 2
+			path: app/Services/TestCreator.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/Services/TestCreator.php
 
 		-
@@ -2277,6 +2567,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/Services/UnparsedSubmissionProcessor.php
 
 		-
@@ -2382,6 +2677,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
+			path: app/Validators/Password.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/Validators/Password.php
 
 		-
@@ -2538,6 +2838,16 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 16
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 13
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
@@ -2749,6 +3059,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 10
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\QueryTests\\:\\:addExtraMeasurements\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
@@ -2807,6 +3122,11 @@ parameters:
 			message: "#^Variable \\$parent_build might not be defined\\.$#"
 			count: 3
 			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ResultsApi.php
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\ResultsApi\\:\\:determineDateRange\\(\\) has no return type specified\\.$#"
@@ -2964,6 +3284,16 @@ parameters:
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 8
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\TestDetails\\:\\:getRelatedBuildTest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestDetails.php
@@ -3004,6 +3334,16 @@ parameters:
 			path: app/cdash/app/Controller/Api/TestGraph.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/TestGraph.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestGraph.php
+
+		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\TestGraph\\:\\:getResponse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestGraph.php
@@ -3030,6 +3370,11 @@ parameters:
 
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$tests_response does not exist\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestOverview.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestOverview.php
 
@@ -3069,6 +3414,16 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$start_of_day with its key variable\\.$#"
 			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
@@ -3157,6 +3512,16 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:getProjects\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewProjects.php
@@ -3225,6 +3590,16 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$test with its value variable\\.$#"
 			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 8
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 11
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
@@ -3434,11 +3809,6 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: """
 				#^Fetching deprecated class constant AUTH_ACCESS_TOKEN of class Github\\\\Client\\:
 				Use the AuthMethod const$#
@@ -3453,6 +3823,11 @@ parameters:
 
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$cached_commits might not exist\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
@@ -3829,6 +4204,16 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 12
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 34
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4030,6 +4415,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GenerateUuid\\(\\) has parameter \\$subprojectname with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetBuildEmailCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4555,6 +4945,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$test$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(BuildEmailCollection;\\)\\: Unexpected token \";\", expected TOKEN_HORIZONTAL_WS at offset 196 on line 6$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -5392,6 +5787,11 @@ parameters:
 			path: app/cdash/app/Model/BuildFailure.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildFailure.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildFailure\\:\\:AddArgument\\(\\) has parameter \\$argument with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildFailure.php
@@ -5601,6 +6001,16 @@ parameters:
 			path: app/cdash/app/Model/BuildGroup.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroup\\:\\:FillFromRow\\(\\) has parameter \\$row with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroup.php
@@ -5790,6 +6200,11 @@ parameters:
 			path: app/cdash/app/Model/BuildGroupRule.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildGroupRule.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:ChangeGroup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
@@ -5946,6 +6361,11 @@ parameters:
 			path: app/cdash/app/Model/BuildInformation.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/app/Model/BuildInformation.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildInformation\\:\\:Fill\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildInformation.php
@@ -6092,6 +6512,16 @@ parameters:
 				v2\\.5\\.0 01/22/2018$#
 			"""
 			count: 6
+			path: app/cdash/app/Model/BuildRelationship.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildRelationship.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/cdash/app/Model/BuildRelationship.php
 
 		-
@@ -6243,6 +6673,16 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildUpdate\\:\\:AddFile\\(\\) has parameter \\$file with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdate.php
@@ -6358,6 +6798,11 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdateFile.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
@@ -6626,6 +7071,11 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFile.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\CoverageFile\\:\\:GetIdFromName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile.php
@@ -6753,6 +7203,11 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 10
+			path: app/cdash/app/Model/CoverageFile2User.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\CoverageFile2User\\:\\:GetCoverageFileId\\(\\) has parameter \\$buildid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
@@ -6805,6 +7260,16 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 3
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 3
 			path: app/cdash/app/Model/CoverageFileLog.php
 
@@ -7246,6 +7711,11 @@ parameters:
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 6
+			path: app/cdash/app/Model/DynamicAnalysis.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\DynamicAnalysis\\:\\:AddDefect\\(\\) has parameter \\$defect with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
@@ -7387,6 +7857,11 @@ parameters:
 			path: app/cdash/app/Model/DynamicAnalysisDefect.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/DynamicAnalysisDefect.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\DynamicAnalysisDefect\\:\\:\\$DynamicAnalysisId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/DynamicAnalysisDefect.php
@@ -7502,6 +7977,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/cdash/app/Model/Image.php
 
 		-
@@ -7874,6 +8354,11 @@ parameters:
 			path: app/cdash/app/Model/PendingSubmissions.php
 
 		-
+			message: "#^Access to an uninitialized property CDash\\\\Model\\\\Project\\:\\:\\$AutoremoveMaxBuilds\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -7963,6 +8448,16 @@ parameters:
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$rep might not exist\\.$#"
 			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 5
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8277,6 +8772,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, array\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects 0\\|2, false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8705,6 +9205,11 @@ parameters:
 			path: app/cdash/app/Model/SubProject.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:CommonBuildQuery\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
@@ -8838,6 +9343,11 @@ parameters:
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 3
 			path: app/cdash/app/Model/SubProjectGroup.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getLabels\\(\\) has invalid return type CDash\\\\Model\\\\Collection\\.$#"
@@ -8996,6 +9506,16 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
+			path: app/cdash/app/Model/User.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/User.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/cdash/app/Model/User.php
 
 		-
@@ -9202,6 +9722,11 @@ parameters:
 			path: app/cdash/app/Model/UserProject.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/UserProject.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\UserProject\\:\\:AddCredential\\(\\) has parameter \\$credential with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/UserProject.php
@@ -9337,6 +9862,16 @@ parameters:
 			path: app/cdash/include/CDash/Config.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/include/CDash/Config.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Config.php
+
+		-
 			message: "#^Method CDash\\\\Config\\:\\:get\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Config.php
@@ -9458,6 +9993,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\ServiceContainer\\:\\:singleton\\(\\) has parameter \\$class_name with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/ServiceContainer.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\ServiceContainer is not subtype of type static\\(CDash\\\\ServiceContainer\\)\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/ServiceContainer.php
 
@@ -10137,6 +10677,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
+
+		-
 			message: "#^Method CDash\\\\Messaging\\\\Topic\\\\BuildErrorTopic\\:\\:getFixes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
@@ -10552,11 +11097,6 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/Topic.php
 
 		-
-			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Topic/Topic.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, CDash\\\\Collection\\\\BuildCollection given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/Topic.php
@@ -10810,6 +11350,16 @@ parameters:
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
+			message: "#^Access to an undefined property CDash\\\\Test\\\\UseCase\\\\UseCase\\:\\:\\$missingTests\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
+			message: "#^Access to an undefined property PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\:\\:\\$Errors\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
 			message: "#^Access to an undefined property PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\:\\:\\$Id\\.$#"
 			count: 5
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
@@ -10854,6 +11404,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Build\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
+			message: "#^PHPDoc tag @var with type Build is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
 
@@ -11859,6 +12414,11 @@ parameters:
 			path: app/cdash/include/api_common.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/api_common.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
 			path: app/cdash/include/api_common.php
@@ -12428,6 +12988,16 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 5
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 10
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 3
 			path: app/cdash/include/common.php
@@ -12572,6 +13142,16 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
 			message: "#^Access to an undefined property object\\:\\:\\$Id\\.$#"
 			count: 1
 			path: app/cdash/include/ctestparserutils.php
@@ -12678,6 +13258,16 @@ parameters:
 		-
 			message: "#^Function extract_type_from_buildstamp\\(\\) has parameter \\$buildstamp with no type specified\\.$#"
 			count: 1
+			path: app/cdash/include/ctestparserutils.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparserutils.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
 			path: app/cdash/include/ctestparserutils.php
 
 		-
@@ -12909,6 +13499,16 @@ parameters:
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$results does not exist\\.$#"
 			count: 3
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 6
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 15
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -13192,6 +13792,16 @@ parameters:
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 16
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
 			message: "#^Method CompareCoveragePhpFilters\\:\\:getDefaultFilter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/filterdataFunctions.php
@@ -13368,6 +13978,11 @@ parameters:
 
 		-
 			message: "#^Method ViewTestPhpFilters\\:\\:getSqlField\\(\\) has parameter \\$field with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/filterdataFunctions.php
 
@@ -13574,6 +14189,11 @@ parameters:
 
 		-
 			message: "#^Instanceof between PDOStatement and PDOStatement will always evaluate to true\\.$#"
+			count: 1
+			path: app/cdash/include/pdo.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
@@ -14833,6 +15453,16 @@ parameters:
 			path: app/cdash/include/repository.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 29
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 2
 			path: app/cdash/include/repository.php
@@ -14846,6 +15476,16 @@ parameters:
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
+			count: 2
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Access to an undefined property UpdateHandler\\:\\:\\$BuildId\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
 
 		-
 			message: "#^Anonymous function has an unused use \\$buildid\\.$#"
@@ -14929,6 +15569,16 @@ parameters:
 		-
 			message: "#^Function get_email_summary\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
 			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 7
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 14
 			path: app/cdash/include/sendemail.php
 
 		-
@@ -15393,6 +16043,16 @@ parameters:
 			path: app/cdash/include/upgrade_functions.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 18
+			path: app/cdash/include/upgrade_functions.php
+
+		-
 			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
@@ -15425,6 +16085,16 @@ parameters:
 
 		-
 			message: "#^Function handle_error\\(\\) has parameter \\$msg with no type specified\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
@@ -15500,6 +16170,11 @@ parameters:
 
 		-
 			message: "#^Function rest_put not found\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/build.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/build.php
 
@@ -15619,6 +16294,11 @@ parameters:
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 5
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -15690,6 +16370,16 @@ parameters:
 			message: "#^Function CDash\\\\Api\\\\v1\\\\ComputeClassifier\\\\value_to_string\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
@@ -15817,6 +16507,11 @@ parameters:
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/getSubmissionFile.php
@@ -15890,6 +16585,16 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
 			message: "#^Variable \\$user2project might not be defined\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/manageBuildGroup.php
@@ -15929,6 +16634,11 @@ parameters:
 
 		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\ManageMeasurements\\\\rest_post\\(\\) has parameter \\$projectid with no type specified\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageMeasurements.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/manageMeasurements.php
 
@@ -16098,6 +16808,11 @@ parameters:
 			path: app/cdash/public/api/v1/project.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Variable \\$filetype might not be defined\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
@@ -16106,6 +16821,11 @@ parameters:
 			message: "#^Variable property access on mixed\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/relateBuilds.php
 
 		-
 			message: "#^Call to method RetryHandler\\:\\:increment\\(\\) with incorrect case\\: Increment$#"
@@ -16604,6 +17324,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/DatabaseTest.php
 
 		-
+			message: "#^PHPDoc tag @var with type PDOStatement&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/DatabaseTest.php
+
+		-
 			message: "#^Call to an undefined method CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\|CDash\\\\Test\\\\UseCase\\\\ConfigUseCase\\|CDash\\\\Test\\\\UseCase\\\\TestUseCase\\|CDash\\\\Test\\\\UseCase\\\\UpdateUseCase\\:\\:setChecker\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
@@ -16763,6 +17488,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$parser contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/MessengerTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type AbstractHandler&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/MessengerTest.php
 
@@ -16955,6 +17685,31 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
+			message: "#^PHPDoc tag @var with type ActionableBuildInterface&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type App\\\\Models\\\\Site is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\BuildGroup&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Project is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
 			message: "#^Property CommitAuthorSubscriptionBuilderTest\\:\\:\\$diff has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
@@ -17088,6 +17843,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
+
+		-
 			message: "#^Property UserSubscriptionBuilderTest\\:\\:\\$diff has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -17137,6 +17897,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$build contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
 
@@ -17310,6 +18075,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$build contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 2
+			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
@@ -17627,6 +18397,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
 
 		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
+
+		-
 			message: "#^Property FixedTopicTest\\:\\:\\$diff has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
@@ -17727,6 +18502,11 @@ parameters:
 		-
 			message: "#^PHPDoc tag @var for variable \\$build2 contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 2
+			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
+			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
 
 		-
@@ -17894,6 +18674,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$build contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
@@ -18137,6 +18922,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$build contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
 
@@ -18589,6 +19379,11 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$sut contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 
@@ -19196,6 +19991,16 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$tests contains generic class Illuminate\\\\Support\\\\Collection but does not specify its types\\: TKey, TValue$#"
+			count: 4
+			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type CDash\\\\Test\\\\UseCase\\\\UseCase is not subtype of type CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\|CDash\\\\Test\\\\UseCase\\\\ConfigUseCase\\|CDash\\\\Test\\\\UseCase\\\\TestUseCase\\|CDash\\\\Test\\\\UseCase\\\\UpdateUseCase\\.$#"
+			count: 5
+			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
+
+		-
+			message: "#^PHPDoc tag @var with type Illuminate\\\\Support\\\\Collection is not subtype of type CDash\\\\Model\\\\TestCollection\\.$#"
 			count: 4
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
@@ -19857,6 +20662,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_test_manager.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/kwtest/kw_test_manager.php
+
+		-
 			message: "#^Method TestManager\\:\\:_installdb4test\\(\\) has parameter \\$port with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_test_manager.php
@@ -19940,6 +20750,16 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
@@ -20388,16 +21208,6 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_web_tester.php
-
-		-
-			message: "#^Parameter \\#1 \\$page of method KWWebTestCase\\:\\:analyse\\(\\) expects object, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_web_tester.php
-
-		-
 			message: "#^Parameter \\#1 \\$prefix of function uniqid expects string, int\\<0, max\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -20414,6 +21224,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$encoding \\(SimpleEncoding\\) of method CDashControllerUserAgent\\:\\:fetch\\(\\) should be contravariant with parameter \\$encoding \\(SimpleFormEncoding\\) of method SimpleUserAgent\\:\\:fetch\\(\\)$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -20865,6 +21680,11 @@ parameters:
 			path: app/cdash/tests/test_aggregatecoverage.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
 			message: "#^Method AggregateCoverageTestCase\\:\\:checkCoverage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatecoverage.php
@@ -20906,6 +21726,16 @@ parameters:
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
 
@@ -21065,6 +21895,11 @@ parameters:
 			path: app/cdash/tests/test_authtoken.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
 			message: "#^Method AuthTokenTestCase\\:\\:normalSubmit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
@@ -21170,7 +22005,7 @@ parameters:
 			path: app/cdash/tests/test_authtoken.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
 
@@ -21288,6 +22123,11 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
 			message: "#^Method AutoRemoveBuildsOnSubmitTestCase\\:\\:enableAutoRemoveConfigSetting\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -21339,6 +22179,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 14
 			path: app/cdash/tests/test_bazeljson.php
 
 		-
@@ -21458,6 +22303,11 @@ parameters:
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
 			message: "#^Method BranchCoverageTestCase\\:\\:clearPriorBranchCoverageResults\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
@@ -21493,8 +22343,8 @@ parameters:
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 2
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
+			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
@@ -21573,6 +22423,16 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_builddetails.php
+
+		-
 			message: "#^Method BuildDetailsTestCase\\:\\:__construct\\(\\) with return type void returns int but should not return anything\\.$#"
 			count: 1
 			path: app/cdash/tests/test_builddetails.php
@@ -21610,11 +22470,6 @@ parameters:
 		-
 			message: "#^Method BuildDetailsTestCase\\:\\:testViewTestReturnsProperFormatForParentBuilds\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/cdash/tests/test_builddetails.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 7
 			path: app/cdash/tests/test_builddetails.php
 
 		-
@@ -21662,6 +22517,11 @@ parameters:
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 9
+			path: app/cdash/tests/test_buildfailuredetails.php
+
+		-
 			message: "#^Method BuildFailureDetailsTestCase\\:\\:testBuildFailureDetails\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildfailuredetails.php
@@ -21699,6 +22559,16 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildgrouprule.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildgrouprule.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildgrouprule.php
 
@@ -21741,6 +22611,11 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 3
+			path: app/cdash/tests/test_buildmodel.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
 			path: app/cdash/tests/test_buildmodel.php
 
 		-
@@ -21848,6 +22723,11 @@ parameters:
 
 		-
 			message: "#^Empty array passed to foreach\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildproperties.php
 
@@ -22074,6 +22954,11 @@ parameters:
 			path: app/cdash/tests/test_committerinfo.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_committerinfo.php
+
+		-
 			message: "#^Method CommitterInfoTestCase\\:\\:testCommitterInfo\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_committerinfo.php
@@ -22091,6 +22976,16 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$file with its value variable\\.$#"
 			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/cdash/tests/test_compressedtest.php
 
 		-
@@ -22127,6 +23022,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/tests/test_configurewarnings.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
 			path: app/cdash/tests/test_configurewarnings.php
 
 		-
@@ -22171,6 +23071,11 @@ parameters:
 			path: app/cdash/tests/test_consistenttestingday.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
 			message: "#^Method CoverageDirectoriesTestCase\\:\\:testCoverageDirectories\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_coveragedirectories.php
@@ -22199,11 +23104,6 @@ parameters:
 		-
 			message: "#^Method CreateProjectPermissionsTestCase\\:\\:testCreateProjectPermissions\\(\\) throws checked exception PDOException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
-			path: app/cdash/tests/test_createprojectpermissions.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 11
 			path: app/cdash/tests/test_createprojectpermissions.php
 
 		-
@@ -22256,6 +23156,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 6
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
@@ -22350,11 +23255,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
@@ -22458,11 +23358,6 @@ parameters:
 
 		-
 			message: "#^Method DeferredSubmissionsTestCase\\:\\:verifyNormalSubmission\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_deferredsubmissions.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_deferredsubmissions.php
 
@@ -22638,6 +23533,16 @@ parameters:
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_dynamicanalysissummary.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_dynamicanalysissummary.php
+
+		-
 			message: "#^Method DynamicAnalysisSummaryTestCase\\:\\:VerifyStandaloneBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_dynamicanalysissummary.php
@@ -22705,11 +23610,6 @@ parameters:
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 3
-			path: app/cdash/tests/test_edituser.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 7
 			path: app/cdash/tests/test_edituser.php
 
 		-
@@ -22804,6 +23704,11 @@ parameters:
 			path: app/cdash/tests/test_excludesubprojects.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
 			message: "#^Method ExcludeSubProjectsTestCase\\:\\:testExcludeAllButOneSubProject\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_excludesubprojects.php
@@ -22847,6 +23752,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/cdash/tests/test_expectedandmissing.php
 
 		-
@@ -22896,6 +23806,11 @@ parameters:
 			path: app/cdash/tests/test_expiredbuildrules.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expiredbuildrules.php
+
+		-
 			message: "#^Method ExpiredBuildRulesTestCase\\:\\:checkForGroup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_expiredbuildrules.php
@@ -22937,6 +23852,11 @@ parameters:
 			message: "#^Method ExtractTarTestCase\\:\\:testExtractTarArchiveTarWithInvalidFile\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_extracttar.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filterblocks.php
 
 		-
 			message: "#^Method FilterBlocksTestCase\\:\\:testFilterBlocks\\(\\) has no return type specified\\.$#"
@@ -23006,6 +23926,11 @@ parameters:
 			path: app/cdash/tests/test_filterbuilderrors.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterbuilderrors.php
+
+		-
 			message: "#^Method FilterBuildErrorsTestCase\\:\\:testFilterBuildErrors\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_filterbuilderrors.php
@@ -23037,6 +23962,11 @@ parameters:
 			path: app/cdash/tests/test_filtertestlabels.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
 			message: "#^Method FilterTestLabelsTestCase\\:\\:testFilterLabels\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_filtertestlabels.php
@@ -23052,6 +23982,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 16
 			path: app/cdash/tests/test_hidecolumns.php
 
 		-
@@ -23119,6 +24054,11 @@ parameters:
 			message: "#^Property ImageComparisonTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_imagecomparison.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
 
 		-
 			message: "#^Method IndexFiltersTestCase\\:\\:filter\\(\\) has no return type specified\\.$#"
@@ -23205,12 +24145,12 @@ parameters:
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
-			message: "#^Method IssueCreationTestCase\\:\\:testIssueCreation\\(\\) has no return type specified\\.$#"
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
+			message: "#^Method IssueCreationTestCase\\:\\:testIssueCreation\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_issuecreation.php
 
@@ -23230,32 +24170,22 @@ parameters:
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
 			message: "#^Method JavaJSONCoverageTestCase\\:\\:testJavaJSONCoverage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_javajsoncoverage.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
-			path: app/cdash/tests/test_javajsoncoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_javajsoncoverage.php
+			path: app/cdash/tests/test_jscovercoverage.php
 
 		-
 			message: "#^Method JSCoverCoverageTestCase\\:\\:testJSCoverCoverage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_jscovercoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_jscovercoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_jscovercoverage.php
 
@@ -23384,16 +24314,21 @@ parameters:
 			path: app/cdash/tests/test_managebanner.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_managebanner.php
-
-		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 21
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 9
 			path: app/cdash/tests/test_managemeasurements.php
 
 		-
@@ -23542,11 +24477,6 @@ parameters:
 			path: app/cdash/tests/test_manageusers.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_manageusers.php
-
-		-
 			message: """
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
@@ -23565,6 +24495,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 5
 			path: app/cdash/tests/test_multicoverage.php
 
 		-
@@ -23595,16 +24530,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 2
-			path: app/cdash/tests/test_multicoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_multicoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 1
 			path: app/cdash/tests/test_multicoverage.php
 
 		-
@@ -23656,6 +24581,16 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$build with its value variable\\.$#"
 			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 32
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -23789,6 +24724,11 @@ parameters:
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_namedmeasurements.php
+
+		-
 			message: "#^Method NamedMeasurementsTestCase\\:\\:testNamedMeasurements\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_namedmeasurements.php
@@ -23820,17 +24760,17 @@ parameters:
 			path: app/cdash/tests/test_nobackup.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_nobackup.php
+
+		-
 			message: "#^Method NoBackupTestCase\\:\\:testNoBackup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_nobackup.php
 
 		-
 			message: "#^Method NoBackupTestCase\\:\\:testNoBackup\\(\\) throws checked exception PDOException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/cdash/tests/test_nobackup.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_nobackup.php
 
@@ -23863,6 +24803,11 @@ parameters:
 			path: app/cdash/tests/test_notesapi.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_notesapi.php
+
+		-
 			message: "#^Method NotesAPICase\\:\\:testNotesAPI\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_notesapi.php
@@ -23888,6 +24833,11 @@ parameters:
 			path: app/cdash/tests/test_numericupdate.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
 			message: "#^Method OpenCoverCoverageTestCase\\:\\:tearDown\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_opencovercoverage.php
@@ -23900,16 +24850,6 @@ parameters:
 		-
 			message: "#^Method OpenCoverCoverageTestCase\\:\\:testOpenCoverCoverageWithDataJson\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/cdash/tests/test_opencovercoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_opencovercoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 2
 			path: app/cdash/tests/test_opencovercoverage.php
 
 		-
@@ -23946,6 +24886,11 @@ parameters:
 			message: "#^Property ParallelSubmissionsTestCase\\:\\:\\$Original has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_parallelsubmissions.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_passwordcomplexity.php
 
 		-
 			message: "#^Method PasswordComplexityTestCase\\:\\:complexityTest\\(\\) has no return type specified\\.$#"
@@ -24172,21 +25117,6 @@ parameters:
 			path: app/cdash/tests/test_pubproject.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_pubproject.php
-
-		-
-			message: "#^Parameter \\#1 \\$mystring of method KWWebTestCase\\:\\:findString\\(\\) expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_pubproject.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of method WebTestCase\\:\\:assertText\\(\\) expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_pubproject.php
-
-		-
 			message: "#^Property PubProjectTestCase\\:\\:\\$ProjectId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_pubproject.php
@@ -24245,6 +25175,11 @@ parameters:
 			path: app/cdash/tests/test_putdynamicbuilds.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_querytests.php
+
+		-
 			message: "#^Method QueryTestsTestCase\\:\\:testQueryTests\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_querytests.php
@@ -24268,6 +25203,11 @@ parameters:
 			message: "#^Method RecoverPasswordTestCase\\:\\:testRecoverPassword\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_recoverpassword.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_redundanttests.php
 
 		-
 			message: "#^Method RedundantTestsTestCase\\:\\:testRedundantTests\\(\\) has no return type specified\\.$#"
@@ -24298,6 +25238,11 @@ parameters:
 			message: "#^Property RegisterUserTestCase\\:\\:\\$project is unused\\.$#"
 			count: 1
 			path: app/cdash/tests/test_registeruser.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_rehashpassword.php
 
 		-
 			message: "#^Method RehashPasswordTestCase\\:\\:testSubscribeProjectShowsLabels\\(\\) has no return type specified\\.$#"
@@ -24568,6 +25513,11 @@ parameters:
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 23
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
 			message: "#^Method SequenceIndependenceTestCase\\:\\:PerformOrderTest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_sequenceindependence.php
@@ -24662,11 +25612,6 @@ parameters:
 
 		-
 			message: "#^Method SiteStatisticsTestCase\\:\\:testSiteStatistics\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_sitestatistics.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_sitestatistics.php
 
@@ -24836,6 +25781,16 @@ parameters:
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
 			message: "#^Method SubProjectNextPreviousTestCase\\:\\:testSubProjectNextPrevious\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
@@ -24865,6 +25820,11 @@ parameters:
 			message: "#^Property SubProjectOrderTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
 
 		-
 			message: "#^Method SubProjectTestFiltersTestCase\\:\\:testSubProjectTestFilters\\(\\) has no return type specified\\.$#"
@@ -24971,6 +25931,11 @@ parameters:
 			path: app/cdash/tests/test_testgraphpermissions.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
 			message: "#^Method TestGraphPermissionsTestCase\\:\\:__construct\\(\\) throws checked exception PDOException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testgraphpermissions.php
@@ -24991,16 +25956,6 @@ parameters:
 			path: app/cdash/tests/test_testgraphpermissions.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_testgraphpermissions.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 4
-			path: app/cdash/tests/test_testgraphpermissions.php
-
-		-
 			message: "#^Property TestGraphPermissionsTestCase\\:\\:\\$build has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testgraphpermissions.php
@@ -25013,6 +25968,11 @@ parameters:
 		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 5
 			path: app/cdash/tests/test_testhistory.php
 
 		-
@@ -25061,6 +26021,11 @@ parameters:
 			path: app/cdash/tests/test_testhistory.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testimages.php
+
+		-
 			message: "#^Method TestImagesTestCase\\:\\:testTestImages\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testimages.php
@@ -25097,16 +26062,21 @@ parameters:
 			path: app/cdash/tests/test_testoverview.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 7
-			path: app/cdash/tests/test_testoverview.php
-
-		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
 			path: app/cdash/tests/test_timeline.php
 
 		-
@@ -25249,6 +26219,11 @@ parameters:
 			path: app/cdash/tests/test_timestatus.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timestatus.php
+
+		-
 			message: "#^Method TimeStatusTestCase\\:\\:testTimeStatus\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timestatus.php
@@ -25337,6 +26312,16 @@ parameters:
 			path: app/cdash/tests/test_truncateoutput.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
 			message: "#^Method TruncateOutputTestCase\\:\\:removeBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_truncateoutput.php
@@ -25395,6 +26380,16 @@ parameters:
 				#^Call to deprecated method query\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_uniquediffs.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uniquediffs.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uniquediffs.php
 
@@ -25477,6 +26472,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_updateappend.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 11
 			path: app/cdash/tests/test_updateappend.php
 
 		-
@@ -25591,6 +26591,16 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 17
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 9
+			path: app/cdash/tests/test_upgrade.php
+
+		-
 			message: "#^Method UpgradeTestCase\\:\\:getMaintenancePage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_upgrade.php
@@ -25671,6 +26681,11 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
 			message: "#^Method UploadFileTestCase\\:\\:testSubmitUploadXML\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uploadfile.php
@@ -25701,6 +26716,11 @@ parameters:
 			path: app/cdash/tests/test_uploadfile.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_user.php
+
+		-
 			message: "#^Method UserTestCase\\:\\:testUser\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_user.php
@@ -25719,11 +26739,6 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 1
-			path: app/cdash/tests/test_usernotes.php
-
-		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 3
 			path: app/cdash/tests/test_usernotes.php
 
 		-
@@ -25786,11 +26801,6 @@ parameters:
 			path: app/cdash/tests/test_viewdynamicanalysisfile.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_viewdynamicanalysisfile.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewmap.php
@@ -25804,6 +26814,11 @@ parameters:
 			message: "#^Method ViewSubProjectsTestCase\\:\\:testViewSubProjects\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojectslinkoption.php
 
 		-
 			message: "#^Method ViewSubProjectsLinkOptionTestCase\\:\\:getTrilinosLink\\(\\) has no return type specified\\.$#"
@@ -25829,6 +26844,16 @@ parameters:
 			message: "#^Property ViewSubProjectsLinkOptionTestCase\\:\\:\\$project is unused\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewsubprojectslinkoption.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 4
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
 			message: "#^Method TrilinosSubmissionTestCase\\:\\:submitFiles\\(\\) has no return type specified\\.$#"
@@ -25924,6 +26949,11 @@ parameters:
 
 		-
 			message: "#^Foreach overwrites \\$line with its value variable\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
@@ -26214,6 +27244,16 @@ parameters:
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
 			message: "#^Method GCovTarHandler\\:\\:Parse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
@@ -26360,6 +27400,11 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
 			message: "#^Method JSCoverTarHandler\\:\\:Parse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -26413,6 +27458,16 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
@@ -26526,6 +27581,11 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$coverageSummary with its value variable\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 6
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
 
 		-
@@ -26729,6 +27789,11 @@ parameters:
 		-
 			message: "#^Class stack referenced with incorrect case\\: Stack\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/abstract_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/abstract_handler.php
 
 		-
@@ -26997,6 +28062,11 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 30
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
 			message: "#^Method BuildHandler\\:\\:GetCommitAuthors\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
@@ -27202,6 +28272,11 @@ parameters:
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 14
+			path: app/cdash/xml_handlers/configure_handler.php
+
+		-
 			message: "#^Method ConfigureHandler\\:\\:CreateBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/configure_handler.php
@@ -27367,6 +28442,11 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 12
+			path: app/cdash/xml_handlers/coverage_handler.php
+
+		-
 			message: "#^Method CoverageHandler\\:\\:__construct\\(\\) has parameter \\$projectID with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/coverage_handler.php
@@ -27459,6 +28539,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/coverage_junit_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 14
 			path: app/cdash/xml_handlers/coverage_junit_handler.php
 
 		-
@@ -27567,6 +28652,11 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 7
+			path: app/cdash/xml_handlers/coverage_log_handler.php
+
+		-
 			message: "#^Method CoverageLogHandler\\:\\:__construct\\(\\) has parameter \\$projectID with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/coverage_log_handler.php
@@ -27662,6 +28752,11 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/done_handler.php
+
+		-
 			message: "#^Method DoneHandler\\:\\:__construct\\(\\) has parameter \\$projectID with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/done_handler.php
@@ -27743,7 +28838,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property DynamicAnalysisHandler\\:\\:\\$BuildName\\.$#"
-			count: 4
+			count: 5
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
@@ -27779,6 +28874,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 7
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 23
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
@@ -27937,6 +29037,16 @@ parameters:
 			path: app/cdash/xml_handlers/note_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 5
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
 			message: "#^Method NoteHandler\\:\\:__construct\\(\\) has parameter \\$projectID with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/note_handler.php
@@ -28073,6 +29183,16 @@ parameters:
 			path: app/cdash/xml_handlers/project_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/project_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 9
+			path: app/cdash/xml_handlers/project_handler.php
+
+		-
 			message: "#^Method ProjectHandler\\:\\:__construct\\(\\) has parameter \\$projectid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/project_handler.php
@@ -28171,6 +29291,11 @@ parameters:
 			message: "#^Property ProjectHandler\\:\\:\\$SubProjects has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/project_handler.php
+
+		-
+			message: "#^Class RetryHandler has an uninitialized property \\$Retries\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/retry_handler.php
 
 		-
 			message: "#^Method RetryHandler\\:\\:__construct\\(\\) has parameter \\$filename with no type specified\\.$#"
@@ -28363,6 +29488,11 @@ parameters:
 			path: app/cdash/xml_handlers/sax_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/stack.php
+
+		-
 			message: "#^Method stack\\:\\:at\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/stack.php
@@ -28425,6 +29555,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 5
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 35
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
@@ -28603,6 +29738,11 @@ parameters:
 			path: app/cdash/xml_handlers/testing_junit_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 21
+			path: app/cdash/xml_handlers/testing_junit_handler.php
+
+		-
 			message: "#^Method TestingJUnitHandler\\:\\:__construct\\(\\) has parameter \\$projectID with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/testing_junit_handler.php
@@ -28753,6 +29893,16 @@ parameters:
 			path: app/cdash/xml_handlers/update_handler.php
 
 		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 9
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 23
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
 			message: "#^Method UpdateHandler\\:\\:GetCommitAuthors\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/update_handler.php
@@ -28861,6 +30011,16 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 11
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
@@ -29099,6 +30259,11 @@ parameters:
 			path: database/migrations/2020_01_10_120602_drop_cdash_at_home.php
 
 		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 3
+			path: database/migrations/2020_02_17_112005_reformat_test_data.php
+
+		-
 			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: database/migrations/2020_02_17_112005_reformat_test_data.php
@@ -29291,6 +30456,26 @@ parameters:
 			message: "#^Property Tests\\\\Feature\\\\ProjectPermissions\\:\\:\\$public_project has no type specified\\.$#"
 			count: 1
 			path: tests/Feature/ProjectPermissions.php
+
+		-
+			message: "#^Class Tests\\\\Feature\\\\PurgeUnusedProjectsCommand has an uninitialized property \\$project1\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: tests/Feature/PurgeUnusedProjectsCommand.php
+
+		-
+			message: "#^Class Tests\\\\Feature\\\\PurgeUnusedProjectsCommand has an uninitialized property \\$project2\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: tests/Feature/PurgeUnusedProjectsCommand.php
+
+		-
+			message: "#^@dataProvider adminRoutes related method must be public\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
+
+		-
+			message: "#^@dataProvider protectedRoutes related method must be public\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
 
 		-
 			message: "#^Method Tests\\\\Feature\\\\RouteAccessTest\\:\\:adminRoutes\\(\\) is unused\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,6 +31,7 @@ parameters:
 
     treatPhpDocTypesAsCertain: false
     checkUninitializedProperties: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
 
     level: 6
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,7 @@ parameters:
             missingCheckedExceptionInThrows: true
 
     treatPhpDocTypesAsCertain: false
+    checkUninitializedProperties: true
 
     level: 6
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,4 +36,5 @@ parameters:
     level: 6
 
 includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - phpstan-baseline.neon


### PR DESCRIPTION
PHPStan offers a set of "bleeding edge" rules which are the stable rules which will be added in the next major release.  We already use many of these rules through our usage of various optional packages, but there's no reason to not turn on additional static analysis rules.  The only major difference between bleeding edge and our current setup is that bleeding edge mandates usage of the strict equality (`===` and `!==`) operators.  We already use the optional exception-checking rules which are included in bleeding edge.

In addition to adding the bleeding edge rules, I have also enabled two more optional rules which are not included in any of our optional packages.