### PR TITLE
Standardize page titles

### DIFF
--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -193,7 +193,7 @@ class QueryTests extends ResultsApi
     public function getResponse()
     {
         $response = begin_JSON_response();
-        $response['title'] = "CDash : {$this->project->Name}";
+        $response['title'] = "{$this->project->Name} - Query Tests";
         $response['showcalendar'] = 1;
 
         // If parentid is set we need to lookup the date for this build

--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -59,7 +59,7 @@ class TestDetails extends BuildTestApi
 
         $this->setDate($this->build->GetDate());
 
-        $response['title'] = "CDash : {$this->project->Name}";
+        $response['title'] = "{$this->project->Name} - Tests";
         get_dashboard_JSON_by_name($this->project->Name, $this->date, $response);
 
         $project_response = [];

--- a/app/cdash/app/Controller/Api/ViewNotes.php
+++ b/app/cdash/app/Controller/Api/ViewNotes.php
@@ -33,7 +33,7 @@ class ViewNotes extends BuildApi
     public function getResponse()
     {
         $response = begin_JSON_response();
-        $response['title'] = "CDash : {$this->project->Name}";
+        $response['title'] = "{$this->project->Name} - Build Notes";
 
         $this->setDate(TestingDay::get($this->project, $this->build->StartTime));
         get_dashboard_JSON_by_name($this->project->Name, $this->date, $response);

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -54,7 +54,7 @@ class ViewTest extends BuildApi
         $this->setDate($this->build->GetDate());
 
         $response = begin_JSON_response();
-        $response['title'] = "CDash : {$this->project->Name}";
+        $response['title'] = "{$this->project->Name} - Tests";
         $response['groupid'] = $this->build->GroupId;
         get_dashboard_JSON_by_name($this->project->Name, $this->date, $response);
 

--- a/app/cdash/public/api/v1/buildSummary.php
+++ b/app/cdash/public/api/v1/buildSummary.php
@@ -57,7 +57,7 @@ if (!can_access_project($project->Id)) {
 $date = TestingDay::get($project, $build->StartTime);
 
 $response = begin_JSON_response();
-$response['title'] = "CDash : $project->Name";
+$response['title'] = "$project->Name - Build Summary";
 
 $previous_buildid = $build->GetPreviousBuildId();
 $current_buildid = $build->GetCurrentBuildId();

--- a/app/cdash/public/api/v1/overview.php
+++ b/app/cdash/public/api/v1/overview.php
@@ -81,7 +81,7 @@ if ($config->get('CDASH_MEMCACHE_ENABLED') &&
 // begin JSON response that is used to render this page
 $response = begin_JSON_response();
 get_dashboard_JSON_by_name($projectname, $date, $response);
-$response['title'] = "CDash Overview : $projectname";
+$response['title'] = "$projectname - Overview";
 $response['showcalendar'] = 1;
 
 $menu['previous'] = "overview.php?project=$projectname&date=$previousdate";

--- a/app/cdash/public/api/v1/testSummary.php
+++ b/app/cdash/public/api/v1/testSummary.php
@@ -78,7 +78,7 @@ if (!can_access_project($projectid)) {
 
 $response = begin_JSON_response();
 $response['showcalendar'] = 1;
-$response['title'] = "CDash : $projectname";
+$response['title'] = "$projectname - Test Summary";
 get_dashboard_JSON_by_name($projectname, $date, $response);
 $response['testName'] = $testName;
 

--- a/app/cdash/tests/data/BuildDetails/InsightExperimentalExample_Expected.json
+++ b/app/cdash/tests/data/BuildDetails/InsightExperimentalExample_Expected.json
@@ -6,7 +6,7 @@
     },
     "header": "views\/partials\/header.html",
     "footer": "views\/partials\/footer.html",
-    "title": "CDash : SubProjectExample",
+    "title": "SubProjectExample",
     "groupid": 6,
     "datetime": "Wednesday, March 30 2016 11:36:41",
     "date": "2009-02-23",


### PR DESCRIPTION
#1351 created a standardized page title system, but failed to update a handful of the page titles which are set via an API response instead of a Blade template.  The ultimate goal of course is to set the page title in some sort of centralized location, but that work will occur at a later point.  In the meantime, this PR fixes all of the issues for the moment so the 3.2 release at least ships with something reasonable.