### PR TITLE
Delete unnecessary includes

### DIFF
--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use CDash\Database;
 use Illuminate\Console\Command;
 
-
 require_once 'include/autoremove.php';
 
 class AutoRemoveBuilds extends Command

--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use CDash\Database;
 use Illuminate\Console\Command;
 
-require_once 'include/common.php';
 require_once 'include/pdo.php';
 require_once 'include/autoremove.php';
 

--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use CDash\Database;
 use Illuminate\Console\Command;
 
-require_once 'include/pdo.php';
+
 require_once 'include/autoremove.php';
 
 class AutoRemoveBuilds extends Command

--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -8,7 +8,8 @@ use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
-include_once 'include/common.php';
+require_once 'include/common.php';
+require_once 'include/pdo.php';
 require_once 'include/defines.php';
 
 abstract class AbstractController extends BaseController

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use PDO;
 
-require_once('include/repository.php');
+require_once 'include/repository.php';
 
 final class BuildController extends AbstractBuildController
 {

--- a/app/Http/Controllers/FilterController.php
+++ b/app/Http/Controllers/FilterController.php
@@ -3,7 +3,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 
-include_once 'include/filterdataFunctions.php';
+require_once 'include/filterdataFunctions.php';
 
 class FilterController extends AbstractController
 {

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-include_once 'include/repository.php';
+require_once 'include/repository.php';
 
 final class TestController extends AbstractProjectController
 {

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -19,7 +19,6 @@ use Illuminate\Support\Facades\Storage;
 
 use UpdateHandler;
 
-include_once 'include/common.php';
 require_once 'include/ctestparser.php';
 require_once 'include/sendemail.php';
 

--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -111,7 +111,6 @@ class BuildTest extends Model
     // Only used in api/v1/viewTest.php
     public static function marshal($data, $buildid, $projectid, $projectshowtesttime, $testtimemaxstatus, $testdate): array
     {
-        require_once 'include/common.php';
         $marshaledStatus = self::marshalStatus($data['status']);
         if ($data['details'] === 'Disabled') {
             $marshaledStatus = array('Not Run', 'disabled-test');

--- a/app/Services/UnparsedSubmissionProcessor.php
+++ b/app/Services/UnparsedSubmissionProcessor.php
@@ -31,8 +31,6 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
-
-
 /**
  * This class handles submissions that should be parsed on the server-side
  * by CDash. This is in contrast to the XML files that are typically generated

--- a/app/Services/UnparsedSubmissionProcessor.php
+++ b/app/Services/UnparsedSubmissionProcessor.php
@@ -31,7 +31,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 
-require_once 'include/common.php';
+
 
 /**
  * This class handles submissions that should be parsed on the server-side

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -32,8 +32,6 @@ use CDash\Model\BuildUpdateFile;
 use CDash\Model\PendingSubmissions;
 use CDash\Model\Project;
 
-require_once 'include/log.php';
-
 /**
  * Class GitHub
  * @package CDash\Lib\Repository

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Model;
 
-include_once 'include/common.php';
 include_once 'include/ctestparserutils.php';
 include_once 'include/repository.php';
 

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -16,8 +16,8 @@
 
 namespace CDash\Model;
 
-include_once 'include/ctestparserutils.php';
-include_once 'include/repository.php';
+require_once 'include/ctestparserutils.php';
+require_once 'include/repository.php';
 
 use App\Models\Test;
 use App\Services\TestingDay;

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -15,7 +15,6 @@
 =========================================================================*/
 namespace CDash\Model;
 
-
 require_once 'include/repository.php';
 
 use CDash\Config;

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 namespace CDash\Model;
 
-require_once 'include/common.php';
+
 require_once 'include/repository.php';
 
 use CDash\Config;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -15,7 +15,6 @@
 =========================================================================*/
 namespace CDash\Model;
 
-require_once  'include/common.php';
 require_once 'include/cdashmail.php';
 
 use CDash\Collection\SubscriberCollection;
@@ -639,7 +638,6 @@ class Project
             $this->WebApiKey = $project_array['webapikey'];
             if ($this->WebApiKey == '') {
                 // If no web API key exists, we add one
-                include_once 'include/common.php';
                 $newKey = generate_password(40);
                 $this->PDO->executePrepared('
                     UPDATE project SET webapikey=? WHERE id=?
@@ -1644,7 +1642,7 @@ class Project
         $totalUploadSize = $this->GetUploadsTotalSize();
 
         if ($totalUploadSize > $this->UploadQuota) {
-            require_once 'include/common.php';
+
             add_log('Upload quota exceeded, removing old files', 'Project::CullUploadedFiles',
                 LOG_INFO, $this->Id);
 

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -17,7 +17,7 @@ namespace CDash\Model;
 
 use CDash\Database;
 
-require_once 'include/common.php';
+
 
 class User
 {

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -17,8 +17,6 @@ namespace CDash\Model;
 
 use CDash\Database;
 
-
-
 class User
 {
     public $Id;

--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -29,6 +29,8 @@ use DI\ContainerBuilder;
 
 use Tests\TestCase;
 
+require_once 'include/common.php';
+
 class CDashTestCase extends TestCase
 {
     protected $mockPDO;

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-require_once 'include/common.php';
+
 
 
 use CDash\Model\Build;

--- a/app/cdash/include/autoremove.php
+++ b/app/cdash/include/autoremove.php
@@ -20,7 +20,7 @@ use CDash\Database;
 function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
 {
     require_once 'include/pdo.php';
-    require_once 'include/common.php';
+
 
     if (!$force && !config('cdash.autoremove_builds')) {
         return;
@@ -71,7 +71,7 @@ function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
 function removeFirstBuilds($projectid, $days, $maxbuilds, $force = false, $echo = true)
 {
     require_once 'include/pdo.php';
-    require_once 'include/common.php';
+
 
     @set_time_limit(0);
     $remove_builds = config('cdash.autoremove_builds');

--- a/app/cdash/include/autoremove.php
+++ b/app/cdash/include/autoremove.php
@@ -19,7 +19,7 @@ use CDash\Database;
 /** Remove builds by their group-specific auto-remove timeframe setting */
 function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
 {
-    require_once 'include/pdo.php';
+
 
 
     if (!$force && !config('cdash.autoremove_builds')) {
@@ -70,7 +70,7 @@ function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
 /** Remove the first builds that are at the beginning of the queue */
 function removeFirstBuilds($projectid, $days, $maxbuilds, $force = false, $echo = true)
 {
-    require_once 'include/pdo.php';
+
 
 
     @set_time_limit(0);

--- a/app/cdash/include/ctestparser.php
+++ b/app/cdash/include/ctestparser.php
@@ -180,7 +180,7 @@ function parse_put_submission($filehandler, $projectid, $expected_md5)
 /** Main function to parse the incoming xml from ctest */
 function ctest_parse($filehandle, $projectid, $expected_md5 = '')
 {
-    require_once 'include/common.php';
+
     include 'include/version.php';
 
     // Check if this is a new style PUT submission.

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -20,7 +20,6 @@
 //
 
 require_once 'include/pdo.php';
-include_once 'include/common.php';
 require_once 'include/cdashmail.php';
 
 use CDash\Config;
@@ -889,7 +888,6 @@ function sendEmailExpectedBuilds($projectid, $currentstarttime): void
 /** Remove the buildemail that have been there from more than 48h */
 function cleanBuildEmail(): void
 {
-    include_once 'include/common.php';
     $now = date(FMT_DATETIME, time() - 3600 * 48);
 
     $db = Database::getInstance();
@@ -899,7 +897,6 @@ function cleanBuildEmail(): void
 /** Clean the usertemp table if more than 24hrs */
 function cleanUserTemp(): void
 {
-    include_once 'include/common.php';
     $now = date(FMT_DATETIME, time() - 3600 * 24);
 
     $db = Database::getInstance();
@@ -909,7 +906,6 @@ function cleanUserTemp(): void
 /** Send an email to administrator of the project for users who are not registered */
 function sendEmailUnregisteredUsers(int $projectid, $cvsauthors): void
 {
-    include_once 'include/common.php';
     $config = Config::getInstance();
     $unregisteredusers = array();
     foreach ($cvsauthors as $author) {
@@ -974,7 +970,6 @@ function sendEmailUnregisteredUsers(int $projectid, $cvsauthors): void
 /** Add daily changes if necessary */
 function addDailyChanges(int $projectid): void
 {
-    include_once 'include/common.php';
     include_once 'include/sendemail.php';
 
     $project = new Project();

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -970,7 +970,7 @@ function sendEmailUnregisteredUsers(int $projectid, $cvsauthors): void
 /** Add daily changes if necessary */
 function addDailyChanges(int $projectid): void
 {
-    include_once 'include/sendemail.php';
+    require_once 'include/sendemail.php';
 
     $project = new Project();
     $project->Id = $projectid;
@@ -1194,7 +1194,7 @@ function addDailyChanges(int $projectid): void
         }
 
         // Remove the first builds of the project
-        include_once 'include/autoremove.php';
+        require_once 'include/autoremove.php';
         removeFirstBuilds($projectid, $project->AutoremoveTimeframe, $project->AutoremoveMaxBuilds);
         removeBuildsGroupwise($projectid, $project->AutoremoveMaxBuilds);
     }

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -19,7 +19,7 @@
 // the input, the project's nightly start time, now
 //
 
-require_once 'include/pdo.php';
+
 require_once 'include/cdashmail.php';
 
 use CDash\Config;

--- a/app/cdash/include/log.php
+++ b/app/cdash/include/log.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 
 require_once 'include/defines.php';
-require_once 'include/pdo.php';
+
 
 
 use Illuminate\Support\Facades\Log;

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -14,8 +14,6 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-require_once 'include/log.php';
-
 use CDash\Database;
 
 /**

--- a/app/cdash/include/repository.php
+++ b/app/cdash/include/repository.php
@@ -858,7 +858,7 @@ function generate_bugtracker_new_issue_link($build, $project)
     }
 
     // Use our email functions to generate a message body and title for this build.
-    require_once('include/sendemail.php');
+    require_once 'include/sendemail.php';
     $errors = check_email_errors(intval($build->Id), false, 0, true);
     $emailtext = [];
     foreach ($errors as $errorkey => $nerrors) {

--- a/app/cdash/include/repository.php
+++ b/app/cdash/include/repository.php
@@ -14,9 +14,6 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-require_once 'include/log.php';
-
-use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\ServiceContainer;
 use CDash\Database;

--- a/app/cdash/include/sendemail.php
+++ b/app/cdash/include/sendemail.php
@@ -347,8 +347,6 @@ function get_email_summary(int $buildid, array $errors, $errorkey, int $maxitems
 /** Generate the title and body for a broken build. */
 function generate_broken_build_message(array $emailtext, $Build, $Project): array|false
 {
-    include_once 'include/common.php';
-
     $config = Config::getInstance();
     $serverURI = $config->getBaseUrl();
 
@@ -502,7 +500,6 @@ function generate_broken_build_message(array $emailtext, $Build, $Project): arra
 /** function to send email to site maintainers when the update step fails */
 function send_update_email(UpdateHandler $handler, int $projectid): void
 {
-    include_once 'include/common.php';
     require_once 'include/pdo.php';
 
     $Project = new Project();

--- a/app/cdash/include/sendemail.php
+++ b/app/cdash/include/sendemail.php
@@ -500,7 +500,7 @@ function generate_broken_build_message(array $emailtext, $Build, $Project): arra
 /** function to send email to site maintainers when the update step fails */
 function send_update_email(UpdateHandler $handler, int $projectid): void
 {
-    require_once 'include/pdo.php';
+
 
     $Project = new Project();
     $Project->Id = $projectid;

--- a/app/cdash/public/api/v1/build.php
+++ b/app/cdash/public/api/v1/build.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\Build;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 
 use CDash\Database;

--- a/app/cdash/public/api/v1/build.php
+++ b/app/cdash/public/api/v1/build.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\Build;
 
-
 require_once 'include/api_common.php';
 
 use CDash\Database;

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\BuildGroup;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 require_once 'include/version.php';
 

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\BuildGroup;
 
-
 require_once 'include/api_common.php';
 require_once 'include/version.php';
 

--- a/app/cdash/public/api/v1/computeClassifier.php
+++ b/app/cdash/public/api/v1/computeClassifier.php
@@ -17,7 +17,7 @@
 namespace CDash\Api\v1\ComputeClassifier;
 
 require_once 'include/log.php';
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 
 $builds = $_GET['builds'];

--- a/app/cdash/public/api/v1/computeClassifier.php
+++ b/app/cdash/public/api/v1/computeClassifier.php
@@ -16,8 +16,6 @@
 
 namespace CDash\Api\v1\ComputeClassifier;
 
-require_once 'include/log.php';
-
 require_once 'include/api_common.php';
 
 $builds = $_GET['builds'];

--- a/app/cdash/public/api/v1/deleteSubmissionFile.php
+++ b/app/cdash/public/api/v1/deleteSubmissionFile.php
@@ -17,7 +17,7 @@
 namespace CDash\Api\v1\DeleteSubmissionFile;
 
 
-include_once 'include/ctestparser.php';
+require_once 'include/ctestparser.php';
 
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;

--- a/app/cdash/public/api/v1/deleteSubmissionFile.php
+++ b/app/cdash/public/api/v1/deleteSubmissionFile.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\DeleteSubmissionFile;
 
-
 require_once 'include/ctestparser.php';
 
 use Illuminate\Support\Facades\Storage;

--- a/app/cdash/public/api/v1/deleteSubmissionFile.php
+++ b/app/cdash/public/api/v1/deleteSubmissionFile.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\DeleteSubmissionFile;
 
-require_once 'include/pdo.php';
+
 include_once 'include/ctestparser.php';
 
 use Illuminate\Support\Facades\Storage;

--- a/app/cdash/public/api/v1/deleteSubmissionFile.php
+++ b/app/cdash/public/api/v1/deleteSubmissionFile.php
@@ -17,7 +17,6 @@
 namespace CDash\Api\v1\DeleteSubmissionFile;
 
 require_once 'include/pdo.php';
-include_once 'include/common.php';
 include_once 'include/ctestparser.php';
 
 use Illuminate\Support\Facades\Storage;

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\ExpectedBuild;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 
 use App\Models\User;

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\ExpectedBuild;
 
-
 require_once 'include/api_common.php';
 
 use App\Models\User;

--- a/app/cdash/public/api/v1/getSubmissionFile.php
+++ b/app/cdash/public/api/v1/getSubmissionFile.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\GetSubmissionFile;
 
-require_once 'include/pdo.php';
+
 
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;

--- a/app/cdash/public/api/v1/getSubmissionFile.php
+++ b/app/cdash/public/api/v1/getSubmissionFile.php
@@ -17,7 +17,6 @@
 namespace CDash\Api\v1\GetSubmissionFile;
 
 require_once 'include/pdo.php';
-include_once 'include/common.php';
 
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;

--- a/app/cdash/public/api/v1/getSubmissionFile.php
+++ b/app/cdash/public/api/v1/getSubmissionFile.php
@@ -16,8 +16,6 @@
 
 namespace CDash\Api\v1\GetSubmissionFile;
 
-
-
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/app/cdash/public/api/v1/getbuildid.php
+++ b/app/cdash/public/api/v1/getbuildid.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\GetBuildID;
 
-require_once 'include/common.php';
+
 require_once 'include/api_common.php';
 require_once 'include/pdo.php';
 

--- a/app/cdash/public/api/v1/getbuildid.php
+++ b/app/cdash/public/api/v1/getbuildid.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\GetBuildID;
 
 
 require_once 'include/api_common.php';
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 

--- a/app/cdash/public/api/v1/getbuildid.php
+++ b/app/cdash/public/api/v1/getbuildid.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\GetBuildID;
 
-
 require_once 'include/api_common.php';
 
 

--- a/app/cdash/public/api/v1/getuserid.php
+++ b/app/cdash/public/api/v1/getuserid.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\GetUserID;
 
-require_once 'include/common.php';
+
 require_once 'include/api_common.php';
 require_once 'include/pdo.php';
 

--- a/app/cdash/public/api/v1/getuserid.php
+++ b/app/cdash/public/api/v1/getuserid.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\GetUserID;
 
-
 require_once 'include/api_common.php';
 
 

--- a/app/cdash/public/api/v1/getuserid.php
+++ b/app/cdash/public/api/v1/getuserid.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\GetUserID;
 
 
 require_once 'include/api_common.php';
-require_once 'include/pdo.php';
+
 
 use App\Models\User;
 use CDash\Model\Project;

--- a/app/cdash/public/api/v1/hasfile.php
+++ b/app/cdash/public/api/v1/hasfile.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\HasFile;
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/public/api/v1/hasfile.php
+++ b/app/cdash/public/api/v1/hasfile.php
@@ -17,7 +17,7 @@
 namespace CDash\Api\v1\HasFile;
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 

--- a/app/cdash/public/api/v1/hasfile.php
+++ b/app/cdash/public/api/v1/hasfile.php
@@ -16,9 +16,6 @@
 
 namespace CDash\Api\v1\HasFile;
 
-
-
-
 use CDash\Database;
 
 $md5sums_get = isset($_GET['md5sums']) ? htmlspecialchars($_GET['md5sums']) : '';

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\Index;
 
-
 require_once 'include/api_common.php';
 require_once 'include/filterdataFunctions.php';
 

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\Index;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 require_once 'include/filterdataFunctions.php';
 

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\ManageBuildGroup;
 
-require_once 'include/pdo.php';
+
 
 
 use App\Services\PageTimer;

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -17,7 +17,7 @@
 namespace CDash\Api\v1\ManageBuildGroup;
 
 require_once 'include/pdo.php';
-require_once 'include/common.php';
+
 
 use App\Services\PageTimer;
 use CDash\Database;

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -16,9 +16,6 @@
 
 namespace CDash\Api\v1\ManageBuildGroup;
 
-
-
-
 use App\Services\PageTimer;
 use CDash\Database;
 use CDash\Model\BuildGroup;

--- a/app/cdash/public/api/v1/manageMeasurements.php
+++ b/app/cdash/public/api/v1/manageMeasurements.php
@@ -15,8 +15,6 @@
 
 namespace CDash\Api\v1\ManageMeasurements;
 
-
-
 require_once 'include/api_common.php';
 
 use App\Models\Measurement;

--- a/app/cdash/public/api/v1/manageMeasurements.php
+++ b/app/cdash/public/api/v1/manageMeasurements.php
@@ -15,7 +15,7 @@
 
 namespace CDash\Api\v1\ManageMeasurements;
 
-require_once 'include/pdo.php';
+
 
 require_once 'include/api_common.php';
 

--- a/app/cdash/public/api/v1/manageMeasurements.php
+++ b/app/cdash/public/api/v1/manageMeasurements.php
@@ -16,7 +16,7 @@
 namespace CDash\Api\v1\ManageMeasurements;
 
 require_once 'include/pdo.php';
-require_once 'include/common.php';
+
 require_once 'include/api_common.php';
 
 use App\Models\Measurement;

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\ManageOverview;
 
-
 include_once 'include/api_common.php';
 
 use App\Services\PageTimer;

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -17,7 +17,6 @@
 namespace CDash\Api\v1\ManageOverview;
 
 require_once 'include/pdo.php';
-include_once 'include/common.php';
 include_once 'include/api_common.php';
 
 use App\Services\PageTimer;

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\ManageOverview;
 
-require_once 'include/pdo.php';
+
 include_once 'include/api_common.php';
 
 use App\Services\PageTimer;

--- a/app/cdash/public/api/v1/overview.php
+++ b/app/cdash/public/api/v1/overview.php
@@ -10,7 +10,7 @@
 
 namespace CDash\Api\v1\Overview;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 require_once 'include/memcache_functions.php';
 

--- a/app/cdash/public/api/v1/overview.php
+++ b/app/cdash/public/api/v1/overview.php
@@ -10,7 +10,6 @@
 
 namespace CDash\Api\v1\Overview;
 
-
 require_once 'include/api_common.php';
 require_once 'include/memcache_functions.php';
 

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\Project;
 
 require_once 'include/pdo.php';
 require_once 'include/api_common.php';
-require_once 'include/common.php';
+
 
 
 use CDash\Model\Project;
@@ -134,7 +134,7 @@ function rest_post($user)
 
 function get_repo_url_example()
 {
-    require_once 'include/common.php';
+
     require_once 'include/repository.php';
     $url = get_param('url');
     $type = get_param('type');

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -16,7 +16,6 @@
 
 namespace CDash\Api\v1\Project;
 
-
 require_once 'include/api_common.php';
 
 

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\Project;
 
-require_once 'include/pdo.php';
+
 require_once 'include/api_common.php';
 
 

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\SubProject;
 
-require_once 'include/pdo.php';
+
 
 use App\Services\PageTimer;
 

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -17,7 +17,6 @@
 namespace CDash\Api\v1\SubProject;
 
 require_once 'include/pdo.php';
-include_once 'include/common.php';
 
 use App\Services\PageTimer;
 

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -16,8 +16,6 @@
 
 namespace CDash\Api\v1\SubProject;
 
-
-
 use App\Services\PageTimer;
 
 use CDash\Database;

--- a/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
@@ -12,7 +12,6 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-require_once 'include/log.php';
 use CDash\Model\Build;
 use CDash\Model\BuildRelationship;
 use CDash\Model\Project;

--- a/app/cdash/tests/kwtest/kw_db.php
+++ b/app/cdash/tests/kwtest/kw_db.php
@@ -14,8 +14,6 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-require_once dirname(dirname(dirname(__FILE__))) . '/include/pdo.php';
-
 /**
  *    db object to allow the user to interact with
  *    a database

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -315,7 +315,6 @@ class KWWebTestCase extends WebTestCase
 
     public function userExists($email)
     {
-        require_once('include/pdo.php');
         $pdo = get_link_identifier()->getPdo();
         $user_table = qid('user');
         $stmt = $pdo->prepare("SELECT id FROM $user_table WHERE email = ?");

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -315,7 +315,6 @@ class KWWebTestCase extends WebTestCase
 
     public function userExists($email)
     {
-        require_once('include/common.php');
         require_once('include/pdo.php');
         $pdo = get_link_identifier()->getPdo();
         $user_table = qid('user');

--- a/app/cdash/tests/test_actualbranchcoverage.php
+++ b/app/cdash/tests/test_actualbranchcoverage.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/test_branchcoverage.php';
 
-require_once 'include/pdo.php';
+
 
 
 class ActualBranchCoverageTestCase extends BranchCoverageTestCase

--- a/app/cdash/tests/test_actualbranchcoverage.php
+++ b/app/cdash/tests/test_actualbranchcoverage.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/test_branchcoverage.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 

--- a/app/cdash/tests/test_addbuildapi.php
+++ b/app/cdash/tests/test_addbuildapi.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Build;
 

--- a/app/cdash/tests/test_addbuildapi.php
+++ b/app/cdash/tests/test_addbuildapi.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Build;

--- a/app/cdash/tests/test_aggregatecoverage.php
+++ b/app/cdash/tests/test_aggregatecoverage.php
@@ -18,7 +18,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class AggregateCoverageTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_aggregatecoverage.php
+++ b/app/cdash/tests/test_aggregatecoverage.php
@@ -17,7 +17,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class AggregateCoverageTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_api.php
+++ b/app/cdash/tests/test_api.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class APITestCase extends KWWebTestCase

--- a/app/cdash/tests/test_api.php
+++ b/app/cdash/tests/test_api.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 class APITestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Models\AuthToken;

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use App\Models\AuthToken;
 use App\Services\AuthTokenService;

--- a/app/cdash/tests/test_autoremovebuilds.php
+++ b/app/cdash/tests/test_autoremovebuilds.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class AutoRemoveBuildsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -11,7 +11,7 @@ use CDash\Model\Project;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 
 class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_branchcoverage.php
+++ b/app/cdash/tests/test_branchcoverage.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\PendingSubmissions;

--- a/app/cdash/tests/test_branchcoverage.php
+++ b/app/cdash/tests/test_branchcoverage.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Build;

--- a/app/cdash/tests/test_buildconfigure.php
+++ b/app/cdash/tests/test_buildconfigure.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_buildconfigure.php
+++ b/app/cdash/tests/test_buildconfigure.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class BuildDetailsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class BuildDetailsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_buildfailuredetails.php
+++ b/app/cdash/tests/test_buildfailuredetails.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class BuildFailureDetailsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_buildfailuredetails.php
+++ b/app/cdash/tests/test_buildfailuredetails.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class BuildFailureDetailsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_buildgetdate.php
+++ b/app/cdash/tests/test_buildgetdate.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\Project;

--- a/app/cdash/tests/test_buildgrouprule.php
+++ b/app/cdash/tests/test_buildgrouprule.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_buildgrouprule.php
+++ b/app/cdash/tests/test_buildgrouprule.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\BuildError;

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Build;

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use App\Services\TestCreator;
 

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Services\TestCreator;

--- a/app/cdash/tests/test_buildrelationship.php
+++ b/app/cdash/tests/test_buildrelationship.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_buildrelationship.php
+++ b/app/cdash/tests/test_buildrelationship.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_buildusernote.php
+++ b/app/cdash/tests/test_buildusernote.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\BuildUserNote;

--- a/app/cdash/tests/test_buildusernote.php
+++ b/app/cdash/tests/test_buildusernote.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\BuildUserNote;
 

--- a/app/cdash/tests/test_configurewarnings.php
+++ b/app/cdash/tests/test_configurewarnings.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\BuildConfigure;

--- a/app/cdash/tests/test_configurewarnings.php
+++ b/app/cdash/tests/test_configurewarnings.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_coveragedirectories.php
+++ b/app/cdash/tests/test_coveragedirectories.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_coveragedirectories.php
+++ b/app/cdash/tests/test_coveragedirectories.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_createprojectpermissions.php
+++ b/app/cdash/tests/test_createprojectpermissions.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class CreateProjectPermissionsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_createprojectpermissions.php
+++ b/app/cdash/tests/test_createprojectpermissions.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class CreateProjectPermissionsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_createpublicdashboard.php
+++ b/app/cdash/tests/test_createpublicdashboard.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class CreatePublicDashboardTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_crosssubprojectcoverage.php
+++ b/app/cdash/tests/test_crosssubprojectcoverage.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_csvexport.php
+++ b/app/cdash/tests/test_csvexport.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class ExportToCSVTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_csvexport.php
+++ b/app/cdash/tests/test_csvexport.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class ExportToCSVTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_dailyupdatefile.php
+++ b/app/cdash/tests/test_dailyupdatefile.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\DailyUpdateFile;
 

--- a/app/cdash/tests/test_dailyupdatefile.php
+++ b/app/cdash/tests/test_dailyupdatefile.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\DailyUpdateFile;

--- a/app/cdash/tests/test_deferredsubmissions.php
+++ b/app/cdash/tests/test_deferredsubmissions.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/test_branchcoverage.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Models\AuthToken;

--- a/app/cdash/tests/test_deferredsubmissions.php
+++ b/app/cdash/tests/test_deferredsubmissions.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/test_branchcoverage.php';
 
-require_once 'include/pdo.php';
+
 
 use App\Models\AuthToken;
 use CDash\Model\Project;

--- a/app/cdash/tests/test_disabledtests.php
+++ b/app/cdash/tests/test_disabledtests.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class DisabledTestsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_disabledtests.php
+++ b/app/cdash/tests/test_disabledtests.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class DisabledTestsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/ctestparser.php';
 require_once 'include/pdo.php';
 

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -2,7 +2,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 require_once 'include/ctestparser.php';
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\PendingSubmissions;

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class DynamicAnalysisSummaryTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class DynamicAnalysisSummaryTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -8,7 +8,7 @@ use CDash\Config;
 use Illuminate\Support\Facades\DB;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class EmailTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_expectedandmissing.php
+++ b/app/cdash/tests/test_expectedandmissing.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_expectedandmissing.php
+++ b/app/cdash/tests/test_expectedandmissing.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_expiredbuildrules.php
+++ b/app/cdash/tests/test_expiredbuildrules.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 use CDash\Database;
 use CDash\Model\BuildGroup;
 

--- a/app/cdash/tests/test_externallinksfromtests.php
+++ b/app/cdash/tests/test_externallinksfromtests.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class ExternalLinksFromTestsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_externallinksfromtests.php
+++ b/app/cdash/tests/test_externallinksfromtests.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class ExternalLinksFromTestsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_extracttar.php
+++ b/app/cdash/tests/test_extracttar.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'include/common.php';
+
 
 class ExtractTarTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_filterbuilderrors.php
+++ b/app/cdash/tests/test_filterbuilderrors.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_filterbuilderrors.php
+++ b/app/cdash/tests/test_filterbuilderrors.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_filtertestlabels.php
+++ b/app/cdash/tests/test_filtertestlabels.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class FilterTestLabelsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_filtertestlabels.php
+++ b/app/cdash/tests/test_filtertestlabels.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class FilterTestLabelsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_hidecolumns.php
+++ b/app/cdash/tests/test_hidecolumns.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class HideColumnsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_hidecolumns.php
+++ b/app/cdash/tests/test_hidecolumns.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class HideColumnsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_image.php
+++ b/app/cdash/tests/test_image.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Image;
 

--- a/app/cdash/tests/test_image.php
+++ b/app/cdash/tests/test_image.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Image;

--- a/app/cdash/tests/test_imagecomparison.php
+++ b/app/cdash/tests/test_imagecomparison.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Image;

--- a/app/cdash/tests/test_imagecomparison.php
+++ b/app/cdash/tests/test_imagecomparison.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Image;
 

--- a/app/cdash/tests/test_indexfilters.php
+++ b/app/cdash/tests/test_indexfilters.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class IndexFiltersTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_indexfilters.php
+++ b/app/cdash/tests/test_indexfilters.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class IndexFiltersTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_indexnextprevious.php
+++ b/app/cdash/tests/test_indexnextprevious.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\Project;

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 require_once 'include/repository.php';
 

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'include/pdo.php';
+
 require_once 'include/repository.php';
 
 use App\Models\User;

--- a/app/cdash/tests/test_junithandler.php
+++ b/app/cdash/tests/test_junithandler.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_junithandler.php
+++ b/app/cdash/tests/test_junithandler.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_limitedbuilds.php
+++ b/app/cdash/tests/test_limitedbuilds.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_limitedbuilds.php
+++ b/app/cdash/tests/test_limitedbuilds.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_managemeasurements.php
+++ b/app/cdash/tests/test_managemeasurements.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 

--- a/app/cdash/tests/test_managemeasurements.php
+++ b/app/cdash/tests/test_managemeasurements.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 
 class ManageMeasurementsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_multicoverage.php
+++ b/app/cdash/tests/test_multicoverage.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class MultiCoverageTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_multicoverage.php
+++ b/app/cdash/tests/test_multicoverage.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class MultiCoverageTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class MultipleSubprojectsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class MultipleSubprojectsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_nobackup.php
+++ b/app/cdash/tests/test_nobackup.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class NoBackupTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_nobackup.php
+++ b/app/cdash/tests/test_nobackup.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class NoBackupTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_notesapi.php
+++ b/app/cdash/tests/test_notesapi.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 

--- a/app/cdash/tests/test_notesapi.php
+++ b/app/cdash/tests/test_notesapi.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 
 class NotesAPICase extends KWWebTestCase

--- a/app/cdash/tests/test_opencovercoverage.php
+++ b/app/cdash/tests/test_opencovercoverage.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once(dirname(__FILE__).'/cdash_test_case.php');
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class OpenCoverCoverageTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_opencovercoverage.php
+++ b/app/cdash/tests/test_opencovercoverage.php
@@ -5,7 +5,7 @@
 //
 require_once(dirname(__FILE__).'/cdash_test_case.php');
 
-require_once 'include/pdo.php';
+
 
 class OpenCoverCoverageTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_outputcolor.php
+++ b/app/cdash/tests/test_outputcolor.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;

--- a/app/cdash/tests/test_outputcolor.php
+++ b/app/cdash/tests/test_outputcolor.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_parallelsubmissions.php
+++ b/app/cdash/tests/test_parallelsubmissions.php
@@ -7,7 +7,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/trilinos_submission_test.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_parallelsubmissions.php
+++ b/app/cdash/tests/test_parallelsubmissions.php
@@ -6,7 +6,7 @@
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 require_once 'tests/trilinos_submission_test.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_pdoexecutelogserrors.php
+++ b/app/cdash/tests/test_pdoexecutelogserrors.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class PdoExecuteLogsErrorsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_projectmodel.php
+++ b/app/cdash/tests/test_projectmodel.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use App\Models\User;
 use CDash\Model\Project;

--- a/app/cdash/tests/test_projectmodel.php
+++ b/app/cdash/tests/test_projectmodel.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Models\User;

--- a/app/cdash/tests/test_putdynamicbuilds.php
+++ b/app/cdash/tests/test_putdynamicbuilds.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\BuildGroup;

--- a/app/cdash/tests/test_putdynamicbuilds.php
+++ b/app/cdash/tests/test_putdynamicbuilds.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_recoverpassword.php
+++ b/app/cdash/tests/test_recoverpassword.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 
 use CDash\Model\User;
 

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -51,7 +51,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
 
     public function testBuildRemovalWorksAsExpected()
     {
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
 

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -52,7 +52,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
     public function testBuildRemovalWorksAsExpected()
     {
 
-        require_once 'include/pdo.php';
+
 
 
         $time = gmdate(FMT_DATETIME);

--- a/app/cdash/tests/test_replacebuild.php
+++ b/app/cdash/tests/test_replacebuild.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class ReplaceBuildTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_replacebuild.php
+++ b/app/cdash/tests/test_replacebuild.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class ReplaceBuildTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_seconds_from_interval.php
+++ b/app/cdash/tests/test_seconds_from_interval.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 
 class SecondsFromIntervalTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class SequenceIndependenceTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_setup_repositories.php
+++ b/app/cdash/tests/test_setup_repositories.php
@@ -4,7 +4,7 @@
 // are relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_submission_assign_buildid.php
+++ b/app/cdash/tests/test_submission_assign_buildid.php
@@ -1,6 +1,6 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 
 use CDash\Model\Build;
 use CDash\Model\BuildInformation;

--- a/app/cdash/tests/test_subprojectemail.php
+++ b/app/cdash/tests/test_subprojectemail.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Models\User;

--- a/app/cdash/tests/test_subprojectemail.php
+++ b/app/cdash/tests/test_subprojectemail.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use App\Models\User;
 use CDash\Model\Label;

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class SubProjectNextPreviousTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class SubProjectNextPreviousTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_subscribeprojectshowlabels.php
+++ b/app/cdash/tests/test_subscribeprojectshowlabels.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_subscribeprojectshowlabels.php
+++ b/app/cdash/tests/test_subscribeprojectshowlabels.php
@@ -2,7 +2,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Label;

--- a/app/cdash/tests/test_summaryemail.php
+++ b/app/cdash/tests/test_summaryemail.php
@@ -5,7 +5,7 @@ use CDash\Model\Project;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class SummaryEmailTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_summaryemail.php
+++ b/app/cdash/tests/test_summaryemail.php
@@ -4,7 +4,7 @@ use CDash\Model\BuildGroup;
 use CDash\Model\Project;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class SummaryEmailTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_testgraphpermissions.php
+++ b/app/cdash/tests/test_testgraphpermissions.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class TestGraphPermissionsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_testgraphpermissions.php
+++ b/app/cdash/tests/test_testgraphpermissions.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class TestGraphPermissionsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_testhistory.php
+++ b/app/cdash/tests/test_testhistory.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_testhistory.php
+++ b/app/cdash/tests/test_testhistory.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_testoverview.php
+++ b/app/cdash/tests/test_testoverview.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/pdo.php';
+
 
 class TestOverviewTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_timeline.php
+++ b/app/cdash/tests/test_timeline.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_timeline.php
+++ b/app/cdash/tests/test_timeline.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_timeoutsandmissingtests.php
+++ b/app/cdash/tests/test_timeoutsandmissingtests.php
@@ -2,7 +2,7 @@
 use CDash\Config;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class TimeoutsAndMissingTestsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_timeoutsandmissingtests.php
+++ b/app/cdash/tests/test_timeoutsandmissingtests.php
@@ -3,7 +3,7 @@ use CDash\Config;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class TimeoutsAndMissingTestsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_timestatus.php
+++ b/app/cdash/tests/test_timestatus.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Database;

--- a/app/cdash/tests/test_timestatus.php
+++ b/app/cdash/tests/test_timestatus.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Database;
 use CDash\Test\UseCase\TestUseCase;

--- a/app/cdash/tests/test_truncateoutput.php
+++ b/app/cdash/tests/test_truncateoutput.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__).'/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class TruncateOutputTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_truncateoutput.php
+++ b/app/cdash/tests/test_truncateoutput.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__).'/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class TruncateOutputTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_uniquediffs.php
+++ b/app/cdash/tests/test_uniquediffs.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class UniqueDiffsTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_uniquediffs.php
+++ b/app/cdash/tests/test_uniquediffs.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class UniqueDiffsTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_updateappend.php
+++ b/app/cdash/tests/test_updateappend.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 class UppdateAppendTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_updateappend.php
+++ b/app/cdash/tests/test_updateappend.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class UppdateAppendTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use App\Models\User;
 use CDash\Model\UserProject;

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use App\Models\User;

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -108,7 +108,7 @@ class UpgradeTestCase extends KWWebTestCase
 
     public function testGetVendorVersion()
     {
-        require_once 'include/pdo.php';
+
 
         $version = pdo_get_vendor_version();
         list($major, $minor, ) = $version? explode(".", $version) : array(null,null,null);
@@ -142,7 +142,7 @@ class UpgradeTestCase extends KWWebTestCase
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-        require_once 'include/pdo.php';
+
 
         $retval = 0;
         $old_table = 'testbuildfailure';
@@ -283,7 +283,7 @@ class UpgradeTestCase extends KWWebTestCase
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-        require_once 'include/pdo.php';
+
 
         $retval = 0;
 
@@ -363,7 +363,7 @@ class UpgradeTestCase extends KWWebTestCase
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-        require_once 'include/pdo.php';
+
 
         $retval = 0;
         $table_name = 'testsite';
@@ -590,7 +590,7 @@ class UpgradeTestCase extends KWWebTestCase
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-        require_once 'include/pdo.php';
+
 
         $retval = 0;
         $configure_table_name = 'testconfigure';
@@ -754,7 +754,7 @@ class UpgradeTestCase extends KWWebTestCase
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-        require_once 'include/pdo.php';
+
 
         $config = Config::getInstance();
         $pdo = Database::getInstance()->getPdo();

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -141,7 +141,7 @@ class UpgradeTestCase extends KWWebTestCase
     public function testBuildFailureDetailsUpgrade()
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
         $retval = 0;
@@ -282,7 +282,7 @@ class UpgradeTestCase extends KWWebTestCase
     public function testUpgradeDurations()
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
         $retval = 0;
@@ -362,7 +362,7 @@ class UpgradeTestCase extends KWWebTestCase
     public function testSiteConstraintUpgrade()
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
         $retval = 0;
@@ -589,7 +589,7 @@ class UpgradeTestCase extends KWWebTestCase
     public function testBuild2ConfigureUpgrade()
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
         $retval = 0;
@@ -753,7 +753,7 @@ class UpgradeTestCase extends KWWebTestCase
     public function testPopulateTestDuration()
     {
         require_once dirname(__FILE__) . '/cdash_test_case.php';
-        require_once 'include/common.php';
+
         require_once 'include/pdo.php';
 
         $config = Config::getInstance();

--- a/app/cdash/tests/test_uploadfile.php
+++ b/app/cdash/tests/test_uploadfile.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 class UploadFileTestCase extends KWWebTestCase
 {

--- a/app/cdash/tests/test_uploadfile.php
+++ b/app/cdash/tests/test_uploadfile.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 class UploadFileTestCase extends KWWebTestCase

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\User;

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -6,7 +6,7 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\User;
 

--- a/app/cdash/tests/test_usernotes.php
+++ b/app/cdash/tests/test_usernotes.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-require_once 'include/pdo.php';
+
 
 use CDash\Model\Project;
 

--- a/app/cdash/tests/test_usernotes.php
+++ b/app/cdash/tests/test_usernotes.php
@@ -4,7 +4,7 @@
 // relative to the top of the CDash source tree
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
-require_once 'include/common.php';
+
 require_once 'include/pdo.php';
 
 use CDash\Model\Project;

--- a/app/cdash/tests/test_viewdynamicanalysisfile.php
+++ b/app/cdash/tests/test_viewdynamicanalysisfile.php
@@ -24,8 +24,6 @@ class ViewDynamicAnalysisFileTestCase extends KWWebTestCase
 
     public function testNextPrevious()
     {
-        require_once('include/pdo.php');
-
         // Get id of existing build.
         $pdo = get_link_identifier()->getPdo();
         $stmt = $pdo->query(

--- a/app/cdash/tests/test_viewdynamicanalysisfile.php
+++ b/app/cdash/tests/test_viewdynamicanalysisfile.php
@@ -24,7 +24,6 @@ class ViewDynamicAnalysisFileTestCase extends KWWebTestCase
 
     public function testNextPrevious()
     {
-        require_once('include/common.php');
         require_once('include/pdo.php');
 
         // Get id of existing build.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20602,22 +20602,22 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:getSent\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:getSent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:isError\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:isError\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:read\\(\\) has no return type specified\\.$#"
+			message: "#^Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:read\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -20717,12 +20717,12 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:\\$read has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:\\$read has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:874\\:\\:\\$response has no type specified\\.$#"
+			message: "#^Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester\\.php\\:872\\:\\:\\$response has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -18,6 +18,7 @@ trait CreatesApplication
         $app->make(Kernel::class)->bootstrap();
 
         require_once 'include/common.php';
+        require_once 'include/pdo.php';
 
         return $app;
     }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,6 +17,8 @@ trait CreatesApplication
 
         $app->make(Kernel::class)->bootstrap();
 
+        require_once 'include/common.php';
+
         return $app;
     }
 }


### PR DESCRIPTION
A small handful of common files are included in many places where the include statement is not necessary.  By moving the includes to core code paths, we can remove all of the repetitive includes.