### PR TITLE
Fix missing `/build/<id>` project URL

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -75,6 +75,7 @@ class BuildController extends ProjectController
             ->with('cdashCss', $this->cdashCss)
             ->with('date', json_encode($this->date))
             ->with('logo', json_encode($this->logo))
+            ->with('project', $this->project)
             ->with('projectname', json_encode($this->project->Name))
             ->with('title', $page_title);
     }


### PR DESCRIPTION
#1351 failed to properly handle links to the corresponding project on the `/build/<id>`, `/build/<id>/notes`, and `/build/<id>/configure` pages.