### PR TITLE
Accept POST route for `buildOverview.php`

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -117,7 +117,7 @@ Route::any('/ajax/getviewcoverage.php', 'CoverageController@ajaxGetViewCoverage'
 
 Route::any('/ajax/showcoveragegraph.php', 'CoverageController@ajaxShowCoverageGraph');
 
-Route::get('/buildOverview.php', 'BuildController@buildOverview');
+Route::match(['get', 'post'], '/buildOverview.php', 'BuildController@buildOverview');
 
 Route::get('/buildProperties.php', 'BuildPropertiesController@buildProperties');
 


### PR DESCRIPTION
This PR fixes a bug on `buildOverview.php` where the group selection dropdown was unusable since the corresponding POST request was not being accepted.