### PR TITLE
Fix page header formatting when invalid project provided

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -52,7 +52,7 @@
         <div id="headername2">
             <span id="subheadername">
                 @if(isset($title))
-                    @if(isset($project))
+                    @if(isset($project) && $project->Exists())
                         {{ $project->Name }} -
                     @endif
                     {{ $title }}


### PR DESCRIPTION
Fixes an issue introduced by #1351 where the page header might improperly show as "- <title>" with a leading dash when an invalid project is specified.  This issue primarily occurred on pages with a project selector containing an "all projects" option, such as the banner management page.