### PR TITLE
Migrate backend of `Project` model to Eloquent

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -550,7 +550,6 @@ final class AdminController extends AbstractController
             delete_unused_rows('labelemail', 'projectid', 'project');
             delete_unused_rows('project2repositories', 'projectid', 'project');
             delete_unused_rows('dailyupdate', 'projectid', 'project');
-            delete_unused_rows('projectrobot', 'projectid', 'project');
             delete_unused_rows('subproject', 'projectid', 'project');
             delete_unused_rows('coveragefilepriority', 'projectid', 'project');
             delete_unused_rows('test', 'projectid', 'project');

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -13,6 +13,7 @@ use CDash\Model\CoverageFile;
 use CDash\Model\CoverageFile2User;
 use CDash\Model\CoverageFileLog;
 use CDash\Model\CoverageSummary;
+use App\Models\Project as EloquentProject;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Http\JsonResponse;
@@ -71,11 +72,9 @@ final class CoverageController extends AbstractBuildController
         }
 
         // If the projectid is not set and there is only one project we go directly to the page
-        if (!isset($projectid)) {
-            $projectids = $Project->GetIds();
-            if (count($projectids) == 1) {
-                $projectid = $projectids[0];
-            }
+        // TODO: (williamjallen) Should this be one project in all of CDash, or one project we can see?
+        if (!isset($projectid) && EloquentProject::count() === 1) {
+            $projectid = EloquentProject::all()->firstOrFail()->id;
         }
         $projectid = intval($projectid);
 

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -5,6 +5,7 @@ use App\Models\User;
 use CDash\Config;
 use CDash\Database;
 use CDash\Model\Project;
+use App\Models\Project as EloquentProject;
 use CDash\Model\UserProject;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -31,11 +32,8 @@ final class ManageProjectRolesController extends AbstractProjectController
         $project = new Project();
 
         // If the projectid is not set and there is only one project we go directly to the page
-        if (!isset($projectid)) {
-            $projectids = $project->GetIds();
-            if (count($projectids) == 1) {
-                $projectid = $projectids[0];
-            }
+        if (!isset($projectid) && EloquentProject::count() === 1) {
+            $projectid = EloquentProject::all()->firstOrFail()->id;
         }
         $projectid = intval($projectid);
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -73,7 +73,7 @@ final class ProjectController extends AbstractProjectController
 
         $project_response = [];
         if ($this->project->Exists()) {
-            $project_response = $this->project->ConvertToJSON($User);
+            $project_response = $this->project->ConvertToJSON();
 
             // Get the spam list
             $spambuilds = $this->project->GetBlockedBuilds();

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -107,7 +107,7 @@ final class ProjectOverviewController extends AbstractProjectController
         if ($has_subprojects) {
             // Detect if the subprojects are split up into groups.
             $groups = $this->project->GetSubProjectGroups();
-            if (is_array($groups) && !empty($groups)) {
+            if (count($groups) > 0) {
                 $has_subproject_groups = true;
                 foreach ($groups as $group) {
                     // Store subproject groups in an array keyed by id.

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -102,7 +102,7 @@ final class SubProjectController extends AbstractProjectController
                 'coverage_threshold' => $subProjectGroup->GetCoverageThreshold(),
             ];
             $groups[] = $group;
-            if ($subProjectGroup->GetIsDefault()) {
+            if ($subProjectGroup->GetIsDefault() > 0) {
                 $response['default_group_id'] = $group['id'];
             }
         }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property string $homeurl
+ * @property string $cvsurl
+ * @property string $bugtrackerurl
+ * @property string $bugtrackerfileurl
+ * @property string $bugtrackernewissueurl
+ * @property string $bugtrackertype
+ * @property string $documentationurl
+ * @property int $imageid
+ * @property int $public
+ * @property int $coveragethreshold
+ * @property string $testingdataurl
+ * @property string $nightlytime
+ * @property string $googletracker
+ * @property int $emaillowcoverage
+ * @property int $emailtesttimingchanged
+ * @property int $emailbrokensubmission
+ * @property int $emailredundantfailures
+ * @property int $emailadministrator
+ * @property int $showipaddresses
+ * @property string $cvsviewertype
+ * @property int $testtimestd
+ * @property int $testtimestdthreshold
+ * @property int $showtesttime
+ * @property int $testtimemaxstatus
+ * @property int $emailmaxitems
+ * @property int $emailmaxchars
+ * @property int $displaylabels
+ * @property int $autoremovetimeframe
+ * @property int $autoremovemaxbuilds
+ * @property int $uploadquota
+ * @property string $webapikey
+ * @property int $tokenduration
+ * @property int $showcoveragecode
+ * @property int $sharelabelfilters
+ * @property int $authenticatesubmissions
+ * @property int $viewsubprojectslink
+ *
+ * @mixin Builder<Project>
+ */
+class Project extends Model
+{
+    protected $table = 'project';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'name',
+        'description',
+        'homeurl',
+        'cvsurl',
+        'bugtrackerurl',
+        'bugtrackerfileurl',
+        'bugtrackernewissueurl',
+        'bugtrackertype',
+        'documentationurl',
+        'imageid',
+        'public',
+        'coveragethreshold',
+        'testingdataurl',
+        'nightlytime',
+        'googletracker',
+        'emaillowcoverage',
+        'emailtesttimingchanged',
+        'emailbrokensubmission',
+        'emailredundantfailures',
+        'emailadministrator',
+        'showipaddresses',
+        'cvsviewertype',
+        'testtimestd',
+        'testtimestdthreshold',
+        'showtesttime',
+        'testtimemaxstatus',
+        'emailmaxitems',
+        'emailmaxchars',
+        'displaylabels',
+        'autoremovetimeframe',
+        'autoremovemaxbuilds',
+        'uploadquota',
+        'webapikey',
+        'tokenduration',
+        'showcoveragecode',
+        'sharelabelfilters',
+        'authenticatesubmissions',
+        'viewsubprojectslink',
+    ];
+}

--- a/app/cdash/app/Model/BuildUpdateFile.php
+++ b/app/cdash/app/Model/BuildUpdateFile.php
@@ -53,25 +53,6 @@ class BuildUpdateFile
 
         $db = Database::getInstance();
 
-        // Check if we have a robot file for this build
-        $robot = $db->executePreparedSingleRow('
-                     SELECT authorregex
-                     FROM projectrobot, build, build2update
-                     WHERE
-                         projectrobot.projectid=build.projectid
-                         AND build2update.buildid=build.id
-                         AND build2update.updateid=?
-                         AND robotname=?
-                 ', [intval($this->UpdateId), $this->Author]);
-
-        if (!empty($robot)) {
-            $regex = $robot['authorregex'];
-            preg_match($regex, $this->Log, $matches);
-            if (isset($matches[1])) {
-                $this->Author = $matches[1];
-            }
-        }
-
         $query = $db->executePrepared('
                      INSERT INTO updatefile (
                          updateid,

--- a/app/cdash/include/ctestparser.php
+++ b/app/cdash/include/ctestparser.php
@@ -262,7 +262,7 @@ function ctest_parse($filehandle, $projectid, $expected_md5 = '')
         $Project->Id = $projectid;
 
         $Project->SendEmailToAdmin('Cannot create handler based on XML content',
-            'An XML submission from ' . $ip . ' to the project ' . get_project_name($projectid) . ' cannot be parsed. The content of the file is as follow: ' . $content);
+            'An XML submission from ' . $ip . ' to the project ' . get_project_name($projectid) . ' cannot be parsed. The content of the file is as follows: ' . $content);
 
         abort(400, 'Could not create handler based on xml content');
     }

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -1012,23 +1012,6 @@ function addDailyChanges(int $projectid): void
             $revision = $commit['revision'];
             $priorrevision = $commit['priorrevision'];
 
-            // Check if we have a robot file for this build
-            $robot = $db->executePreparedSingleRow('
-                         SELECT authorregex
-                         FROM projectrobot
-                         WHERE
-                             projectid=?
-                             AND robotname=?
-                     ', [$projectid, $author]);
-
-            if (!empty($robot)) {
-                $regex = $robot['authorregex'];
-                preg_match($regex, $commit['comment'], $matches);
-                if (isset($matches[1])) {
-                    $author = addslashes($matches[1]);
-                }
-            }
-
             if (!in_array(stripslashes($author), $cvsauthors)) {
                 $cvsauthors[] = stripslashes($author);
             }

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -114,14 +114,15 @@ function rest_post($user)
     // If we should block a spammer's build.
     if (isset($_REQUEST['AddBlockedBuild']) && !empty($_REQUEST['AddBlockedBuild'])) {
         $response['blockedid'] =
-            add_blocked_build($project, $_REQUEST['AddBlockedBuild']);
+            $project->AddBlockedBuild($_REQUEST['AddBlockedBuild']['buildname'],
+                $_REQUEST['AddBlockedBuild']['sitename'], $_REQUEST['AddBlockedBuild']['ipaddress']);
         echo json_encode($response);
         return;
     }
 
     // If we should remove a build from the blocked list.
     if (isset($_REQUEST['RemoveBlockedBuild']) && !empty($_REQUEST['RemoveBlockedBuild'])) {
-        remove_blocked_build($project, $_REQUEST['RemoveBlockedBuild']);
+        $project->RemoveBlockedBuild((int) $_REQUEST['RemoveBlockedBuild']['id']);
         return;
     }
 
@@ -160,7 +161,7 @@ function rest_get($user)
     if (!can_administrate_project($project->Id)) {
         return;
     }
-    $response['project'] = $project->ConvertToJSON($user);
+    $response['project'] = $project->ConvertToJSON();
     echo json_encode($response);
     http_response_code(200);
 }
@@ -234,7 +235,7 @@ function create_project(&$response, $user)
     }
 
     $response['projectcreated'] = 1;
-    $response['project'] = $Project->ConvertToJSON($user);
+    $response['project'] = $Project->ConvertToJSON();
     http_response_code(200);
 }
 
@@ -286,17 +287,6 @@ function populate_project($Project)
                 $repo_passwords, $repo_branches);
         }
     }
-}
-
-function add_blocked_build(Project $Project, $blocked_build)
-{
-    return $Project->AddBlockedBuild($blocked_build['buildname'],
-        $blocked_build['sitename'], $blocked_build['ipaddress']);
-}
-
-function remove_blocked_build(Project $Project, $blocked_build): void
-{
-    $Project->RemoveBlockedBuild($blocked_build['id']);
 }
 
 function set_logo($Project): void

--- a/app/cdash/tests/test_compressedtest.php
+++ b/app/cdash/tests/test_compressedtest.php
@@ -17,14 +17,13 @@ class CompressedTestCase extends KWWebTestCase
         echo "1. testSubmissionCompressedTest\n";
 
         // Create project.
-        $settings = array(
-                'Name' => 'TestCompressionExample',
-                'Description' => 'Project compression example',
-                'CvsUrl' => 'public.kitware.com/cgi-bin/viewcvs.cgi/?cvsroot=TestCompressionExample',
-                'CvsViewerType' => 'github',
-                'BugTrackerFileUrl' =>  'http://public.kitware.com/Bug/view.php?id=',
-                'RobotName' => 'itkrobot',
-                'RobotRegex' => '^(?:(?:\w|\.)+)\s+((?:\w|\.|\@)+)^');
+        $settings = [
+            'Name' => 'TestCompressionExample',
+            'Description' => 'Project compression example',
+            'CvsUrl' => 'public.kitware.com/cgi-bin/viewcvs.cgi/?cvsroot=TestCompressionExample',
+            'CvsViewerType' => 'github',
+            'BugTrackerFileUrl' =>  'http://public.kitware.com/Bug/view.php?id=',
+        ];
         $this->createProject($settings);
 
         // Make sure we can submit to it.
@@ -32,7 +31,6 @@ class CompressedTestCase extends KWWebTestCase
         $this->submission('TestCompressionExample', $file);
     }
 
-    /** */
     public function testGITUpdate()
     {
         echo "4. testGITUpdate\n";
@@ -77,30 +75,6 @@ class CompressedTestCase extends KWWebTestCase
         if (!str_contains($found, $expected)) {
             $this->fail("expected $expected but found $found for revisiondiff");
             return;
-        }
-
-        // Test if the robot worked
-        $robot_verified = false;
-        foreach ($response['updategroups'][0]['directories'] as $directory) {
-            if ($directory['name'] != 'subdir') {
-                continue;
-            }
-            foreach ($directory['files'] as $file) {
-                if ($file['filename'] == 'bar.txt') {
-                    if ($file['author'] == 'jjomier') {
-                        if (str_contains($file['log'], 'r883 jjomier')) {
-                            $robot_verified = true;
-                        } else {
-                            $this->fail("Expected r883 jjomier but found " . $file['log']);
-                        }
-                    } else {
-                        $this->fail("Expected jjomier, found " . $file['filename']);
-                    }
-                }
-            }
-        }
-        if (!$robot_verified) {
-            $this->fail("Failed to verify robot");
         }
 
         $this->pass('Test passed');

--- a/app/cdash/tests/test_projectmodel.php
+++ b/app/cdash/tests/test_projectmodel.php
@@ -8,7 +8,6 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
 
-use App\Models\User;
 use CDash\Model\Project;
 
 class ProjectModelTestCase extends KWWebTestCase
@@ -21,14 +20,6 @@ class ProjectModelTestCase extends KWWebTestCase
     public function testProjectModel()
     {
         $project = new Project();
-
-        $this->assertTrue($project->GetNumberOfErrorConfigures(0, 0) === false, 'GetNumberOfErrorConfigures!=false');
-        $this->assertTrue($project->GetNumberOfWarningConfigures(0, 0) === false, 'GetNumberOfWarningConfigures!=false');
-        $this->assertTrue($project->GetNumberOfPassingConfigures(0, 0) === false, 'GetNumberOfPassingConfigures!=false');
-        $this->assertTrue($project->GetNumberOfPassingTests(0, 0) === false, 'GetNumberOfPassingTests!=false');
-        $this->assertTrue($project->GetNumberOfFailingTests(0, 0) === false, 'GetNumberOfFailingTests!=false');
-        $this->assertTrue($project->GetNumberOfNotRunTests(0, 0) === false, 'GetNumberOfNotRunTests!=false');
-        $this->assertTrue($project->SendEmailToAdmin('', '') === false, 'SendEmailToAdmin!=false');
 
         if (!($project->Delete() === false)) {
             $this->fail("Project::Delete didn't return false for no id");
@@ -59,9 +50,7 @@ class ProjectModelTestCase extends KWWebTestCase
     {
         $project = new Project();
         $project->Id = 0;
-        $User = new user();
-        $User->id = 1;
-        $output = $project->ConvertToJSON($User);
+        $output = $project->ConvertToJSON();
 
         $this->assertFalse(in_array('PDO', array_keys($output)));
     }

--- a/database/migrations/2023_07_07_143440_delete_projectrobot_table.php
+++ b/database/migrations/2023_07_07_143440_delete_projectrobot_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::drop('projectrobot');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('projectrobot', function (Blueprint $table) {
+            $table->integer('projectid')->index();
+            $table->string('robotname')->index();
+            $table->string('authorregex', 512);
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -573,7 +573,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 62
+			count: 61
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -588,6 +588,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:manageCoverage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:manageCoverage\\(\\) throws checked exception Illuminate\\\\Support\\\\ItemNotFoundException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -821,7 +826,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 3
+			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -856,6 +861,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:viewPage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:viewPage\\(\\) throws checked exception Illuminate\\\\Support\\\\ItemNotFoundException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
@@ -1022,7 +1032,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
@@ -6784,19 +6794,6 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
 		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildUpdateFile.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildUpdateFile.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdateFile.php
@@ -8355,63 +8352,15 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function add_last_sql_error\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 43
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
-			count: 9
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_execute\\(\\)\\:
-				v2\\.5\\.0 01/22/2018$#
-			"""
-			count: 4
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/Project.php
 
 		-
 			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 47
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 24
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
@@ -8422,7 +8371,7 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8436,8 +8385,18 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
+			message: "#^Casting to int something that's already int\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 27
+			count: 21
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Project\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8447,22 +8406,12 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 5
+			count: 3
 			path: app/cdash/app/Model/Project.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 4
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:AddBlockedBuild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:AddBuildGroup\\(\\) has parameter \\$buildgroup with no type specified\\.$#"
-			count: 1
+			count: 2
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -8476,7 +8425,7 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:AddLogo\\(\\) has parameter \\$filetype with no type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Project\\:\\:AddLogo\\(\\) throws checked exception Illuminate\\\\Database\\\\Eloquent\\\\ModelNotFoundException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8511,17 +8460,12 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:ConvertToJSON\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Project\\:\\:Delete\\(\\) throws checked exception Illuminate\\\\Database\\\\Eloquent\\\\ModelNotFoundException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:Exists\\(\\) throws checked exception PDOException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:ExistsByName\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Project\\:\\:Delete\\(\\) throws checked exception LogicException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8541,22 +8485,7 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetBuildsDailyAverage\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetBuildsDailyAverage\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetBuildsDailyAverage\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetCoverageThreshold\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8571,157 +8500,7 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorBuilds\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorConfigures\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfErrorConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfFailingTests\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfFailingTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfFailingTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfNotRunTests\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfNotRunTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfNotRunTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingBuilds\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingConfigures\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingTests\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingTests\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfPassingTests\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfSubProjects\\(\\) has parameter \\$date with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningBuilds\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningBuilds\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningBuilds\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningConfigures\\(\\) has parameter \\$childrenOnly with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningConfigures\\(\\) has parameter \\$endUTCdate with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetNumberOfWarningConfigures\\(\\) has parameter \\$startUTCdate with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8736,17 +8515,7 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:GetSubscriberCollection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:RemoveBlockedBuild\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Project\\:\\:SetNightlyTime\\(\\) has parameter \\$nightly_time with no type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Project\\:\\:Save\\(\\) throws checked exception Illuminate\\\\Database\\\\Eloquent\\\\MassAssignmentException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8762,11 +8531,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\|null given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8926,16 +8690,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$RobotName has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$RobotRegex has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$ShareLabelFilters has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -8992,11 +8746,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$WebApiKey has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -13320,7 +13069,7 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 9
+			count: 8
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -13343,7 +13092,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 6
+			count: 5
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -16693,16 +16442,6 @@ parameters:
 			path: app/cdash/public/api/v1/project.php
 
 		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\Project\\\\add_blocked_build\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/project.php
-
-		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\Project\\\\add_blocked_build\\(\\) has parameter \\$blocked_build with no type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/project.php
-
-		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\Project\\\\create_project\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
@@ -16739,11 +16478,6 @@ parameters:
 
 		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\Project\\\\populate_project\\(\\) has parameter \\$Project with no type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/project.php
-
-		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\Project\\\\remove_blocked_build\\(\\) has parameter \\$blocked_build with no type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
 
@@ -22969,18 +22703,13 @@ parameters:
 			path: app/cdash/tests/test_compressedtest.php
 
 		-
-			message: "#^Foreach overwrites \\$file with its value variable\\.$#"
+			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_compressedtest.php
 
 		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 2
-			path: app/cdash/tests/test_compressedtest.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 3
+			count: 1
 			path: app/cdash/tests/test_compressedtest.php
 
 		-

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -714,55 +714,6 @@
                     </font>
                   </td>
                 </tr>
-                <tr>
-                  <td />
-                  <td>
-                    <div align="right">
-                      <strong>Repository Robot:</strong>
-                    </div>
-                  </td>
-                  <td>
-                    <input
-                      id="robotname"
-                      v-model="cdash.project.RobotName"
-                      name="robotname"
-                      type="text"
-                      size="15"
-                      @change="cdash.changesmade = true"
-                      @focus="showHelp('cvsrobot_help')"
-                    > regex:
-                    <input
-                      id="robotregex"
-                      v-model="cdash.project.RobotRegex"
-                      name="robotregex"
-                      type="text"
-                      size="22"
-                      @change="cdash.changesmade = true"
-                      @focus="showHelp('cvsrobot_help')"
-                    >
-                    <a
-                      href="http://www.cdash.org/Wiki/CDash:Administration#Creating_a_project"
-                      target="blank"
-                    >
-                      <img
-                        :src="$baseURL + '/img/help.gif'"
-                        border="0"
-                        @mouseover="showHelp('cvsrobot_help')"
-                      >
-                    </a>
-                    <span
-                      id="cvsrobot_help"
-                      class="help_content"
-                    >
-                      <b>Repository Robot</b>
-                      <br>
-                      Some repositories have a robot in charge of checking in files
-                      from another repository. For CDash to be able to assign an author to the checkin
-                      files a regular expression must be defined to allow extraction of the author name
-                      from the robot checkin.
-                    </span>
-                  </td>
-                </tr>
                 <template v-for="repo in cdash.project.repositories">
                   <tr>
                     <td />


### PR DESCRIPTION
The `Project` model is one of the largest models in the CDash codebase, and it would be completely impractical to convert the entire thing to Eloquent at one time.  Instead, I have taken an "adapter" approach similar to the approach taken in #1539, in which the public-facing interface of the old project class remains (mostly) the same, while the business logic of most methods is outsourced to the new Eloquent-based project model.

In addition to switching the code to use the Eloquent-based project when possible, I have also undertaken a general refactor of the model, deleting unused code, simplifying parameters and return types, converting all database queries to Laravel's query system, and other general maintenance tasks.

I have also completely eliminated the `projectrobot` table and associated code since it is currently impossible to add new data to the `projectrobot` table, and the existing data is not used for anything.

Given how large of a refactor this is, this PR should not be merged until after the 3.2 release branch is created.