### PR TITLE
Redirect `viewProjects.php` to login if no public projects

### DIFF
--- a/app/Http/Controllers/ViewProjectsController.php
+++ b/app/Http/Controllers/ViewProjectsController.php
@@ -2,13 +2,26 @@
 namespace App\Http\Controllers;
 
 use CDash\Database;
+use CDash\Model\Project;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 class ViewProjectsController extends AbstractController
 {
-    public function viewAllProjects(): View
+    public function viewAllProjects(): View|RedirectResponse
     {
+        $num_public_projects = (int) DB::select('
+                                     SELECT COUNT(*) AS c FROM project WHERE public=?
+                                 ', [Project::ACCESS_PUBLIC])[0]->c;
+
+        // If there are no public projects to see, redirect to the login page
+        if (!Auth::check() && $num_public_projects === 0) {
+            return $this->redirectToLogin();
+        }
+
         return view("project.view-all-projects");
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31222,6 +31222,11 @@ parameters:
 			path: tests/Feature/CDashTest.php
 
 		-
+			message: "#^Method Tests\\\\Feature\\\\CDashTest\\:\\:testViewProjectsRedirectNoPublicProjects\\(\\) throws checked exception LogicException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/CDashTest.php
+
+		-
 			message: "#^Call to an undefined method Mockery\\\\Expectation\\:\\:shouldReceive\\(\\)\\.$#"
 			count: 3
 			path: tests/Feature/LdapAuthWithRulesTest.php


### PR DESCRIPTION
The default `viewProjects.php` landing page may be confusing for some users if there are not signed in and no public projects exist.  Since the only thing the user can do anyway is navigate to the login page, this PR causes a redirect to the login page for users who are not signed in and cannot see any public projects.