### PR TITLE
Don't attempt to display group if no group defined

### DIFF
--- a/app/cdash/public/viewSubProjectDependenciesGraph.xsl
+++ b/app/cdash/public/viewSubProjectDependenciesGraph.xsl
@@ -61,7 +61,10 @@ This circle plot captures the interrelationships among subgroups. Mouse over any
     }
 
     function mouseOvered(d) {
-      var header1Text = "Name: " + d.key + ", Group: " + d.group;
+      var header1Text = "Name: " + d.key;
+      if (d.group !== undefined) {
+        header1Text += ", Group: " + d.group;
+      }
       $('#header1').html(header1Text);
       if (d.depends) {
         var depends = "&lt;p&gt;Depends: ";


### PR DESCRIPTION
This PR fixes a small UI issue on the subproject dependency graph page when a project is not assigned a group.  This page needs a significant overhaul eventually, but I will defer that until sometime in the future.

Example of error:
![image](https://github.com/Kitware/CDash/assets/16820599/8685e38a-37f9-4db2-98a9-4ddea35cd30d)
