### PR TITLE
Display `buildOverview.php` logs in monospace font

### DIFF
--- a/app/cdash/public/buildOverview.xsl
+++ b/app/cdash/public/buildOverview.xsl
@@ -43,7 +43,7 @@
     <xsl:for-each select="error">
     <b><xsl:value-of select="buildname"/>: </b>
     <xsl:for-each select="text">
-      <xsl:value-of select="."/><br/>
+      <pre style="white-space: pre-wrap;"><xsl:value-of select="."/></pre>
     </xsl:for-each>
     </xsl:for-each>
   </xsl:if>
@@ -54,7 +54,7 @@
     <xsl:for-each select="warning">
     <b><xsl:value-of select="buildname"/>: </b>
     <xsl:for-each select="text">
-      <xsl:value-of select="."/><br/>
+      <pre style="white-space: pre-wrap;"><xsl:value-of select="."/></pre>
     </xsl:for-each>
     </xsl:for-each>
   </xsl:if>

--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -35,6 +35,7 @@
     @else
         <link rel="stylesheet" type="text/css" href="{{ asset('css/jquery.dataTables.css') }}"/>
         <link rel="stylesheet" type="text/css" href="{{ asset('css/cdash.css') }}"/>
+        <link rel="stylesheet" href="{{ asset('css/bootstrap.min.css') }}"/>
         <script src="{{ asset("js/CDash_${js_version}.min.js") }}"></script>
         <script src="{{ asset('js/tooltip.js') }}" type="text/javascript" charset="utf-8"></script>
         <script src="{{ asset('js/jquery.tablesorter.js') }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
The log messages on `buildOverview.php` are now displayed in a shaded "prepared text" area to match other locations where we display similar data.

Before:
![image](https://github.com/Kitware/CDash/assets/16820599/50a5db8b-7479-4634-bf78-02bdb7f36024)

After:
![image](https://github.com/Kitware/CDash/assets/16820599/0714ac3e-784e-44bf-8474-6a386bc1f126)
