### PR TITLE
Refactor project controller

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 
 include_once 'include/common.php';
+require_once 'include/defines.php';
 
 abstract class AbstractController extends BaseController
 {

--- a/app/Http/Controllers/EditProjectController.php
+++ b/app/Http/Controllers/EditProjectController.php
@@ -1,71 +1,27 @@
 <?php
 namespace App\Http\Controllers;
 
-require_once 'include/common.php';
-require_once 'include/defines.php';
-
-use App\Services\ProjectPermissions;
-use CDash\Model\Project;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 class EditProjectController extends ProjectController
 {
-    protected $build;
-
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    protected function setup($project_id = null): void
-    {
-        if (!is_null($project_id)) {
-            $this->project = new Project();
-            $this->project->Id = $project_id;
-            $this->project->Fill();
-        }
-    }
-
     // Render the create project form.
     public function create()
     {
-        $this->setup();
-        if (!Auth::check()) {
-            return $this->redirectToLogin();
-        }
-        if (Gate::allows('create-project')) {
-            $project_name = 'CDash';
-            return view('admin.project')
-                ->with('date', json_encode($this->date))
-                ->with('logo', json_encode($this->logo))
-                ->with('projectid', 0)
-                ->with('projectname', json_encode($project_name))
-                ->with('title', 'Create Project');
-        } else {
-            abort(403, 'You do not have permission to access this page.');
-        }
+        Gate::authorize('create-project');
+
+        return view('admin.project')
+            ->with('title', 'Create Project');
     }
 
     // Render the edit project form.
     public function edit($project_id)
     {
-        $this->setup($project_id);
-        if (!Auth::check()) {
-            return $this->redirectToLogin();
-        }
-        if (!$this->project->Exists()) {
-            abort(404);
-        }
-        if (Gate::allows('edit-project', $this->project)) {
-            return view('admin.project')
-                ->with('date', json_encode($this->date))
-                ->with('logo', json_encode($this->logo))
-                ->with('projectid', $project_id)
-                ->with('projectname', json_encode($this->project->Name))
-                ->with('title', "Edit Project");
-        } else {
-            abort(403, 'You do not have permission to access this page.');
-        }
+        $this->setProjectById((int) $project_id);
+        Gate::authorize('edit-project', $this->project);
+
+        return view('admin.project')
+            ->with('project', $this->project)
+            ->with('title', 'Edit Project');
     }
 }

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -2,51 +2,18 @@
 
 namespace App\Http\Controllers;
 
-require_once 'include/common.php';
-require_once 'include/defines.php';
-
-use App\Services\ProjectPermissions;
-use CDash\Model\Project;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 class ManageMeasurementsController extends ProjectController
 {
-    protected $project;
-
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    protected function setup($project_id = null): void
-    {
-        if (!is_null($project_id)) {
-            $this->project = new Project();
-            $this->project->Id = $project_id;
-        }
-        parent::setup($this->project);
-    }
-
     // Render the 'manage measurements' page.
     public function show($project_id)
     {
-        $this->setup($project_id);
-        if (!Auth::check()) {
-            return $this->redirectToLogin();
-        }
-        if (!$this->project->Exists()) {
-            abort(404);
-        }
-        if (Gate::allows('edit-project', $this->project)) {
-            return view('admin.measurements')
-                ->with('date', json_encode($this->date))
-                ->with('logo', json_encode($this->logo))
-                ->with('projectid', $project_id)
-                ->with('projectname', json_encode($this->project->Name))
-                ->with('title', "{$this->project->Name} : Test Measurements");
-        } else {
-            abort(403, 'You do not have permission to access this page.');
-        }
+        $this->setProjectById((int) $project_id);
+        Gate::authorize('edit-project', $this->project);
+
+        return view('admin.measurements')
+            ->with('project', $this->project)
+            ->with('title', 'Test Measurements');
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -1,54 +1,41 @@
 <?php
 namespace App\Http\Controllers;
 
-require_once 'include/common.php';
-require_once 'include/defines.php';
-
 use App\Services\TestingDay;
-use App\Services\ProjectPermissions;
 use CDash\Model\Project;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 
 abstract class ProjectController extends AbstractController
 {
-    protected $authOk;
-    protected $date;
-    protected $logo;
-    protected $project;
+    protected string $date;
+    protected Project $project;
 
     public function __construct()
     {
-        $this->project = null;
-        $this->authOk = false;
         $this->date = date(FMT_DATETIME);
-        $this->logo = env('APP_URL') . '/img/cdash.svg';
     }
 
     /** Retrieve common data used by all project-specific pages in CDash. */
-    protected function setup(Project $project = null): void
+    protected function setProject(Project $project): void
     {
-        if (is_null($project)) {
-            return;
-        }
-
-        // Check if user is authorized to view this project.
-        if (Gate::allows('view-project', $project)) {
-            $this->authOk = true;
-        } else {
-            $this->authOk = false;
-            if (Auth::check()) {
-                abort(403, 'You do not have permission to access this page.');
-            }
-            // redirectToLogin() gets called later on.
-            return;
-        }
+        Gate::authorize('view-project', $project);
 
         $this->project = $project;
         $this->project->Fill();
-        if ($project->ImageId) {
-            $this->logo = env('APP_URL') . "/image/{$this->project->ImageId}";
-        }
         $this->date = TestingDay::get($this->project, date(FMT_DATETIME));
+    }
+
+    protected function setProjectById(int $projectid): void
+    {
+        $project = new Project();
+        $project->Id = $projectid;
+        $this->setProject($project);
+    }
+
+    protected function setProjectByName(string $project_name): void
+    {
+        $project = new Project();
+        $project->FindByName($project_name);
+        $this->setProject($project);
     }
 }

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -1,43 +1,15 @@
 <?php
 namespace App\Http\Controllers;
 
-require_once 'include/defines.php';
-
 use App\Models\BuildTest;
-use CDash\Model\Project;
 
 class TestController extends ProjectController
 {
-    protected $project;
-
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    protected function setup(Project $project = null): void
-    {
-        parent::setup($this->project);
-    }
-
     // Render the test details page.
     public function details($buildtest_id = null)
     {
-        if (!$buildtest_id) {
-            abort(404);
-        }
         $buildtest = BuildTest::findOrFail($buildtest_id);
-        $this->project = new Project();
-        $this->project->Id = $buildtest->test->projectid;
-        $this->setup($this->project);
-        if (!$this->authOk) {
-            return $this->redirectToLogin();
-        }
-        return view('test.details')
-            ->with('buildtest', json_encode($buildtest))
-            ->with('date', json_encode($this->date))
-            ->with('logo', json_encode($this->logo))
-            ->with('projectname', json_encode($this->project->Name))
-            ->with('title', "{$this->project->Name} : Test Details");
+        $this->setProjectById($buildtest->test->projectid);
+        return view('test.details');
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -349,24 +349,6 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 2
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Deprecated in PHP 8\\.0\\: Required parameter \\$page_name follows optional parameter \\$build_id\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
@@ -392,28 +374,8 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:renderBuildPage\\(\\) has parameter \\$build_id with no type specified\\.$#"
+			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:setBuild\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:renderBuildPage\\(\\) has parameter \\$page_name with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:renderBuildPage\\(\\) has parameter \\$page_title with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:setup\\(\\) has parameter \\$build_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:setup\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 2
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -423,11 +385,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:summary\\(\\) has parameter \\$build_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\BuildController\\:\\:\\$build has no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
 
@@ -544,32 +501,12 @@ parameters:
 			path: app/Http/Controllers/EditProjectController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:create\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/EditProjectController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:edit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/EditProjectController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:edit\\(\\) has parameter \\$project_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/EditProjectController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:edit\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 2
-			path: app/Http/Controllers/EditProjectController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:setup\\(\\) has parameter \\$project_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/EditProjectController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:\\$build has no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/EditProjectController.php
 
@@ -582,47 +519,12 @@ parameters:
 			path: app/Http/Controllers/ManageBannerController.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageBannerController.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageBannerController.php
-
-		-
-			message: "#^Variable \\$edit in isset\\(\\) is never defined\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageBannerController.php
-
-		-
-			message: "#^Variable \\$projectid in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageBannerController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:setup\\(\\) has parameter \\$project_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageMeasurementsController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:show\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:show\\(\\) has parameter \\$project_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageMeasurementsController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:show\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 2
-			path: app/Http/Controllers/ManageMeasurementsController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\ManageMeasurementsController\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
@@ -817,31 +719,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: app/Http/Controllers/OAuthController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectController\\:\\:setup\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\ProjectController\\:\\:\\$authOk has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\ProjectController\\:\\:\\$date has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\ProjectController\\:\\:\\$logo has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\ProjectController\\:\\:\\$project has no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
 
 		-
 			message: """
@@ -1092,16 +969,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\TestController\\:\\:details\\(\\) has parameter \\$buildtest_id with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/TestController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\TestController\\:\\:details\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/TestController.php
-
-		-
-			message: "#^Property App\\\\Http\\\\Controllers\\\\TestController\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
 

--- a/resources/views/admin/measurements.blade.php
+++ b/resources/views/admin/measurements.blade.php
@@ -3,5 +3,5 @@
 ])
 
 @section('main_content')
-    <manage-measurements v-bind:projectid="{{ $projectid }}"></manage-measurements>
+    <manage-measurements v-bind:projectid="{{ $project->Id ?? 0 }}"></manage-measurements>
 @endsection

--- a/resources/views/admin/project.blade.php
+++ b/resources/views/admin/project.blade.php
@@ -3,5 +3,5 @@
 ])
 
 @section('main_content')
-    <edit-project v-bind:projectid="{{ $projectid }}"></edit-project>
+    <edit-project v-bind:projectid="{{ $project->Id ?? 0 }}"></edit-project>
 @endsection


### PR DESCRIPTION
We currently perform project access control checks at the top of many controller functions.  Laravel's Gate library supports authorization checking which allows us to move the duplicate access control checks to a central location.  We were also previously abusing several OOP design principles in our controller class hierarchy, which I have cleaned up as part of this refactor.  There is still a considerable amount of work left to be done to fully utilize the controller class hierarchy, but this work is a starting place from which future work can be done.

This PR directly depends upon the changes in #1419, and should be merged after #1447, #1446, and #1441 in the interest of resolving potential merge conflicts easily.