### PR TITLE
Fix missing import in `getviewcoverage.php`

### DIFF
--- a/app/cdash/public/ajax/getviewcoverage.php
+++ b/app/cdash/public/ajax/getviewcoverage.php
@@ -16,6 +16,7 @@
 
 require_once 'include/pdo.php';
 include_once 'include/common.php';
+include_once 'include/api_common.php';
 require_once 'include/filterdataFunctions.php';
 
 use App\Models\User;


### PR DESCRIPTION
Fixes an issue introduced by #1379 by adding a missing import.