### PR TITLE
Add stale project cleanup Artisan command

### DIFF
--- a/app/Console/Commands/PurgeUnusedProjects.php
+++ b/app/Console/Commands/PurgeUnusedProjects.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use CDash\Model\Project;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class PurgeUnusedProjects extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'projects:clean';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Delete projects with no builds';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        set_time_limit(0);
+
+        $result = DB::select('SELECT id FROM project');
+        $all_project_ids = [];
+        foreach ($result as $row) {
+            $all_project_ids[] = (int) $row->id;
+        }
+
+        foreach ($all_project_ids as $projectid) {
+            $project = new Project();
+            $project->Id = $projectid;
+            $project->Fill();
+
+            if ($project->GetNumberOfBuilds() === 0) {
+                echo 'Deleting project: ' . $project->Name . PHP_EOL;
+                $project->Delete();
+            }
+        }
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -111,6 +111,8 @@ add_unit_test(/CDash/XmlHandler/DynamicAnalysisHandler)
 add_unit_test(/CDash/XmlHandler/TestingHandler)
 add_unit_test(/CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
+
 add_laravel_test(/Feature/TestSchemaMigration)
 add_laravel_test(/Feature/MeasurementPositionMigration)
 add_laravel_test(/Feature/RemoveMeasurementCheckboxesMigration)

--- a/tests/Feature/PurgeUnusedProjectsCommand.php
+++ b/tests/Feature/PurgeUnusedProjectsCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use CDash\Model\Build;
+use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class PurgeUnusedProjectsCommand extends TestCase
+{
+    private Project $project1;
+    private Project $project2;
+
+    /**
+     * Feature test for the build:remove artisan command.
+     *
+     * @return void
+     */
+    public function testAutoRemoveBuildsCommand()
+    {
+        // Make a project.
+        $this->project1 = new Project();
+        $this->project1->Name = 'DontRemoveProject';
+        $this->project1->Save();
+        $this->project1->InitialSetup();
+
+        // Make a build for the project.
+        $build = new Build();
+        $build->Name = 'test';
+        $build->ProjectId = $this->project1->Id;
+        $build->SiteId = 1;
+        $build->SetStamp('20090223-0115-Experimental');
+        $build->StartTime = '2009-02-23 01:15:00';
+        $build->EndTime = '2009-02-23 01:15:00';
+        $build->SubmitTime = '2009-02-23 01:15:00';
+        $build->AddBuild();
+
+        // Make another project.
+        $this->project2 = new Project();
+        $this->project2->Name = 'RemoveProject';
+        $this->project2->Save();
+        $this->project2->InitialSetup();
+
+
+        // Run the command.
+        $this->artisan('projects:clean');
+
+        // Confirm that project 2 was deleted but project 1 was not
+        self::assertEquals(0, DB::select("SELECT COUNT(*) AS c FROM project WHERE name = 'RemoveProject'")[0]->c);
+        self::assertEquals(1, DB::select("SELECT COUNT(*) AS c FROM project WHERE name = 'DontRemoveProject'")[0]->c);
+
+    }
+
+    public function tearDown() : void
+    {
+        if (isset($this->project1)) {
+            $this->project1->Delete();
+        }
+        if (isset($this->project2)) {
+            $this->project2->Delete();
+        }
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
CDash instances such as [my.cdash.org](https://my.cdash.org) which allow any user to create a project can accumulate a large number of stale projects which have no recent builds or activity and are otherwise just taking up space.

This PR introduces a new `projects:clean` Artisan command which automatically deletes any projects which have no builds associated with them.