### PR TITLE
Add `type` to build metadata API response

### DIFF
--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -341,7 +341,7 @@ class QueryTests extends ResultsApi
             $output_select = ', testoutput.output';
         }
 
-        $sql = "SELECT b.id AS buildid, b.name AS buildname, b.starttime, b.siteid, b.parentid,
+        $sql = "SELECT b.id AS buildid, b.name AS buildname, b.starttime, b.siteid, b.parentid, b.type,
             build2test.id AS buildtestid, build2test.details, build2test.outputid,
             build2test.status, build2test.time, build2test.timestatus,
             site.name AS sitename, test.name AS testname $output_select
@@ -374,6 +374,7 @@ class QueryTests extends ResultsApi
 
             $test['testname'] = $row['testname'];
             $test['site'] = $row['sitename'];
+            $test['type'] = $row['type'];
             $test['buildName'] = $row['buildname'];
 
             $test['buildstarttime'] =

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -439,7 +439,7 @@ class Build
             'starttime' => $build->StartTime,
             'endtime' => $build->EndTime,
             'groupid' => $build->GroupId,
-
+            'type' => $build->Type,
         ];
 
         if ($build->GetSubProjectName()) {


### PR DESCRIPTION
The build `type` has been added to the API endpoints `api/v1/viewTest.php` and `api/v1/queryTests.php`.  The `type` field is not used in the UI, but is present in case users want to write their own scripts which query the CDash API.