### PR TITLE
Display configure command as prepared text

### DIFF
--- a/resources/js/components/BuildConfigure.vue
+++ b/resources/js/components/BuildConfigure.vue
@@ -30,21 +30,19 @@
         </tr>
         <tr>
           <td align="left">
-            <b>Configure Command: </b>{{ cdash.configures[0].command }}
+            <b>Configure Command: </b>
+            <pre class="pre-wrap">{{ cdash.configures[0].command }}</pre>
           </td>
         </tr>
         <tr>
           <td align="left">
-            <b>Configure Return Value: </b>{{ cdash.configures[0].status }}
+            <b>Configure Return Value: </b>
+            <pre class="pre-wrap">{{ cdash.configures[0].status }}</pre>
           </td>
         </tr>
         <tr>
           <td align="left">
             <b>Configure Output:</b>
-          </td>
-        </tr>
-        <tr>
-          <td align="left">
             <pre>{{ cdash.configures[0].output }}</pre>
           </td>
         </tr>
@@ -119,21 +117,19 @@
                 </tr>
                 <tr>
                   <td align="left">
-                    <b>Configure Command: </b>{{ configure.command }}
+                    <b>Configure Command:</b>
+                    <pre class="pre-wrap">{{ configure.command }}</pre>
                   </td>
                 </tr>
                 <tr>
                   <td align="left">
-                    <b>Configure Return Value: </b>{{ configure.status }}
+                    <b>Configure Return Value:</b>
+                    <pre class="pre-wrap">{{ configure.status }}</pre>
                   </td>
                 </tr>
                 <tr>
                   <td align="left">
                     <b>Configure Output:</b>
-                  </td>
-                </tr>
-                <tr>
-                  <td align="left">
                     <pre>{{ configure.output }}</pre>
                   </td>
                 </tr>
@@ -170,3 +166,9 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.pre-wrap {
+  white-space: pre-wrap;
+}
+</style>

--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -645,17 +645,15 @@
         <b>End Time: </b>{{ cdash.configure.endtime }}
         <br>
 
-        <b>Configure Command: </b> {{ cdash.configure.command }}
-        <br>
+        <b>Configure Command:</b>
+        <pre class="pre-wrap">{{ cdash.configure.command }}</pre>
 
-        <b>Configure Return Value: </b> {{ cdash.configure.status }}
-        <br>
+        <b>Configure Return Value:</b>
+        <pre class="pre-wrap">{{ cdash.configure.status }}</pre>
 
-        <b>Configure Output: </b>
-        <br>
+        <b>Configure Output:</b>
 
         <pre>{{ cdash.configure.output }}</pre>
-        <br>
 
         <a
           id="configure_link"
@@ -676,8 +674,7 @@
       </div>
       <br>
 
-      <b>Build command: </b><tt>{{ cdash.build.command }}</tt>
-      <br>
+      <b>Build command: </b><pre class="pre-wrap">{{ cdash.build.command }}</pre>
 
       <b>Start Time: </b>{{ cdash.build.starttime }}
       <br>
@@ -1063,7 +1060,12 @@ export default {
 </script>
 
 <style scoped>
+
 .dart th, .dart td {
   padding: 3px 7px;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
 }
 </style>


### PR DESCRIPTION
The configure output is currently displayed as prepared text in multiple locations, but the configure command itself is not.  The configure command can get quite lengthy at times, and is certainly technical, so it seems reasonable to also display it as prepared text.

Before:
<img width="1371" alt="image" src="https://github.com/Kitware/CDash/assets/16820599/85bbae1b-2b8e-4565-a4d6-01946f0612c7">

After:
<img width="1380" alt="image" src="https://github.com/Kitware/CDash/assets/16820599/9e18803d-2eb0-4df8-9f5c-56c68d59ebd8">
