### PR TITLE
Bump default MySQL version to 8.0

### DIFF
--- a/docker/docker-compose.mysql.yml
+++ b/docker/docker-compose.mysql.yml
@@ -6,7 +6,7 @@ services:
       DB_PORT: 3306
 
   database:
-    image: mysql/mysql-server:5.7
+    image: mysql/mysql-server:8.0
     container_name: cdash_mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
We currently have MySQL 5.7 listed as the default version of MySQL when deploying via Docker.  MySQL 5.7 will no longer be supported beyond October 2023, and our flagship [open.cdash.org](https://open.cdash.org) instance has been running MySQL 8.x for some time.  

Fixes #1409.