### PR TITLE
Add index to improve `/projects` performance

### DIFF
--- a/database/migrations/2023_07_17_124401_build_projectid_submittime_index.php
+++ b/database/migrations/2023_07_17_124401_build_projectid_submittime_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('build', function (Blueprint $table) {
+            $table->index(['projectid', 'submittime']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('build', function (Blueprint $table) {
+            $table->dropIndex(['projectid', 'submittime']);
+        });
+    }
+};


### PR DESCRIPTION
The `/projects` page effectively serves as the homepage for CDash.  Prior to this change, the API for `/projects` took ~1s to load on a large development instance.  After adding this index, the page load time dropped to an almost negligible 0.1 seconds.  Rather than scanning through an entire section of an index to find the maximum submit time, the database can now find the maximum submit time for a given project directly.