### PR TITLE
Improve revision URL handling when no repository specified

### DIFF
--- a/app/cdash/include/repository.php
+++ b/app/cdash/include/repository.php
@@ -691,6 +691,10 @@ function get_revision_url($projectid, $revision, $priorrevision)
     $project = $db->executePreparedSingleRow('SELECT cvsviewertype, cvsurl FROM project WHERE id=?', [intval($projectid)]);
     $projecturl = $project['cvsurl'];
 
+    if (strlen($projecturl) === 0) {
+        return '';
+    }
+
     $cvsviewertype = strtolower($project['cvsviewertype']);
     $revisionfonction = 'get_' . $cvsviewertype . '_revision_url';
 

--- a/resources/views/build/update.blade.php
+++ b/resources/views/build/update.blade.php
@@ -12,11 +12,13 @@
 
         <div ng-if="::cdash.update.revision">
             <b>Revision: </b>
-            <a ng-href="{{::cdash.update.revisionurl}}">{{::cdash.update.revision}}</a>
+            <tt><a ng-if="::cdash.update.revisionurl.length > 0" ng-href="{{::cdash.update.revisionurl}}">{{::cdash.update.revision}}</a></tt>
+            <tt ng-if="::cdash.update.revisionurl.length === 0" >{{::cdash.update.revision}}</tt>
         </div>
         <div ng-if="::cdash.update.priorrevision">
             <b>Prior Revision: </b>
-            <a ng-href="{{::cdash.update.revisiondiff}}">{{::cdash.update.priorrevision}}</a>
+            <tt><a ng-if="::cdash.update.revisiondiff.length > 0" ng-href="{{::cdash.update.revisiondiff}}">{{::cdash.update.priorrevision}}</a></tt>
+            <tt ng-if="::cdash.update.revisiondiff.length === 0" ng-href="{{::cdash.update.revisiondiff}}">{{::cdash.update.priorrevision}}</tt>
         </div>
 
         <br/>


### PR DESCRIPTION
When a project does not have a repository URL specified, various places on the UI display the url `http(s)://&<hash>`.  One particular place this is displayed is at the top of `viewUpdate.php`.  The current "URL" is totally meaningless of course, and it would be better to not attempt to provide a URL at all unless one is set for the project. 