### PR TITLE
Remove unnecessary `remove_build()` data handling

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12799,7 +12799,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 67
+			count: 6
 			path: app/cdash/include/common.php
 
 		-
@@ -12856,7 +12856,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 15
+			count: 14
 			path: app/cdash/include/common.php
 
 		-


### PR DESCRIPTION
The `remove_build()` currently does a significant amount of unnecessary work, passing data back and forth between the database and web server, when it could be done entirely on the database side.  This PR simplifies a handful of locations where it was possible to execute the entire operation in SQL.  I also converted all of the database functions to Laravel's DB system along the way.

Ultimately it would be good to replace most of this logic with the database's build-in foreign-key relationships.  Doing so requires a significant amount of effort, so I have deferred that to a future time.  I plan to come back and look at setting up such foreign-key relationships for as many of the simple tables as possible in the near future, once this PR is merged.