### PR TITLE
Add custom error templates for 4xx errors

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -48,7 +48,7 @@ class RegisterController extends AbstractController
     public function showRegistrationForm(Request $request)
     {
         if (config('auth.user_registration_form_enabled') === false) {
-            return response("Registration via form is disabled", 404);
+            abort(404, 'Registration via form is disabled');
         }
         // We can route a user here with our form pre-populated
         $params = [

--- a/app/Http/Controllers/CDash.php
+++ b/app/Http/Controllers/CDash.php
@@ -63,7 +63,7 @@ class CDash extends AbstractController
                 $response = $this->handleRequest();
             }
         } else {
-            $response = response('Not found', 404);
+            abort(404);
         }
 
         $status = http_response_code();

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -33,7 +33,7 @@ class RouteServiceProvider extends ServiceProvider
             if ($image->Load()) {
                 return $image;
             }
-            return abort(404);
+            abort(404);
         });
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -374,11 +374,6 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:setBuild\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:summary\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,10 @@ parameters:
         uncheckedExceptionRegexes:
             - '#^Exception$#'
             - '#^RuntimeException$#'  # Ideally we should catch these too, but there are a lot of uncaught usages here
+
+        uncheckedExceptionClasses:
+            - 'Symfony\Component\HttpKernel\Exception\HttpException'
+
         check:
             tooWideThrowType: true
             missingCheckedExceptionInThrows: true

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -1,0 +1,13 @@
+@extends('cdash', [
+    'title' => '401 Unauthorized'
+])
+
+@section('main_content')
+    @if(strlen($exception->getMessage()) > 0)
+        {{ $exception->getMessage() }}
+    @elseif(Auth::check())
+        You do not have access to the requested page.
+    @else
+        You must be logged in to view the requested page.
+    @endif
+@endsection

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,11 @@
+@extends('cdash', [
+    'title' => '403 Forbidden'
+])
+
+@section('main_content')
+    @if(strlen($exception->getMessage()) > 0)
+        {{ $exception->getMessage() }}
+    @else
+        You do not have access to the requested page.
+    @endif
+@endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,11 @@
+@extends('cdash', [
+    'title' => '404 Not Found'
+])
+
+@section('main_content')
+    @if(strlen($exception->getMessage()) > 0)
+        {{ $exception->getMessage() }}
+    @else
+        The requested page does not exist.
+    @endif
+@endsection

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,0 +1,7 @@
+@extends('cdash', [
+    'title' => $exception->getStatusCode()
+])
+
+@section('main_content')
+    {{ $exception->getMessage() }}
+@endsection


### PR DESCRIPTION
We currently use Laravel's default error handlers for 4xx errors.  The default handlers do not display the exception message, so it is impossible to determine the cause of a given error.

This PR adds custom templates for 4xx HTTP errors.  5xx-category errors are logged, and there is nothing an end user can do to resolve a 5xx-category error so there is no need to display an error message.