### PR TITLE
Fix 404 when filtering coverage display

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -109,7 +109,7 @@ Route::get('/viewUpdate.php', 'AdminController@viewUpdate');
 
 Route::get('/viewTest.php', 'ViewTestController@viewTest');
 
-Route::get('/viewCoverage.php', 'CoverageController@viewCoverage');
+Route::match(['get', 'post'], '/viewCoverage.php', 'CoverageController@viewCoverage');
 
 Route::get('/viewCoverageFile.php', 'CoverageController@viewCoverageFile');
 


### PR DESCRIPTION
Re-create the POST route for the getCoverage file which will re-enable the filtering of the coverage files.

Fixes: #1518