### PR TITLE
Re-route CTest configuration page

### DIFF
--- a/app/Http/Controllers/CTestConfigurationController.php
+++ b/app/Http/Controllers/CTestConfigurationController.php
@@ -8,21 +8,15 @@ use Illuminate\View\View;
 
 class CTestConfigurationController extends ProjectController
 {
-    public function get(): View|RedirectResponse|Response
+    public function get(int $id): Response
     {
-        // Checks
-        if (!isset($_GET['projectid']) || !is_numeric($_GET['projectid'])) {
-            abort(400, 'Not a valid projectid!');
-        }
-
-        $this->setProjectById((int) $_GET['projectid']);
-
+        $this->setProjectById($id);
 
         // TODO: (williamjallen) replace this loop with a single query via a new method in the SubProject class.
         $subprojects = [];
-        foreach ($this->project->GetSubProjects() as $id) {
+        foreach ($this->project->GetSubProjects() as $subproject_id) {
             $subproject = new SubProject();
-            $subproject->SetId($id);
+            $subproject->SetId($subproject_id);
             $subproject->Fill();
             $subprojects[] = $subproject;
         }

--- a/app/cdash/tests/test_pubproject.php
+++ b/app/cdash/tests/test_pubproject.php
@@ -49,7 +49,7 @@ class PubProjectTestCase extends KWWebTestCase
 
     public function testEditProject()
     {
-        $content = $this->get($this->url . "/generateCTestConfig.php?projectid=$this->ProjectId");
+        $content = $this->get($this->url . "/project/$this->ProjectId/ctest_configuration");
         $expected = '## This file should be placed in the root directory of your project.';
         if (!$this->findString($content, $expected)) {
             $this->assertText($content, $expected);

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -17,7 +17,7 @@
       <a :href="$baseURL + '/project/' + cdash.project.Id + '/edit'">edit the project</a>
       <br>
       Click here to
-      <a :href="$baseURL + '/generateCTestConfig.php?projectid=' + cdash.project.Id">download the CTest configuration file</a>
+      <a :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">download the CTest configuration file</a>
       <br>
     </div>
     <div v-else>
@@ -1653,7 +1653,7 @@
                     </div>
                   </td>
                   <td>
-                    <a :href="$baseURL + '/generateCTestConfig.php?projectid=' + cdash.project.Id">
+                    <a :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">
                       CTestConfig.cmake
                     </a>
                     <a

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,15 @@ Route::get('/project/new', 'EditProjectController@create');
 
 Route::get('/project/{id}/testmeasurements', 'ManageMeasurementsController@show');
 
+Route::get('/project/{id}/ctest_configuration', 'CTestConfigurationController@get')->whereNumber('id');
+Route::get('/generateCTestConfig.php', function (Request $request) {
+    $projectid = $request->query('projectid');
+    if (!is_numeric($projectid)) {
+        abort(400, 'Not a valid projectid!');
+    }
+    return redirect("/project/{$projectid}/ctest_configuration", 301);
+});
+
 Route::get('/test/{id}', 'TestController@details');
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
@@ -92,8 +101,6 @@ Route::get('/testDetails.php', function (Request $request) {
     }
     abort(404);
 });
-
-Route::get('/generateCTestConfig.php', 'CTestConfigurationController@get');
 
 Route::get('/viewProjects.php', 'ViewProjectsController@viewAllProjects');
 


### PR DESCRIPTION
This PR is part of an ongoing effort to refactor our routes to eliminate *.php routes and create a coherent route structure.