### PR TITLE
Time entire request

### DIFF
--- a/app/Services/PageTimer.php
+++ b/app/Services/PageTimer.php
@@ -16,28 +16,30 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Facades\Log;
+
 /**
  * This class handles page load time calculations, reporting, and logging.
  **/
 class PageTimer
 {
-    protected $start;
-    protected $end;
-    protected $duration;
+    protected float $start;
+    protected float $end;
+    protected float $duration;
 
     public function __construct()
     {
         $this->end = 0.0;
-        $this->start = microtime(true);
+        $this->start = LARAVEL_START;
     }
 
     public function end(&$response)
     {
         $this->end = microtime(true);
-        $this->duration = round($this->end - $this->start, 2);
+        $this->duration = round($this->end - LARAVEL_START, 2);
         if ($this->duration > config('cdash.slow_page_time')) {
             $url = $_SERVER['REQUEST_URI'];
-            \Log::warning("Slow page: $url took $this->duration to load");
+            Log::warning("Slow page: $url took $this->duration seconds to load");
         }
         $response['generationtime'] = $this->duration;
     }

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -17,15 +17,18 @@
 require_once dirname(__FILE__) . '/../../../../vendor/autoload.php';
 require_once dirname(__FILE__) . '/kw_unlink.php';
 
-use App\Http\Controllers\CDash;
+// This is used by several of the tests, but the Laravel entrypoint is not used for
+// such tests, meaning that this could be undefined.
+if (!defined('LARAVEL_START')) {
+    define('LARAVEL_START', microtime(true));
+}
+
 use App\Models\User;
 use CDash\Config;
 use CDash\Model\Project;
 use App\Http\Kernel;
-use Illuminate\Auth\AuthManager;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1843,21 +1843,6 @@ parameters:
 			path: app/Services/PageTimer.php
 
 		-
-			message: "#^Property App\\\\Services\\\\PageTimer\\:\\:\\$duration has no type specified\\.$#"
-			count: 1
-			path: app/Services/PageTimer.php
-
-		-
-			message: "#^Property App\\\\Services\\\\PageTimer\\:\\:\\$end has no type specified\\.$#"
-			count: 1
-			path: app/Services/PageTimer.php
-
-		-
-			message: "#^Property App\\\\Services\\\\PageTimer\\:\\:\\$start has no type specified\\.$#"
-			count: 1
-			path: app/Services/PageTimer.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\:\\:\\$measurements\\.$#"
 			count: 1
 			path: app/Services/TestCreator.php
@@ -22352,22 +22337,22 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:getSent\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:getSent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:isError\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:isError\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:read\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:read\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -22467,12 +22452,12 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:\\$read has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:\\$read has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:878\\:\\:\\$response has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:881\\:\\:\\$response has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -38,7 +38,7 @@ $version = Config::getVersion();
                 </span>
             @elseif(isset($vue) && $vue === true)
                 | <span id="generation-time"></span> {{-- Will be filled by Vue --}}
-            @elseif(defined('LARAVEL_START')) {{-- LARAVEL_START might not be defined in the testing environment --}}
+            @else
                 <span>
                     | {{ round(microtime(true) - LARAVEL_START, 2) }}s
                 </span>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,12 @@
 
 namespace Tests;
 
+// This is used by several of the tests, but the Laravel entrypoint is not used for
+// such tests, meaning that this could be undefined.
+if (!defined('LARAVEL_START')) {
+    define('LARAVEL_START', microtime(true));
+}
+
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
The `PageTimer` class is currently used in a variety of API routes to provide insight into the amount of time needed to complete a given response.  The current start time is based upon the time when the `PageTimer` class is instantiated.  This approach provides an inaccurate measure of the overall time, since the `PageTimer` object is often created after much of the request has already been completed.  In fact, some parts of the codebase execute multiple database queries before the timer gets started.  Laravel's `LARAVEL_START` constant is defined at the start of each request, and provides a more accurate request start time.

In the future, I hope to get rid of the `PageTimer` class entirely and incorporate the timing logic into a standardized API response.