### PR TITLE
Simplify project access control logic

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use CDash\Database;
-use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
@@ -37,11 +36,9 @@ class MapController extends ProjectController
 
         $db = Database::getInstance();
 
-        $project_array = $db->executePreparedSingleRow('SELECT * FROM project WHERE id=?', [$this->project->Id]);
+        list($previousdate, $currenttime, $nextdate) = get_dates($date, $this->project->NightlyTime);
 
-        list($previousdate, $currenttime, $nextdate) = get_dates($date, $project_array['nightlytime']);
-
-        $nightlytime = strtotime($project_array['nightlytime']);
+        $nightlytime = strtotime($this->project->NightlyTime);
 
         $nightlyhour = gmdate('H', $nightlytime);
         $nightlyminute = gmdate('i', $nightlytime);

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -14,9 +14,12 @@ class Admin
     public function handle(Request $request, Closure $next)
     {
         $user = Auth::user();
-        if ($user === null || !$user->IsAdmin()) {
+        if ($user === null) {
             session(['url.intended' => url()->current()]);
             return redirect('/login');
+        }
+        if (!$user->IsAdmin()) {
+            abort(403, 'You must be an administrator to access this page.');
         }
 
         return $next($request);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -429,11 +429,6 @@ parameters:
 			path: app/Http/Controllers/CDash.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\CTestConfigurationController\\:\\:get\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/CTestConfigurationController.php
-
-		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
 				04/01/2023$#
@@ -645,14 +640,6 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
-			path: app/Http/Controllers/MapController.php
-
-		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
 			path: app/Http/Controllers/MapController.php
 
 		-
@@ -877,14 +864,6 @@ parameters:
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 4
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
 			count: 2
 			path: app/Http/Controllers/SubProjectController.php
 
@@ -895,46 +874,8 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$bugurl might not be defined\\.$#"
 			count: 2
 			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$docurl might not be defined\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$googletracker might not be defined\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$homeurl might not be defined\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$projectpublic might not be defined\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: "#^Variable \\$svnurl might not be defined\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
 			message: """
@@ -949,17 +890,12 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
-			message: "#^Foreach overwrites \\$project_array with its value variable\\.$#"
-			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -31318,6 +31254,26 @@ parameters:
 			message: "#^Property Tests\\\\Feature\\\\ProjectPermissions\\:\\:\\$public_project has no type specified\\.$#"
 			count: 1
 			path: tests/Feature/ProjectPermissions.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\RouteAccessTest\\:\\:adminRoutes\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\RouteAccessTest\\:\\:adminRoutes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\RouteAccessTest\\:\\:protectedRoutes\\(\\) is unused\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\RouteAccessTest\\:\\:protectedRoutes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Feature/RouteAccessTest.php
 
 		-
 			message: "#^Property Tests\\\\Feature\\\\UserCommand\\:\\:\\$user has no type specified\\.$#"

--- a/tests/Traits/CreatesProjects.php
+++ b/tests/Traits/CreatesProjects.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Traits;
+
+use \CDash\Model\Project;
+
+trait CreatesProjects
+{
+    public function makePublicProject(): Project
+    {
+        $project = new Project();
+        $project->Name = 'PublicProject';
+        $project->Public = Project::ACCESS_PUBLIC;
+        $project->Save();
+        return $project;
+    }
+}


### PR DESCRIPTION
#1449 refactored a significant amount of project access control code, but a couple controllers were missed.  `MapController`, `SubProjectController`, and `SubscribeProjectController` now extend `ProjectController` and are able to take advantage of a common access control check.