### PR TITLE
Properly query the USER_CREATE_PROJECTS variable

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -109,7 +109,7 @@ class ProjectController extends AbstractProjectController
             $project_response['TestTimeMaxStatus'] = 3;
             $project_response['TestTimeStd'] = 4.0;
             $project_response['TestTimeStdThreshold'] = 1.0;
-            if (!$config->get('CDASH_USER_CREATE_PROJECTS') || $User->IsAdmin()) {
+            if (!boolval(config('cdash.user_create_projects')) || $User->IsAdmin()) {
                 $project_response['UploadQuota'] = 1;
             }
             $project_response['WarningsFilter'] = "";

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -8,7 +8,6 @@ use App\Models\Test;
 use App\Models\TestImage;
 use App\Models\User;
 use App\Services\ProjectPermissions;
-use CDash\Config;
 use CDash\Model\Image;
 use CDash\Model\Project;
 use Illuminate\Auth\Access\Response;
@@ -61,8 +60,7 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         Gate::define('create-project', function (User $user) {
-            $config = Config::getInstance();
-            if (!$user->IsAdmin() && !$config->get('CDASH_USER_CREATE_PROJECTS')) {
+            if (!$user->IsAdmin() && !boolval(config('cdash.user_create_projects'))) {
                 return Response::denyWithStatus(403, 'You do not have permission to create new projects.');
             }
             return Response::allow();

--- a/app/cdash/tests/test_createprojectpermissions.php
+++ b/app/cdash/tests/test_createprojectpermissions.php
@@ -7,8 +7,6 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'include/common.php';
 require_once 'include/pdo.php';
 
-use CDash\Config;
-
 class CreateProjectPermissionsTestCase extends KWWebTestCase
 {
     protected $BuildId;
@@ -106,8 +104,7 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
         $this->assertTrue(property_exists($response, 'error'));
 
         // Modify config, enable user-creatable projects.
-        $config = Config::getInstance();
-        $config->set('CDASH_USER_CREATE_PROJECTS', true);
+        config(['cdash.user_create_projects' => true]);
         unset($_GET['projectid']);
         $response = $this->get($this->url . '/api/v1/createProject.php');
         $response = json_decode($response);

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -77,5 +77,6 @@ return [
     'allow_submit_only_tokens' => env('ALLOW_SUBMIT_ONLY_TOKENS', true),
     'unlimited_projects' => $unlimited_projects,
     'use_compression' => env('USE_COMPRESSION', true),
+    'user_create_projects' => env('USER_CREATE_PROJECTS', false),
     'use_vcs_api' => env('USE_VCS_API', true),
 ];


### PR DESCRIPTION
Use the config singleton to properly query the value of USER_CREATE_PROJECTS when checking for permission at the creation of projects.

Fixes: #1602