### PR TITLE
Cache routes and views during build

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -5,6 +5,8 @@ mix.disableNotifications();
 const ESLintPlugin = require('eslint-webpack-plugin');
 const ReplaceInFileWebpackPlugin = require('replace-in-file-webpack-plugin');
 
+const { exec } = require('child_process');
+
 // Clean up from previous webpack runs.
 del = require('del'),
 del.sync('public/build/css');
@@ -149,6 +151,9 @@ mix.sass('resources/sass/app.scss', 'public/laravel/css').version();
 
 // Added this line to get mocha testing working with versioning.
 mix.copy('resources/js/app.js', 'public/main.js');
+
+exec('php artisan route:cache');
+exec('php artisan view:cache');
 
 mix.webpackConfig({
   plugins: webpack_plugins


### PR DESCRIPTION
Laravel recommends [caching routes](https://laravel.com/docs/10.x/routing#route-caching) and [precompiling views](https://laravel.com/docs/10.x/views#optimizing-views) on production systems to maximize performance.  This PR adds route caching and view precompilation during the `mix` build. In my local testing, I observed a 3-5% speedup due to these optimizations.