### PR TITLE
Fix test summary error when no results

### DIFF
--- a/app/cdash/public/api/v1/testSummary.php
+++ b/app/cdash/public/api/v1/testSummary.php
@@ -266,6 +266,7 @@ $numfailed = 0;
 $numtotal = 0;
 $test_measurements = [];
 
+$builds_response = [];
 foreach ($result as $row) {
     $buildid = $row['buildid'];
     $build_response = array();
@@ -410,7 +411,7 @@ $response['csvlink'] = $_SERVER['REQUEST_URI'] . '&export=csv';
 $response['columncount'] = count($columns);
 $response['numfailed'] = $numfailed;
 $response['numtotal'] = $numtotal;
-$response['percentagepassed'] = round($numpassed / $numtotal, 2) * 100;
+$response['percentagepassed'] = $numtotal > 0 ? round($numpassed / $numtotal, 2) * 100 : 0;
 
 $pageTimer->end($response);
 echo json_encode($response);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16938,11 +16938,6 @@ parameters:
 			path: app/cdash/public/api/v1/testSummary.php
 
 		-
-			message: "#^Implicit array creation is not allowed \\- variable \\$builds_response might not exist\\.$#"
-			count: 2
-			path: app/cdash/public/api/v1/testSummary.php
-
-		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$etest might not exist\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/testSummary.php
@@ -16950,11 +16945,6 @@ parameters:
 		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
-			path: app/cdash/public/api/v1/testSummary.php
-
-		-
-			message: "#^Variable \\$builds_response might not be defined\\.$#"
-			count: 3
 			path: app/cdash/public/api/v1/testSummary.php
 
 		-


### PR DESCRIPTION
The API endpoint for `testSummary.php` currently returns a 500 error when there are no rows to be displayed.  This endpoint has other significant issues and desperately needs a complete refactor, but this PR should at least make it return a sensible response given a realistic input.