### PR TITLE
Fix buildSummary page notes API call

### DIFF
--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -421,6 +421,10 @@
 
       <div v-if="cdash.user.id > 0">
         <!-- Add Notes -->
+        <img
+          :src="$baseURL + '/img/document.png'"
+          title="graph"
+        >
         <a
           id="toggle_note"
           @click="toggleNote()"
@@ -1042,7 +1046,7 @@ export default {
 
     addNote: function() {
       this.$axios
-        .post('api/v1/addUserNote.php', {
+        .post('/api/v1/addUserNote.php', {
           buildid: this.cdash.build.id,
           Status: this.cdash.noteStatus,
           AddNote: this.cdash.noteText


### PR DESCRIPTION
Add a leading slash to the API URL string to avoid keeping the "/build/" part of the URL from being added to the API call. If it was included, the Laravel routing wouldn't recognize it as an API call and return a 404.

Add an icon to show that the content is clickable, like other examples later on in the page

Fixes: #1429