### PR TITLE
Demote severity of 'No note text' to info

### DIFF
--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -115,7 +115,7 @@ class NoteHandler extends AbstractHandler
             } elseif (!$this->NoteCreator->name) {
                 \Log::error("Note missing name for build #{$this->Build->Id}");
             } elseif (!$this->NoteCreator->text) {
-                \Log::error("No note text for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
+                \Log::info("No note text for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
             } elseif ($this->Timestamp === 0) {
                 \Log::error("No note time for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
             } else {


### PR DESCRIPTION
We've noticed tons of entries for this log message on open.cdash.org. They stem from projects that choose to upload lots of logs for their builds, some of which happen to be empty.

Since this is ultimately a client-side issue, demote the severity of this log entry from 'error' to 'info' so as to make them easier to filter out on the server side.