### PR TITLE
Redirect `/editUser.php` to `/profile`

### DIFF
--- a/app/Http/Middleware/PasswordExpired.php
+++ b/app/Http/Middleware/PasswordExpired.php
@@ -21,7 +21,7 @@ class PasswordExpired
     public function handle($request, Closure $next)
     {
         if (Auth::check()) {
-            $password_expired_path = '/editUser.php';
+            $password_expired_path = '/profile';
             if (!Str::contains(url()->current(), $password_expired_path)) {
                 /** @var User $user */
                 $user = Auth::user();

--- a/app/cdash/tests/test_edituser.php
+++ b/app/cdash/tests/test_edituser.php
@@ -16,13 +16,13 @@ class EditUserTestCase extends KWWebTestCase
     {
         //make sure we can't visit the editUser page while logged out
 
-        if (!$this->expectsPageRequiresLogin('/editUser.php')) {
+        if (!$this->expectsPageRequiresLogin('/profile')) {
             return 1;
         }
 
         //make sure we can visit the page while logged in
         $this->login();
-        $content = $this->get($this->url . '/editUser.php');
+        $content = $this->get($this->url . '/profile');
         if (strpos($content, 'My Profile') === false) {
             $this->fail("'My Profile' not found when expected");
             return 1;
@@ -54,7 +54,7 @@ class EditUserTestCase extends KWWebTestCase
         //log in with new email address
         $this->logout();
         $this->login('simpletest2@localhost', 'simpletest');
-        $content = $this->get($this->url . '/editUser.php');
+        $content = $this->get($this->url . '/profile');
 
         // test incorrect old password
         if (!$this->SetFieldByName('oldpasswd', 'incorrect')) {
@@ -118,7 +118,7 @@ class EditUserTestCase extends KWWebTestCase
         $this->login('simpletest2@localhost', '12345');
 
         //change details back so following tests aren't messed up
-        $content = $this->get($this->url . '/editUser.php');
+        $content = $this->get($this->url . '/profile');
         if (!$this->SetFieldByName('fname', 'administrator')) {
             $this->fail('SetFieldByName on first name returned false');
             return 1;
@@ -144,7 +144,7 @@ class EditUserTestCase extends KWWebTestCase
         //log back in with old email address to fix password
         $this->logout();
         $this->login('simpletest@localhost', '12345');
-        $content = $this->get($this->url . '/editUser.php');
+        $content = $this->get($this->url . '/profile');
         if (!$this->SetFieldByName('oldpasswd', '12345')) {
             $this->fail('SetFieldByName on password returned false');
             return 1;

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,8 +125,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/user.php', 'UserController@userPage');
 
     // TODO: (williamjallen) send the POST route to a different function
-    Route::get('/editUser.php', 'UserController@edit');
-    Route::post('/editUser.php', 'UserController@edit');
+    Route::match(['get', 'post'], '/profile', 'UserController@edit');
+    Route::permanentRedirect('/editUser.php', '/profile');
 
     // TODO: (williamjallen) send the POST route to a different function
     Route::get('/subscribeProject.php', 'SubscribeProjectController@subscribeProject');

--- a/tests/Feature/PasswordRotation.php
+++ b/tests/Feature/PasswordRotation.php
@@ -67,7 +67,7 @@ class PasswordRotation extends TestCase
 
         // Make sure we get redirected.
         $response = $this->actingAs($this->user)->get('/viewProjects.php');
-        $response->assertRedirect('editUser.php?password_expired=1');
+        $response->assertRedirect('/profile?password_expired=1');
 
         // Fail to change due to re-using the same password.
         $_POST = [
@@ -76,7 +76,7 @@ class PasswordRotation extends TestCase
             'passwd2' => '12345',
             'updatepassword' => 'Update Password',
         ];
-        $response = $this->actingAs($this->user)->post('/editUser.php');
+        $response = $this->actingAs($this->user)->post('/profile');
         $response->assertSee('You have recently used this password');
 
         // Get the current password hash to compare against later.
@@ -95,7 +95,7 @@ class PasswordRotation extends TestCase
             'passwd2' => 'qwert',
             'updatepassword' => 'Update Password',
         ];
-        $response = $this->actingAs($this->user)->post('/editUser.php');
+        $response = $this->actingAs($this->user)->post('/profile');
         $response->assertSee('Your password has been updated');
 
         $_POST = [
@@ -104,7 +104,7 @@ class PasswordRotation extends TestCase
             'passwd2' => 'asdfg',
             'updatepassword' => 'Update Password',
         ];
-        $response = $this->actingAs($this->user)->post('/editUser.php');
+        $response = $this->actingAs($this->user)->post('/profile');
         $response->assertSee('Your password has been updated');
 
         // Make sure the oldest password was deleted since we're only keeping
@@ -123,7 +123,7 @@ class PasswordRotation extends TestCase
             'passwd2' => '12345',
             'updatepassword' => 'Update Password',
         ];
-        $response = $this->actingAs($this->user)->post('/editUser.php');
+        $response = $this->actingAs($this->user)->post('/profile');
         $response->assertSee('Your password has been updated');
     }
 }

--- a/tests/Feature/RouteAccessTest.php
+++ b/tests/Feature/RouteAccessTest.php
@@ -53,7 +53,7 @@ class RouteAccessTest extends TestCase
     {
         return [
             ['/user.php'],
-            ['/editUser.php'],
+            ['/profile'],
             ['/subscribeProject.php'],
             ['/manageProjectRoles.php'],
             ['/manageCoverage.php'],


### PR DESCRIPTION
This PR is part of an ongoing effort to refactor our routes to eliminate `*.php` routes and create a coherent route structure.