### PR TITLE
Fix `editSite.php` error when no sites claimed

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -128,11 +128,11 @@ class SiteController extends AbstractController
 
         // Post
         @$claimsites = $_POST['claimsites'];
-        @$availablesites = $_POST['availablesites'];
-        @$checkedsites = $_POST['checkedsites'];
+        $availablesites = $_POST['availablesites'] ?? [];
+        $checkedsites = $_POST['checkedsites'] ?? [];
         if ($claimsites) {
             foreach ($availablesites as $siteid) {
-                if (@array_key_exists($siteid, $checkedsites)) {
+                if (array_key_exists($siteid, $checkedsites)) {
                     self::add_site2user(intval($siteid), intval($userid));
                 } else {
                     self::remove_site2user(intval($siteid), intval($userid));


### PR DESCRIPTION
Fixes #1560.

It's worth noting that the edit site page as a whole is in desperate need of an overhaul and I plan to refactor it sometime soon.  This PR only attempts to fix the error noted in #1560, and does not make an attempt to fix all outstanding issues with this page.