### PR TITLE
Push menu to right side on all pages

### DIFF
--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -577,7 +577,7 @@ class KWWebTestCase extends WebTestCase
             $response = $client->request('GET', "{$this->url}/login");
             $html = "{$response->getBody()}";
             $dom = new \DOMDocument();
-            $dom->loadHTML($html);
+            @$dom->loadHTML($html);
             $token = $dom->getElementById('csrf-token')
                 ->getAttribute('value');
 

--- a/resources/js/components/page-header/HeaderNav.vue
+++ b/resources/js/components/page-header/HeaderNav.vue
@@ -1,61 +1,59 @@
 <template>
-  <nav
+  <ul
     v-if="showNav"
-    class="projectnav clearfix"
+    class="projectnav_controls clearfix"
   >
-    <ul class="projectnav_controls clearfix">
-      <li
-        id="header-nav-previous-btn"
-        :class="previousClass"
-      >
-        <a :href="previous">
-          <svg
-            id="i-chevron-left"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 32 32"
-            width="8"
-            height="8"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="4"
-          >
-            <path d="M20 30 L8 16 20 2" />
-          </svg>
-          PREV
-        </a>
-      </li>
-      <li
-        id="header-nav-current-btn"
-        :class="currentClass"
-      >
-        <a :href="current">CURRENT</a>
-      </li>
-      <li
-        id="header-nav-next-btn"
-        :class="nextClass"
-      >
-        <a :href="next">
-          NEXT
-          <svg
-            id="i-chevron-right"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 32 32"
-            width="8"
-            height="8"
-            fill="none"
-            stroke="currentcolor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="4"
-          >
-            <path d="M12 30 L24 16 12 2" />
-          </svg>
-        </a>
-      </li>
-    </ul>
-  </nav>
+    <li
+      id="header-nav-previous-btn"
+      :class="previousClass"
+    >
+      <a :href="previous">
+        <svg
+          id="i-chevron-left"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 32 32"
+          width="8"
+          height="8"
+          fill="none"
+          stroke="currentcolor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="4"
+        >
+          <path d="M20 30 L8 16 20 2" />
+        </svg>
+        PREV
+      </a>
+    </li>
+    <li
+      id="header-nav-current-btn"
+      :class="currentClass"
+    >
+      <a :href="current">CURRENT</a>
+    </li>
+    <li
+      id="header-nav-next-btn"
+      :class="nextClass"
+    >
+      <a :href="next">
+        NEXT
+        <svg
+          id="i-chevron-right"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 32 32"
+          width="8"
+          height="8"
+          fill="none"
+          stroke="currentcolor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="4"
+        >
+          <path d="M12 30 L24 16 12 2" />
+        </svg>
+      </a>
+    </li>
+  </ul>
 </template>
 
 <script>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -65,11 +65,10 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
             </span>
         </div>
 
-
-        @if(isset($angular) && $angular === true)
-            @verbatim
-                <div ng-if="cdash.menu.previous || cdash.menu.current || cdash.menu.next" class="projectnav clearfix">
-                    <ul class="projectnav_controls clearfix">
+        <nav class="projectnav clearfix">
+            @if(isset($angular) && $angular === true)
+                @verbatim
+                    <ul ng-if="cdash.menu.previous || cdash.menu.current || cdash.menu.next" class="projectnav_controls clearfix">
                         <li class="btnprev">
                             <a ng-if="cdash.menu.previous"
                                ng-href="{{::cdash.menu.previous}}{{::cdash.filterurl}}">Prev</a>
@@ -87,14 +86,11 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
                             </a>
                         </li>
                     </ul>
-                </div>
-
-            @endverbatim
-        @elseif(isset($vue) && $vue === true)
-            <header-nav></header-nav>
-        @else {{-- Put a dummy element here to fill the space --}}
-            <div class="projectnav"></div>
-        @endif
+                @endverbatim
+            @elseif(isset($vue) && $vue === true)
+                <header-nav></header-nav>
+            @endif
+        </nav>
 
 
         @if(isset($angular) && $angular === true)


### PR DESCRIPTION
#1351 refactored the top nav bar but failed to cover all the possible cases, meaning that the menu on the right side could show up on the left side if the center nav was not visible.  This PR simplifies the code significantly to reduce the number of cases which have to be covered.

Before:
![image](https://github.com/Kitware/CDash/assets/16820599/3620e24e-6a10-4606-af6e-6e0d6f76ff25)

After:
![image](https://github.com/Kitware/CDash/assets/16820599/30fa3c48-0c9c-412d-bf18-0514515064fd)
