### PR TITLE
Fix unclosed HTML on login page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -16,7 +16,6 @@
 @section('main_content')
     @includeIf('local.login')
     <div id="message" style="color: green;"></div>
-    <div class="container-fluid">
     @if ($show_login_form)
         <form method="POST" action="login" name="loginform" id="loginform">
             <input type="hidden" name="_token" id="csrf-token" value="{{ csrf_token() }}" />


### PR DESCRIPTION
Fixes a regression introduced by #1386 where the login page HTML contained an unclosed `<div>` element.