### PR TITLE
Fix duplicate login page when rendering via AngularJS

### DIFF
--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -55,14 +55,16 @@
         ng-controller="{{ $angular_controller }}"
     @endif
 >
+{{-- This is a horrible hack which allows AngularJS to show the login page when prompted by the API --}}
+@if(isset($angular) && $angular === true)
+    <div ng-if="cdash.requirelogin == 1" ng-include="'login'"></div>
+    <div ng-if="cdash.requirelogin != 1" id="app">
+@else
     <div id="app">
+@endif
         @section('header')
             @include('components.header')
         @show
-
-        @if(isset($angular) && $angular === true)
-            <div ng-if="cdash.requirelogin == 1" ng-include="'login'"></div>
-        @endif
 
         <div id="main_content"
             @if(isset($angular) && $angular === true)


### PR DESCRIPTION
Fixes #1467 by redirecting the user to the login page instead of including it via AngularJS.  This change will benefit from the error response standardization introduced in #1479.