### PR TITLE
Add install step for developers

### DIFF
--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,0 +1,4 @@
+vendor
+node_modules
+storage
+bootstrap/cache

--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -33,7 +33,7 @@ RUN apt-get update                                                         \
 # Install xdebug and newer version of CMake for development builds
 RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                                \
   apt-get update                                                           \
-  && apt-get install -y cmake                                              \
+  && apt-get install -y cmake rsync                                        \
   && pecl install xdebug                                                   \
   && docker-php-ext-enable xdebug;                                         \
 fi
@@ -73,6 +73,10 @@ RUN chown -R www-data:www-data /etc/apache2
 
 # Disable git repo ownership check system wide
 RUN git config --system --add safe.directory '*'
+
+RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                               \
+  echo "alias cdash_install='rsync -r -l --exclude-from /cdash_src/.rsyncignore /cdash_src/ /cdash'" >> /etc/bash.bashrc; \
+fi
 
 # Run the rest of the commands as www-data
 USER www-data

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -9,6 +9,8 @@ services:
     build:
       args:
         DEVELOPMENT_BUILD: 1
+    volumes:
+      - ..:/cdash_src:ro
 
   selenium-hub:
     image: selenium/hub:3.141.59-mercury


### PR DESCRIPTION
The developer experience is currently rather poor for developers using our Docker environment.  Without custom patches, the only way to test new code changes is to rebuild the image and start a new container.

Given that we now have separate production and development configurations, I thought it might be helpful to upstream an installation patch I have been using locally for some time.  The source code directory is mounted as a read-only volume in `/cdash_src`, and the `cdash_install` alias runs a script which copies new code changes into the `/cdash` directory.  This is particularly useful when paired with a separate terminal session running `npm run watch-poll`, which automatically compiles all of our static assets with mix whenever new changes are made.

The alternative to this approach is to to simply mount `/cdash` as a shared volume.  The downside of mounting a shared volume to `/cdash` is that the volume must either be read-only, with all compilation occurring on the host side, and thus requiring the developer to have `npm` and `php`/`composer` installed, or to have a read-write volume with the potential for code running in the container to inadvertently overwrite the source code on the host.  After accidentally writing files in the midst of my local source code several times, I found that mounting a read-only volume to `/cdash_src` and then copying the code to `/cdash` was the most effective way to develop CDash.

I've personally found that the changes in this PR vastly improve my productivity as a CDash developer but I'm interested in any comments other developers may have regarding this matter.