### PR TITLE
Clean up `AuthTokenController` access control logic

### DIFF
--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -4,25 +4,19 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-require_once 'include/common.php';
-require_once 'include/defines.php';
-
 use App\Models\AuthToken;
 use App\Services\AuthTokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Http\Request;
 
 class AuthTokenController extends AbstractController
 {
-    public function manage(): Response
+    public function manage(): View
     {
-        if (!Auth::check()) {
-            return $this->redirectToLogin();
-        }
-
-        return response()->view('admin.manage-authtokens');
+        return view('admin.manage-authtokens');
     }
 
     /**
@@ -31,11 +25,6 @@ class AuthTokenController extends AbstractController
      */
     public function fetchAll(): JsonResponse
     {
-        $user = Auth::user();
-        if ($user === null || !$user->IsAdmin()) {
-            return response()->json(['error' => 'Permissions error'], status: Response::HTTP_FORBIDDEN);
-        }
-
         $token_array = AuthTokenService::getAllTokens();
         $token_map = [];
         foreach ($token_array as $token) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,8 +51,6 @@ Route::get('ping', function (Response $response) {
     return $response;
 });
 
-Route::get('/authtokens/manage', 'AuthTokenController@manage');
-
 Route::get('/image/{image}', 'ImageController@image');
 Route::get('/displayImage.php', function (Request $request) {
     $imgid = $request->query('imgid');
@@ -149,6 +147,8 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/editSite.php', 'SiteController@editSite');
 
     Route::middleware(['admin'])->group(function () {
+        Route::get('/authtokens/manage', 'AuthTokenController@manage');
+
         Route::get('/upgrade.php', 'AdminController@upgrade');
         Route::post('/upgrade.php', 'AdminController@upgrade');
 


### PR DESCRIPTION
#1447 simplified our administrator access control code but the auth token controller was missed.