### PR TITLE
Fix failing PHPStan test

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -429,11 +429,6 @@ parameters:
 			path: app/Http/Controllers/CDash.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\CTestConfigurationController\\:\\:get\\(\\) throws checked exception Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\HttpException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/CTestConfigurationController.php
-
-		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
 				04/01/2023$#


### PR DESCRIPTION
PHPStan is currently failing on master due to a conflict between two recently-merged PRs.  In the future, we may want to take a look at GitHub's new "Merge Queue" feature.