### PR TITLE
Truncate test names to 255 characters

### DIFF
--- a/app/Services/TestCreator.php
+++ b/app/Services/TestCreator.php
@@ -41,7 +41,7 @@ class TestCreator
     public $testCommand;
     public $testDetails;
     public $testOutput;
-    public $testName;
+    private $testName;
     public $testPath;
     public $testStatus;
 
@@ -153,6 +153,14 @@ class TestCreator
             $compressed_output = $this->testOutput;
         }
         $this->testOutput = $compressed_output;
+    }
+
+    /**
+     * Set test name, truncated to 255 characters.
+     */
+    public function setTestName(string $testName): void
+    {
+        $this->testName = substr($testName, 0, 255);
     }
 
     /**

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -63,7 +63,7 @@ class BuildPropertiesTestCase extends KWWebTestCase
         $testcreator = new TestCreator;
         $testcreator->projectid = $this->Project->Id;
         $testcreator->testDetails = '';
-        $testcreator->testName = 'BuildPropUnitTest';
+        $testcreator->setTestName('BuildPropUnitTest');
         $testcreator->testPath = '/tmp';
         $testcreator->testCommand = 'echo foo';
         $testcreator->testOutput = 'foo';

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -270,7 +270,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $test_creator->projectid = 1;
         $test_creator->alreadyCompressed = false;
         $test_creator->testDetails = 'Completed';
-        $test_creator->testName = 'removal test';
+        $test_creator->setTestName('removal test');
         $test_creator->testPath = '/path/to/removal/test';
         $test_creator->testCommand = 'php test_removebuilds.php';
         $test_creator->testOutput = 'build removed successfully';
@@ -299,7 +299,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $test_creator2->projectid = 1;
         $test_creator2->alreadyCompressed = false;
         $test_creator2->testDetails = 'Completed';
-        $test_creator2->testName = 'shared test';
+        $test_creator2->setTestName('shared test');
         $test_creator2->testPath = '/path/to/shared/test';
         $test_creator2->testCommand = 'php test_sharedbuilds.php';
         $test_creator2->testOutput = 'build shared successfully';

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -174,7 +174,7 @@ class BazelJSONHandler extends NonSaxHandler
             $testCreator->projectid = $this->Project->Id;
             $testCreator->testCommand = $this->CommandLine;
             $testCreator->testDetails = $testdata->details;
-            $testCreator->testName = $testdata->name;
+            $testCreator->setTestName($testdata->name);
             $testCreator->testStatus = $testdata->status;
 
             if (array_key_exists($testdata->name, $this->TestsOutput)) {

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -266,7 +266,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
         } elseif ($parent == 'TEST') {
             switch ($element) {
                 case 'NAME':
-                    $this->TestCreator->testName = $data;
+                    $this->TestCreator->setTestName($data);
                     break;
                 case 'PATH':
                     $this->TestCreator->testPath = $data;

--- a/app/cdash/xml_handlers/testing_junit_handler.php
+++ b/app/cdash/xml_handlers/testing_junit_handler.php
@@ -146,7 +146,7 @@ class TestingJUnitHandler extends AbstractHandler
                 }
             }
 
-            $this->TestCreator->testName = $attributes['NAME'];
+            $this->TestCreator->setTestName($attributes['NAME']);
             $this->TestCreator->testPath = $attributes['CLASSNAME'];
         } elseif ($name == 'TESTSUITE') {
             // If the XML file doesn't have a <Site> tag then we use the information


### PR DESCRIPTION
This fixes unique key constraint violations we were noticing on open.cdash.org for tests whose names are longer than this limit.