### PR TITLE
Optimize `viewProject.php` database queries

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3175,33 +3175,8 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewNotes.php
 
 		-
-			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$activeProjectDays\\.$#"
-			count: 5
-			path: app/cdash/app/Controller/Api/ViewProjects.php
-
-		-
-			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$config\\.$#"
-			count: 2
-			path: app/cdash/app/Controller/Api/ViewProjects.php
-
-		-
 			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$pageTimer\\.$#"
 			count: 1
-			path: app/cdash/app/Controller/Api/ViewProjects.php
-
-		-
-			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$projectids\\.$#"
-			count: 3
-			path: app/cdash/app/Controller/Api/ViewProjects.php
-
-		-
-			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$showAllProjects\\.$#"
-			count: 6
-			path: app/cdash/app/Controller/Api/ViewProjects.php
-
-		-
-			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$user\\.$#"
-			count: 2
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
 		-
@@ -3211,7 +3186,7 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:getProjects\\(\\) throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
 		-
@@ -3221,6 +3196,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:getVisibleProjects\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$projectids has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 


### PR DESCRIPTION
`viewProject.php` currently executes multiple queries in a loop, one for each project displayed on the page.  This results in hundreds of unnecessary queries being executed during a single page load.  The queries have been simplified such that a constant number of larger queries are executed.  In my relatively small development environment, this resulted in a roughly 50% page load speedup.  This speedup is likely even larger on production systems with a large number of projects and builds.