### PR TITLE
Change GetUsersFromProject to only return arrays

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -217,7 +217,10 @@ final class CoverageController extends AbstractBuildController
         // Send an email
         if (isset($_POST['sendEmail'])) {
             $coverageThreshold = $Project->GetCoverageThreshold();
-            $userids = $CoverageFile2User->GetUsersFromProject();
+            $userids = DB::table('coveragefilepriority')
+                        ->join('coveragefile2user', 'coveragefilepriority.id', '=', 'coveragefile2user.fileid')
+                        ->where('coveragefilepriority.projectid', '=', intval($projectid))->distinct()
+                        ->pluck('userid')->toArray();
             foreach ($userids as $userid) {
                 $CoverageFile2User->UserId = $userid;
                 $fileids = $CoverageFile2User->GetFiles();

--- a/app/cdash/app/Model/CoverageFile2User.php
+++ b/app/cdash/app/Model/CoverageFile2User.php
@@ -13,6 +13,7 @@
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
+
 namespace CDash\Model;
 
 use CDash\Database;
@@ -284,36 +285,6 @@ class CoverageFile2User
         }
 
         return intval($query_result['id']);
-    }
-
-    /**
-     * Get the list of authors for the project
-     *
-     * @return array<int>|false
-     */
-    public function GetUsersFromProject(): array|false
-    {
-        if (!isset($this->ProjectId) || $this->ProjectId < 1) {
-            abort(500, 'CoverageFile2User:GetUsersFromProject: projectid not valid');
-        }
-
-        $db = Database::getInstance();
-        $query_result = $db->executePrepared('
-                            SELECT DISTINCT userid
-                            FROM coveragefile2user, coveragefilepriority
-                            WHERE
-                                coveragefilepriority.id=coveragefile2user.fileid
-                                AND coveragefilepriority.projectid=?
-                        ', [intval($this->ProjectId)]);
-        if (empty($query_result)) {
-            add_last_sql_error('CoverageFile2User:GetUsersFromProject');
-            return false;
-        }
-        $userids = [];
-        foreach ($query_result as $query_array) {
-            $userids[] = intval($query_array['userid']);
-        }
-        return $userids;
     }
 
     /** Assign the last author */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6550,7 +6550,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 13
+			count: 12
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -6566,7 +6566,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 11
+			count: 10
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -6579,7 +6579,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
+			count: 4
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-


### PR DESCRIPTION
When there are no users linked to a project coverage file, the GetUsersFromProject function returns false, assuming that an empty query_result means an error.  Returning false created a 500 error when the caller function attempted to loop over the return.

Change the function to use Laravel's query system and eliminate the places where boolean values were returned.