### PR TITLE
Define API controller parent classes as "abstract"

### DIFF
--- a/app/cdash/app/Controller/Api.php
+++ b/app/cdash/app/Controller/Api.php
@@ -21,7 +21,7 @@ use CDash\Database;
 /**
  * Parent class for all API controllers.
  **/
-class Api
+abstract class Api
 {
     const BEGIN_EPOCH = '1980-01-01 00:00:00';
 

--- a/app/cdash/app/Controller/Api/BuildApi.php
+++ b/app/cdash/app/Controller/Api/BuildApi.php
@@ -23,7 +23,7 @@ use CDash\Model\Project;
  * Parent class for all API controllers responsible for displaying
  * information about a particular build.
  **/
-class BuildApi extends ResultsApi
+abstract class BuildApi extends ResultsApi
 {
     protected $project;
 

--- a/app/cdash/app/Controller/Api/BuildTestApi.php
+++ b/app/cdash/app/Controller/Api/BuildTestApi.php
@@ -26,7 +26,7 @@ use CDash\Model\Build;
  * Parent class for all API controllers responsible for displaying
  * information about a particular test run.
  **/
-class BuildTestApi extends BuildApi
+abstract class BuildTestApi extends BuildApi
 {
     public $buildtest;
     public $test;

--- a/app/cdash/app/Controller/Api/ProjectApi.php
+++ b/app/cdash/app/Controller/Api/ProjectApi.php
@@ -21,7 +21,7 @@ use CDash\Model\Project;
 /**
  * Parent class for all API controllers that deal with a particular project.
  **/
-class ProjectApi extends \CDash\Controller\Api
+abstract class ProjectApi extends \CDash\Controller\Api
 {
     protected $project;
 

--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -25,7 +25,7 @@ use CDash\Model\Project;
  * Parent class for all API controllers responsible for displaying
  * build/test results.
  **/
-class ResultsApi extends ProjectApi
+abstract class ResultsApi extends ProjectApi
 {
     public $filterdata;
 


### PR DESCRIPTION
We currently treat the parent classes in our API controller inheritance hierarchy like abstract classes, even though they are currently defined as concrete classes from which objects can be instantiated.  In this PR, I have marked all of the parent classes as "abstract".