### PR TITLE
Deprecate `addBuild.php` API endpoint

### DIFF
--- a/app/cdash/public/api/v1/addBuild.php
+++ b/app/cdash/public/api/v1/addBuild.php
@@ -24,6 +24,10 @@ use App\Models\Site;
 use CDash\ServiceContainer;
 use Symfony\Component\HttpFoundation\Response;
 
+/**********************************************************************************
+ * NOTE: THIS API ENDPOINT IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE. *
+ **********************************************************************************/
+
 if ($_SERVER['REQUEST_METHOD'] != 'POST') {
     return response('Not Implemented', Response::HTTP_NOT_IMPLEMENTED);
 }
@@ -61,7 +65,10 @@ if (!$build->Id) {
     abort(500, 'Error creating build');
 }
 
-$response = ['buildid' => $build->Id];
+$response = [
+    'buildid' => $build->Id,
+    'deprecated' => true,
+];
 if ($build_created) {
     return response()->json($response, 201);
 } else {


### PR DESCRIPTION
The endpoint `/api/v1/addBuild.php` was first added in #694, but is no longer used in the CDash codebase.  Since this endpoint may be used by external scripts, it has been deprecated temporarily and will be removed entirely in a future release.

It would also be good to provide a notice about this deprecation in the CDash 3.2 release notes.