### PR TITLE
Render build groups one at a time on index page

### DIFF
--- a/app/cdash/public/js/controllers/index.js
+++ b/app/cdash/public/js/controllers/index.js
@@ -56,6 +56,8 @@ CDash.filter("showEmptyBuildsLast", function () {
   $scope.showfilters = false;
   $scope.showsettings = false;
 
+  $scope.buildgroup_limit = 1;
+
   // Check if we have a cookie for auto-refresh.
   const refresh_cookie = $.cookie('cdash_refresh') === 'true';
   if (refresh_cookie) {
@@ -258,6 +260,19 @@ CDash.filter("showEmptyBuildsLast", function () {
       anchors.jumpToAnchor($location.hash());
     }
 
+    $scope.incrementDisplayedBuildgroups();
+  };
+
+  // This is a hack to load one build group at a time. Doing so makes the page "feel" faster because the
+  // first build group gets rendered faster than it would if everything got rendered at once.
+  $scope.incrementDisplayedBuildgroups = function() {
+    setTimeout(function() {
+      if ($scope.buildgroup_limit < $scope.cdash.buildgroups.length) {
+        $scope.buildgroup_limit++;
+        $scope.incrementDisplayedBuildgroups();
+        $scope.$digest();
+      }
+    }, 100);
   };
 
 

--- a/app/cdash/public/views/index.html
+++ b/app/cdash/public/views/index.html
@@ -150,7 +150,7 @@
       <ng-include ng-if="::cdash.subproject.dependencies.length > 0" ng-init="cdash.tableName = 'SubProject Dependencies'; cdash.subprojects = cdash.subproject.dependencies" src="'build/views/partials/subProjectTable_@@version.html'"></ng-include>
 
       <!-- BuildGroups -->
-      <div ng-repeat="buildgroup in ::cdash.buildgroups | orderBy:'position'" class="buildgroup"
+      <div ng-repeat="buildgroup in cdash.buildgroups | orderBy:'position'| limitTo:buildgroup_limit" class="buildgroup"
            buildgroup>
       </div>  <!-- end BuildGroups -->
 

--- a/app/cdash/public/views/partials/build.html
+++ b/app/cdash/public/views/partials/build.html
@@ -86,7 +86,7 @@
       <a href="" ng-click="toggleAdminOptions(build)">
         <img name="adminoptions" src="img/folder.png" class="icon"/>
       </a>
-      <img src="img/loading.gif" ng-show="build.loading == 1"/>
+      <img src="img/loading.gif" ng-if="build.loading == 1"/>
     </div>
   </div>
 
@@ -170,10 +170,10 @@
             <b>{{::group.name}}</b>:
           </td>
           <td ng-if="::group.name == buildgroup.name" colspan="2">
-            <a ng-show="build.expected == 0" href="" ng-click="toggleExpected(build, group.id)">
+            <a ng-if="build.expected == 0" href="" ng-click="toggleExpected(build, group.id)">
               [mark as expected]
             </a>
-            <a ng-show="build.expected == 1 || build.expectedandmissing == 1" href="" ng-click="toggleExpected(build, group.id)">
+            <a ng-if="build.expected == 1 || build.expectedandmissing == 1" href="" ng-click="toggleExpected(build, group.id)">
               [mark as non expected]
             </a>
           </td>
@@ -195,10 +195,10 @@
            tooltip-append-to-body="true"
            uib-tooltip="Done builds will be overwritten if a new one is submitted with the same site, build name, and timestamp."
       >
-        <a ng-show="build.done == 0" href="" ng-click="toggleDone(build)">
+        <a ng-if="build.done == 0" href="" ng-click="toggleDone(build)">
           [mark as done]
         </a>
-        <a ng-show="build.done == 1" href="" ng-click="toggleDone(build)">
+        <a ng-if="build.done == 1" href="" ng-click="toggleDone(build)">
           [mark as not done]
         </a>
       </div>


### PR DESCRIPTION
The index page is currently unacceptably slow for large projects due to a large rendering delay.  On large dashboards such as the VTK dashboard, AngularJS takes in excess of 5 seconds to render once it receives a response from the API.

The render delay itself is an unavoidable limitation of AngularJS, but it's possible to hide some of it by prioritizing content at the top of the page.  By rendering one build group at a time, we can put content in front of the user's eyes faster than if it was all rendered at once.

Although the total render time is still roughly the same, this PR drops the time before a user sees the first build group from 5 seconds to 1.5 seconds on the VTK dashboard.  Since the user is unlikely to begin navigating the page before the other build groups render, the page appears to take 1.5 seconds to load.

In the future, the same approach could be applied to build rows within build groups.  We could render the first hundred rows initially and then load the rest later.