### PR TITLE
Fix display of data on subprojects page

### DIFF
--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1056,10 +1056,10 @@ class Project
         }
 
         $build = $this->PDO->executePreparedSingleRow('
-                     SELECT submittime
+                     SELECT starttime
                      FROM build
                      WHERE projectid=?
-                     ORDER BY submittime DESC
+                     ORDER BY starttime DESC
                      LIMIT 1
                  ', [intval($this->Id)]);
 
@@ -1068,11 +1068,11 @@ class Project
             return false;
         }
 
-        if (!is_array($build) || !array_key_exists('submittime', $build)) {
+        if (!is_array($build) || !array_key_exists('starttime', $build)) {
             return false;
         }
 
-        return date(FMT_DATETIMESTD, strtotime($build['submittime'] . 'UTC'));
+        return date(FMT_DATETIMESTD, strtotime($build['starttime'] . 'UTC'));
     }
 
     /** Get the total number of builds for a project*/

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1205,7 +1205,7 @@ function get_dates($date, $nightlytime): array
     $nightlyminute = intval(date('i', $nightlytime));
     $nightlysecond = intval(date('s', $nightlytime));
 
-    if (!isset($date) || strlen($date) == 0) {
+    if (strlen($date) === 0) {
         $date = date(FMT_DATE); // the date is always the date of the server
 
         if (date(FMT_TIME) > date(FMT_TIME, $nightlytime)) {

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -154,17 +154,18 @@ if (isset($_GET['subproject'])) {
                 $dependency_response = array();
                 $DependProject = new SubProject();
                 $DependProject->SetId($dependency);
+                $result = $DependProject->CommonBuildQuery($beginning_UTCDate, $end_UTCDate, false);
                 $dependency_response['name'] = $DependProject->GetName();
                 $dependency_response['name_encoded'] = urlencode($DependProject->GetName());
-                $dependency_response['nbuilderror'] = $DependProject->GetNumberOfErrorBuilds($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['nbuildwarning'] = $DependProject->GetNumberOfWarningBuilds($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['nbuildpass'] = $DependProject->GetNumberOfPassingBuilds($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['nconfigureerror'] = $DependProject->GetNumberOfErrorConfigures($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['nconfigurewarning'] = $DependProject->GetNumberOfWarningConfigures($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['nconfigurepass'] = $DependProject->GetNumberOfPassingConfigures($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['ntestpass'] = $DependProject->GetNumberOfPassingTests($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['ntestfail'] = $DependProject->GetNumberOfFailingTests($beginning_UTCDate, $end_UTCDate);
-                $dependency_response['ntestnotrun'] = $DependProject->GetNumberOfNotRunTests($beginning_UTCDate, $end_UTCDate);
+                $dependency_response['nbuilderror'] = (int) $result['nbuilderrors'];
+                $dependency_response['nbuildwarning'] = (int) $result['nbuildwarnings'];
+                $dependency_response['nbuildpass'] = (int) $result['npassingbuilds'];
+                $dependency_response['nconfigureerror'] = (int) $result['nconfigureerrors'];
+                $dependency_response['nconfigurewarning'] = (int) $result['nconfigurewarnings'];
+                $dependency_response['nconfigurepass'] = (int) $result['npassingconfigures'];
+                $dependency_response['ntestpass'] = (int) $result['ntestspassed'];
+                $dependency_response['ntestfail'] = (int) $result['ntestsfailed'];
+                $dependency_response['ntestnotrun'] = (int) $result['ntestsnotrun'];
                 if (strlen($DependProject->GetLastSubmission()) === 0) {
                     $dependency_response['lastsubmission'] = 'NA';
                 } else {

--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -576,9 +576,8 @@ textarea {
 }
 
 /* used for angular table sorting */
-.glyphicon-none:before {
-  content: "\e113";
-  color: transparent !important;
+.glyphicon-none {
+  display: none;
 }
 
 /* add border to bottom of table */

--- a/app/cdash/public/views/partials/subProjectTable.html
+++ b/app/cdash/public/views/partials/subProjectTable.html
@@ -5,64 +5,64 @@
     </tr>
     <tr class="table-heading">
 
-      <th align="center" rowspan="2" width="20%" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'name', $event)">
+      <th rowspan="2" style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'name', $event)">
         <b>SubProject</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-name') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('name') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <td align="center" colspan="3" width="20%"><b>Configure</b></td>
-      <td align="center" colspan="3" width="20%"><b>Build</b></td>
-      <td align="center" colspan="3" width="20%"><b>Test</b></td>
+      <td colspan="3" style="text-align: center;"><b>Configure</b></td>
+      <td colspan="3" style="text-align: center;"><b>Build</b></td>
+      <td colspan="3" style="text-align: center;"><b>Test</b></td>
 
-      <th ng-if="cdash.showlastsubmission" align="center" rowspan="2" width="20%" class="nob" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'lastsubmission', $event)">
-        <b>Last submission</b>
+      <th ng-if="cdash.showlastsubmission" rowspan="2" class="nob" style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'lastsubmission', $event)">
+        <b>Start Time</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-lastsubmission') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('lastsubmission') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
     </tr>
     <tr class="table-heading">
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigureerror', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nconfigureerror', $event)">
         <b>Error</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigureerror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigureerror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurewarning', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurewarning', $event)">
         <b>Warning</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigurewarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigurewarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurepass', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nconfigurepass', $event)">
         <b>Pass</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nconfigurepass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nconfigurepass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuilderror', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nbuilderror', $event)">
         <b>Error</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuilderror') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuilderror') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuildwarning', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nbuildwarning', $event)">
         <b>Warning</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuildwarning') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuildwarning') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'nbuildpass', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'nbuildpass', $event)">
         <b>Pass</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-nbuildpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('nbuildpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestnotrun', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'ntestnotrun', $event)">
         <b>Not Run</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestnotrun') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestnotrun') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestfail', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'ntestfail', $event)">
         <b>Fail</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestfail') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestfail') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
 
-      <th align="center" style="cursor: pointer" ng-click="updateOrderByFields(sortSubProjects, 'ntestpass', $event)">
+      <th style="cursor: pointer; text-align: center;" ng-click="updateOrderByFields(sortSubProjects, 'ntestpass', $event)">
         <b>Pass</b>
         <span class="glyphicon" ng-class="sortSubProjects.orderByFields.indexOf ('-ntestpass') != -1 ? 'glyphicon-chevron-down' : (sortSubProjects.orderByFields.indexOf ('ntestpass') != -1 ? 'glyphicon-chevron-up' : 'glyphicon-none')"></span>
       </th>
@@ -132,7 +132,7 @@
       </td>
 
       <td ng-if="cdash.showlastsubmission" align="center" class="nob">
-        {{subproject.lastsubmission}}
+        {{subproject.starttime}}
       </td>
     </tr>
   </tbody>

--- a/app/cdash/public/views/viewSubProjects.html
+++ b/app/cdash/public/views/viewSubProjects.html
@@ -23,7 +23,7 @@
           <td align="center" colspan="3" width="20%"><b>Build</b></td>
           <td align="center" colspan="3" width="20%"><b>Test</b></td>
           <td ng-show="cdash.showlastsubmission == 1" align="center" rowspan="2" width="20%" class="nob">
-            <b>Last submission</b>
+            <b>Start Time</b>
           </td>
         </tr>
 
@@ -105,7 +105,7 @@
           </td>
 
           <td ng-if="cdash.showlastsubmission" align="center" class="nob">
-            {{cdash.project.lastsubmission}}
+            {{cdash.project.starttime}}
           </td>
         </tr>
       </table>

--- a/app/cdash/tests/test_viewsubprojects.php
+++ b/app/cdash/tests/test_viewsubprojects.php
@@ -34,20 +34,20 @@ class ViewSubProjectsTestCase extends KWWebTestCase
                         'nbuildpass' => 1,
                         'nconfigureerror' => 0,
                         'nconfigurewarning' => 2,
-                        'nconfigurepass' => 2,
+                        'nconfigurepass' => 0,
                         'ntestpass' => 90,
                         'ntestfail' => 30,
                         'ntestnotrun' => 0,
-                        'lastsubmission' => '2016-07-11 11:57:31');
+                        'starttime' => '2011-07-22 11:15:59');
                 foreach ($expected_values as $k => $v) {
-                    if (!$subproject[$k] === $v) {
+                    if ($subproject[$k] !== $v) {
                         $this->fail("Expected $v for TrilinosFramework $k, found " . $subproject[$k]);
                     }
                 }
             } elseif ($subproject['name'] === 'Zoltan') {
                 $found_zoltan = true;
-                if ($subproject['lastsubmission'] !== 'NA') {
-                    $this->fail("Expected NA for Zoltan lastsubmission, found " . $subproject['lastsubmission']);
+                if ($subproject['starttime'] !== 'NA') {
+                    $this->fail("Expected NA for Zoltan starttime, found " . $subproject['starttime']);
                 }
             }
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8986,7 +8986,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 11
+			count: 8
 			path: app/cdash/app/Model/SubProject.php
 
 		-
@@ -9034,7 +9034,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 12
+			count: 9
 			path: app/cdash/app/Model/SubProject.php
 
 		-
@@ -9080,141 +9080,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorBuilds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfErrorConfigures\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfFailingTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfFailingTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfFailingTests\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfNotRunTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfNotRunTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfNotRunTests\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingBuilds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingConfigures\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfPassingTests\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningBuilds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetNumberOfWarningConfigures\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
@@ -13149,11 +13014,6 @@ parameters:
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			message: "#^Variable \\$date in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -18434,11 +18294,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
-			path: app/cdash/public/api/v1/viewSubProjects.php
-
-		-
-			message: "#^Foreach overwrites \\$row with its value variable\\.$#"
-			count: 9
 			path: app/cdash/public/api/v1/viewSubProjects.php
 
 		-
@@ -28420,16 +28275,6 @@ parameters:
 
 		-
 			message: "#^Method ViewSubProjectsTestCase\\:\\:testViewSubProjects\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_viewsubprojects.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_viewsubprojects.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between bool and 0\\|1\\|2\\|30\\|90\\|'2016\\-07\\-11 11\\:57\\:31' will always evaluate to false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewsubprojects.php
 


### PR DESCRIPTION
`viewSubProjects.php` currently shows data for the beginning of time by default if no date parameter is specified.  Most CDash pages show results from the most recent testing day by default.  This PR changes the behavior of `viewSubProjects.php` such that it now shows results for the latest testing day.

The original issue was likely a regression due to an improperly-placed negation in the relevant test.  PHPStan caught the issue, but the error was ignored as one of the pre-existing issues ignored when PHPStan was initially set up.

It is worth noting that this page creates an extraordinary number of database queries and the underlying subproject logic should be refactored to simplify these queries into a handful of larger queries.