### PR TITLE
Index `(testid,buildid)` pairs in `build2test` table

### DIFF
--- a/database/migrations/2023_07_14_151406_build2test_index.php
+++ b/database/migrations/2023_07_14_151406_build2test_index.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('build2test', function (Blueprint $table) {
+            $table->index(['testid', 'buildid']);
+            $table->index(['buildid', 'testid']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('build2test', function (Blueprint $table) {
+            $table->dropIndex(['testid', 'buildid']);
+            $table->dropIndex(['buildid', 'testid']);
+        });
+    }
+};


### PR DESCRIPTION
The `build2test` table is a pivot table which is used to relate builds and tests.  The most common use case involves joining the `build2test` table with the `build` and `test` tables via its `testid` and `buildid` columns.  Each individual column in the `build2test` table is indexed, but using any relation between testids and buildids requires the database to load the entire `build2test` row.  This is the primary cause of the widespread slowness on the test summary page, amongst other things.

I have added indices on `(buildid,testid)` and `(testid,buildid)`.  During a trial run on a large development database, I observed a significant speedup on `testSummary.php`, going from 60+ seconds to less than one for an average page load.  Due to the size of the `build2test` table, CDash administrators should be aware that creating these indices may take a significant amount of time.  On a large development database, it took more than 20 minutes.