### PR TITLE
Remove unused controller properties

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -15,19 +15,6 @@ abstract class AbstractController extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
-    protected $cdashCss;
-    protected $user;
-
-    public function __construct()
-    {
-        $this->cdashCss = asset(get_css_file());
-
-        // Get the current user, if applicable.
-        $this->user = [
-            'id' => Auth::id()
-        ];
-    }
-
     /** Returns the version used to find compiled css and javascript files */
     public static function getJsVersion(): string
     {

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -72,7 +72,6 @@ class BuildController extends ProjectController
         }
         return view("build.{$page_name}")
             ->with('build', json_encode($this->build))
-            ->with('cdashCss', $this->cdashCss)
             ->with('date', json_encode($this->date))
             ->with('logo', json_encode($this->logo))
             ->with('project', $this->project)

--- a/app/Http/Controllers/EditProjectController.php
+++ b/app/Http/Controllers/EditProjectController.php
@@ -36,7 +36,6 @@ class EditProjectController extends ProjectController
         if (ProjectPermissions::userCanCreateProject(Auth::user())) {
             $project_name = 'CDash';
             return view('admin.project')
-                ->with('cdashCss', $this->cdashCss)
                 ->with('date', json_encode($this->date))
                 ->with('logo', json_encode($this->logo))
                 ->with('projectid', 0)
@@ -59,7 +58,6 @@ class EditProjectController extends ProjectController
         }
         if (ProjectPermissions::userCanEditProject(Auth::user(), $this->project)) {
             return view('admin.project')
-                ->with('cdashCss', $this->cdashCss)
                 ->with('date', json_encode($this->date))
                 ->with('logo', json_encode($this->logo))
                 ->with('projectid', $project_id)

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -39,7 +39,6 @@ class ManageMeasurementsController extends ProjectController
         }
         if (ProjectPermissions::userCanEditProject(Auth::user(), $this->project)) {
             return view('admin.measurements')
-                ->with('cdashCss', $this->cdashCss)
                 ->with('date', json_encode($this->date))
                 ->with('logo', json_encode($this->logo))
                 ->with('projectid', $project_id)

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -18,7 +18,6 @@ abstract class ProjectController extends AbstractController
 
     public function __construct()
     {
-        parent::__construct();
         $this->project = null;
         $this->authOk = false;
         $this->date = date(FMT_DATETIME);

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -35,7 +35,6 @@ class TestController extends ProjectController
         }
         return view('test.details')
             ->with('buildtest', json_encode($buildtest))
-            ->with('cdashCss', $this->cdashCss)
             ->with('date', json_encode($this->date))
             ->with('logo', json_encode($this->logo))
             ->with('projectname', json_encode($this->project->Name))

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -147,16 +147,6 @@ parameters:
 			path: app/Exceptions/Handler.php
 
 		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\AbstractController\\:\\:\\$cdashCss has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/AbstractController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\AbstractController\\:\\:\\$user has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/AbstractController.php
-
-		-
 			message: "#^Backtick operator is not allowed\\. Use shell_exec\\(\\) instead\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
@@ -313,11 +303,6 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^App\\\\Http\\\\Controllers\\\\Auth\\\\ForgotPasswordController\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/Auth/ForgotPasswordController.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Http\\\\Controllers\\\\Auth\\\\LoginController\\:\\:\\$decayMinutes\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/LoginController.php
@@ -326,16 +311,6 @@ parameters:
 			message: "#^Access to an undefined property App\\\\Http\\\\Controllers\\\\Auth\\\\LoginController\\:\\:\\$maxAttempts\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/LoginController.php
-
-		-
-			message: "#^App\\\\Http\\\\Controllers\\\\Auth\\\\LoginController\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/Auth/LoginController.php
-
-		-
-			message: "#^App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/Auth/RegisterController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:create\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
@@ -356,16 +331,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
-
-		-
-			message: "#^App\\\\Http\\\\Controllers\\\\Auth\\\\ResetPasswordController\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/Auth/ResetPasswordController.php
-
-		-
-			message: "#^App\\\\Http\\\\Controllers\\\\Auth\\\\VerificationController\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/Auth/VerificationController.php
 
 		-
 			message: "#^Call to function is_numeric\\(\\) with int will always evaluate to true\\.$#"
@@ -470,11 +435,6 @@ parameters:
 			message: "#^Property App\\\\Http\\\\Controllers\\\\BuildController\\:\\:\\$build has no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^App\\\\Http\\\\Controllers\\\\CDash\\:\\:__construct\\(\\) does not call parent constructor from App\\\\Http\\\\Controllers\\\\AbstractController\\.$#"
-			count: 1
-			path: app/Http/Controllers/CDash.php
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"


### PR DESCRIPTION
#1351 eliminated all usages of the `id` and `cdashCss` properties in the abstract controller, but failed to remove the properties themselves.