### PR TITLE
Convert echoed error messages to thrown exceptions in models

### DIFF
--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -46,8 +46,7 @@ class BuildError
     public function Insert(): bool
     {
         if (!$this->BuildId) {
-            echo 'BuildError::Insert(): BuildId not set<br>';
-            return false;
+            abort(500, 'BuildError::Insert(): BuildId not set.');
         }
 
         if (empty($this->SourceLine)) {

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -80,8 +80,7 @@ class BuildFailure
     public function Insert(): bool
     {
         if (!$this->BuildId) {
-            echo 'BuildFailure::Insert(): BuildId not set<br>';
-            return false;
+            abort(500, 'BuildFailure::Insert(): BuildId not set.');
         }
 
         $workingDirectory = $this->WorkingDirectory ?? '';

--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -501,7 +501,6 @@ class BuildGroup
                              WHERE groupid=?
                          )
                      ', [$this->Id]);
-        echo pdo_error();
 
         foreach ($oldbuilds as $oldbuilds_array) {
             // Move the builds
@@ -521,8 +520,7 @@ class BuildGroup
                              FROM buildgroup
                              WHERE name='Experimental' AND projectid=?
                          ", [$this->ProjectId]);
-            }
-            echo pdo_error();
+            };
             $grouptype = $query['id'];
 
             $this->PDO->executePrepared('
@@ -530,7 +528,6 @@ class BuildGroup
                 SET groupid=?
                 WHERE buildid=?
             ', [$grouptype, $buildid]);
-            echo pdo_error();
         }
 
         // Delete the buildgroupposition and update the position

--- a/app/cdash/app/Model/BuildUpdate.php
+++ b/app/cdash/app/Model/BuildUpdate.php
@@ -59,8 +59,7 @@ class BuildUpdate
     public function Insert(): int|bool
     {
         if (strlen($this->BuildId) == 0 || !is_numeric($this->BuildId)) {
-            echo 'BuildUpdate:Insert BuildId not set';
-            return false;
+            abort(500, 'BuildUpdate:Insert BuildId not set');
         }
 
         // Avoid a race condition when parallel processing.
@@ -211,8 +210,7 @@ class BuildUpdate
     public function GetNumberOfFiles(): int|false
     {
         if (!$this->UpdateId) {
-            echo 'BuildUpdate::GetNumberOfFiles(): Id not set';
-            return false;
+            abort(500, 'BuildUpdate::GetNumberOfFiles(): Id not set');
         }
 
         $row = DB::table('buildupdate')
@@ -230,8 +228,7 @@ class BuildUpdate
     public function GetUpdateForBuild(): array|false
     {
         if (!$this->BuildId) {
-            echo 'BuildUpdate::GetUpdateStatusForBuild(): BuildId not set';
-            return false;
+            abort(500, 'BuildUpdate::GetUpdateStatusForBuild(): BuildId not set');
         }
 
         $sql = "
@@ -271,8 +268,7 @@ class BuildUpdate
     public function GetNumberOfErrors(): int|false
     {
         if (!$this->BuildId) {
-            echo 'BuildUpdate::GetNumberOfErrors(): BuildId not set';
-            return false;
+            abort(500, 'BuildUpdate::GetNumberOfErrors(): BuildId not set');
         }
 
         $db = Database::getInstance();
@@ -293,8 +289,7 @@ class BuildUpdate
     public function AssociateBuild(int $siteid, string $name, $stamp): bool
     {
         if (!$this->BuildId) {
-            echo 'BuildUpdate::AssociateBuild(): BuildId not set';
-            return false;
+            abort(500, 'BuildUpdate::AssociateBuild(): BuildId not set');
         }
 
         // If we already have something in the databse we return

--- a/app/cdash/app/Model/BuildUpdateFile.php
+++ b/app/cdash/app/Model/BuildUpdateFile.php
@@ -35,8 +35,7 @@ class BuildUpdateFile
     public function Insert(): bool
     {
         if (strlen($this->UpdateId) == 0) {
-            echo 'BuildUpdateFile:Insert UpdateId not set';
-            return false;
+            abort(500, 'BuildUpdateFile:Insert UpdateId not set');
         }
 
         // Sometimes the checkin date is not found in that case we put the usual date

--- a/app/cdash/app/Model/Coverage.php
+++ b/app/cdash/app/Model/Coverage.php
@@ -76,8 +76,7 @@ class Coverage
     public function GetFiles(): array|false
     {
         if (!$this->BuildId) {
-            echo 'Coverage GetFiles(): BuildId not set';
-            return false;
+            abort(500, 'Coverage GetFiles(): BuildId not set');
         }
 
         return EloquentCoverage::where('buildid', $this->BuildId)->pluck('fileid')->toArray();

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -171,8 +171,7 @@ class CoverageFile
     public function GetPath()
     {
         if (!$this->Id) {
-            echo 'CoverageFile GetPath(): Id not set';
-            return false;
+            abort(500, 'CoverageFile GetPath(): Id not set');
         }
 
         $stmt = $this->PDO->prepare(
@@ -189,8 +188,7 @@ class CoverageFile
     public function GetMetric()
     {
         if (!$this->Id) {
-            echo 'CoverageFile GetMetric(): Id not set';
-            return false;
+            abort(500, 'CoverageFile GetMetric(): Id not set');
         }
 
         $stmt = $this->PDO->prepare(

--- a/app/cdash/app/Model/CoverageFile2User.php
+++ b/app/cdash/app/Model/CoverageFile2User.php
@@ -61,13 +61,11 @@ class CoverageFile2User
     public function Insert(): bool
     {
         if (!isset($this->UserId) || $this->UserId < 1) {
-            echo 'CoverageFile2User:Insert: UserId not set';
-            return false;
+            abort(500, 'CoverageFile2User:Insert: UserId not set');
         }
 
         if ($this->FullPath == '' || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:Insert: FullPath or ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:Insert: FullPath or ProjectId not set');
         }
 
         // Check if is already in the database
@@ -112,8 +110,7 @@ class CoverageFile2User
     public function RemoveAuthors(): bool
     {
         if ($this->FullPath == '' || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:RemoveAuthors: FullPath or ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:RemoveAuthors: FullPath or ProjectId not set');
         }
 
         $db = Database::getInstance();
@@ -190,8 +187,7 @@ class CoverageFile2User
     public function GetAuthors(): array|false
     {
         if ($this->FullPath == '' || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:GetAuthors: FullPath or ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:GetAuthors: FullPath or ProjectId not set');
         }
 
         $db = Database::getInstance();
@@ -219,8 +215,7 @@ class CoverageFile2User
     public function GetId(): int|false
     {
         if ($this->FullPath == '' || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:GetId: FullPath or ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:GetId: FullPath or ProjectId not set');
         }
 
         $db = Database::getInstance();
@@ -249,8 +244,7 @@ class CoverageFile2User
     public function GetFiles(): array|false
     {
         if (!isset($this->UserId) || $this->UserId < 1) {
-            echo 'CoverageFile2User:GetFiles: UserId not set';
-            return false;
+            abort(500, 'CoverageFile2User:GetFiles: UserId not set');
         }
 
         $db = Database::getInstance();
@@ -271,8 +265,7 @@ class CoverageFile2User
     public function GetCoverageFileId($buildid): int|false
     {
         if ($this->FileId == 0) {
-            echo 'CoverageFile2User:GetCoverageFileId: FileId not set';
-            return false;
+            abort(500, 'CoverageFile2User:GetCoverageFileId: FileId not set');
         }
 
         $db = Database::getInstance();
@@ -301,8 +294,7 @@ class CoverageFile2User
     public function GetUsersFromProject(): array|false
     {
         if (!isset($this->ProjectId) || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:GetUsersFromProject: projectid not valid';
-            return false;
+            abort(500, 'CoverageFile2User:GetUsersFromProject: projectid not valid');
         }
 
         $db = Database::getInstance();
@@ -328,13 +320,11 @@ class CoverageFile2User
     public function AssignLastAuthor(int $buildid): bool
     {
         if (!isset($this->ProjectId) || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:AssignLastAuthor: ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:AssignLastAuthor: ProjectId not set');
         }
 
         if ($buildid === 0) {
-            echo 'CoverageFile2User:AssignLastAuthor: buildid not valid';
-            return false;
+            abort(500, 'CoverageFile2User:AssignLastAuthor: buildid not valid');
         }
 
         // Find the files associated with the build
@@ -363,13 +353,11 @@ class CoverageFile2User
     public function AssignAllAuthors(int $buildid): bool
     {
         if (!isset($this->ProjectId) || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:AssignLastAuthor: ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:AssignLastAuthor: ProjectId not set');
         }
 
         if ($buildid === 0) {
-            echo 'CoverageFile2User:AssignLastAuthor: buildid not valid';
-            return false;
+            abort(500, 'CoverageFile2User:AssignLastAuthor: buildid not valid');
         }
 
         // Find the files associated with the build
@@ -398,8 +386,7 @@ class CoverageFile2User
     public function GetPriority(): int|false
     {
         if ($this->FullPath == '' || $this->ProjectId < 1) {
-            echo 'CoverageFile2User:GetPriority: FullPath or ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:GetPriority: FullPath or ProjectId not set');
         }
 
         $db = Database::getInstance();
@@ -419,12 +406,10 @@ class CoverageFile2User
     public function SetPriority(int $priority): bool
     {
         if ($this->ProjectId == 0) {
-            echo 'CoverageFile2User:SetPriority:ProjectId not set';
-            return false;
+            abort(500, 'CoverageFile2User:SetPriority:ProjectId not set');
         }
         if ($this->FullPath == '') {
-            echo 'CoverageFile2User:SetPriority:FullPath not set';
-            return false;
+            abort(500, 'CoverageFile2User:SetPriority:FullPath not set');
         }
         $db = Database::getInstance();
         $query_result = $db->executePreparedSingleRow('

--- a/app/cdash/app/Model/CoverageSummary.php
+++ b/app/cdash/app/Model/CoverageSummary.php
@@ -43,8 +43,7 @@ class CoverageSummary
     public function RemoveAll(): bool
     {
         if (!$this->BuildId) {
-            echo 'CoverageSummary::RemoveAll(): BuildId not set';
-            return false;
+            abort(500, 'CoverageSummary::RemoveAll(): BuildId not set');
         }
 
         $db = Database::getInstance();
@@ -90,8 +89,7 @@ class CoverageSummary
     public function Insert($append = false): bool
     {
         if (!$this->BuildId || !is_numeric($this->BuildId)) {
-            echo 'CoverageSummary::Insert(): BuildId not set';
-            return false;
+            abort(500, 'CoverageSummary::Insert(): BuildId not set');
         }
 
         if (count($this->Coverages) > 0) {

--- a/app/cdash/app/Model/DailyUpdate.php
+++ b/app/cdash/app/Model/DailyUpdate.php
@@ -34,8 +34,7 @@ class DailyUpdate
     public function GetAuthors(string $filename, bool $onlylast = false): array|false
     {
         if (!$this->ProjectId) {
-            echo 'DailyUpdate::GetAuthors(): ProjectId is not set<br>';
-            return false;
+            abort(500, 'DailyUpdate::GetAuthors(): ProjectId is not set');
         }
 
         // Check if the note already exists

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -69,8 +69,7 @@ class DynamicAnalysis
     public function GetNumberOfErrors(): int|false
     {
         if (strlen($this->BuildId) == 0) {
-            echo 'DynamicAnalysis::GetNumberOfErrors BuildId not set';
-            return false;
+            abort(500, 'DynamicAnalysis::GetNumberOfErrors BuildId not set');
         }
 
         $db = Database::getInstance();
@@ -88,8 +87,7 @@ class DynamicAnalysis
     public function RemoveAll(): bool
     {
         if (strlen($this->BuildId) == 0) {
-            echo 'DynamicAnalysis::RemoveAll BuildId not set';
-            return false;
+            abort(500, 'DynamicAnalysis::RemoveAll BuildId not set');
         }
 
         $this->BuildId = intval($this->BuildId);
@@ -162,8 +160,7 @@ class DynamicAnalysis
     public function Insert()
     {
         if (strlen($this->BuildId) == 0) {
-            echo 'DynamicAnalysis::Insert BuildId not set';
-            return false;
+            abort(500, 'DynamicAnalysis::Insert BuildId not set');
         }
 
         $max_log_length = 1024 * 1024;

--- a/app/cdash/app/Model/DynamicAnalysisDefect.php
+++ b/app/cdash/app/Model/DynamicAnalysisDefect.php
@@ -27,8 +27,7 @@ class DynamicAnalysisDefect
     public function Insert(): bool
     {
         if (strlen($this->DynamicAnalysisId) == 0) {
-            echo 'DynamicAnalysisDefect::Insert DynamicAnalysisId not set';
-            return false;
+            abort(500, 'DynamicAnalysisDefect::Insert DynamicAnalysisId not set');
         }
 
         $db = Database::getInstance();

--- a/app/cdash/app/Model/LabelEmail.php
+++ b/app/cdash/app/Model/LabelEmail.php
@@ -55,18 +55,15 @@ class LabelEmail
     public function Insert(): bool
     {
         if (!$this->ProjectId) {
-            echo 'LabelEmail Insert(): ProjectId not set';
-            return false;
+            abort(500, 'LabelEmail Insert(): ProjectId not set');
         }
 
         if (!$this->UserId) {
-            echo 'LabelEmail Insert(): UserId not set';
-            return false;
+            abort(500, 'LabelEmail Insert(): UserId not set');
         }
 
         if (!$this->LabelId) {
-            echo 'LabelEmail Insert(): LabelId not set';
-            return false;
+            abort(500, 'LabelEmail Insert(): LabelId not set');
         }
 
         if (!$this->Exists()) {
@@ -86,13 +83,11 @@ class LabelEmail
     public function UpdateLabels(array|null $labels): bool
     {
         if (!$this->ProjectId) {
-            echo 'LabelEmail UpdateLabels(): ProjectId not set';
-            return false;
+            abort(500, 'LabelEmail UpdateLabels(): ProjectId not set');
         }
 
         if (!$this->UserId) {
-            echo 'LabelEmail UpdateLabels(): UserId not set';
-            return false;
+            abort(500, 'LabelEmail UpdateLabels(): UserId not set');
         }
 
         if ($labels === null) {
@@ -123,13 +118,11 @@ class LabelEmail
     public function GetLabels(): array|false
     {
         if (empty($this->ProjectId)) {
-            echo 'LabelEmail GetLabels(): ProjectId not set';
-            return false;
+            abort(500, 'LabelEmail GetLabels(): ProjectId not set');
         }
 
         if (empty($this->UserId)) {
-            echo 'LabelEmail GetLabels(): UserId not set';
-            return false;
+            abort(500, 'LabelEmail GetLabels(): UserId not set');
         }
 
         $db = Database::getInstance();

--- a/app/cdash/app/Model/SubProjectGroup.php
+++ b/app/cdash/app/Model/SubProjectGroup.php
@@ -92,8 +92,7 @@ class SubProjectGroup
         }
 
         if ($this->Id < 1) {
-            echo 'SubProjectGroup GetName(): Id not set';
-            return false;
+            abort(500, 'SubProjectGroup GetName(): Id not set');
         }
 
         $db = Database::getInstance();

--- a/app/cdash/app/Model/UserProject.php
+++ b/app/cdash/app/Model/UserProject.php
@@ -99,13 +99,11 @@ class UserProject
     public function Save(): bool
     {
         if (!$this->ProjectId) {
-            echo 'UserProject::Save(): no ProjectId specified';
-            return false;
+            abort(500, 'UserProject::Save(): no ProjectId specified');
         }
 
         if (!$this->UserId) {
-            echo 'UserProject::Save(): no UserId specified';
-            return false;
+            abort(500, 'UserProject::Save(): no UserId specified');
         }
 
         $db = Database::getInstance();
@@ -176,8 +174,7 @@ class UserProject
     public function GetUsers(int $role = -1): array|false
     {
         if (!$this->ProjectId) {
-            echo 'UserProject GetUsers(): ProjectId not set';
-            return false;
+            abort(500, 'UserProject GetUsers(): ProjectId not set');
         }
 
         $db = Database::getInstance();
@@ -360,8 +357,7 @@ class UserProject
     public function GetProjects(): array|false
     {
         if (!$this->UserId) {
-            echo 'UserProject GetProjects(): UserId not set';
-            return false;
+            abort(500, 'UserProject GetProjects(): UserId not set');
         }
 
         $stmt = $this->PDO->prepare(

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5369,14 +5369,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_error\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/cdash/app/Model/BuildGroup.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""


### PR DESCRIPTION
As we gradually move the codebase to Laravel, we want to control all output through Laravel alone.  A common pattern throughout the CDash codebase is the usage of the echo command to output error messages, which unintentionally conflicts with other output such as JSON output in an API response.  Furthermore, these error cases are not logged, so CDash administrators are not automatically alerted if users are repeatedly experiencing an error.

In this PR, I have switched all of the echoed error messages to thrown exceptions via Laravel's `abort()` helper.  These exceptions will show up in the logs (if configured), and the exceptions will be forced through the same centralized error handling system for greater consistency across pages.