### PR TITLE
Fix links to subprojects in subprojects table

### DIFF
--- a/app/cdash/public/views/partials/subProjectTable.html
+++ b/app/cdash/public/views/partials/subProjectTable.html
@@ -72,7 +72,7 @@
   <tbody>
     <tr ng-repeat="subproject in cdash.subprojects |orderBy:sortSubProjects.orderByFields|showEmptySubProjectsLast:sortSubProjects.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
       <td align="center" >
-        <a ng-href="index.php?subproject={{subproject.name_encoded}}&{{cdash.linkparams}}">
+        <a ng-href="index.php?subproject={{subproject.name_encoded}}&project={{::cdash.projectname_encoded}}&date={{::cdash.date}}">
           {{subproject.name}}
         </a>
       </td>


### PR DESCRIPTION
The link to each subproject in the subprojects table when viewing one of the subprojects is currently missing a date parameter.  This PR fixes the date parameter, using the same data source used on `viewSubProjects.php`.