### PR TITLE
Link to sites and builds in coverage and dynamic analysis sections

### DIFF
--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -444,6 +444,7 @@ foreach ($build_rows as $build_array) {
             $coverage_groups[$groupId]['coverages'][] = $coverage_response;
         } else {
             $coverage_response['site'] = $build_array['sitename'];
+            $coverage_response['siteid'] = $build_array['siteid'];
             $coverage_response['buildname'] = $build_array['name'];
             $response['coverages'][] = $coverage_response;
         }

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -462,6 +462,7 @@ foreach ($build_rows as $build_array) {
 
         $DA_response = array();
         $DA_response['site'] = $build_array['sitename'];
+        $DA_response['siteid'] = $build_array['siteid'];
         $DA_response['buildname'] = $build_array['name'];
         $DA_response['buildid'] = (int) $build_array['id'];
         $DA_response['checker'] = $build_array['checker'];

--- a/app/cdash/public/views/index.html
+++ b/app/cdash/public/views/index.html
@@ -413,7 +413,9 @@
               </td>
 
               <td ng-if="::cdash.childview != 1" class="paddt" align="left">
-                {{::da.buildname}}
+                <a ng-href="build/{{::da.buildid}}">
+                  {{::da.buildname}}
+                </a>
               </td>
 
               <td class="paddt" class="center-text">{{::da.checker}}</td>

--- a/app/cdash/public/views/index.html
+++ b/app/cdash/public/views/index.html
@@ -409,7 +409,9 @@
               </td>
 
               <td ng-if="::cdash.childview != 1" class="paddt" align="left">
-                {{::da.site}}
+                <a ng-href="viewSite.php?siteid={{::da.siteid}}&project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+                  {{::da.site}}
+                </a>
               </td>
 
               <td ng-if="::cdash.childview != 1" class="paddt" align="left">

--- a/app/cdash/public/views/index.html
+++ b/app/cdash/public/views/index.html
@@ -292,7 +292,9 @@
           <tbody ng-if="::!cdash.coveragegroups || cdash.coveragegroups.length == 0" id="coveragebody">
             <tr class="child_row" ng-repeat="coverage in cdash.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
               <td ng-if="::cdash.childview != 1" align="left" class="paddt">
-                {{::coverage.site}}
+                <a ng-href="viewSite.php?siteid={{::coverage.siteid}}&project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+                  {{::coverage.site}}
+                </a>
               </td>
 
               <td ng-if="::cdash.childview != 1" align="left" class="paddt">

--- a/app/cdash/public/views/index.html
+++ b/app/cdash/public/views/index.html
@@ -296,7 +296,9 @@
               </td>
 
               <td ng-if="::cdash.childview != 1" align="left" class="paddt">
-                {{::coverage.buildname}}
+                <a ng-href="build/{{::coverage.buildid}}">
+                  {{::coverage.buildname}}
+                </a>
               </td>
 
               <td ng-if="::cdash.childview == 1" align="left" class="paddt">


### PR DESCRIPTION
Build rows in the coverage and dynamic analysis sections of the index page currently do not link to the corresponding site or build like normal build rows do.  Adding these links is trivial to do, and there is no reason not to.

Closes #810.