### PR TITLE
Move `setVersion()` to `AdminController.php`

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -640,7 +640,7 @@ class AdminController extends AbstractController
             AddTableField('site', 'outoforder', 'tinyint(1)', 'smallint', '0');
 
             // Set the database version
-            setVersion();
+            $this->setVersion();
 
             // Put that the upgrade is done in the log
             add_log('Upgrade done.', 'upgrade-2-2');
@@ -750,7 +750,7 @@ class AdminController extends AbstractController
             AddUniqueConstraintToDiffTables();
 
             // Set the database version
-            setVersion();
+            $this->setVersion();
 
             // Put that the upgrade is done in the log
             add_log('Upgrade done.', 'upgrade-2-4');
@@ -829,7 +829,7 @@ class AdminController extends AbstractController
             AddUniqueConstraintToSiteTable('site');
 
             // Set the database version
-            setVersion();
+            $this->setVersion();
 
             // Put that the upgrade is done in the log
             add_log('Upgrade done.', 'upgrade-2-6');
@@ -854,7 +854,7 @@ class AdminController extends AbstractController
             }
 
             // Set the database version
-            setVersion();
+            $this->setVersion();
 
             // Put that the upgrade is done in the log
             add_log('Upgrade done.', 'upgrade-2-8');
@@ -874,7 +874,7 @@ class AdminController extends AbstractController
             Artisan::call('migrate --force');
 
             // Set the database version
-            setVersion();
+            $this->setVersion();
 
             // Put that the upgrade is done in the log
             add_log('Upgrade done.', 'upgrade-3-0');
@@ -1362,7 +1362,7 @@ class AdminController extends AbstractController
                         $xml .= '<db_created>1</db_created>';
 
                         // Set the database version
-                        setVersion();
+                        $this->setVersion();
                     }
                 }
             }
@@ -1375,5 +1375,30 @@ class AdminController extends AbstractController
             'xsl_content' => generate_XSLT($xml, base_path() . '/app/cdash/public/install', true),
             'title' => 'Installation'
         ]);
+    }
+
+    /**
+     * Set the CDash version number in the database
+     */
+    private function setVersion(): void
+    {
+        $config = Config::getInstance();
+        $db = Database::getInstance();
+
+        $major = $config->get('CDASH_VERSION_MAJOR');
+        $minor = $config->get('CDASH_VERSION_MINOR');
+        $patch = $config->get('CDASH_VERSION_PATCH');
+
+        $stmt = $db->query('SELECT major FROM version');
+        $version = [$major, $minor, $patch];
+
+        if (pdo_num_rows($stmt) == 0) {
+            $sql = 'INSERT INTO version (major, minor, patch) VALUES (?, ?, ?)';
+        } else {
+            $sql = 'UPDATE version SET major=?, minor=?, patch=?';
+        }
+
+        $stmt = $db->prepare($sql);
+        $db->execute($stmt, $version);
     }
 }

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -319,31 +319,6 @@ function add_last_sql_error($functionname, $projectid = 0, $buildid = 0, $resour
 }
 
 /**
- * Set the CDash version number in the database
- */
-function setVersion(): void
-{
-    $config = Config::getInstance();
-    $db = Database::getInstance();
-
-    $major = $config->get('CDASH_VERSION_MAJOR');
-    $minor = $config->get('CDASH_VERSION_MINOR');
-    $patch = $config->get('CDASH_VERSION_PATCH');
-
-    $stmt = $db->query('SELECT major FROM version');
-    $version = [$major, $minor, $patch];
-
-    if (pdo_num_rows($stmt) == 0) {
-        $sql = 'INSERT INTO version (major, minor, patch) VALUES (?, ?, ?)';
-    } else {
-        $sql = 'UPDATE version SET major=?, minor=?, patch=?';
-    }
-
-    $stmt = $db->prepare($sql);
-    $db->execute($stmt, $version);
-}
-
-/**
  * TODO: (williamjallen) This function's return type is excessively complex and makes it
  *       difficult to handle.
  *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -183,7 +183,7 @@ parameters:
 				#^Call to deprecated function pdo_num_rows\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 2
+			count: 3
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -215,7 +215,7 @@ parameters:
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 1
+			count: 2
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -237,6 +237,14 @@ parameters:
 		-
 			message: """
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
+				04/22/2023  Use Laravel query builder or Eloquent instead$#
+			"""
+			count: 2
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: """
+				#^Call to deprecated method query\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
@@ -11770,14 +11778,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -11789,7 +11789,7 @@ parameters:
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/include/common.php
 
 		-
@@ -11819,14 +11819,6 @@ parameters:
 		-
 			message: """
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 2
-			path: app/cdash/include/common.php
-
-		-
-			message: """
-				#^Call to deprecated method query\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1


### PR DESCRIPTION
`setVersion()` is only used in `AdminController.php` as part of the CDash installation process.  There is no reason for it to be in `common.php` alongside other functions which are used in many different places.

This purely internal change is part of my ongoing effort to trim down the size of `common.php` and causes no external behavior change.