### PR TITLE
Populate "Manage SubProjects" list by default

### DIFF
--- a/app/cdash/public/api/v1/manageSubProject.php
+++ b/app/cdash/public/api/v1/manageSubProject.php
@@ -48,12 +48,6 @@ $userid = $user->id;
 // List the available projects that this user has admin rights to.
 $projectid = intval($_GET['projectid'] ?? 0);
 
-if (!can_access_project($projectid)) {
-    $response['error'] = 'You do not have permission to view this project.';
-    echo json_encode($response);
-    return;
-}
-
 $sql = 'SELECT id,name FROM project';
 $params = [];
 if ($user->IsAdmin() == false) {


### PR DESCRIPTION
The "Manage SubProjects" page currently doesn't populate the list of projects properly, meaning that there is no way to select a project to edit.

This PR fixes the issue by fixing a faulty project access control check.