### PR TITLE
Fix email sent for errors in Update.xml

### DIFF
--- a/app/cdash/app/Model/BuildUpdate.php
+++ b/app/cdash/app/Model/BuildUpdate.php
@@ -247,7 +247,7 @@ class BuildUpdate
 
         $query = $this->PDO->prepare($sql);
         $query->bindParam(':buildid', $this->BuildId);
-
+        $query->execute();
         return $query->fetch(PDO::FETCH_ASSOC);
     }
 

--- a/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
+++ b/app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
@@ -51,12 +51,9 @@ class EmailBuilder extends SubscriptionNotificationBuilder
      */
     public function createNotification(SubscriptionInterface $subscription, $templateName)
     {
-        $message = null;
         $subject_template = "email.{$templateName}.subject";
         $template = "email.{$templateName}";
 
-
-        // $blade = new Blade((array)$this->templateDirectory, $this->cacheDirectory);
         $data = ['subscription' => $subscription];
         $subject = view($subject_template)->with($data);
         $body = view($template)->with($data);
@@ -69,28 +66,6 @@ class EmailBuilder extends SubscriptionNotificationBuilder
         // todo: this doesn't really belong here, refactor asap
         $this->setBuildEmailCollection($message, $subscription);
         return $message;
-    }
-
-    /**
-     * The purpose of this method is to remove duplicate topics from the topic collection. It is
-     * possible to have duplicate topics under the conditions where, say, a build was included
-     * because the build was authored by the user then included again because it matched a label
-     * to which the user is subscribed. Duplicates must be removed so that they are not output
-     * multiple times by the notification decorators.
-     *
-     * @param SubscriptionInterface $subscription
-     * @return bool
-     */
-    protected function uniquifyTopics(SubscriptionInterface $subscription)
-    {
-        $topics = $subscription->getTopicCollection();
-
-        /** @var LabeledTopic $labeled */
-        $labeled = $topics->remove('Labeled');
-        if ($labeled) {
-            $labeled->mergeTopics($topics);
-        }
-        return !!$topics->count();
     }
 
     /**

--- a/app/cdash/tests/data/EmailProjectExample/update_error.xml
+++ b/app/cdash/tests/data/EmailProjectExample/update_error.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Update mode="Client" Generator="ctest-2.6-patch 0">
+  <Site>Dash20.kitware</Site>
+  <BuildName>update_error</BuildName>
+  <BuildStamp>20090225-0100-Nightly</BuildStamp>
+  <StartDateTime>Feb 24 05:01 Eastern Standard Time</StartDateTime>
+  <StartTime>1235383325</StartTime>
+  <UpdateCommand>"/usr/bin/false" "fetch"</UpdateCommand>
+  <UpdateType>GIT</UpdateType>
+  <EndDateTime>Feb 24 05:02 Eastern Standard Time</EndDateTime>
+  <EndTime>1235383333</EndTime>
+  <ElapsedMinutes>0</ElapsedMinutes>
+  <UpdateReturnStatus>Update command failed:
+"/usr/bin/false" "fetch"</UpdateReturnStatus>
+</Update>

--- a/app/cdash/tests/js/e2e_tests/viewBuildError.js
+++ b/app/cdash/tests/js/e2e_tests/viewBuildError.js
@@ -2,32 +2,32 @@ require('../pages/catchConsoleErrors.page.js');
 describe("viewBuildError", function() {
 
   it("shows 0 errors'", function() {
-    browser.get('viewBuildError.php?buildid=6');
+    browser.get('viewBuildError.php?buildid=7');
     expect(element(by.className('num-errors')).getText()).toContain("0 Errors");
   });
 
   it("deltan shows 0 errors'", function() {
-    browser.get('viewBuildError.php?buildid=6&onlydeltan=1');
+    browser.get('viewBuildError.php?buildid=7&onlydeltan=1');
     expect(element(by.className('num-errors')).getText()).toContain("0 Errors");
   });
 
   it("deltap shows 0 errors'", function() {
-    browser.get('viewBuildError.php?buildid=6&onlydeltap=1');
+    browser.get('viewBuildError.php?buildid=7&onlydeltap=1');
     expect(element(by.className('num-errors')).getText()).toContain("0 Errors");
   });
 
   it("type=1 shows 10 warnings", function() {
-    browser.get('viewBuildError.php?buildid=6&type=1');
+    browser.get('viewBuildError.php?buildid=7&type=1');
     expect(element(by.className('num-errors')).getText()).toContain("10 Warnings");
   });
 
   it("displays build errors inline", function() {
-    browser.get('viewBuildError.php?buildid=74&type=0');
+    browser.get('viewBuildError.php?buildid=75&type=0');
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });
 
   it("displays build errors inline on parent builds", function() {
-    browser.get('viewBuildError.php?buildid=73&type=0');
+    browser.get('viewBuildError.php?buildid=74&type=0');
     expect(browser.getPageSource()).toContain("some-test-subproject");
     expect(browser.getPageSource()).toContain("error: 'foo' was not declared in this scope");
   });

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -192,8 +192,7 @@ class KWWebTestCase extends WebTestCase
             if ($this->findString($content, 'ERROR') ||
                 $this->findString($content, 'WARNING')
             ) {
-                throw new Exception(var_export($content, true));
-                $this->fail('Log file has errors or warnings');
+                $this->fail('Log file has errors or warnings... ' . var_export($content, true));
                 return false;
             }
             return $content;

--- a/app/cdash/tests/test_projectwebpage.php
+++ b/app/cdash/tests/test_projectwebpage.php
@@ -165,9 +165,10 @@ class ProjectWebPageTestCase extends KWWebTestCase
 
     public function testSubmissionInDb()
     {
-        $query = 'SELECT id, stamp, name, type, generator, command FROM build WHERE id=6';
+        // TODO: (williamjallen) This is a terrible test with hardcoded values.  The ID should be determined dynamically.
+        $query = 'SELECT id, stamp, name, type, generator, command FROM build WHERE id=7';
         $result = $this->db->query($query);
-        $expected = array('id' => '6',
+        $expected = array('id' => '7',
             'stamp' => '20090223-0100-Nightly',
             'name' => 'Win32-MSVC2009',
             'type' => 'Nightly',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9396,22 +9396,7 @@ parameters:
 			path: app/cdash/include/Messaging/FactoryInterface.php
 
 		-
-			message: "#^Call to an undefined method CDash\\\\Messaging\\\\Topic\\\\LabeledTopic\\:\\:mergeTopics\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
-
-		-
 			message: "#^Method CDash\\\\Messaging\\\\Notification\\\\Email\\\\EmailBuilder\\:\\:setBuildEmailCollection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
-			count: 1
-			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, CDash\\\\Messaging\\\\Topic\\\\LabeledTopic given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
 
@@ -14798,7 +14783,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/include/sendemail.php
 
 		-
@@ -21835,22 +21820,22 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:getSent\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:getSent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:isError\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:isError\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:read\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:read\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -21950,12 +21935,12 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:\\$read has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:\\$read has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:875\\:\\:\\$response has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:\\$response has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -21976,7 +21961,7 @@ parameters:
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-

--- a/resources/views/email/issue.blade.php
+++ b/resources/views/email/issue.blade.php
@@ -49,6 +49,9 @@ Total {{ $topic->getTopicDescription() }}: {{ $topic->getTopicCount() }}
 @foreach($subscription->getTopicCollection() as $type => $topic)
 <?php
 $collection = $topic->getTopicCollection();
+if ($collection === null) {
+    continue;
+}
 $size = Subscription::getMaxDisplayItems();
 if ($collection instanceof \Illuminate\Support\Collection) {
     $items = $collection->take($size);


### PR DESCRIPTION
CDash currently throws an HTTP 500 response when attempting to send an email
about errors in a submitted Update.xml file.

This PR fixes the 500 error and cleans up a variety of other small issues in the notification code.  In the future, it would be good to give the notification code a more thorough cleanup, since the current code is difficult to debug due to the lack of correct type annotations, complex inheritance hierarchy, and large amounts of dead code.

Fixes https://github.com/Kitware/CDash/issues/1498