### PR TITLE
Fix broken `LDAP_FILTERS_ON` functionality

### DIFF
--- a/app/Rules/LdapFilterRules.php
+++ b/app/Rules/LdapFilterRules.php
@@ -21,7 +21,7 @@ class LdapFilterRules extends Rule
             $user = $this->user;
             $connection = $user->getQuery()->getConnection();
             $result = $connection->search($user->getDn(), $filter, ['dn', 'cn']);
-            if (is_resource($result)) {
+            if ($result !== false) {
                 $isValid = $connection->countEntries($result) > 0;
                 $connection->freeResult($result);
             }


### PR DESCRIPTION
As of PHP 8.1.0, the return value of ldap_search() is no longer a resource.