### PR TITLE
Add PHP query cache

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -814,7 +814,7 @@ class CoverageController extends AbstractController
 
         checkUserPolicy($projectid);
 
-        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid]);
+        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
         if (empty($project_array)) {
             return view('cdash', [
                 'xsl' => true,

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -59,7 +59,7 @@ class MapController extends AbstractController
 
         $db = Database::getInstance();
 
-        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid]);
+        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
 
         list($previousdate, $currenttime, $nextdate) = get_dates($date, $project_array['nightlytime']);
 

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -32,7 +32,7 @@ class SubProjectController extends AbstractController
         }
 
         $db = Database::getInstance();
-        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid]);
+        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
         if (!empty($project_array)) {
             $svnurl = make_cdash_url(htmlentities($project_array['cvsurl']));
             $homeurl = make_cdash_url(htmlentities($project_array['homeurl']));
@@ -156,7 +156,7 @@ class SubProjectController extends AbstractController
         }
 
         $db = Database::getInstance();
-        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid]);
+        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
         if (!empty($project_array)) {
             $svnurl = make_cdash_url(htmlentities($project_array['cvsurl']));
             $homeurl = make_cdash_url(htmlentities($project_array['homeurl']));

--- a/app/cdash/app/Model/BuildErrorFilter.php
+++ b/app/cdash/app/Model/BuildErrorFilter.php
@@ -105,10 +105,9 @@ class BuildErrorFilter
 
     private function Fill()
     {
-        $stmt = $this->PDO->prepare(
-            'SELECT * FROM build_filters WHERE projectid = :projectid');
-        $this->PDO->execute($stmt, [':projectid' => $this->Project->Id]);
-        $row = $stmt->fetch();
+        $row = $this->PDO->executePreparedSingleRow('
+                   SELECT * FROM build_filters WHERE projectid = ?
+               ', [(int) $this->Project->Id], true);
         if ($row) {
             $this->ErrorsFilter = $row['errors'];
             $this->WarningsFilter = $row['warnings'];

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -534,12 +534,9 @@ class Project
 
     public function GetIdByName()
     {
-        $pdo = Database::getInstance()->getPdo();
-        $stmt = $pdo->prepare('SELECT id FROM project WHERE name = :name');
-        $stmt->bindParam(':name', $this->Name);
-        pdo_execute($stmt);
-        $stmt->bindColumn('id', $this->Id);
-        $stmt->fetch(\PDO::FETCH_BOUND);
+        $this->Id = (int) $this->PDO->executePreparedSingleRow('
+                              SELECT id FROM project WHERE name = ?
+                          ', [$this->Name], true)['id'];
         return $this->Id;
     }
 
@@ -596,7 +593,7 @@ class Project
 
         $project_array = $this->PDO->executePreparedSingleRow('
                              SELECT * FROM project WHERE id=?
-                         ', [intval($this->Id)]);
+                         ', [intval($this->Id)], true);
         if ($project_array === false) {
             add_last_sql_error('Project Fill', $this->Id);
             return;
@@ -653,7 +650,7 @@ class Project
         // Check if we have a robot
         $robot = $this->PDO->executePreparedSingleRow('
                      SELECT * FROM projectrobot WHERE projectid=?
-                 ', [intval($this->Id)]);
+                 ', [intval($this->Id)], true);
         if ($robot === false) {
             add_last_sql_error('Project Fill', $this->Id);
             return;
@@ -667,7 +664,7 @@ class Project
         // Check if we have filters
         $build_filters = $this->PDO->executePreparedSingleRow('
                              SELECT * FROM build_filters WHERE projectid=?
-                         ', [intval($this->Id)]);
+                         ', [intval($this->Id)], true);
         if ($build_filters === false) {
             add_last_sql_error('Project Fill', $this->Id);
             throw new Exception(var_export($this->Id, true));
@@ -1428,7 +1425,7 @@ class Project
             $query .= ' AND build.parentid IN (-1, 0)';
         }
 
-        $project = $this->PDO->executePreparedSingleRow($query, $params);
+        $project = $this->PDO->executePreparedSingleRow($query, $params, true);
         if ($project === false) {
             add_last_sql_error('Project GetNumberOfFailingTests', $this->Id);
             return false;
@@ -1462,7 +1459,7 @@ class Project
             $query .= ' AND build.parentid IN (-1, 0)';
         }
 
-        $project = $this->PDO->executePreparedSingleRow($query, $params);
+        $project = $this->PDO->executePreparedSingleRow($query, $params, true);
         if ($project === false) {
             add_last_sql_error('Project GetNumberOfNotRunTests', $this->Id);
             return false;

--- a/app/cdash/app/Model/SubProject.php
+++ b/app/cdash/app/Model/SubProject.php
@@ -450,7 +450,7 @@ class SubProject
         }
 
         $db = Database::getInstance();
-        $project = $db->executePrepared($query, $params);
+        $project = $db->executePrepared($query, $params, true);
 
         if ($project === false) {
             add_last_sql_error("SubProject CommonBuildQuery($extraCriteria)");
@@ -592,7 +592,7 @@ class SubProject
         }
 
         $db = Database::getInstance();
-        $project = $db->executePrepared($queryStr, $params);
+        $project = $db->executePrepared($queryStr, $params, true);
 
         if ($project === false) {
             add_last_sql_error('SubProject GetNumberOfFailingTests');

--- a/app/cdash/public/ajax/getsubprojectdependencies.php
+++ b/app/cdash/public/ajax/getsubprojectdependencies.php
@@ -40,7 +40,7 @@ if ($projectid == 0 || !can_access_project($projectid)) {
 }
 
 $db = Database::getInstance();
-$project = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [intval($projectid)]);
+$project = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
 if (!empty($project)) {
     $svnurl = make_cdash_url(htmlentities($project['cvsurl']));
     $homeurl = make_cdash_url(htmlentities($project['homeurl']));

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -49,7 +49,7 @@ $projectid = $Project->Id;
 $db = Database::getInstance();
 $controller = new IndexController($db, $Project);
 
-$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid]);
+$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$projectid], true);
 if (!empty($project_array)) {
     $projectname = $project_array['name'];
 

--- a/app/cdash/public/api/v1/testSummary.php
+++ b/app/cdash/public/api/v1/testSummary.php
@@ -61,7 +61,7 @@ $pageTimer = new PageTimer();
 
 $db = Database::getInstance();
 
-$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [intval($projectid)]);
+$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [intval($projectid)], true);
 if (!empty($project_array)) {
     $projectname = $project_array['name'];
     $nightlytime = $project_array['nightlytime'];

--- a/app/cdash/public/generateCTestConfig.php
+++ b/app/cdash/public/generateCTestConfig.php
@@ -34,7 +34,7 @@ if (!isset($projectid) || !is_numeric($projectid)) {
 }
 
 $db = Database::getInstance();
-$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [intval($projectid)]);
+$project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [intval($projectid)], true);
 if (empty($project_array)) {
     return;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,11 +27,6 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, array\\|bool\\|string\\|null\\> given\\.$#"
-			count: 2
-			path: app/Console/Commands/AutoRemoveBuilds.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Console/Commands/MigrateConfig.php
@@ -5388,7 +5383,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property CDash\\\\Model\\\\BuildErrorFilter\\:\\:\\$PDO\\.$#"
-			count: 8
+			count: 7
 			path: app/cdash/app/Model/BuildErrorFilter.php
 
 		-
@@ -5928,11 +5923,6 @@ parameters:
 			path: app/cdash/app/Model/BuildGroup.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroup.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\BuildGroup\\:\\:\\$Description has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroup.php
@@ -6147,11 +6137,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:SoftDeleteExpiredRules\\(\\) has parameter \\$now with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
 
@@ -7835,11 +7820,6 @@ parameters:
 			path: app/cdash/app/Model/Image.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Image.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Image\\:\\:\\$Checksum has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
@@ -8219,7 +8199,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8251,15 +8231,7 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 24
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
+			count: 25
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8949,11 +8921,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$repository of class CDash\\\\Service\\\\RepositoryService constructor expects CDash\\\\Lib\\\\Repository\\\\RepositoryInterface, CDash\\\\Model\\\\RepositoryInterface given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Repository.php
 
@@ -10083,7 +10050,22 @@ parameters:
 			path: app/cdash/include/CDash/Config.php
 
 		-
+			message: "#^Method CDash\\\\Database\\:\\:cacheQuery\\(\\) has parameter \\$query_params with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
 			message: "#^Method CDash\\\\Database\\:\\:createPreparedArray\\(\\) throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Method CDash\\\\Database\\:\\:execute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Method CDash\\\\Database\\:\\:execute\\(\\) has parameter \\$input_parameters with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
 
@@ -10104,6 +10086,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Database\\:\\:executePreparedSingleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Method CDash\\\\Database\\:\\:getCachedQuery\\(\\) has parameter \\$query_params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
 
@@ -13375,11 +13362,6 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			message: "#^Parameter \\#4 \\$resultcontainer of function xslt_process expects string, null given\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -13855,11 +13837,6 @@ parameters:
 
 		-
 			message: "#^Offset 'filename' on array\\{author\\?\\: string, comment\\?\\: string, directory\\: string, email\\?\\: string, filename\\: string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
@@ -14501,11 +14478,6 @@ parameters:
 
 		-
 			message: "#^Function pdo_execute\\(\\) has parameter \\$input_parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_execute\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
@@ -17061,11 +17033,6 @@ parameters:
 			path: app/cdash/public/api/v1/build.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 2
-			path: app/cdash/public/api/v1/build.php
-
-		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -17666,11 +17633,6 @@ parameters:
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$response might not exist\\.$#"
 			count: 3
-			path: app/cdash/public/api/v1/expectedbuild.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
@@ -19337,11 +19299,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$stmt contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/DatabaseTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, string\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/DatabaseTest.php
 
@@ -23289,11 +23246,6 @@ parameters:
 			path: app/cdash/tests/manageCoverageTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 2
-			path: app/cdash/tests/manageCoverageTest.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of method WebTestCase\\:\\:setFieldByName\\(\\) expects string, int given\\.$#"
 			count: 2
 			path: app/cdash/tests/manageCoverageTest.php
@@ -23608,11 +23560,6 @@ parameters:
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_actualtrilinossubmission.php
-
-		-
 			message: "#^Method AddBuildAPITestCase\\:\\:testBuildRelationships\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_addbuildapi.php
@@ -23814,11 +23761,6 @@ parameters:
 
 		-
 			message: "#^Method AttachedFilesTestCase\\:\\:testAttachedFiles\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_attachedfiles.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_attachedfiles.php
 
@@ -24130,21 +24072,6 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, int\\> given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, int\\|string\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, int\\|string\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
 			message: "#^Property AutoRemoveBuildsOnSubmitTestCase\\:\\:\\$config_file has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -24382,11 +24309,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_buildconfigure.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildconfigure.php
 
@@ -24906,11 +24828,6 @@ parameters:
 			path: app/cdash/tests/test_changeid.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_changeid.php
-
-		-
 			message: "#^Property ChangeIdTestCase\\:\\:\\$ProjectId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_changeid.php
@@ -25027,16 +24944,6 @@ parameters:
 			path: app/cdash/tests/test_configurewarnings.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, int\\|string\\|false\\|null\\> given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_configurewarnings.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_configurewarnings.php
-
-		-
 			message: "#^Property ConfigureWarningTestCase\\:\\:\\$ProjectId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_configurewarnings.php
@@ -25059,11 +24966,6 @@ parameters:
 
 		-
 			message: "#^Method ConsistentTestingDayTestCase\\:\\:testConsistentTestingDay\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_consistenttestingday.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_consistenttestingday.php
 
@@ -25832,11 +25734,6 @@ parameters:
 
 		-
 			message: "#^Method ExpiredBuildRulesTestCase\\:\\:testExpiredBuildRules\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_expiredbuildrules.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, int\\|string\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_expiredbuildrules.php
 
@@ -27944,11 +27841,6 @@ parameters:
 			path: app/cdash/tests/test_subprojectorder.php
 
 		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, mixed\\> given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_subprojectorder.php
-
-		-
 			message: "#^Property SubProjectOrderTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectorder.php
@@ -28749,11 +28641,6 @@ parameters:
 
 		-
 			message: "#^Method UpgradeTestCase\\:\\:testUpgradeDurations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_upgrade.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<string, int\\> given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_upgrade.php
 
@@ -32238,11 +32125,6 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
-			path: tests/Feature/AutoRemoveBuildsCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$input_parameters of method CDash\\\\Database\\:\\:execute\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
-			count: 3
 			path: tests/Feature/AutoRemoveBuildsCommand.php
 
 		-


### PR DESCRIPTION
There are a handful of small queries which are executed repeatedly when loading some pages.  There is no need to fetch the same results over and over again, so I have added an optional "cache" parameter to one of the database functions which specifies whether the query and corresponding result should be cached.  On `index.php`, this results in significantly fewer queries being executed.  There is still work to do, but this PR serves as a starting point for future work.