### PR TITLE
Replace `json_error_response()` with `abort()`

### DIFF
--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -38,8 +38,7 @@ class TestGraph extends BuildTestApi
     {
         $type = $_GET['type'];
         if (!in_array($type, $this->validTypes)) {
-            json_error_response(['error' => 'Invalid type of graph requested.']);
-            return [];
+            abort(400, 'Invalid type of graph requested.');
         }
 
         $chart_data = [];
@@ -70,7 +69,7 @@ class TestGraph extends BuildTestApi
             case 'measurement':
                 $measurement_name = $_GET['measurementname'];
                 if (!isset($measurement_name) || !is_string($measurement_name)) {
-                    json_error_response(['error' => 'No measurement requested.']);
+                    abort(400, 'No measurement requested.');
                 }
                 $chart_data[] = [
                     'label' => $measurement_name,

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -77,8 +77,7 @@ class Timeline extends Index
             case 'viewBuildGroup.php':
                 return $this->chartForBuildGroup();
             default:
-                json_error_response('Unexpected value for page');
-                break;
+                abort(404, 'Unexpected value for page');
         }
     }
 
@@ -102,7 +101,7 @@ class Timeline extends Index
         $defect_types = $request->session()->get('defecttypes');
 
         if (!$defect_types) {
-            json_error_response('No defecttypes defined in your session');
+            abort(400, 'No defecttypes defined in your session');
         }
         $this->defectTypes = $defect_types;
 
@@ -118,7 +117,7 @@ class Timeline extends Index
             ORDER BY starttime";
         $stmt = $this->db->prepare($query);
         if (!pdo_execute($stmt, [$this->project->Id])) {
-            json_error_response('Failed to load results');
+            abort(500, 'Failed to load results');
         }
 
         return $this->getTimelineChartData($stmt);
@@ -150,8 +149,7 @@ class Timeline extends Index
                 $this->filterSQL
                 ORDER BY starttime");
         if (!pdo_execute($stmt, [':projectid' => $this->project->Id])) {
-            json_error_response('Failed to load results');
-            return [];
+            abort(500, 'Failed to load results');
         }
         $response = $this->getTimelineChartData($stmt);
         $response['colors'] = [
@@ -186,8 +184,7 @@ class Timeline extends Index
                 $this->filterSQL
                 ORDER BY starttime");
         if (!pdo_execute($stmt, [':projectid' => $this->project->Id])) {
-            json_error_response('Failed to load results');
-            return [];
+            abort(500, 'Failed to load results');
         }
         $this->includeCleanBuilds = false;
         $response = $this->getTimelineChartData($stmt);
@@ -207,10 +204,7 @@ class Timeline extends Index
         $buildgroup->SetProjectId($this->project->Id);
         $buildgroup->SetName($groupname);
         if (!$buildgroup->Exists()) {
-            $error_msg =
-                "BuildGroup '$groupname' does not exist for project '" . $this->project->Name . "'";
-            json_error_response(['error' => $error_msg], 404);
-            return[];
+            abort(404, "BuildGroup '$groupname' does not exist for project '" . $this->project->Name . "'");
         }
 
         $this->defectTypes = [
@@ -248,8 +242,7 @@ class Timeline extends Index
                 ':buildgroupname' => $groupname
             ];
             if (!pdo_execute($stmt, $query_params)) {
-                json_error_response('Failed to load results');
-                return [];
+                abort(500, 'Failed to load results');
             }
             $builds = [];
             while ($row = $stmt->fetch()) {

--- a/app/cdash/include/CDash/System.php
+++ b/app/cdash/include/CDash/System.php
@@ -161,6 +161,7 @@ class System
     /**
      * @param $exit_message
      * @return void
+     * @deprecated 06/15/2023 Use abort() to exit cleanly instead.
      */
     public function system_exit($exit_message = '')
     {

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -211,6 +211,7 @@ function get_request_build($required = true)
  *
  * @param $response
  * @param int $code
+ * @deprecated 15/06/2023 Use abort() to exit cleanly instead.
  */
 function json_error_response($response, $code = 400)
 {

--- a/app/cdash/public/api/v1/addBuild.php
+++ b/app/cdash/public/api/v1/addBuild.php
@@ -58,12 +58,12 @@ if ($subProjectName) {
 // Call AddBuild() to create the build or get the ID of an existing build.
 $build_created = $build->AddBuild();
 if (!$build->Id) {
-    json_error_response(['error' => 'Error creating build'], 500);
+    abort(500, 'Error creating build');
 }
 
 $response = ['buildid' => $build->Id];
 if ($build_created) {
-    json_error_response($response, 201);
+    return response()->json($response, 201);
 } else {
-    json_error_response($response, 200);
+    return response()->json($response, 200);
 }

--- a/app/cdash/public/api/v1/buildProperties.php
+++ b/app/cdash/public/api/v1/buildProperties.php
@@ -30,17 +30,17 @@ if (!function_exists('CDash\Api\v1\BuildProperties\get_defects_for_builds')) {
     function get_defects_for_builds()
     {
         if (!array_key_exists('buildid', $_GET)) {
-            json_error_response('Missing parameter: buildid');
+            abort(400, 'Missing parameter: buildid');
         }
         if (!array_key_exists('defect', $_GET)) {
-            json_error_response('Missing parameter: defect');
+            abort(400, 'Missing parameter: defect');
         }
 
         if (!is_array($_GET['buildid']) || count($_GET['buildid']) < 1) {
-            json_error_response("No builds specified");
+            abort(400, "No builds specified");
         }
         if (!is_array($_GET['defect']) || count($_GET['defect']) < 1) {
-            json_error_response("No defects specified");
+            abort(400, "No defects specified");
         }
 
         $pdo = Database::getInstance()->getPdo();

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -65,7 +65,7 @@ switch ($method) {
 function rest_get($pdo, $projectid)
 {
     if (!isset($_GET['buildgroupid'])) {
-        json_error_response(['error' => 'buildgroupid not specified'], 400);
+        abort(400, 'buildgroupid not specified');
     }
     $buildgroupid = pdo_real_escape_numeric($_GET['buildgroupid']);
 
@@ -134,7 +134,7 @@ function rest_delete()
             isset($wildcard['match']) ? convert_wildcards($wildcard['match']) : '';
         $buildgrouprule->GroupId = $wildcard['buildgroupid'];
         if (!$buildgrouprule->Delete(true)) {
-            json_error_response(['error' => pdo_error()], 500);
+            abort(500, 'Something went wrong...');
         }
     }
 
@@ -160,7 +160,7 @@ function rest_delete()
         }
 
         if (!$buildgrouprule->Delete(true)) {
-            json_error_response(['error' => pdo_error()], 500);
+            abort(500, 'Something went wrong...');
         }
     }
 }
@@ -193,7 +193,7 @@ function rest_post($pdo, $projectid)
         $response['id'] = $BuildGroup->GetId();
         $response['name'] = $BuildGroup->GetName();
         $response['autoremovetimeframe'] = $BuildGroup->GetAutoRemoveTimeFrame();
-        json_error_response($response, $status_code);
+        return response()->json($response, $status_code);
     }
 
     if (isset($_POST['newLayout'])) {
@@ -240,7 +240,7 @@ function rest_post($pdo, $projectid)
         $group = $_POST['group'];
         if ($group['id'] < 1) {
             $error_msg = 'Please select a group for these builds';
-            json_error_response(['error' => $error_msg], 400);
+            abort(400, $error_msg);
         }
 
         $builds = $_POST['builds'];
@@ -277,7 +277,7 @@ function rest_post($pdo, $projectid)
             $buildgrouprule->StartTime = $now;
             $buildgrouprule->EndTime = '1980-01-01 00:00:00';
             if (!$buildgrouprule->Save()) {
-                json_error_response(['error' => 'Error saving rule'], 500);
+                abort(500, 'Error saving rule');
             }
         }
     }
@@ -288,7 +288,7 @@ function rest_post($pdo, $projectid)
         $groupid = $group['id'];
         if ($groupid < 1) {
             $error_msg = 'Please select a BuildGroup to define.';
-            json_error_response(['error' => $error_msg], 400);
+            abort(400, $error_msg);
         }
 
         $nameMatch = convert_wildcards($_POST['nameMatch']);
@@ -301,7 +301,7 @@ function rest_post($pdo, $projectid)
         $buildgrouprule->SiteId = -1;
         $buildgrouprule->StartTime = $now;
         if (!$buildgrouprule->Save()) {
-            json_error_response(['error' => 'Error saving rule'], 500);
+            abort(500, 'Error saving rule');
         }
     }
 
@@ -333,7 +333,7 @@ function rest_post($pdo, $projectid)
         $buildgrouprule->ParentGroupId = $parentgroupid;
         $buildgrouprule->StartTime = $now;
         if (!$buildgrouprule->Save()) {
-            json_error_response(['error' => 'Error saving rule'], 500);
+            abort(500, 'Error saving rule');
         }
 
         // Respond with a JSON representation of this new rule.
@@ -386,7 +386,7 @@ function rest_put($projectid)
             pdo_real_escape_numeric($buildgroup['autoremovetimeframe']));
 
         if (!$BuildGroup->Save()) {
-            json_error_response(['error' => 'Failed to save BuildGroup'], 500);
+            abort(500, 'Failed to save BuildGroup');
         }
     }
 

--- a/app/cdash/public/api/v1/computeClassifier.php
+++ b/app/cdash/public/api/v1/computeClassifier.php
@@ -22,7 +22,7 @@ require_once 'include/api_common.php';
 
 $builds = $_GET['builds'];
 if (count($builds) < 1) {
-    json_error_response('No builds found, cannot compute classifier');
+    abort(400, 'No builds found, cannot compute classifier');
 }
 
 // Decode input data from JSON.

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -57,9 +57,7 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_get')) {
         $response = array();
 
         if (!array_key_exists('currenttime', $_REQUEST)) {
-            $response['error'] = "currenttime not specified.";
-            json_error_response($response);
-            return;
+            abort(400, '"currenttime" not specified in request.');
         }
         $currenttime = pdo_real_escape_numeric($_REQUEST['currenttime']);
         $currentUTCtime = gmdate(FMT_DATETIME, $currenttime);
@@ -108,10 +106,7 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_post')) {
     function rest_post($siteid, $buildgroupid, $buildname, $buildtype)
     {
         if (!array_key_exists('newgroupid', $_REQUEST)) {
-            $response = array();
-            $response['error'] = 'newgroupid not specified.';
-            json_error_response($response);
-            return;
+            abort(400, 'newgroupid not specified.');
         }
 
         $newgroupid =
@@ -134,9 +129,7 @@ if (!is_null($rest_json)) {
 $required_params = array('siteid', 'groupid', 'name', 'type');
 foreach ($required_params as $param) {
     if (!array_key_exists($param, $_REQUEST)) {
-        $response['error'] = "$param not specified.";
-        json_error_response($response);
-        return;
+        abort(400, "$param not specified.");
     }
 }
 $siteid = pdo_real_escape_numeric($_REQUEST['siteid']);
@@ -147,8 +140,7 @@ $buildtype = htmlspecialchars(pdo_real_escape_string($_REQUEST['type']));
 // Make sure the user has access to this project.
 $buildgroup = new BuildGroup();
 if (!$buildgroup->SetId($buildgroupid)) {
-    json_error_response(
-        ['error' => "Could not find project for buildgroup #$buildgroupid"]);
+    abort(404, "Could not find project for buildgroup #$buildgroupid");
 }
 $projectid = $buildgroup->GetProjectId();
 if (!can_access_project($projectid)) {
@@ -160,17 +152,13 @@ $method = $_SERVER['REQUEST_METHOD'];
 // Make sure the user is an admin before proceeding with non-read-only methods.
 if ($method != 'GET') {
     if (!Auth::check()) {
-        $response['error'] = 'No session found.';
-        json_error_response($response, 401);
-        return;
+        abort(401, 'No session found.');
     }
 
     $project = new Project();
     $project->Id = $projectid;
     if (!Gate::allows('edit-project', $project)) {
-        $response['error'] = 'You do not have permission to access this page';
-        json_error_response($response, 403);
-        return;
+        abort(403, 'You do not have permission to access this page');
     }
 }
 

--- a/app/cdash/public/api/v1/manageMeasurements.php
+++ b/app/cdash/public/api/v1/manageMeasurements.php
@@ -51,8 +51,7 @@ function rest_delete()
 {
     $id = $_REQUEST['id'];
     if (!$id) {
-        $response = ['error' => 'Invalid measurement ID provided.'];
-        json_error_response($response, 400);
+        abort(400, 'Invalid measurement ID provided.');
     }
     Measurement::destroy($id);
     http_response_code(200);

--- a/app/cdash/public/api/v1/relateBuilds.php
+++ b/app/cdash/public/api/v1/relateBuilds.php
@@ -36,10 +36,13 @@ $relatedid = get_param('relatedid');
 
 // Create objects from these parameters.
 $service = ServiceContainer::getInstance();
+/** @var Build $build */
 $build = $service->create(Build::class);
 $build->Id = $buildid;
+/** @var Build $relatedbuild */
 $relatedbuild = $service->create(Build::class);
 $relatedbuild->Id = $relatedid;
+/** @var BuildRelationship $buildRelationship */
 $buildRelationship = $service->create(BuildRelationship::class);
 $buildRelationship->Build = $build;
 $buildRelationship->RelatedBuild = $relatedbuild;
@@ -50,10 +53,9 @@ $error_msg = '';
 if ($request_method == 'GET') {
     if ($buildRelationship->Exists()) {
         $buildRelationship->Fill();
-        json_error_response($buildRelationship->marshal(), 200);
+        return response()->json($buildRelationship->marshal());
     }
-    $error_msg = "No relationship exists between Builds $buildid and $relatedid";
-    json_error_response(['error' => $error_msg], 404);
+    abort(404, "No relationship exists between Builds $buildid and $relatedid");
 }
 
 if ($request_method == 'DELETE') {
@@ -61,13 +63,13 @@ if ($request_method == 'DELETE') {
         if ($buildRelationship->Exists()) {
             if (!$buildRelationship->Delete($error_msg)) {
                 if ($error_msg) {
-                    json_error_response($error_msg, 400);
+                    abort(400, $error_msg);
                 } else {
-                    json_error_response('Error deleting relationship', 500);
+                    abort(500, 'Error deleting relationship');
                 }
             }
         }
-        json_error_response('', 204);
+        abort(204);
     }
     return;
 }
@@ -90,10 +92,10 @@ if ($request_method == 'POST') {
     }
     if (!$buildRelationship->Save($error_msg)) {
         if ($error_msg) {
-            json_error_response(['error' => $error_msg], 400);
+            abort(400, $error_msg);
         } else {
-            json_error_response(['error' => 'Error saving relationship'], 500);
+            abort(500, 'Error saving relationship');
         }
     }
-    json_error_response($buildRelationship->marshal(), $exit_status);
+    return response()->json($buildRelationship->marshal(), $exit_status);
 }

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -287,7 +287,5 @@ function get_subprojectid()
 
 function echo_error($msg, $status = 400)
 {
-    $response = [];
-    $response['error'] = $msg;
-    json_error_response($response, $status);
+    abort($status, $msg);
 }

--- a/app/cdash/public/api/v1/testDetails.php
+++ b/app/cdash/public/api/v1/testDetails.php
@@ -33,13 +33,12 @@ $db = Database::getInstance();
 
 $buildtestid = $_GET['buildtestid'];
 if (!isset($buildtestid) || !is_numeric($buildtestid)) {
-    json_error_response(['error' => 'A valid test was not specified.']);
+    abort(400, 'A valid test was not specified.');
 }
 
 $buildtest = BuildTest::where('id', '=', $buildtestid)->first();
 if ($buildtest === null) {
-    json_error_response(['error' => 'test not found'], 404);
-    return;
+    abort(404, 'test not found');
 }
 
 

--- a/app/cdash/public/api/v1/testGraph.php
+++ b/app/cdash/public/api/v1/testGraph.php
@@ -33,16 +33,14 @@ if (is_null($build)) {
 
 $testid = pdo_real_escape_numeric($_GET['testid']);
 if (!isset($testid) || !is_numeric($testid)) {
-    json_error_response(['error' => 'A valid test was not specified.']);
-    return;
+    abort(400, 'A valid test was not specified.');
 }
 
 $buildtest = BuildTest::where('buildid', '=', $build->Id)
     ->where('testid', '=', $testid)
     ->first();
 if ($buildtest === null) {
-    json_error_response(['error' => 'test not found'], 404);
-    return;
+    abort(404, 'test not found');
 }
 
 $controller = new Controller($db, $buildtest);

--- a/app/cdash/public/api/v1/viewDynamicAnalysisFile.php
+++ b/app/cdash/public/api/v1/viewDynamicAnalysisFile.php
@@ -32,20 +32,20 @@ $response = [];
 
 // Make sure a valid id was specified.
 if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
-    json_error_response('Not a valid id!');
+    abort(400, 'Not a valid id!');
 }
 $id = $_GET['id'];
 $DA = new DynamicAnalysis();
 $DA->Id = $id;
 if (!$DA->Fill()) {
-    json_error_response('Not a valid id!');
+    abort(400, 'Not a valid id!');
 }
 
 // Get the build associated with this analysis.
 $build = new Build();
 $build->Id = $DA->BuildId;
 if (!$build->Exists()) {
-    json_error_response('This build does not exist. Maybe it has been deleted.');
+    abort(404, 'This build does not exist. Maybe it has been deleted.');
 }
 $build->FillFromId($build->Id);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11528,6 +11528,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated function json_error_response\\(\\)\\:
+				15/06/2023 Use abort\\(\\) to exit cleanly instead\\.$#
+			"""
+			count: 10
+			path: app/cdash/include/api_common.php
+
+		-
+			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -15806,6 +15814,14 @@ parameters:
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
 		-
+			message: """
+				#^Call to deprecated function json_error_response\\(\\)\\:
+				15/06/2023 Use abort\\(\\) to exit cleanly instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
 			message: "#^Function handle_error\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
@@ -15819,6 +15835,14 @@ parameters:
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/addBuild.php
+
+		-
+			message: """
+				#^Call to deprecated function json_error_response\\(\\)\\:
+				15/06/2023 Use abort\\(\\) to exit cleanly instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/public/api/v1/addUserNote.php
 
 		-
 			message: "#^Call to function is_array\\(\\) with string\\|false will always evaluate to false\\.$#"
@@ -16046,14 +16070,6 @@ parameters:
 				04/22/2023$#
 			"""
 			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_error\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
@@ -16501,11 +16517,6 @@ parameters:
 		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\ExpectedBuild\\\\rest_post\\(\\) has parameter \\$siteid with no type specified\\.$#"
 			count: 1
-			path: app/cdash/public/api/v1/expectedbuild.php
-
-		-
-			message: "#^Implicit array creation is not allowed \\- variable \\$response might not exist\\.$#"
-			count: 3
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
@@ -17113,6 +17124,14 @@ parameters:
 			path: app/cdash/public/api/v1/overview.php
 
 		-
+			message: """
+				#^Call to deprecated function json_error_response\\(\\)\\:
+				15/06/2023 Use abort\\(\\) to exit cleanly instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Call to function is_array\\(\\) with string\\|false will always evaluate to false\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
@@ -17241,11 +17260,6 @@ parameters:
 			message: "#^Variable property access on mixed\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 2
-			path: app/cdash/public/api/v1/relateBuilds.php
 
 		-
 			message: "#^Call to method RetryHandler\\:\\:increment\\(\\) with incorrect case\\: Increment$#"


### PR DESCRIPTION
#1479 introduced a centralized error-handling system which returns a JSON error message for API routes and an HTML error page for pages with content which is meant to be consumed by humans.  The recommended way to trigger the new error handling system is through Laravel's `abort()` function which throws and then catches an exception, rather than using the current `json_error_response()` function which simply returns a JSON response and then exits.  Exiting is problematic for our simpletest-based tests, because they won't catch the fact that the program exited prematurely with an error without running the remainder of the test suite.

This PR replaces most of the existing usages of `json_error_response()` with an equivalent `abort()`.  The remaining usages of `json_error_response()` are more difficult to resolve and will be fixed in future PRs once I refactor the underlying infrastructure.