### PR TITLE
Refactor `Coverage` model

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -464,8 +464,8 @@ class CoverageController extends AbstractBuildController
                               SELECT
                                   sum(loctested) as loctested,
                                   sum(locuntested) as locuntested,
-                                  sum(branchstested) as branchstested,
-                                  sum(branchsuntested) as branchsuntested
+                                  sum(branchestested) as branchestested,
+                                  sum(branchesuntested) as branchesuntested
                               FROM coverage
                               WHERE buildid=?
                               GROUP BY buildid
@@ -475,8 +475,8 @@ class CoverageController extends AbstractBuildController
         $xml .= add_XML_value('loctested', $coverage_array['loctested']);
         $xml .= add_XML_value('locuntested', $coverage_array['locuntested']);
 
-        $xml .= add_XML_value('branchstested', $coverage_array['branchstested']);
-        $xml .= add_XML_value('branchsuntested', $coverage_array['branchsuntested']);
+        $xml .= add_XML_value('branchestested', $coverage_array['branchestested']);
+        $xml .= add_XML_value('branchesuntested', $coverage_array['branchesuntested']);
         $percentcoverage = compute_percentcoverage(
             $coverage_array['loctested'], $coverage_array['locuntested']);
 
@@ -572,8 +572,8 @@ class CoverageController extends AbstractBuildController
                             SELECT
                                 c.locuntested,
                                 c.loctested,
-                                c.branchstested,
-                                c.branchsuntested,
+                                c.branchestested,
+                                c.branchesuntested,
                                 c.functionstested,
                                 c.functionsuntested,
                                 cf.fullpath
@@ -594,15 +594,15 @@ class CoverageController extends AbstractBuildController
             // Compute the coverage metric for bullseye.  (branch coverage without line coverage)
             if (
                 ($coveragefile_array['loctested'] == 0 && $coveragefile_array['locuntested'] == 0) &&
-                ($coveragefile_array['branchstested'] > 0 || $coveragefile_array['branchsuntested'] > 0 ||
+                ($coveragefile_array['branchestested'] > 0 || $coveragefile_array['branchesuntested'] > 0 ||
                     $coveragefile_array['functionstested'] > 0 || $coveragefile_array['functionsuntested'] > 0)) {
                 // Metric coverage
                 $metric = 0;
                 if ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested'] > 0) {
                     $metric += $coveragefile_array['functionstested'] / ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested']);
                 }
-                if ($coveragefile_array['branchstested'] + $coveragefile_array['branchsuntested'] > 0) {
-                    $metric += $coveragefile_array['branchstested'] / ($coveragefile_array['branchstested'] + $coveragefile_array['branchsuntested']);
+                if ($coveragefile_array['branchestested'] + $coveragefile_array['branchesuntested'] > 0) {
+                    $metric += $coveragefile_array['branchestested'] / ($coveragefile_array['branchestested'] + $coveragefile_array['branchesuntested']);
                     $metric /= 2.0;
                 }
 
@@ -868,26 +868,26 @@ class CoverageController extends AbstractBuildController
             $end = $start + (int)($_GET['iDisplayLength'] ?? 0);
         }
 
-        //add columns for branches only if(total_branchsuntested+total_branchstested)>0
-        $total_branchsuntested = 0;
-        $total_branchstested = 0;
+        //add columns for branches only if(total_branchesuntested+total_branchestested)>0
+        $total_branchesuntested = 0;
+        $total_branchestested = 0;
         $coverage_branches = $db->executePreparedSingleRow('
                                  SELECT
-                                     sum(branchstested) AS total_branchstested,
-                                     sum(branchsuntested) AS total_branchsuntested
+                                     sum(branchestested) AS total_branchestested,
+                                     sum(branchesuntested) AS total_branchesuntested
                                  FROM coverage
                                  WHERE buildid = ?
                                  GROUP BY buildid
                              ', [$this->build->Id]);
         if (!empty($coverage_branches)) {
-            $total_branchsuntested = intval($coverage_branches['total_branchsuntested']);
-            $total_branchstested = intval($coverage_branches['total_branchstested']);
+            $total_branchesuntested = intval($coverage_branches['total_branchesuntested']);
+            $total_branchestested = intval($coverage_branches['total_branchestested']);
         }
 
         /* Sorting */
         $sortby = 'filename';
         if (isset($_GET['iSortCol_0'])) {
-            if (($total_branchsuntested + $total_branchstested) > 0) {
+            if (($total_branchesuntested + $total_branchestested) > 0) {
                 switch (intval($_GET['iSortCol_0'])) {
                     case 0:
                         $sortby = 'filename';
@@ -971,8 +971,8 @@ class CoverageController extends AbstractBuildController
                                 c.fileid,
                                 c.locuntested,
                                 c.loctested,
-                                c.branchstested,
-                                c.branchsuntested,
+                                c.branchestested,
+                                c.branchesuntested,
                                 c.functionstested,
                                 c.functionsuntested,
                                 cfp.priority
@@ -1018,8 +1018,8 @@ class CoverageController extends AbstractBuildController
             // Compute the coverage metric for bullseye (branch coverage without line coverage)
             if (($coveragefile_array['loctested'] == 0 &&
                     $coveragefile_array['locuntested'] == 0) &&
-                ($coveragefile_array['branchstested'] > 0 ||
-                    $coveragefile_array['branchsuntested'] > 0 ||
+                ($coveragefile_array['branchestested'] > 0 ||
+                    $coveragefile_array['branchesuntested'] > 0 ||
                     $coveragefile_array['functionstested'] > 0 ||
                     $coveragefile_array['functionsuntested'] > 0)) {
                 // Metric coverage
@@ -1027,12 +1027,12 @@ class CoverageController extends AbstractBuildController
                 if ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested'] > 0) {
                     $metric += $coveragefile_array['functionstested'] / ($coveragefile_array['functionstested'] + $coveragefile_array['functionsuntested']);
                 }
-                if ($coveragefile_array['branchstested'] + $coveragefile_array['branchsuntested'] > 0) {
-                    $metric += $coveragefile_array['branchstested'] / ($coveragefile_array['branchstested'] + $coveragefile_array['branchsuntested']);
+                if ($coveragefile_array['branchestested'] + $coveragefile_array['branchesuntested'] > 0) {
+                    $metric += $coveragefile_array['branchestested'] / ($coveragefile_array['branchestested'] + $coveragefile_array['branchesuntested']);
                     $metric /= 2.0;
                 }
-                $covfile['branchesuntested'] = $coveragefile_array['branchsuntested'];
-                $covfile['branchestested'] = $coveragefile_array['branchstested'];
+                $covfile['branchesuntested'] = $coveragefile_array['branchesuntested'];
+                $covfile['branchestested'] = $coveragefile_array['branchestested'];
                 $covfile['functionsuntested'] = $coveragefile_array['functionsuntested'];
                 $covfile['functionstested'] = $coveragefile_array['functionstested'];
 
@@ -1042,8 +1042,8 @@ class CoverageController extends AbstractBuildController
             } else {
                 // coverage metric for gcov
                 $metric = 0;
-                $covfile['branchesuntested'] = $coveragefile_array['branchsuntested'];
-                $covfile['branchestested'] = $coveragefile_array['branchstested'];
+                $covfile['branchesuntested'] = $coveragefile_array['branchesuntested'];
+                $covfile['branchestested'] = $coveragefile_array['branchestested'];
                 if (($covfile['branchestested'] + $covfile['branchesuntested']) > 0) {
                     $metric += $covfile['branchestested'] / ($covfile['branchestested'] + $covfile['branchesuntested']);
                 }
@@ -1470,7 +1470,7 @@ class CoverageController extends AbstractBuildController
             }
 
             //Next column (Branch Percentage)
-            if ($coveragetype === 'gcov' && ($total_branchstested + $total_branchsuntested) > 0) {
+            if ($coveragetype === 'gcov' && ($total_branchestested + $total_branchesuntested) > 0) {
                 $nextcolumn = '<div style="position:relative; width: 190px;">
                    <div style="position:relative; float:left;
                    width: 123px; height: 12px; background: #bdbdbd url(\'img/progressbar.gif\') top left no-repeat;">

--- a/app/Models/Coverage.php
+++ b/app/Models/Coverage.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $buildid
+ * @property int $fileid
+ * @property int $covered
+ * @property int $loctested
+ * @property int $locuntested
+ * @property int $branchestested
+ * @property int $branchesuntested
+ * @property int $functionstested
+ * @property int $functionsuntested
+ *
+ * @mixin Builder<Coverage>
+ */
+class Coverage extends Model
+{
+    protected $table = 'coverage';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'fileid',
+        'covered',
+        'loctested',
+        'locuntested',
+        'branchestested',
+        'branchesuntested',
+        'functionstested',
+        'functionsuntested',
+    ];
+}

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -194,7 +194,7 @@ class CoverageFile
         }
 
         $stmt = $this->PDO->prepare(
-            'SELECT loctested, locuntested, branchstested, branchsuntested,
+            'SELECT loctested, locuntested, branchestested, branchesuntested,
                 functionstested, functionsuntested
                 FROM coverage WHERE fileid=:id');
         $stmt->bindParam(':id', $this->Id);
@@ -210,20 +210,20 @@ class CoverageFile
         $coveragemetric = 1;
         $loctested = $row['loctested'];
         $locuntested = $row['locuntested'];
-        $branchstested = $row['branchstested'];
-        $branchsuntested = $row['branchsuntested'];
+        $branchestested = $row['branchestested'];
+        $branchesuntested = $row['branchesuntested'];
         $functionstested = $row['functionstested'];
         $functionsuntested = $row['functionsuntested'];
 
         // Compute the coverage metric for bullseye
-        if ($branchstested > 0 || $branchsuntested > 0 || $functionstested > 0 || $functionsuntested > 0) {
+        if ($branchestested > 0 || $branchesuntested > 0 || $functionstested > 0 || $functionsuntested > 0) {
             // Metric coverage
             $metric = 0;
             if ($functionstested + $functionsuntested > 0) {
                 $metric += $functionstested / ($functionstested + $functionsuntested);
             }
-            if ($branchsuntested + $branchsuntested > 0) {
-                $metric += $branchsuntested / ($branchstested + $branchsuntested);
+            if ($branchesuntested + $branchesuntested > 0) {
+                $metric += $branchesuntested / ($branchestested + $branchesuntested);
                 $metric /= 2.0;
             }
             $coveragemetric = $metric;
@@ -247,7 +247,7 @@ class CoverageFile
     public function GetIdFromName($file, $buildid)
     {
         $stmt = $this->PDO->prepare(
-            'SELECT id FROM coveragefile
+            'SELECT coveragefile.id FROM coveragefile
                 INNER JOIN coverage ON (coveragefile.id=coverage.fileid)
                 WHERE fullpath LIKE :fullpath AND coverage.buildid=:buildid');
         $file_with_wildcard = "%$file%";

--- a/app/cdash/app/Model/CoverageSummary.php
+++ b/app/cdash/app/Model/CoverageSummary.php
@@ -129,8 +129,8 @@ class CoverageSummary
                 $covered = $coverage->Covered;
                 $loctested = $coverage->LocTested;
                 $locuntested = $coverage->LocUntested;
-                $branchstested = $coverage->BranchesTested;
-                $branchsuntested = $coverage->BranchesUntested;
+                $branchestested = $coverage->BranchesTested;
+                $branchesuntested = $coverage->BranchesUntested;
                 $functionstested = $coverage->FunctionsTested;
                 $functionsuntested = $coverage->FunctionsUntested;
 
@@ -143,11 +143,11 @@ class CoverageSummary
                 if (empty($locuntested)) {
                     $locuntested = 0;
                 }
-                if (empty($branchstested)) {
-                    $branchstested = 0;
+                if (empty($branchestested)) {
+                    $branchestested = 0;
                 }
-                if (empty($branchsuntested)) {
-                    $branchsuntested = 0;
+                if (empty($branchesuntested)) {
+                    $branchesuntested = 0;
                 }
                 if (empty($functionstested)) {
                     $functionstested = 0;
@@ -163,7 +163,7 @@ class CoverageSummary
                 if ($append) {
                     // UPDATE (instead of INSERT) if this coverage already
                     // exists.
-                    $existing_row_updated = DB::transaction(function () use ($coverage, $covered, $loctested, $locuntested, $branchstested, $branchsuntested, $functionstested, $functionsuntested) {
+                    $existing_row_updated = DB::transaction(function () use ($coverage, $covered, $loctested, $locuntested, $branchestested, $branchesuntested, $functionstested, $functionsuntested) {
                         $existing_coverage_row = DB::table('coverage')
                             ->where('buildid', $this->BuildId)
                             ->where('fileid', $coverage->CoverageFile->Id)
@@ -177,8 +177,8 @@ class CoverageSummary
                                     'covered' => $covered,
                                     'loctested' => $loctested,
                                     'locuntested' => $locuntested,
-                                    'branchstested' => $branchstested,
-                                    'branchsuntested' => $branchsuntested,
+                                    'branchestested' => $branchestested,
+                                    'branchesuntested' => $branchesuntested,
                                     'functionstested' => $functionstested,
                                     'functionsuntested' => $functionsuntested,
                                 ]);
@@ -194,8 +194,8 @@ class CoverageSummary
                         'covered' => $covered,
                         'loctested' => $loctested,
                         'locuntested' => $locuntested,
-                        'branchstested' => $branchstested,
-                        'branchsuntested' => $branchsuntested,
+                        'branchestested' => $branchestested,
+                        'branchesuntested' => $branchesuntested,
                         'functionstested' => $functionstested,
                         'functionsuntested' => $functionsuntested,
                     ]);

--- a/app/cdash/public/viewCoverage.xsl
+++ b/app/cdash/public/viewCoverage.xsl
@@ -43,15 +43,15 @@
                  <td align="right"><xsl:value-of select="cdash/coverage/locuntested"/></td>
 
               </tr>
-              <xsl:if test="(cdash/coverage/branchstested + cdash/coverage/branchsuntested) > 0">
+              <xsl:if test="(cdash/coverage/branchestested + cdash/coverage/branchesuntested) > 0">
                 <tr class="trodd">
 
                    <td align="left">Tested branches</td>
-                   <td align="right"><xsl:value-of select="cdash/coverage/branchstested"/></td>
+                   <td align="right"><xsl:value-of select="cdash/coverage/branchestested"/></td>
                 </tr>
                 <tr class="treven">
                    <td align="left">Untested branches</td>
-                   <td align="right"><xsl:value-of select="cdash/coverage/branchsuntested"/></td>
+                   <td align="right"><xsl:value-of select="cdash/coverage/branchesuntested"/></td>
 
                 </tr>
               </xsl:if>
@@ -268,7 +268,7 @@
       <!-- gcov -->
       <xsl:if test="cdash/coverage/coveragetype='gcov'">
         <th width="10%" align="center">Lines not covered</th>
-        <xsl:if test="(cdash/coverage/branchstested + cdash/coverage/branchsuntested) > 0">
+        <xsl:if test="(cdash/coverage/branchestested + cdash/coverage/branchesuntested) > 0">
           <th width="10%" align="center">Branch percentage</th>
           <th width="10%" align="center">Branches not covered</th>
         </xsl:if>

--- a/database/migrations/2023_06_29_210505_coverage_primary_key.php
+++ b/database/migrations/2023_06_29_210505_coverage_primary_key.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('coverage', function (Blueprint $table) {
+            $table->integer('id', true);
+            $table->renameColumn('branchstested', 'branchestested');
+            $table->renameColumn('branchsuntested', 'branchesuntested');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('coverage', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->renameColumn('branchestested', 'branchstested');
+            $table->renameColumn('branchesuntested', 'branchsuntested');
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6224,14 +6224,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function add_last_sql_error\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
-			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
@@ -6239,23 +6231,12 @@ parameters:
 			path: app/cdash/app/Model/Coverage.php
 
 		-
-			message: """
-				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Coverage.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Coverage\\>\\:\\:exists\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Coverage.php
 
@@ -6270,12 +6251,7 @@ parameters:
 			path: app/cdash/app/Model/Coverage.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Coverage\\:\\:Exists\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Coverage\\:\\:GetFiles\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Coverage\\:\\:GetFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Coverage.php
 


### PR DESCRIPTION
This PR serves as a trial run of my new approach regarding the modernization of large models for which is is infeasible to replace the model entirely.  Rather than taking the reflection approach used for the `User` classes, I have instead taken an "adapter" approach, such that the public-facing interface of the original `Coverage` class has not changed, but all of the database interactions happen through the public-facing interface of the new eloquent-based `Coverage` class.