### PR TITLE
Use exponential backoff when requeueing Done.xml files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,9 @@ DB_PASSWORD=secret
 # Should CDash only register valid emails
 #REGISTRATION_EMAIL_VERIFY=true
 
+# How long should CDash wait (in seconds) before requeueing an asychronous job?
+#QUEUE_TIMEOUT=2000
+
 # Is this CDash instance configured to use remote queue workers?
 # Enabling this setting additionally requires QUEUE_CONNECTION to be set
 # to some value other than 'sync'.

--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,10 @@ DB_PASSWORD=secret
 # Should CDash only register valid emails
 #REGISTRATION_EMAIL_VERIFY=true
 
+# Number of seconds to use for the basis of exponential backoff when requeuing
+# asynchronous submissions.
+#QUEUE_RETRY_BASE=5
+
 # How long should CDash wait (in seconds) before requeueing an asychronous job?
 #QUEUE_TIMEOUT=2000
 

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -27,6 +27,8 @@ class ProcessSubmission implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $timeout;
+
     public $filename;
     public $projectid;
     public $buildid;
@@ -39,6 +41,8 @@ class ProcessSubmission implements ShouldQueue
      */
     public function __construct($filename, $projectid, $buildid, $expected_md5)
     {
+        $this->timeout = config('cdash.queue_timeout');
+
         $this->filename = $filename;
         $this->projectid = $projectid;
         $this->buildid = $buildid;

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -65,7 +66,12 @@ class Site extends Model
             $this->longitude = $location['longitude'];
         }
 
-        return parent::save($options);
+        try {
+            return parent::save($options);
+        } catch (QueryException $e) {
+            \Log::warning("Failed to save Site {$this->name}");
+            return false;
+        }
     }
 
     private function LookupIP(): void

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -2533,7 +2533,7 @@ class Build
      * Returns the current Build's Site property. This method lazily loads the Site if no such
      * object exists.
      */
-    public function GetSite(): \App\Models\Site
+    public function GetSite(): \App\Models\Site|null
     {
         if (!$this->Site) {
             $this->Site = \App\Models\Site::find($this->SiteId);

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -35,6 +35,7 @@ class DoneHandlerTestCase extends KWWebTestCase
         config(['cdash.remote_workers' => 'true']);
         config(['queue.default' => 'database']);
         file_put_contents($this->ConfigFile, "QUEUE_CONNECTION=database\n", FILE_APPEND | LOCK_EX);
+        file_put_contents($this->ConfigFile, "QUEUE_RETRY_BASE=0\n", FILE_APPEND | LOCK_EX);
         file_put_contents($this->ConfigFile, "REMOTE_WORKERS=true\n", FILE_APPEND | LOCK_EX);
 
         $this->performTest(true);

--- a/app/cdash/xml_handlers/retry_handler.php
+++ b/app/cdash/xml_handlers/retry_handler.php
@@ -20,6 +20,7 @@
 class RetryHandler
 {
     private $FileName;
+    public int $Retries;
 
     public function __construct($filename)
     {
@@ -38,10 +39,11 @@ class RetryHandler
         $xml = simplexml_load_file($this->FileName);
         $attributes = $xml->attributes();
         if (isset($attributes['retries'])) {
-            $xml['retries'] = $attributes['retries'] + 1;
+            $this->Retries = intval($attributes['retries']) + 1;
         } else {
-            $xml['retries'] = 1;
+            $this->Retries = 1;
         }
+        $xml['retries'] = $this->Retries;
 
         return $xml->asXML($this->FileName);
     }

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -69,6 +69,7 @@ return [
     'phpunit_exe' => env('PHPUNIT_EXE', ''),
     'queue_timeout' => env('QUEUE_TIMEOUT', 2000),
     'remote_workers' => env('REMOTE_WORKERS', false),
+    'retry_base' => env('QUEUE_RETRY_BASE', 5),
     'show_last_submission' => env('SHOW_LAST_SUBMISSION', true),
     'slow_page_time' => env('SLOW_PAGE_TIME', 10),
     'token_duration' => env('TOKEN_DURATION', 15811200),

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -67,6 +67,7 @@ return [
     'notify_pull_request' => env('NOTIFY_PULL_REQUEST', false),
     'php_exe' => env('PHP_EXE', ''),
     'phpunit_exe' => env('PHPUNIT_EXE', ''),
+    'queue_timeout' => env('QUEUE_TIMEOUT', 2000),
     'remote_workers' => env('REMOTE_WORKERS', false),
     'show_last_submission' => env('SHOW_LAST_SUBMISSION', true),
     'slow_page_time' => env('SLOW_PAGE_TIME', 10),

--- a/config/queue.php
+++ b/config/queue.php
@@ -38,14 +38,14 @@ return [
             'driver' => 'database',
             'table' => 'jobs',
             'queue' => 'default',
-            'retry_after' => 90,
+            'retry_after' => env('QUEUE_TIMEOUT', 2000) + 60,
         ],
 
         'beanstalkd' => [
             'driver' => 'beanstalkd',
             'host' => 'localhost',
             'queue' => 'default',
-            'retry_after' => 90,
+            'retry_after' => env('QUEUE_TIMEOUT', 2000) + 60,
         ],
 
         'sqs' => [
@@ -61,7 +61,7 @@ return [
             'driver' => 'redis',
             'connection' => 'default',
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 90,
+            'retry_after' => env('QUEUE_TIMEOUT', 2000) + 60,
             'block_for' => null,
         ],
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28535,11 +28535,6 @@ parameters:
 			path: app/cdash/xml_handlers/retry_handler.php
 
 		-
-			message: "#^Only numeric types are allowed in \\+, SimpleXMLElement given on the left side\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
 			message: "#^Property RetryHandler\\:\\:\\$FileName has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/retry_handler.php


### PR DESCRIPTION
After the recent upgrade of open.cdash.org, we noticed many builds were no longer marked as "Done". This was due to the Done.xml handler exhausting its 5 retries while a single large Test.xml file was in the process of being parsed.

We solve this problem by exponentially backing off the requeueing of Done.xml files to give CDash more time to finish parsing any such large XML files for a given build.

Fixes #1603

This PR also contains a couple other semi-related fixes dealing with parallel parsing of submission files.