### PR TITLE
Minify assets

### DIFF
--- a/app/Console/Commands/UpdateDependencies.php
+++ b/app/Console/Commands/UpdateDependencies.php
@@ -51,6 +51,6 @@ class UpdateDependencies extends Command
         exec("npm install");
 
         // Run laravel-mix to builds assets
-        exec("npm run dev");
+        exec("npm run production");
     }
 }

--- a/app/cdash/public/js/controllers/buildProperties.js
+++ b/app/cdash/public/js/controllers/buildProperties.js
@@ -1,5 +1,5 @@
 CDash.controller('BuildPropertiesController',
-  function BuildPropertiesController($filter, $http, $scope, apiLoader, comparators, modalSvc, multisort) {
+  ["$filter", "$http", "$scope", "apiLoader", "comparators", "modalSvc", "multisort", function BuildPropertiesController($filter, $http, $scope, apiLoader, comparators, modalSvc, multisort) {
     apiLoader.loadPageData($scope, 'api/v1/buildProperties.php');
     $scope.finishSetup = function() {
       if ($scope.cdash.builds.length < 1) {
@@ -445,4 +445,4 @@ CDash.controller('BuildPropertiesController',
       $scope.pageChanged();
       $.cookie('cdash_buildProperties_sort', $scope.orderByFields);
     };
-});
+}]);

--- a/app/cdash/public/js/controllers/compareCoverage.js
+++ b/app/cdash/public/js/controllers/compareCoverage.js
@@ -1,5 +1,5 @@
 CDash.controller('CompareCoverageController',
-  function CompareCoverageController($scope, $rootScope, apiLoader, filters, multisort) {
+  ["$scope", "$rootScope", "apiLoader", "filters", "multisort", function CompareCoverageController($scope, $rootScope, apiLoader, filters, multisort) {
     // Hide filters by default.
     $scope.showfilters = false;
 
@@ -18,4 +18,4 @@ CDash.controller('CompareCoverageController',
     $scope.updateOrderByFields = function(obj, field, $event) {
       multisort.updateOrderByFields(obj, field, $event);
     };
-});
+}]);

--- a/app/cdash/public/js/controllers/filters.js
+++ b/app/cdash/public/js/controllers/filters.js
@@ -1,4 +1,5 @@
-angular
+
+FiltersController.$inject = ["$scope", "$rootScope", "$http", "$timeout"];angular
     .module('CDash')
     .controller('FiltersController', FiltersController);
 
@@ -458,15 +459,15 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
 }
 
 angular.module('CDash')
-       .directive('filterRow', function (VERSION) {
+       .directive('filterRow', ["VERSION", function (VERSION) {
   return {
     templateUrl: 'build/views/partials/filterRow_' + VERSION + '.html'
   };
-});
+}]);
 
 angular.module('CDash')
-       .directive('filterButtons', function (VERSION) {
+       .directive('filterButtons', ["VERSION", function (VERSION) {
   return {
     templateUrl: 'build/views/partials/filterButtons_' + VERSION + '.html'
   };
-});
+}]);

--- a/app/cdash/public/js/controllers/head.js
+++ b/app/cdash/public/js/controllers/head.js
@@ -1,4 +1,4 @@
-CDash.controller('HeadController', function HeadController($rootScope, $document) {
+CDash.controller('HeadController', ["$rootScope", "$document", function HeadController($rootScope, $document) {
   // Adapted from:
   // http://www.quirksmode.org/js/cookies.html
   $rootScope.readCookie = function(name) {
@@ -90,4 +90,4 @@ CDash.controller('HeadController', function HeadController($rootScope, $document
     $( "#calendar" ).toggle();
   };
 
-});
+}]);

--- a/app/cdash/public/js/controllers/index.js
+++ b/app/cdash/public/js/controllers/index.js
@@ -48,7 +48,7 @@ CDash.filter("showEmptyBuildsLast", function () {
 })
 
 
-.controller('IndexController', function IndexController($scope, $rootScope, $location, $http, $filter, $timeout, anchors, apiLoader, filters, multisort, modalSvc) {
+.controller('IndexController', ["$scope", "$rootScope", "$location", "$http", "$filter", "$timeout", "anchors", "apiLoader", "filters", "multisort", "modalSvc", function IndexController($scope, $rootScope, $location, $http, $filter, $timeout, anchors, apiLoader, filters, multisort, modalSvc) {
   // Show spinner while page is loading.
   $scope.loading = true;
 
@@ -574,4 +574,4 @@ CDash.filter("showEmptyBuildsLast", function () {
     cookie_name += '_sort';
     return cookie_name;
   };
-});
+}]);

--- a/app/cdash/public/js/controllers/manageBuildGroup.js
+++ b/app/cdash/public/js/controllers/manageBuildGroup.js
@@ -34,7 +34,7 @@ CDash.filter('filter_builds', function() {
   };
 })
 
-.controller('ManageBuildGroupController', function ManageBuildGroupController($scope, $http, apiLoader, modalSvc) {
+.controller('ManageBuildGroupController', ["$scope", "$http", "apiLoader", "modalSvc", function ManageBuildGroupController($scope, $http, apiLoader, modalSvc) {
   apiLoader.loadPageData($scope, 'api/v1/manageBuildGroup.php');
   $scope.finishSetup = function() {
     // Sort BuildGroups by position.
@@ -281,4 +281,4 @@ CDash.filter('filter_builds', function() {
   };
 
 
-});
+}]);

--- a/app/cdash/public/js/controllers/manageOverview.js
+++ b/app/cdash/public/js/controllers/manageOverview.js
@@ -1,4 +1,4 @@
-CDash.controller('ManageOverviewController', function ManageOverviewController($scope, $http, apiLoader) {
+CDash.controller('ManageOverviewController', ["$scope", "$http", "apiLoader", function ManageOverviewController($scope, $http, apiLoader) {
   apiLoader.loadPageData($scope, 'api/v1/manageOverview.php');
   $scope.finishSetup = function() {
     // Setup sortable elements.
@@ -67,4 +67,4 @@ CDash.controller('ManageOverviewController', function ManageOverviewController($
       $("#loading").attr("src", "img/check.gif");
     });
   };
-});
+}]);

--- a/app/cdash/public/js/controllers/manageSubProject.js
+++ b/app/cdash/public/js/controllers/manageSubProject.js
@@ -17,7 +17,7 @@ CDash.filter('filter_subproject_groups', function() {
     return output;
   };
 })
-.controller('ManageSubProjectController', function ManageSubProjectController($scope, $http, apiLoader) {
+.controller('ManageSubProjectController', ["$scope", "$http", "apiLoader", function ManageSubProjectController($scope, $http, apiLoader) {
   apiLoader.loadPageData($scope, 'api/v1/manageSubProject.php');
   $scope.finishSetup = function() {
     // Sort groups by position.
@@ -147,4 +147,4 @@ CDash.filter('filter_subproject_groups', function() {
     });
   };
 
-});
+}]);

--- a/app/cdash/public/js/controllers/overview.js
+++ b/app/cdash/public/js/controllers/overview.js
@@ -1,5 +1,5 @@
 CDash.controller('OverviewController',
-  function OverviewController($scope, $location, anchors, apiLoader) {
+  ["$scope", "$location", "anchors", "apiLoader", function OverviewController($scope, $location, anchors, apiLoader) {
     apiLoader.loadPageData($scope, 'api/v1/overview.php');
     $scope.finishSetup = function() {
       // Expose the jumpToAnchor function to the scope.
@@ -11,7 +11,7 @@ CDash.controller('OverviewController',
         anchors.jumpToAnchor($location.hash());
       }
     };
-});
+}]);
 
 CDash.directive('linechart', function() {
   return {

--- a/app/cdash/public/js/controllers/queryTests.js
+++ b/app/cdash/public/js/controllers/queryTests.js
@@ -1,5 +1,5 @@
 CDash.controller('QueryTestsController',
-  function QueryTestsController($scope, $rootScope, $filter, apiLoader, filters, multisort) {
+  ["$scope", "$rootScope", "$filter", "apiLoader", "filters", "multisort", function QueryTestsController($scope, $rootScope, $filter, apiLoader, filters, multisort) {
     $scope.loading = true;
 
     // Pagination settings.
@@ -80,4 +80,4 @@ CDash.controller('QueryTestsController',
       var field = 'measurements[' + idx + ']';
       $scope.updateOrderByFields(field, $event);
     }
-});
+}]);

--- a/app/cdash/public/js/controllers/subproject.js
+++ b/app/cdash/public/js/controllers/subproject.js
@@ -1,4 +1,4 @@
-CDash.controller('SubProjectController', function SubProjectController($scope, $rootScope, $http) {
+CDash.controller('SubProjectController', ["$scope", "$rootScope", "$http", function SubProjectController($scope, $rootScope, $http) {
   $scope.dataLoaded = false;
 
   $scope.loadData = function(id) {
@@ -129,4 +129,4 @@ CDash.controller('SubProjectController', function SubProjectController($scope, $
     });
   };
 
-});
+}]);

--- a/app/cdash/public/js/controllers/testOverview.js
+++ b/app/cdash/public/js/controllers/testOverview.js
@@ -1,5 +1,5 @@
 CDash.controller('TestOverviewController',
-  function TestOverviewController($scope, $rootScope, $filter, apiLoader, filters, multisort) {
+  ["$scope", "$rootScope", "$filter", "apiLoader", "filters", "multisort", function TestOverviewController($scope, $rootScope, $filter, apiLoader, filters, multisort) {
     $scope.groupChanged = false;
 
     // Hide filters by default.
@@ -98,4 +98,4 @@ CDash.controller('TestOverviewController',
       uri += filters.getString();
       window.location = uri;
     };
-});
+}]);

--- a/app/cdash/public/js/controllers/testSummary.js
+++ b/app/cdash/public/js/controllers/testSummary.js
@@ -1,5 +1,5 @@
 CDash.controller('TestSummaryController',
-  function TestSummaryController($scope, $timeout, apiLoader, multisort) {
+  ["$scope", "$timeout", "apiLoader", "multisort", function TestSummaryController($scope, $timeout, apiLoader, multisort) {
     // Hide filters and graph by default.
     $scope.showfilters = false;
     $scope.showgraph = false;
@@ -47,4 +47,4 @@ CDash.controller('TestSummaryController',
       }
     };
 
-});
+}]);

--- a/app/cdash/public/js/controllers/user.js
+++ b/app/cdash/public/js/controllers/user.js
@@ -1,4 +1,4 @@
-CDash.controller('UserController', function UserController($scope, $http, $timeout, apiLoader) {
+CDash.controller('UserController', ["$scope", "$http", "$timeout", "apiLoader", function UserController($scope, $http, $timeout, apiLoader) {
   apiLoader.loadPageData($scope, 'api/v1/user.php');
 
   $scope.generateToken = function() {
@@ -72,4 +72,4 @@ CDash.controller('UserController', function UserController($scope, $http, $timeo
       $scope.cdash.tokenscope = '';
     }
   }
-});
+}]);

--- a/app/cdash/public/js/controllers/userStatistics.js
+++ b/app/cdash/public/js/controllers/userStatistics.js
@@ -1,5 +1,5 @@
 CDash.controller('UserStatisticsController',
-  function UserStatisticsController($scope, $filter, apiLoader, multisort) {
+  ["$scope", "$filter", "apiLoader", "multisort", function UserStatisticsController($scope, $filter, apiLoader, multisort) {
     // Check for sort order cookie.
     var sort_order = [];
     var sort_cookie_value = $.cookie('cdash_user_stats_sort');
@@ -33,4 +33,4 @@ CDash.controller('UserStatisticsController',
       $scope.cdash.users = $filter('orderBy')($scope.cdash.users, $scope.orderByFields);
       $.cookie('cdash_user_stats_sort', $scope.orderByFields);
     };
-});
+}]);

--- a/app/cdash/public/js/controllers/viewBuildError.js
+++ b/app/cdash/public/js/controllers/viewBuildError.js
@@ -1,5 +1,5 @@
 CDash.controller('ViewBuildErrorController',
-  function BuildErrorController($scope, $sce, apiLoader) {
+  ["$scope", "$sce", "apiLoader", function BuildErrorController($scope, $sce, apiLoader) {
     $scope.loading = true;
     $scope.pagination = [];
     $scope.pagination.buildErrors = [];
@@ -26,8 +26,8 @@ CDash.controller('ViewBuildErrorController',
     $scope.pageChanged = function() {
       $scope.setPage($scope.pagination.currentPage);
     };
-  }).directive('buildError', function (VERSION) {
+  }]).directive('buildError', ["VERSION", function (VERSION) {
       return {
           templateUrl: 'build/views/partials/buildError_' + VERSION + '.html'
       };
-  });
+  }]);

--- a/app/cdash/public/js/controllers/viewDynamicAnalysis.js
+++ b/app/cdash/public/js/controllers/viewDynamicAnalysis.js
@@ -1,4 +1,4 @@
 CDash.controller('ViewDynamicAnalysisController',
-  function ViewDynamicAnalysisController($scope, apiLoader) {
+  ["$scope", "apiLoader", function ViewDynamicAnalysisController($scope, apiLoader) {
     apiLoader.loadPageData($scope, 'api/v1/viewDynamicAnalysis.php');
-});
+}]);

--- a/app/cdash/public/js/controllers/viewDynamicAnalysisFile.js
+++ b/app/cdash/public/js/controllers/viewDynamicAnalysisFile.js
@@ -1,4 +1,4 @@
 CDash.controller('ViewDynamicAnalysisFileController',
-  function ViewDynamicAnalysisFileController($scope, apiLoader) {
+  ["$scope", "apiLoader", function ViewDynamicAnalysisFileController($scope, apiLoader) {
     apiLoader.loadPageData($scope, 'api/v1/viewDynamicAnalysisFile.php');
-});
+}]);

--- a/app/cdash/public/js/controllers/viewProjects.js
+++ b/app/cdash/public/js/controllers/viewProjects.js
@@ -1,6 +1,6 @@
 CDash.controller('ViewProjectsController',
-  function ViewProjectsController($scope, apiLoader) {
+  ["$scope", "apiLoader", function ViewProjectsController($scope, apiLoader) {
     // Hide filters by default.
     $scope.showfilters = false;
     apiLoader.loadPageData($scope, 'api/v1/viewProjects.php');
-});
+}]);

--- a/app/cdash/public/js/controllers/viewSubProjects.js
+++ b/app/cdash/public/js/controllers/viewSubProjects.js
@@ -1,5 +1,5 @@
 CDash.controller('ViewSubProjectsController',
-  function ViewSubProjectsController($scope, multisort, apiLoader) {
+  ["$scope", "multisort", "apiLoader", function ViewSubProjectsController($scope, multisort, apiLoader) {
     // Hide filters by default.
     $scope.showfilters = false;
 
@@ -17,4 +17,4 @@ CDash.controller('ViewSubProjectsController',
       multisort.updateOrderByFields(obj, field, $event);
       $.cookie('cdash_subproject_sort', obj.orderByFields);
     };
-});
+}]);

--- a/app/cdash/public/js/controllers/viewTest.js
+++ b/app/cdash/public/js/controllers/viewTest.js
@@ -1,5 +1,5 @@
 CDash.controller('ViewTestController',
-  function ViewTestController($scope, $rootScope, $http, $filter, $q, apiLoader, multisort, filters) {
+  ["$scope", "$rootScope", "$http", "$filter", "$q", "apiLoader", "multisort", "filters", function ViewTestController($scope, $rootScope, $http, $filter, $q, apiLoader, multisort, filters) {
     $scope.loading = true;
 
     // Pagination settings.
@@ -151,4 +151,4 @@ CDash.controller('ViewTestController',
     $scope.cancelAjax = function() {
       $scope.canceler.resolve();
     }
-});
+}]);

--- a/app/cdash/public/js/controllers/viewUpdate.js
+++ b/app/cdash/public/js/controllers/viewUpdate.js
@@ -1,5 +1,5 @@
 CDash.controller('ViewUpdateController',
-  function ViewUpdateController($scope, $rootScope, $http, apiLoader) {
+  ["$scope", "$rootScope", "$http", "apiLoader", function ViewUpdateController($scope, $rootScope, $http, apiLoader) {
     $scope.graphLoaded = false;
     $scope.graphLoading = false;
     $scope.showGraph = false;
@@ -60,10 +60,10 @@ CDash.controller('ViewUpdateController',
 
       plot = $.plot($("#graph_holder"), [{label: "Number of changed files", data: input.data}], options);
     };
-})
+}])
 
-.directive('updatedFiles', function(VERSION) {
+.directive('updatedFiles', ["VERSION", function(VERSION) {
   return {
     templateUrl: 'build/views/partials/updatedfiles_' + VERSION + '.html'
   }
-});
+}]);

--- a/app/cdash/public/js/directives/autocomplete.js
+++ b/app/cdash/public/js/directives/autocomplete.js
@@ -1,7 +1,7 @@
-CDash.directive('autoComplete', function($parse) {
+CDash.directive('autoComplete', ["$parse", function($parse) {
   return function(scope, element, attrs) {
     element.autocomplete({
       source: $parse(attrs.availableValues)(scope)
     });
   };
-});
+}]);

--- a/app/cdash/public/js/directives/build.js
+++ b/app/cdash/public/js/directives/build.js
@@ -1,5 +1,5 @@
-CDash.directive('build', function (VERSION) {
+CDash.directive('build', ["VERSION", function (VERSION) {
   return {
     templateUrl: 'build/views/partials/build_' + VERSION + '.html'
   }
-});
+}]);

--- a/app/cdash/public/js/directives/buildgroup.js
+++ b/app/cdash/public/js/directives/buildgroup.js
@@ -1,5 +1,5 @@
-CDash.directive('buildgroup', function (VERSION) {
+CDash.directive('buildgroup', ["VERSION", function (VERSION) {
   return {
     templateUrl: 'build/views/partials/buildgroup_' + VERSION + '.html'
   }
-});
+}]);

--- a/app/cdash/public/js/directives/daterange.js
+++ b/app/cdash/public/js/directives/daterange.js
@@ -1,4 +1,4 @@
-CDash.directive('daterange', function (VERSION) {
+CDash.directive('daterange', ["VERSION", function (VERSION) {
   return {
     restrict: 'A',
     templateUrl: 'build/views/partials/daterange_' + VERSION + '.html',
@@ -40,4 +40,4 @@ CDash.directive('daterange', function (VERSION) {
       }
     }
   };
-});
+}]);

--- a/app/cdash/public/js/directives/onFinishRender.js
+++ b/app/cdash/public/js/directives/onFinishRender.js
@@ -1,4 +1,4 @@
-CDash.directive('onFinishRender', function ($timeout) {
+CDash.directive('onFinishRender', ["$timeout", function ($timeout) {
   return {
     restrict: 'A',
     link: function (scope, element, attr) {
@@ -7,4 +7,4 @@ CDash.directive('onFinishRender', function ($timeout) {
       }
     }
   }
-});
+}]);

--- a/app/cdash/public/js/directives/timeline.js
+++ b/app/cdash/public/js/directives/timeline.js
@@ -256,11 +256,12 @@ var timelineController =
       window.location = uri;
     };
 };
+timelineController.$inject = ["$http", "$scope"];
 
-CDash.directive('timeline', function (VERSION) {
+CDash.directive('timeline', ["VERSION", function (VERSION) {
   return {
     restrict: 'A',
     templateUrl: 'build/views/partials/timeline_' + VERSION + '.html',
     controller: timelineController
   };
-});
+}]);

--- a/app/cdash/public/js/services/anchors.js
+++ b/app/cdash/public/js/services/anchors.js
@@ -1,9 +1,9 @@
 // Handle intra-page links.
-CDash.service('anchors', function ($anchorScroll, $location, $timeout) {
+CDash.service('anchors', ["$anchorScroll", "$location", "$timeout", function ($anchorScroll, $location, $timeout) {
   this.jumpToAnchor = function(elementId) {
     $timeout(function() {
       $location.hash(elementId);
       $anchorScroll();
     });
   };
-});
+}]);

--- a/app/cdash/public/js/services/apiLoader.js
+++ b/app/cdash/public/js/services/apiLoader.js
@@ -1,5 +1,5 @@
 // Encapsulate common code involved in loading our page data from the API.
-CDash.factory('apiLoader', function ($http, $rootScope, $window, renderTimer) {
+CDash.factory('apiLoader', ["$http", "$rootScope", "$window", "renderTimer", function ($http, $rootScope, $window, renderTimer) {
   const loadPageData = function(controllerScope, endpoint) {
     controllerScope.loading = true;
 
@@ -38,4 +38,4 @@ CDash.factory('apiLoader', function ($http, $rootScope, $window, renderTimer) {
   return {
     loadPageData: loadPageData
   };
-});
+}]);

--- a/app/cdash/public/js/services/modal.js
+++ b/app/cdash/public/js/services/modal.js
@@ -1,4 +1,4 @@
-CDash.factory('modalSvc', function modalSvc ($uibModal) {
+CDash.factory('modalSvc', ["$uibModal", function modalSvc ($uibModal) {
   const showModal = function(modelId, okFn, template, parent_scope, size, success, error) {
     parent_scope = typeof parent_scope !== 'undefined' ? parent_scope : null;
     size = typeof size !== 'undefined' ? size : 'sm';
@@ -39,4 +39,4 @@ CDash.factory('modalSvc', function modalSvc ($uibModal) {
   return {
     showModal: showModal,
   };
-});
+}]);

--- a/app/cdash/public/js/services/renderTimer.js
+++ b/app/cdash/public/js/services/renderTimer.js
@@ -1,6 +1,6 @@
 // Time how long the initial render takes and add this to the value
 // shown at the bottom of the page.
-CDash.factory('renderTimer', function ($timeout) {
+CDash.factory('renderTimer', ["$timeout", function ($timeout) {
   var initialRender = function(controllerScope, cdash) {
     // Redirect if the API told us to.
     if ('redirect' in cdash) {
@@ -26,4 +26,4 @@ CDash.factory('renderTimer', function ($timeout) {
   return {
     initialRender: initialRender
   };
-});
+}]);

--- a/docker/bash/misc.bash
+++ b/docker/bash/misc.bash
@@ -55,7 +55,7 @@ setup_local_config() {
         fi
 
     ) >> "$__local_config_file"
-    cd /home/kitware/cdash && php artisan config:migrate && php artisan key:generate && npm run dev
+    cd /home/kitware/cdash && php artisan config:migrate && php artisan key:generate && npm run production
 }
 
 local_service_teardown() {

--- a/docs/install.md
+++ b/docs/install.md
@@ -113,7 +113,7 @@ Once you're happy with your config settings, run `npm` to generate CDash's front
 
 ```bash
 # Generate build files
-npm run dev
+npm run production
 ```
 
 ##### Migrating settings from `config.local.php`

--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -9,6 +9,8 @@
     lang="{{ str_replace('_', '-', app()->getLocale()) }}"
     @if(isset($angular) && $angular === true)
         ng-app="CDash"
+        ng-strict-di
+        ng-cloak
     @endif
 >
 <head @if(isset($angular) && $angular === true) ng-controller="HeadController" @endif>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -10,7 +10,7 @@ $version = Config::getVersion();
 <div id="footer" class="clearfix ng-scope">
     <div id="kitwarelogo">
         <a href="https://www.kitware.com">
-            <img src="{{ asset('img/kitware_logo_footer.svg') }}" alt="logo">
+            <img src="{{ asset('img/kitware_logo_footer.svg') }}" alt="logo" height="30">
         </a>
     </div>
 

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -42,7 +42,7 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
                 @if(isset($project) && $logoid > 0)
                     <img id="projectlogo" height="50px" alt="" src="{{ url('/image/' . $logoid) }}" />
                 @elseif(isset($angular) && $angular === true)
-                    <img ng-if="cdash.logoid != 0" id="projectlogo" border="0" height="50px" ng-src="{{ url('/image') }}/@{{::cdash.logoid}}"/>
+                    <img ng-if="cdash.logoid && cdash.logoid != 0" id="projectlogo" border="0" height="50px" ng-src="{{ url('/image') }}/@{{::cdash.logoid}}"/>
                     <img ng-if="!cdash.logoid || cdash.logoid==0" id="projectlogo" border="0" height="50px" src="{{ asset('/img/cdash.svg?rev=2023-05-09') }}"/>
                 @elseif(isset($vue) && $vue === true)
                     <header-logo></header-logo>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -76,8 +76,8 @@ mix.copy('public/views/*.html', 'public/build/views/');
 // Cache busting for angularjs partials.
 var glob = require("glob");
 glob.sync('public/views/partials/*.html').forEach(function(src) {
-  var dest = src.replace('.html', '_' + version + '.html');
-  var dest = dest.replace('views', 'build/views');
+  let dest = src.replace('.html', '_' + version + '.html');
+  dest = dest.replace('views', 'build/views');
   mix.copy(src, dest);
 });
 
@@ -104,8 +104,8 @@ mix.scripts([
   'public/js/bootstrap.min.js',
   'public/js/tooltip.js',
   'public/js/je_compare.js',
-  'node_modules/angular/angular.js',
-  'node_modules/angular-animate/angular-animate.js',
+  'node_modules/angular/angular.min.js',
+  'node_modules/angular-animate/angular-animate.min.js',
   'node_modules/angular-clipboard/angular-clipboard.js',
   'node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js',
   'node_modules/angular-ui-sortable/dist/sortable.js',


### PR DESCRIPTION
Google's [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) tool currently gives CDash a low score on many pages, particularly those using AngularJS for rendering.  The low score is mostly due to slow page load times, and a "flash" as content renders--a metric called the "Cumulative Layout Shift".  I was able to reduce the page load time by one third by minifying the JS and CSS source files.  I also eliminated the "flash" of content on AngularJS pages, resulting in a much lower CLS score.

We previously used "Implicit Annotation" to pass parameters to AngularJS controllers.  Implicit Annotation is not minification-safe as per the [documentation](https://docs.angularjs.org/guide/di#implicit-annotation), so I have added explicit annotations and enabled strict dependency injection as recommended by the documentation.

Before | After
:-------------------------:|:-------------------------:
![image](https://github.com/Kitware/CDash/assets/16820599/c711d269-32b6-4aa6-a7e7-8f9f2cedc204)  |  ![image](https://github.com/Kitware/CDash/assets/16820599/af43c960-6131-40de-90c6-1b4eb8cddb7b)
