### PR TITLE
Fix `onlydeltan` case on build error page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -628,7 +628,7 @@ class BuildController extends AbstractBuildController
                     'stderr' => $resolvedBuildFailure['stderror'],
                     'stderrorrows' => min(10, substr_count($resolvedBuildFailure['stderror'], "\n") + 1),
                     'stdoutput' => $resolvedBuildFailure['stdoutput'],
-                    'stdoutputrows' => min(10, substr_count($resolvedBuildFailure['stdoutputrows'], "\n") + 1),
+                    'stdoutputrows' => min(10, substr_count($resolvedBuildFailure['stdoutput'], "\n") + 1),
                 ));
 
                 $this->addErrorResponse($marshaledResolvedBuildFailure, $response);


### PR DESCRIPTION
This PR fixes an issue on `viewBuildError.php` where the negative delta case was broken.