### PR TITLE
Align edit project dropdown with page content

### DIFF
--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -23,7 +23,6 @@
     <div v-else>
       <table v-if="cdash.edit == 1">
         <tr>
-          <td width="99" />
           <td>
             <div align="right">
               <strong>Project:</strong>


### PR DESCRIPTION
The edit project page currently displays a dropdown which is offset from the rest of the page content.  The dropdown has been moved to the left to match other pages with this layout.

Before:
![image](https://github.com/Kitware/CDash/assets/16820599/87d4d8c6-4ba3-4d6e-8e00-60bc48f7b561)

After:
![image](https://github.com/Kitware/CDash/assets/16820599/a1df2138-6568-4c04-8646-2b53a3c52261)
