### PR TITLE
Display test details command line in monospace font

### DIFF
--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -148,12 +148,11 @@
         <span v-show="showcommandline">Hide Command Line</span>
       </a>
       <transition name="fade">
-        <div
+        <pre
           v-show="showcommandline"
           id="commandline"
-        >
-          {{ cdash.test.command }}
-        </div>
+          style="white-space: pre-wrap;"
+        >{{ cdash.test.command }}</pre>
       </transition>
       <br>
 


### PR DESCRIPTION
The test details command line is currently displayed in regular text, which can be difficult to read when it consists of a long string of symbols.  This PR changes the UI to match other parts of the codebase in which text of this nature is displayed as prepared text in a monospace font.