### PR TITLE
Remove LOC displays from coverage graph

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -1291,3 +1291,10 @@ background-color: #adcae6
   clear:both;
   display:table;
 }
+
+/* https://github.com/flot/flot/issues/1708. Needed to stop entirely black background on legend */
+.legendLayer .background {
+  fill: rgba(255, 255, 255, 0.85);
+  stroke: rgba(0, 0, 0, 0.85);
+  stroke-width: 1;
+  }

--- a/resources/views/coverage/ajax-coverage-graph.blade.php
+++ b/resources/views/coverage/ajax-coverage-graph.blade.php
@@ -18,9 +18,11 @@
         const options = {
             lines: {show: true},
             points: {show: true},
-            xaxis: {mode: "time"},
-            yaxis: {min: 0, max: 100},
-            legend: {position: "nw"},
+            xaxis: {mode: "time", axisLabel: 'Time of build (UTC)',
+                            timeformat: "%Y/%m/%d %H:%M",
+                            timeBase: "milliseconds"},
+            yaxis: {min: 0, max: 100, axisLabel: 'Coverage Percentage',},
+            legend: {position: "nw", show: true},
             grid: {
                 backgroundColor: "#fffaff",
                 clickable: true,
@@ -32,11 +34,33 @@
             colors: ["#0000FF", "#dba255", "#919733"]
         };
 
+        $("<div id='tooltip'></div>").css({
+			position: "absolute",
+			display: "none",
+			border: "1px solid #fdd",
+			padding: "2px",
+			"background-color": "#fee",
+			opacity: 0.80
+		}).appendTo("body");
+
+        $("#grapholder").bind("plothover", function (event, pos, item) {
+
+            if (!pos.x || !pos.y) {
+                return;
+            }
+            if (item) {
+                $("#tooltip").html(`${item.series.label}: ${item.datapoint[1]}<br>LOC Untested: ${locuntested_array[item.dataIndex][1]}<br>LOC Tested: ${loctested_array[item.dataIndex][1]}`)
+                    .css({top: item.pageY+5, left: item.pageX+5})
+                    .fadeIn(200);
+            } else {
+                $("#tooltip").hide();
+            }
+        });
+
+
         $("#grapholder").bind("selected", function (event, area) {
             plot = $.plot($("#grapholder"),
-                [{label: "% coverage", data: percent_array},
-                    {label: "loc tested", data: loctested_array, yaxis: 2},
-                    {label: "loc untested", data: locuntested_array, yaxis: 2}],
+                [{label: "% coverage", data: percent_array}],
                 $.extend(true, {}, options, {xaxis: {min: area.x1, max: area.x2}}));
         });
 
@@ -48,8 +72,6 @@
             }
         });
 
-        plot = $.plot($("#grapholder"), [{label: "% coverage", data: percent_array},
-            {label: "loc tested", data: loctested_array, yaxis: 2},
-            {label: "loc untested", data: locuntested_array, yaxis: 2}], options);
+        plot = $.plot($("#grapholder"), [{label: "% coverage", data: percent_array}], options);
     });
 </script>


### PR DESCRIPTION
To eliminate an error where the Lines Of Code data attempted to access a non-existant yaxis object, remove the plots for LOC from the coverage over time display.

With an update to the design, they may be reintroduced by switching to `yaxes` in the plot's `options` object and then reintroducing the data.

Previous State:

![image](https://github.com/Kitware/CDash/assets/542106/5b6a4c45-e6a0-4e0e-a4df-0bea3f4de2ca)

Current State:
![image](https://github.com/Kitware/CDash/assets/542106/d8df0b3c-2051-45e4-b47e-9a1b7ada8525)
