### PR TITLE
Improve site map handling of missing data

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -125,12 +125,24 @@ class MapController extends AbstractProjectController
         echo pdo_error();
 
         foreach ($site as $site_array) {
+            if ($site_array['processorclockfrequency'] > 0) {
+                $processor_speed = getByteValueWithExtension($site_array['processorclockfrequency'] * 1024 * 1024) . 'Hz';
+            } else {
+                $processor_speed = '';
+            }
+
+            if ($site_array['numberphysicalcpus'] > 0) {
+                $num_physical_cpus = $site_array['numberphysicalcpus'];
+            } else {
+                $num_physical_cpus = '';
+            }
+
             $xml .= '<site>';
             $xml .= add_XML_value('name', $site_array['name']);
             $xml .= add_XML_value('id', $site_array['id']);
             $xml .= add_XML_value('description', $site_array['description']);
-            $xml .= add_XML_value('processor_speed', getByteValueWithExtension($site_array['processorclockfrequency'] * 1024 * 1024));
-            $xml .= add_XML_value('numberphysicalcpus', $site_array['numberphysicalcpus']);
+            $xml .= add_XML_value('processor_speed', $processor_speed);
+            $xml .= add_XML_value('numberphysicalcpus', $num_physical_cpus);
             $xml .= add_XML_value('latitude', $site_array['latitude']);
             $xml .= add_XML_value('longitude', $site_array['longitude']);
             $xml .= add_XML_value('longitude', $site_array['longitude']);

--- a/app/cdash/public/viewMap.xsl
+++ b/app/cdash/public/viewMap.xsl
@@ -71,7 +71,7 @@
 </a>
 </xsl:if>
 </center></td>
-<td><center><xsl:value-of select="processor_speed"/>Hz</center></td>
+<td><center><xsl:value-of select="processor_speed"/></center></td>
 <td><center><xsl:value-of select="numberphysicalcpus"/></center></td>
 </tr>
 </xsl:for-each>


### PR DESCRIPTION
`viewMap.php` currently handles missing data poorly, displaying nonsensical values whenever the expected data is not present.

Before:
![image](https://github.com/Kitware/CDash/assets/16820599/1a07c15b-776a-4323-900c-1a0d49e180ff)

After:
![image](https://github.com/Kitware/CDash/assets/16820599/9e73afc7-79f0-47f8-b37b-c51bb64fbff4)
