### PR TITLE
Redirect `/viewProjects.php` to `/projects`

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -114,6 +114,6 @@ class LoginController extends AbstractController
         // Redirect to SAML2 login URL.
         // Note that we currently one support one SAML2 IdP
         // per CDash instance.
-        return redirect(saml_url('/viewProjects.php', $saml2_tenants_row->uuid));
+        return redirect(saml_url('/projects', $saml2_tenants_row->uuid));
     }
 }

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -71,7 +71,7 @@ class OAuthController extends AbstractController
         Auth::login($user, true);
 
         // TODO: create a default route, i.e. route('default') or route('index')
-        $to = $session->remove('auth.oauth.destination') ?: '/viewProjects.php';
+        $to = $session->remove('auth.oauth.destination') ?: '/projects';
 
         return redirect($to);
     }

--- a/app/cdash/public/compareCoverage.php
+++ b/app/cdash/public/compareCoverage.php
@@ -16,7 +16,7 @@
 
 // If the project name is not set we display the table of projects.
 if (!isset($_GET['project'])) {
-    return \redirect('viewProjects.php');
+    return \redirect('projects');
 }
 require_once dirname(__DIR__).'/config/config.php';
 include_once 'include/common.php';

--- a/app/cdash/public/index.php
+++ b/app/cdash/public/index.php
@@ -17,7 +17,7 @@
 // No project name set.
 if (!isset($_GET['project'])) {
     $default_project = config('cdash.default_project');
-    $url = $default_project ? "index.php?project={$default_project}" : 'viewProjects.php';
+    $url = $default_project ? "index.php?project={$default_project}" : 'projects';
     return \redirect()->away($url);
 }
 

--- a/config/saml2.php
+++ b/config/saml2.php
@@ -72,7 +72,7 @@ return [
     |
     */
 
-    'loginRoute' => env('SAML2_LOGIN_URL', '/viewProjects.php'),
+    'loginRoute' => env('SAML2_LOGIN_URL', '/projects'),
 
     /*
     |--------------------------------------------------------------------------
@@ -83,7 +83,7 @@ return [
     |
     */
 
-    'logoutRoute' => env('SAML2_LOGOUT_URL', '/viewProjects.php'),
+    'logoutRoute' => env('SAML2_LOGOUT_URL', '/projects'),
 
 
     /*

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -8,7 +8,7 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
 <div id="header">
     <div id="headertop">
         <div id="topmenu">
-            <a href="{{ url('/viewProjects.php') }}">All Dashboards</a>
+            <a href="{{ url('/projects') }}">All Dashboards</a>
             @if(Auth::check())
                 <a href="{{ url('/user.php') }}">My CDash</a>
             @endif

--- a/resources/views/project/view-all-projects.blade.php
+++ b/resources/views/project/view-all-projects.blade.php
@@ -64,10 +64,10 @@
             <tr>
                 <td height="1" colspan="14" align="right">
                     <div ng-if="cdash.showoldtoggle" id="showold">
-                        <a ng-show="!cdash.allprojects" href="viewProjects.php?allprojects=1">
+                        <a ng-show="!cdash.allprojects" href="projects?allprojects=1">
                             Show all {{cdash.nprojects}} projects
                         </a>
-                        <a ng-show="cdash.allprojects" href="viewProjects.php">
+                        <a ng-show="cdash.allprojects" href="projects">
                             Hide old projects
                         </a>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,7 +102,8 @@ Route::get('/testDetails.php', function (Request $request) {
 
 Route::get('/ajax/showtestfailuregraph.php', 'TestController@ajaxTestFailureGraph');
 
-Route::get('/viewProjects.php', 'ViewProjectsController@viewAllProjects');
+Route::match(['get', 'post'], '/projects', 'ViewProjectsController@viewAllProjects');
+Route::permanentRedirect('/viewProjects.php', '/projects');
 
 Route::get('/viewUpdate.php', 'AdminController@viewUpdate');
 

--- a/tests/Feature/CDashTest.php
+++ b/tests/Feature/CDashTest.php
@@ -112,10 +112,10 @@ class CDashTest extends TestCase
     public function testViewProjectsRedirectNoPublicProjects(): void
     {
         // If there are no public projects to be shown on the view projects page, we should redirect to the login page.
-        $this->get('/viewProjects.php')->assertRedirect('/login');
+        $this->get('/projects')->assertRedirect('/login');
 
         $normal_user = $this->makeNormalUser();
-        $this->actingAs($normal_user)->get('/viewProjects.php')->assertOk()->assertSeeText('No Projects Found');
+        $this->actingAs($normal_user)->get('/projects')->assertOk()->assertSeeText('No Projects Found');
         $normal_user->delete();
     }
 }


### PR DESCRIPTION
This PR is part of an ongoing effort to refactor our routes to eliminate `*.php` routes and create a coherent route structure.

As the "front page" of CDash, this is a high traffic route so I'm open to opinions on whether this change is desired or not.