### PR TITLE
Add help text to system monitor page

### DIFF
--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -122,7 +122,8 @@ class MonitorController extends AbstractController
             'backlog_length' => $backlog_length,
             'backlog_time' => $backlog_time,
             'time_chart_data' => $time_chart_data,
-            'ticks' => $ticks
+            'ticks' => $ticks,
+            'log_directory' => config('logging.default') === 'stack' ? storage_path('logs') : '',
         ]);
     }
 

--- a/resources/js/components/Monitor.vue
+++ b/resources/js/components/Monitor.vue
@@ -23,6 +23,17 @@
         />
       </div>
     </div>
+    <br>
+    <p>
+      Note: Detailed information about submission failures can be found in the CDash logs.<br>
+      <span v-if="cdash.log_directory.length > 0">
+        Log files can be found in: <tt>{{ cdash.log_directory }}</tt>
+      </span>
+      <span v-else>
+        This CDash instance uses a non-standard logging configuration.  Check your <tt>LOG_CHANNEL</tt>
+        environment setting for more information.
+      </span>
+    </p>
   </section>
 </template>
 <script>


### PR DESCRIPTION
#1436 revamped the system monitor page, with a new visualization of submission processing over time.  This PR adds a small snippet of text at the bottom of the page indicating where administrators can find logs so submission failures can be debugged.