### PR TITLE
Rename abstract controllers

### DIFF
--- a/app/Http/Controllers/AbstractBuildController.php
+++ b/app/Http/Controllers/AbstractBuildController.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Services\TestingDay;
+use CDash\Model\Build;
+
+class AbstractBuildController extends AbstractProjectController
+{
+    protected Build $build;
+
+    // Fetch data used by all build-specific pages in CDash.
+    protected function setBuild(Build $build): void
+    {
+        if (!$build->Exists()) {
+            abort(404, 'Build does not exist. Maybe it has been deleted.');
+        }
+
+        $this->setProject($build->GetProject());
+        $this->build = $build;
+        $this->date = TestingDay::get($this->project, $this->build->StartTime);
+    }
+
+    protected function setBuildById(int $buildid): void
+    {
+        $build = new Build();
+        $build->Id = $buildid;
+        $build->FillFromId($buildid);
+        $this->setBuild($build);
+    }
+}

--- a/app/Http/Controllers/AbstractProjectController.php
+++ b/app/Http/Controllers/AbstractProjectController.php
@@ -5,7 +5,7 @@ use App\Services\TestingDay;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Gate;
 
-abstract class ProjectController extends AbstractController
+abstract class AbstractProjectController extends AbstractController
 {
     protected string $date;
     protected Project $project;

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1,38 +1,12 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Services\TestingDay;
 use CDash\Database;
-use CDash\Model\Build;
-use App\Models\Site;
-use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
-class BuildController extends ProjectController
+class BuildController extends AbstractBuildController
 {
-    protected Build $build;
-
-    // Fetch data used by all build-specific pages in CDash.
-    protected function setBuild(Build $build): void
-    {
-        if (!$build->Exists()) {
-            abort(404, 'Build does not exist. Maybe it has been deleted.');
-        }
-
-        $this->setProject($build->GetProject());
-        $this->build = $build;
-        $this->date = TestingDay::get($this->project, $this->build->StartTime);
-    }
-
-    protected function setBuildById(int $buildid): void
-    {
-        $build = new Build();
-        $build->Id = $buildid;
-        $build->FillFromId($buildid);
-        $this->setBuild($build);
-    }
-
     // Render the build configure page.
     public function configure($build_id = null)
     {

--- a/app/Http/Controllers/CTestConfigurationController.php
+++ b/app/Http/Controllers/CTestConfigurationController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\View\View;
 
-class CTestConfigurationController extends ProjectController
+class CTestConfigurationController extends AbstractProjectController
 {
     public function get(int $id): Response
     {

--- a/app/Http/Controllers/EditProjectController.php
+++ b/app/Http/Controllers/EditProjectController.php
@@ -3,7 +3,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 
-class EditProjectController extends ProjectController
+class EditProjectController extends AbstractProjectController
 {
     // Render the create project form.
     public function create()

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 
-class ManageMeasurementsController extends ProjectController
+class ManageMeasurementsController extends AbstractProjectController
 {
     // Render the 'manage measurements' page.
     public function show($project_id)

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use RuntimeException;
 
-class ManageProjectRolesController extends ProjectController
+class ManageProjectRolesController extends AbstractProjectController
 {
     /**
      * TODO: (williamjallen) this function contains legacy XSL templating and should be converted

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -6,8 +6,7 @@ use CDash\Database;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
-// TODO: (williamjallen) Refactor this to extend ProjectController instead of setting up everything manually.
-class MapController extends ProjectController
+class MapController extends AbstractProjectController
 {
     public function viewMap(): View|RedirectResponse
     {

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -8,7 +8,7 @@ use CDash\Model\SubProject;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
-class SubProjectController extends ProjectController
+class SubProjectController extends AbstractProjectController
 {
     public function dependencies(): View|RedirectResponse
     {

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -11,7 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
-class SubscribeProjectController extends ProjectController
+class SubscribeProjectController extends AbstractProjectController
 {
     /**
      * TODO: (williamjallen) this function contains legacy XSL templating and should be converted

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -3,7 +3,7 @@ namespace App\Http\Controllers;
 
 use App\Models\BuildTest;
 
-class TestController extends ProjectController
+class TestController extends AbstractProjectController
 {
     // Render the test details page.
     public function details($buildtest_id = null)

--- a/app/Http/Controllers/UserStatisticsController.php
+++ b/app/Http/Controllers/UserStatisticsController.php
@@ -5,7 +5,7 @@ use App\Models\User;
 use App\Services\PageTimer;
 use Illuminate\Http\JsonResponse;
 
-class UserStatisticsController extends ProjectController
+class UserStatisticsController extends AbstractProjectController
 {
     public function api(): JsonResponse
     {


### PR DESCRIPTION
#1449 introduced a new inheritance hierarchy which allows more code to be shared between controllers.  As originally written, `BuildController` performs the role of both a regular controller with "business logic" and an abstract controller which is meant to be extended.  The issue with this approach is that extending `BuildController` drags all of the business logic into subclasses when it should be there.

This PR splits the original `BuildController` class into a new `AbstractBuildController` which is meant to be extended, and `BuildController`, which contains the business logic from the original class.  To maintain consistency with this approach, I also renamed `ProjectController` to `AbstractProjectController`.  This also groups all of the abstract controllers together when sorted lexicographically, such as in most IDEs.

It's worth noting that this PR will cause logical conflicts with a number of open PRs.  Resolving those conflicts should be straightforward, but extra care should be taken to rebase PRs appropriately before merging any PR.