### PR TITLE
Refactor dynamic analysis UI

### DIFF
--- a/app/cdash/public/views/viewDynamicAnalysis.html
+++ b/app/cdash/public/views/viewDynamicAnalysis.html
@@ -1,50 +1,61 @@
-      <h3>Dynamic analysis started on {{::cdash.build.buildtime}}</h3>
+<h3>Dynamic analysis started on {{::cdash.build.buildtime}}</h3>
 
-      <table border="0">
-        <tr>
-          <td align="right"><b>Site Name:</b></td>
-          <td>{{::cdash.build.site}}</td>
-        </tr>
-        <tr>
-          <td align="right"><b>Build Name:</b></td>
-          <td>{{::cdash.build.buildname}}</td>
-        </tr>
-      </table>
+<table border="0">
+  <tr>
+    <td align="right"><b>Site Name:</b></td>
+    <td>{{::cdash.build.site}}</td>
+  </tr>
+  <tr>
+    <td align="right"><b>Build Name:</b></td>
+    <td>{{::cdash.build.buildname}}</td>
+  </tr>
+</table>
 
-      <table cellspacing="0">
-        <tr>
-          <th>Name</th>
-          <th>Status</th>
-          <th ng-repeat="defecttype in ::cdash.defecttypes">
-            {{::defecttype.type}}
-          </th>
-          <th ng-if="::cdash.displaylabels">Labels</th>
-        </tr>
+<div class="buildgroup">
+  <table cellspacing="0" class="tabb" width="100%">
+    <thead>
+      <tr class="table-heading1">
+        <td class="center-text botl" colspan="100">Dynamic Analysis</td>
+      </tr>
+      <tr class="table-heading">
+        <th class="column-header">Name</th>
+        <th class="column-header">Status</th>
+        <th ng-repeat="defecttype in ::cdash.defecttypes" class="column-header">
+          {{::defecttype.type}}
+        </th>
+        <th ng-if="::cdash.displaylabels" class="column-header">Labels</th>
+      </tr>
+    </thead>
 
-        <tr align="center"
-            ng-repeat="DA in ::cdash.dynamicanalyses"
-            ng-class-odd="'measurement'">
-          <td align="left">
-            <a ng-href="viewDynamicAnalysisFile.php?id={{::DA.id}}">
-              {{::DA.name}}
-            </a>
-          </td>
+    <tbody>
+      <tr align="center"
+          ng-repeat="DA in ::cdash.dynamicanalyses"
+          ng-class-odd="'odd'"
+          ng-class-even="'even'"
+      >
+        <td align="left">
+          <a ng-href="viewDynamicAnalysisFile.php?id={{::DA.id}}">
+            {{::DA.name}}
+          </a>
+        </td>
 
-          <td ng-class="::DA.status == 'Passed' ? 'normal' : 'error'">
-            {{::DA.status}}
-          </td>
+        <td ng-class="::DA.status == 'Passed' ? 'normal' : 'error'">
+          {{::DA.status}}
+        </td>
 
-          <!-- Show how many defects of each type were found for this test -->
-          <td ng-repeat="numdefects in ::DA.defects track by $index"
-              ng-class="::{warning: numdefects > 0}">
-            <span ng-if="::numdefects > 0">
-              {{::numdefects}}
-            </span>
-          </td>
+        <!-- Show how many defects of each type were found for this test -->
+        <td ng-repeat="numdefects in ::DA.defects track by $index"
+            ng-class="::{warning: numdefects > 0}">
+          <span ng-if="::numdefects > 0">
+            {{::numdefects}}
+          </span>
+        </td>
 
-          <!-- Labels -->
-          <td ng-if="::cdash.displaylabels">
-            {{::DA.labels}}
-          </td>
-        </tr>
-      </table>
+        <!-- Labels -->
+        <td ng-if="::cdash.displaylabels">
+          {{::DA.labels}}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
The dynamic analysis UI was apparently missed during the most recent UI refactor and now sticks out like a sore thumb compared to the rest of the CDash interface.  This PR applies the same styling other CDash tables use for greater UI consistency.

Before:
![image](https://github.com/Kitware/CDash/assets/16820599/ff1392a7-b503-443e-a7d0-a560ae979b5c)

After:
![image](https://github.com/Kitware/CDash/assets/16820599/160ec826-4c49-47bf-90a4-66c3af96d810)

