### PR TITLE
Use Laravel gates for project permissions checking

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -17,6 +17,7 @@ use CDash\Model\Site;
 use CDash\Model\UserProject;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 require_once 'include/filterdataFunctions.php';
@@ -68,7 +69,7 @@ class CoverageController extends AbstractController
         /** @var User $User */
         $User = Auth::user();
         $Project->Id = $projectid;
-        if (!ProjectPermissions::userCanEditProject($User, $Project)) {
+        if (!Gate::allows('edit-project', $Project)) {
             return view('cdash', [
                 'xsl' => true,
                 'xsl_content' => "You don't have the permissions to access this page"

--- a/app/Http/Controllers/EditProjectController.php
+++ b/app/Http/Controllers/EditProjectController.php
@@ -7,6 +7,7 @@ require_once 'include/defines.php';
 use App\Services\ProjectPermissions;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class EditProjectController extends ProjectController
 {
@@ -33,7 +34,7 @@ class EditProjectController extends ProjectController
         if (!Auth::check()) {
             return $this->redirectToLogin();
         }
-        if (ProjectPermissions::userCanCreateProject(Auth::user())) {
+        if (Gate::allows('create-project')) {
             $project_name = 'CDash';
             return view('admin.project')
                 ->with('cdashCss', $this->cdashCss)
@@ -57,7 +58,7 @@ class EditProjectController extends ProjectController
         if (!$this->project->Exists()) {
             abort(404);
         }
-        if (ProjectPermissions::userCanEditProject(Auth::user(), $this->project)) {
+        if (Gate::allows('edit-project', $this->project)) {
             return view('admin.project')
                 ->with('cdashCss', $this->cdashCss)
                 ->with('date', json_encode($this->date))

--- a/app/Http/Controllers/ManageBannerController.php
+++ b/app/Http/Controllers/ManageBannerController.php
@@ -8,6 +8,7 @@ use CDash\Model\Banner;
 use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class ManageBannerController extends AbstractController
@@ -57,7 +58,7 @@ class ManageBannerController extends AbstractController
 
         $project->Id = $projectid;
 
-        if (!ProjectPermissions::userCanEditProject($user, $project)) {
+        if (!Gate::allows('edit-project', $project)) {
             return view('cdash', [
                 'xsl' => true,
                 'xsl_content' => "You don't have the permissions to access this page"

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -8,6 +8,7 @@ require_once 'include/defines.php';
 use App\Services\ProjectPermissions;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class ManageMeasurementsController extends ProjectController
 {
@@ -37,7 +38,7 @@ class ManageMeasurementsController extends ProjectController
         if (!$this->project->Exists()) {
             abort(404);
         }
-        if (ProjectPermissions::userCanEditProject(Auth::user(), $this->project)) {
+        if (Gate::allows('edit-project', $this->project)) {
             return view('admin.measurements')
                 ->with('cdashCss', $this->cdashCss)
                 ->with('date', json_encode($this->date))

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -8,6 +8,7 @@ use App\Services\TestingDay;
 use App\Services\ProjectPermissions;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 abstract class ProjectController extends AbstractController
 {
@@ -33,7 +34,7 @@ abstract class ProjectController extends AbstractController
         }
 
         // Check if user is authorized to view this project.
-        if (ProjectPermissions::userCanViewProject($project)) {
+        if (Gate::allows('view-project', $project)) {
             $this->authOk = true;
         } else {
             $this->authOk = false;

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -9,6 +9,7 @@ use CDash\Database;
 use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 
 class SiteController extends AbstractController
@@ -588,7 +589,7 @@ class SiteController extends AbstractController
             $project = new Project();
             $project->Id = $projectid;
             $project->Fill();
-            if (ProjectPermissions::userCanViewProject($project)) {
+            if (Gate::allows('view-project', $project)) {
                 $xml .= '<project>';
                 $xml .= add_XML_value('id', $projectid);
                 $xml .= add_XML_value('submittime', $site['maxtime']);
@@ -639,7 +640,7 @@ class SiteController extends AbstractController
             $project = new Project();
             $project->Id = $projectid;
             $project->Fill();
-            if (ProjectPermissions::userCanViewProject($project)) {
+            if (Gate::allows('view-project', $project)) {
                 $timespent = round($tt['elapsed'] / 7.0); // average over 7 days
                 $xml .= '<build>';
                 $xml .= add_XML_value('name', $tt['buildname']);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,7 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
+use App\Models\User;
+use App\Services\ProjectPermissions;
+use CDash\Config;
+use CDash\Model\Project;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -24,8 +31,26 @@ class AuthServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerPolicies();
-        \Auth::provider('cdash', function ($app, array $config) {
+        Auth::provider('cdash', function ($app, array $config) {
             return new CDashDatabaseUserProvider($app['hash'], $config['model']);
+        });
+
+        $this->defineGates();
+    }
+
+    private function defineGates(): void
+    {
+        Gate::define('view-project', function (?User $user, Project $project) {
+            return ProjectPermissions::canViewProject($project, $user);
+        });
+
+        Gate::define('edit-project', function (User $user, Project $project) {
+            return ProjectPermissions::canEditProject($project, $user);
+        });
+
+        Gate::define('create-project', function (User $user) {
+            $config = Config::getInstance();
+            return $user->IsAdmin() || $config->get('CDASH_USER_CREATE_PROJECTS');
         });
     }
 }

--- a/app/Services/AuthTokenService.php
+++ b/app/Services/AuthTokenService.php
@@ -10,6 +10,7 @@ use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
@@ -70,7 +71,7 @@ class AuthTokenService
         $project = new Project();
         $project->Id = $project_id;
         $project->Fill();
-        if ($project_id >= 0 && !ProjectPermissions::userCanCreateProjectAuthToken($project)) {
+        if ($project_id >= 0 && !Gate::allows('view-project', $project)) {
             Log::error('Permissions error');
             throw new InvalidArgumentException('Permissions error');
         }
@@ -109,7 +110,7 @@ class AuthTokenService
         $project = new Project();
         $project->Id = $project_id;
         $project->Fill();
-        if (!ProjectPermissions::canViewProject($project, $user)) {
+        if (!Gate::forUser($user)->allows('view-project', $project)) {
             Log::error('Invalid Project');
             return false;
         }

--- a/app/Services/ProjectPermissions.php
+++ b/app/Services/ProjectPermissions.php
@@ -28,8 +28,7 @@ use App\Models\User;
  **/
 class ProjectPermissions
 {
-    // TODO: (William Allen) swap the order of these parameters to match canViewProject()
-    public static function userCanEditProject(User $user, Project $project): bool
+    public static function canEditProject(Project $project, User $user): bool
     {
         // Check if this user is a global admin.
         if ($user->IsAdmin()) {
@@ -46,19 +45,6 @@ class ProjectPermissions
         }
 
         return false;
-    }
-
-    public static function userCanCreateProject(User $user): bool
-    {
-        $config = \CDash\Config::getInstance();
-        return $user->IsAdmin() || $config->get('CDASH_USER_CREATE_PROJECTS');
-    }
-
-    public static function userCanViewProject(Project $project):  bool
-    {
-        /** @var \App\Models\User $user */
-        $user = \Auth::user();
-        return self::canViewProject($project, $user);
     }
 
     public static function canViewProject(Project $project, ?User $user): bool
@@ -79,7 +65,7 @@ class ProjectPermissions
         }
 
         // Global admins have access to all projects.
-        if ($user->admin == 1) {
+        if ($user->IsAdmin()) {
             return true;
         }
 
@@ -99,10 +85,5 @@ class ProjectPermissions
             return false;
         }
         return false;
-    }
-
-    public static function userCanCreateProjectAuthToken(Project $project): bool
-    {
-        return self::userCanViewProject($project);
     }
 }

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -23,6 +23,7 @@ use CDash\Model\Project;
 use CDash\ServiceContainer;
 use CDash\System;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 /**
  *
@@ -57,7 +58,7 @@ function can_access_project($projectid): bool
 
     $project = new Project();
     $project->Id = $projectid;
-    if (ProjectPermissions::userCanViewProject($project)) {
+    if (Gate::allows('view-project', $project)) {
         return true;
     }
 
@@ -92,7 +93,7 @@ function can_administrate_project($projectid)
     }
 
     // Check if the user has the necessary permissions.
-    if (ProjectPermissions::userCanEditProject(Auth::user(), $project)) {
+    if (Gate::allows('edit-project', $project)) {
         return true;
     }
 

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -30,6 +30,7 @@ use CDash\Model\Project;
 use CDash\Model\UserProject;
 use CDash\Model\Site;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 
 require_once 'include/log.php';
 
@@ -369,7 +370,7 @@ function checkUserPolicy($projectid, $onlyreturn = 0): bool|RedirectResponse|Res
         $project->Id = $projectid;
         $project->Fill();
 
-        if (ProjectPermissions::userCanViewProject($project)) {
+        if (Gate::allows('view-project', $project)) {
             return true;
         }
     }

--- a/app/cdash/public/ajax/showtestfailuregraph.php
+++ b/app/cdash/public/ajax/showtestfailuregraph.php
@@ -17,6 +17,7 @@
 use App\Services\ProjectPermissions;
 use CDash\Model\Project;
 use CDash\Database;
+use Illuminate\Support\Facades\Gate;
 
 require_once 'include/pdo.php';
 require_once 'include/common.php';
@@ -25,7 +26,7 @@ require_once 'include/api_common.php';
 $projectid = $_GET['projectid'];
 $project = new Project();
 $project->Id = intval($projectid);
-if (!ProjectPermissions::userCanViewProject($project)) {
+if (!Gate::allows('view-project', $project)) {
     echo 'You are not authorized to view this page.';
     return;
 }

--- a/app/cdash/public/api/v1/createProject.php
+++ b/app/cdash/public/api/v1/createProject.php
@@ -29,6 +29,7 @@ use CDash\Model\Repository;
 use CDash\Model\UserProject;
 use CDash\ServiceContainer;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 $pageTimer = new PageTimer();
 $service = ServiceContainer::getInstance();
@@ -68,10 +69,10 @@ $User = Auth::user();
 $userHasAccess = false;
 if (!is_null($projectid)) {
     // Can they edit this project?
-    $userHasAccess = ProjectPermissions::UserCanEditProject($User, $Project);
+    $userHasAccess = Gate::allows('edit-project', $Project);
 } else {
     // Can they create a new project?
-    $userHasAccess = ProjectPermissions::userCanCreateProject($User);
+    $userHasAccess = Gate::allows('create-project');
 }
 if (!$userHasAccess) {
     $response['error'] = 'You do not have permission to access this page.';

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -27,6 +27,7 @@ use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_delete')) {
     /**
@@ -166,9 +167,7 @@ if ($method != 'GET') {
 
     $project = new Project();
     $project->Id = $projectid;
-    /** @var User $user */
-    $user = Auth::user();
-    if (!ProjectPermissions::userCanEditProject($user, $project)) {
+    if (!Gate::allows('edit-project', $project)) {
         $response['error'] = 'You do not have permission to access this page';
         json_error_response($response, 403);
         return;

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -25,6 +25,7 @@ use App\Services\ProjectPermissions;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 // Read input parameters (if any).
 $rest_input = file_get_contents('php://input');
@@ -85,7 +86,7 @@ function rest_post($user)
             return;
         }
 
-        if (!ProjectPermissions::userCanCreateProject($user)) {
+        if (!Gate::allows('create-project')) {
             // User does not have permission to create a new project.
             $response['error'] = 'You do not have permission to access this page.';
             http_response_code(403);

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -27,14 +27,12 @@ use CDash\Model\Project;
 use CDash\Model\SubProject;
 use CDash\Model\SubProjectGroup;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 // Make sure we have a valid login.
 if (!Auth::check()) {
     return;
 }
-
-/** @var \App\Models\User $user */
-$user = Auth::user();
 
 // Check required parameter.
 @$projectid = $_GET['projectid'];
@@ -52,9 +50,8 @@ $projectid = pdo_real_escape_numeric($projectid);
 // Make sure the user has access to this page.
 $project = new Project;
 $project->Id = $projectid;
-if (!ProjectPermissions::userCanEditProject($user, $project)) {
-    $userid = $user->Id;
-    echo_error("You ($userid) don't have the permissions to access this page ($projectid)", 403);
+if (!Gate::allows('edit-project', $project)) {
+    echo_error("You don't have the permissions to access this page ($projectid)", 403);
     return;
 }
 

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -292,6 +292,9 @@ class KWWebTestCase extends WebTestCase
         $user = $this->getUser($this->actingAs['email']);
         Auth::shouldReceive('check')->andReturn(true);
         Auth::shouldReceive('user')->andReturn($user);
+        Auth::shouldReceive('userResolver')->andReturn(function () use ($user) {
+            return $user;
+        });
         Auth::shouldReceive('id')->andReturn($user->id);
         Auth::shouldReceive('guard')->andReturnSelf();
         Auth::shouldReceive('shouldUse')->andReturn('web');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17262,11 +17262,6 @@ parameters:
 			path: app/cdash/public/api/v1/computeClassifier.php
 
 		-
-			message: "#^Call to static method App\\\\Services\\\\ProjectPermissions\\:\\:userCanEditProject\\(\\) with incorrect case\\: UserCanEditProject$#"
-			count: 1
-			path: app/cdash/public/api/v1/createProject.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|string\\|null given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/createProject.php
@@ -18149,11 +18144,6 @@ parameters:
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/requeueSubmissionFile.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$Id\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/subproject.php
 
 		-
 			message: """
@@ -22735,22 +22725,22 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:getSent\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:getSent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:isError\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:isError\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:read\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:read\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -22850,12 +22840,12 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:\\$read has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:\\$read has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:\\$response has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:\\$response has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 


### PR DESCRIPTION
This PR serves as a first step towards using Laravel gates for all authorization tasks throughout the codebase.  Having all of our gates in a centrally-located place will make it easier to determine what actions a given user can perform.