### PR TITLE
Fix subproject DB queries

### DIFF
--- a/app/cdash/app/Model/SubProject.php
+++ b/app/cdash/app/Model/SubProject.php
@@ -463,7 +463,7 @@ class SubProject
             }
             return $project_array;
         } else {
-            return intval($project['c']);
+            return intval($project[0]['c']);
         }
     }
 
@@ -555,7 +555,7 @@ class SubProject
             }
             return $project_array;
         } else {
-            return intval($project['s']);
+            return intval($project[0]['s']);
         }
     }
 
@@ -605,7 +605,7 @@ class SubProject
             }
             return $project_array;
         } else {
-            return intval($project['s']);
+            return intval($project[0]['s']);
         }
     }
 
@@ -655,7 +655,7 @@ class SubProject
             }
             return $project_array;
         } else {
-            return intval($project['s']);
+            return intval($project[0]['s']);
         }
     }
 


### PR DESCRIPTION
One of the possible cases when querying a subproject was overlooked in #1332, due to a lack of test coverage.  This change is similar to #1402.