### PR TITLE
Fix erroneous message upon creating new buildgroup

### DIFF
--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -50,8 +50,7 @@ switch ($method) {
         rest_delete();
         break;
     case 'POST':
-        rest_post($pdo, $projectid);
-        break;
+        return rest_post($pdo, $projectid);
     case 'PUT':
         rest_put($projectid);
         break;

--- a/app/cdash/tests/js/e2e_tests/manageBuildGroup.js
+++ b/app/cdash/tests/js/e2e_tests/manageBuildGroup.js
@@ -21,6 +21,7 @@ describe("manageBuildGroup", function() {
     element(by.name('newBuildGroupName')).sendKeys('latestBuildGroup');
     element(by.name('newBuildGroupType')).element(by.cssContainingText('option', 'Latest')).click();
     element(by.buttonText('Create BuildGroup')).click();
+    expect(element(by.id('buildgroup_created')).isDisplayed()).toBeTruthy();
 
     // Make sure they're both on our list of current BuildGroups.
     browser.get('manageBuildGroup.php?projectid=5');


### PR DESCRIPTION
When creating a new buildgroup using the manageBuildGroup.php page, CDash would reply:

A group named '\<new group name\>' already exists for this project.

This error message was displayed despite the fact that the new group actually was created successfully.