### PR TITLE
Change `type` to `group` in API response

### DIFF
--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -374,7 +374,7 @@ class QueryTests extends ResultsApi
 
             $test['testname'] = $row['testname'];
             $test['site'] = $row['sitename'];
-            $test['type'] = $row['type'];
+            $test['group'] = $row['type'];
             $test['buildName'] = $row['buildname'];
 
             $test['buildstarttime'] =

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -439,7 +439,7 @@ class Build
             'starttime' => $build->StartTime,
             'endtime' => $build->EndTime,
             'groupid' => $build->GroupId,
-            'type' => $build->Type,
+            'group' => $build->Type,
         ];
 
         if ($build->GetSubProjectName()) {

--- a/app/cdash/tests/test_querytests.php
+++ b/app/cdash/tests/test_querytests.php
@@ -51,5 +51,6 @@ class QueryTestsTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $this->assertEqual(count($jsonobj['builds']), 2);
+        $this->assertEqual($jsonobj['builds'][0]['group'], 'Experimental');
     }
 }


### PR DESCRIPTION
Follows https://github.com/Kitware/CDash/pull/1439.  CDash prefers the "build group" language instead of "build type". 

This PR also adds a small test to verify that the data appears in the `api/v1/queryTests.php` API response.  A similar test needs to be added to `app/cdash/tests/test_builddetails.php` eventually, but a pre-existing issue with that test needs to be resolved first.