### PR TITLE
Apply all "safe" PHP migration style rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,6 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
+        '@PHP54Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP74Migration' => true,
+        '@PHP80Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP80Migration' => true,
+        '@PHP81Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP54Migration' => true,
+        '@PHP70Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP71Migration' => true,
+        '@PHP73Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP73Migration' => true,
+        '@PHP74Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP70Migration' => true,
+        '@PHP71Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/app/Console/Commands/MigrateConfig.php
+++ b/app/Console/Commands/MigrateConfig.php
@@ -67,7 +67,7 @@ class MigrateConfig extends Command
             if (strpos($line, '=') === false) {
                 continue;
             }
-            list($key, $value) = explode('=', $line);
+            [$key, $value] = explode('=', $line);
             $config[$key] = $value;
         }
         fclose($handle);

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -99,7 +99,7 @@ final class AdminController extends AbstractController
                 $dayTo,
                 $yearFrom,
                 $monthFrom,
-                $dayFrom
+                $dayFrom,
             ]);
 
             $builds = [];

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -102,7 +102,7 @@ final class AdminController extends AbstractController
                 $dayFrom
             ]);
 
-            $builds = array();
+            $builds = [];
             foreach ($build as $build_array) {
                 $builds[] = (int) $build_array->id;
             }
@@ -238,7 +238,7 @@ final class AdminController extends AbstractController
 
             // Add new multi-column index to build table.
             // This improves the rendering speed of overview.php.
-            $multi_index = array('projectid', 'parentid', 'starttime');
+            $multi_index = ['projectid', 'parentid', 'starttime'];
             AddTableIndex('build', $multi_index);
 
             // Support for dynamic BuildGroups.

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -79,7 +79,7 @@ class LoginController extends AbstractController
             ->response = response()
                 ->view('auth.login', [
                         'errors' => $e->validator->getMessageBag(),
-                        'title' => 'Login'
+                        'title' => 'Login',
                     ],
                     401
                 );

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -99,7 +99,7 @@ class RegisterController extends AbstractController
             'lastname' => $data['lname'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
-            'institution' => $data['institution']
+            'institution' => $data['institution'],
         ]);
     }
 

--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -32,7 +32,7 @@ final class AuthTokenController extends AbstractController
         }
 
         return response()->json([
-            'tokens' => $token_map
+            'tokens' => $token_map,
         ]);
     }
 

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -687,16 +687,16 @@ final class BuildController extends AbstractBuildController
         $update_groups = [
             [
                 'description' => "{$this->project->Name} Updated Files ($num_updated_files)",
-                'directories' => $updated_files
+                'directories' => $updated_files,
             ],
             [
                 'description' => "Modified Files ($num_modified_files)",
-                'directories' => $modified_files
+                'directories' => $modified_files,
             ],
             [
                 'description' => "Conflicting Files ($num_conflicting_files)",
-                'directories' => $conflicting_files
-            ]
+                'directories' => $conflicting_files,
+            ],
         ];
         $response['updategroups'] = $update_groups;
 
@@ -850,7 +850,7 @@ final class BuildController extends AbstractBuildController
 
         // Site
         $extra_build_fields = [
-            'site' => $this->build->GetSite()->name
+            'site' => $this->build->GetSite()->name,
         ];
 
         // Update
@@ -1177,7 +1177,7 @@ final class BuildController extends AbstractBuildController
         $this->setBuildById(intval($_GET['buildid'] ?? -1));
         $rule = new BuildGroupRule($this->build);
         return response()->json([
-            'expected' => $rule->GetExpected()
+            'expected' => $rule->GetExpected(),
         ]);
     }
 }

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -910,12 +910,12 @@ final class BuildController extends AbstractBuildController
                     ', [intval($resolvedBuildFailure['id'])], $marshaledResolvedBuildFailure);
                 }
 
-                $marshaledResolvedBuildFailure = array_merge($marshaledResolvedBuildFailure, array(
+                $marshaledResolvedBuildFailure = array_merge($marshaledResolvedBuildFailure, [
                     'stderr' => $resolvedBuildFailure['stderror'],
                     'stderrorrows' => min(10, substr_count($resolvedBuildFailure['stderror'], "\n") + 1),
                     'stdoutput' => $resolvedBuildFailure['stdoutput'],
                     'stdoutputrows' => min(10, substr_count($resolvedBuildFailure['stdoutput'], "\n") + 1),
-                ));
+                ]);
 
                 $this->addErrorResponse($marshaledResolvedBuildFailure, $response);
             }

--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -46,8 +46,8 @@ final class BuildPropertiesController extends AbstractBuildController
         if (isset($_GET['begin']) && isset($_GET['end'])) {
             $beginning_date = $_GET['begin'];
             $end_date = $_GET['end'];
-            list($unused, $beginning_timestamp) = get_dates($beginning_date, $this->project->NightlyTime);
-            list($unused, $end_timestamp) = get_dates($end_date, $this->project->NightlyTime);
+            [$unused, $beginning_timestamp] = get_dates($beginning_date, $this->project->NightlyTime);
+            [$unused, $end_timestamp] = get_dates($end_date, $this->project->NightlyTime);
             $datetime = new DateTime();
             $datetime->setTimestamp($end_timestamp);
             $datetime->add(new DateInterval('P1D'));
@@ -62,7 +62,7 @@ final class BuildPropertiesController extends AbstractBuildController
             $date = date(FMT_DATE);
         }
         if (is_null($beginning_timestamp)) {
-            list($unused, $beginning_timestamp) = get_dates($date, $this->project->NightlyTime);
+            [$unused, $beginning_timestamp] = get_dates($date, $this->project->NightlyTime);
             $datetime = new DateTime();
             $datetime->setTimestamp($beginning_timestamp);
             $datetime->add(new DateInterval('P1D'));

--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -81,18 +81,18 @@ final class BuildPropertiesController extends AbstractBuildController
             [
                 'name' => 'builderrors',
                 'prettyname' => 'Errors',
-                'selected' => false
+                'selected' => false,
             ],
             [
                 'name' => 'buildwarnings',
                 'prettyname' => 'Warnings',
-                'selected' => false
+                'selected' => false,
             ],
             [
                 'name' => 'testfailed',
                 'prettyname' => 'Test Failures',
-                'selected' => false
-            ]
+                'selected' => false,
+            ],
         ];
 
         // Mark specified types of defects as selected.
@@ -289,7 +289,7 @@ final class BuildPropertiesController extends AbstractBuildController
                 $defects_response[] = [
                     'descr' => $descr,
                     'type' => $prettyname,
-                    'builds' => []
+                    'builds' => [],
                 ];
                 $idx = count($defects_response) - 1;
             }

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -178,7 +178,7 @@ final class CoverageController extends AbstractBuildController
                     $line = substr($contents, $pos, $pos2 - $pos);
 
                     $file = '';
-                    $authors = array();
+                    $authors = [];
 
                     // first is the svnuser
                     $posfile = strpos($line, ':');
@@ -506,7 +506,7 @@ final class CoverageController extends AbstractBuildController
         if ($this->project->DisplayLabels) {
             // Get the set of labels involved:
             //
-            $labels = array();
+            $labels = [];
 
             $covlabels = $db->executePrepared('
                              SELECT DISTINCT id, text
@@ -596,8 +596,8 @@ final class CoverageController extends AbstractBuildController
                                 AND c.fileid=cf.id
                         ', [intval($this->build->Id)]);
 
-        $directories = array();
-        $covfile_array = array();
+        $directories = [];
+        $covfile_array = [];
         foreach ($coveragefile as $coveragefile_array) {
             $covfile['covered'] = 1;
 
@@ -675,7 +675,7 @@ final class CoverageController extends AbstractBuildController
             $covfile_array[] = $covfile;
         }
 
-        $ncoveragefiles = array();
+        $ncoveragefiles = [];
         $ncoveragefiles[0] = count($directories);
         $ncoveragefiles[1] = 0;
         $ncoveragefiles[2] = 0;
@@ -1080,12 +1080,12 @@ final class CoverageController extends AbstractBuildController
 
         // Contruct the directory view
         if ($status === -1) {
-            $directory_array = array();
+            $directory_array = [];
             foreach ($covfile_array as $covfile) {
                 $fullpath = $covfile['fullpath'];
                 $fullpath = dirname($fullpath);
                 if (!isset($directory_array[$fullpath])) {
-                    $directory_array[$fullpath] = array();
+                    $directory_array[$fullpath] = [];
                     $directory_array[$fullpath]['priority'] = 0;
                     $directory_array[$fullpath]['directory'] = 1;
                     $directory_array[$fullpath]['covered'] = 1;

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -1756,7 +1756,7 @@ final class CoverageController extends AbstractBuildController
 
         $date = isset($_GET['date']) ? htmlspecialchars($_GET['date']) : null;
 
-        list($previousdate, $currentstarttime, $nextdate) = get_dates($date, $this->project->NightlyTime);
+        [$previousdate, $currentstarttime, $nextdate] = get_dates($date, $this->project->NightlyTime);
 
         $response = begin_JSON_response();
         $response['title'] = $this->project->Name . ' - Compare Coverage';

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -50,7 +50,7 @@ final class CoverageController extends AbstractBuildController
         if (!isset($userid) || !is_numeric($userid)) {
             return view('cdash', [
                 'xsl' => true,
-                'xsl_content' => 'Not a valid userid!'
+                'xsl_content' => 'Not a valid userid!',
             ]);
         }
 
@@ -84,7 +84,7 @@ final class CoverageController extends AbstractBuildController
         if (!Gate::allows('edit-project', $Project)) {
             return view('cdash', [
                 'xsl' => true,
-                'xsl_content' => "You don't have the permissions to access this page"
+                'xsl_content' => "You don't have the permissions to access this page",
             ]);
         }
 
@@ -374,7 +374,7 @@ final class CoverageController extends AbstractBuildController
             'xsl' => true,
             'xsl_content' => generate_XSLT($xml, base_path() . '/app/cdash/public/manageCoverage', true),
             'project' => $Project,
-            'title' => 'Manage Coverage'
+            'title' => 'Manage Coverage',
         ]);
     }
 
@@ -730,7 +730,7 @@ final class CoverageController extends AbstractBuildController
             'xsl' => true,
             'xsl_content' => generate_XSLT($xml, 'viewCoverage', true),
             'project' => $this->project,
-            'title' => 'Coverage'
+            'title' => 'Coverage',
         ]);
     }
 

--- a/app/Http/Controllers/FilterController.php
+++ b/app/Http/Controllers/FilterController.php
@@ -17,7 +17,7 @@ final class FilterController extends AbstractController
             'limit',
             'othercombine',
             'showfilters',
-            'showlimit'
+            'showlimit',
         ];
         foreach ($filterdata as $key => $value) {
             if (!in_array($key, $fields_to_preserve)) {

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -49,7 +49,7 @@ final class ManageProjectRolesController extends AbstractProjectController
         if (!$current_user->IsAdmin() && $role <= 1) {
             return view('cdash', [
                 'xsl' => true,
-                'xsl_content' => "You don't have the permissions to access this page!"
+                'xsl_content' => "You don't have the permissions to access this page!",
             ]);
         }
 
@@ -385,7 +385,7 @@ final class ManageProjectRolesController extends AbstractProjectController
                              intval($project_array['id']),
                              intval($project_array['id']),
                              intval($project_array['id']),
-                             $date
+                             $date,
                          ]);
 
                 add_last_sql_error('ManageProjectRole');
@@ -409,7 +409,7 @@ final class ManageProjectRolesController extends AbstractProjectController
             'xsl' => true,
             'xsl_content' => generate_XSLT($xml, base_path() . '/app/cdash/public/manageProjectRoles', true),
             'project' => $project,
-            'title' => 'Project Roles'
+            'title' => 'Project Roles',
         ]);
     }
 

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -35,7 +35,7 @@ final class MapController extends AbstractProjectController
 
         $db = Database::getInstance();
 
-        list($previousdate, $currenttime, $nextdate) = get_dates($date, $this->project->NightlyTime);
+        [$previousdate, $currenttime, $nextdate] = get_dates($date, $this->project->NightlyTime);
 
         $nightlytime = strtotime($this->project->NightlyTime);
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -85,7 +85,7 @@ final class ProjectController extends AbstractProjectController
 
             $repositories = $this->project->GetRepositories();
             foreach ($repositories as $repository) {
-                $repository_response = array();
+                $repository_response = [];
                 $repository_response['url'] = $repository['url'];
                 $repository_response['username'] = $repository['username'];
                 $repository_response['password'] = $repository['password'];

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -55,23 +55,23 @@ final class ProjectOverviewController extends AbstractProjectController
         ];
 
         // sanitized versions of these measurements.
-        $clean_measurements = array(
+        $clean_measurements = [
             'configure warnings' => 'configure_warnings',
             'configure errors'   => 'configure_errors',
             'build warnings'     => 'build_warnings',
             'build errors'       => 'build_errors',
-            'failing tests'      => 'failing_tests');
+            'failing tests'      => 'failing_tests'];
 
         // for static analysis, we only care about errors & warnings.
-        $static_measurements = array('errors', 'warnings');
+        $static_measurements = ['errors', 'warnings'];
 
         // information on how to sort by the various build measurements
-        $sort = array(
+        $sort = [
             'configure warnings' => '-configure.warning',
             'configure errors'   => '-configure.error',
             'build warnings'     => '-compilation.warning',
             'build errors'       => '-compilation.error',
-            'failing tests'      => '-test.fail');
+            'failing tests'      => '-test.fail'];
 
         // get the build groups that are included in this project's overview,
         // split up by type (currently only static analysis and general builds).
@@ -83,8 +83,8 @@ final class ProjectOverviewController extends AbstractProjectController
                      ORDER BY obg.position
                  ', [$this->project->Id]);
 
-        $build_groups = array();
-        $static_groups = array();
+        $build_groups = [];
+        $static_groups = [];
 
         foreach ($query as $group_row) {
             if ($group_row->type === 'build') {
@@ -101,9 +101,9 @@ final class ProjectOverviewController extends AbstractProjectController
         }
 
         $has_subproject_groups = false;
-        $subproject_groups = array();
-        $coverage_categories = array();
-        $coverage_build_group_names = array();
+        $subproject_groups = [];
+        $coverage_categories = [];
+        $coverage_build_group_names = [];
         if ($has_subprojects) {
             // Detect if the subprojects are split up into groups.
             $groups = $this->project->GetSubProjectGroups();
@@ -117,7 +117,7 @@ final class ProjectOverviewController extends AbstractProjectController
                     // for this group.
                     $group_name = $group->GetName();
                     $threshold = $group->GetCoverageThreshold();
-                    $coverage_category = array();
+                    $coverage_category = [];
                     $coverage_category['name'] = $group_name;
                     $coverage_category['position'] = $group->GetPosition();
                     $coverage_category['low'] = 0.7 * $threshold;
@@ -126,7 +126,7 @@ final class ProjectOverviewController extends AbstractProjectController
                     $coverage_categories[] = $coverage_category;
                 }
                 // Also save a 'Total' category to summarize across groups.
-                $coverage_category = array();
+                $coverage_category = [];
                 $coverage_category['name'] = 'Total';
                 $coverage_category['position'] = 0;
                 $threshold = intval($this->project->CoverageThreshold);
@@ -139,7 +139,7 @@ final class ProjectOverviewController extends AbstractProjectController
 
         $threshold = $this->project->CoverageThreshold;
         if (!$has_subproject_groups) {
-            $coverage_category = array();
+            $coverage_category = [];
             $coverage_category['name']  = 'coverage';
             $coverage_category['position']  = 1;
             $coverage_category['low'] = 0.7 * $threshold;
@@ -165,27 +165,27 @@ final class ProjectOverviewController extends AbstractProjectController
         // are defined:
         //   coverage_data[day][build group][coverage group] = percent_coverage
         //   dynamic_analysis_data[day][group][checker] = num_defects
-        $overview_data = array();
-        $coverage_data = array();
-        $dynamic_analysis_data = array();
+        $overview_data = [];
+        $coverage_data = [];
+        $dynamic_analysis_data = [];
 
         for ($i = 0; $i < $date_range; $i++) {
-            $overview_data[$i] = array();
+            $overview_data[$i] = [];
             foreach ($build_groups as $build_group) {
                 $build_group_name = $build_group['name'];
 
                 // overview
-                $overview_data[$i][$build_group_name] = array();
+                $overview_data[$i][$build_group_name] = [];
 
                 // dynamic analysis
-                $dynamic_analysis_data[$i][$build_group_name] = array();
+                $dynamic_analysis_data[$i][$build_group_name] = [];
             }
 
             // coverage
             foreach ($coverage_build_group_names as $build_group_name) {
                 foreach ($coverage_categories as $coverage_category) {
                     $category_name = $coverage_category['name'];
-                    $coverage_data[$i][$build_group_name][$category_name] = array();
+                    $coverage_data[$i][$build_group_name][$category_name] = [];
                     $coverage_array =
                 &$coverage_data[$i][$build_group_name][$category_name];
                     $coverage_array['loctested'] = 0;
@@ -197,7 +197,7 @@ final class ProjectOverviewController extends AbstractProjectController
             // static analysis
             foreach ($static_groups as $static_group) {
                 $static_group_name = $static_group['name'];
-                $overview_data[$i][$static_group_name] = array();
+                $overview_data[$i][$static_group_name] = [];
             }
         }
 
@@ -237,12 +237,12 @@ final class ProjectOverviewController extends AbstractProjectController
 
         // If we have multiple coverage builds in a single day we will also
         // show the aggregate.
-        $aggregate_tracker = array();
+        $aggregate_tracker = [];
         $show_aggregate = false;
 
         // Keep track of the different types of dynamic analysis that are being
         // performed on our build groups of interest.
-        $dynamic_analysis_types = array();
+        $dynamic_analysis_types = [];
 
         // TODO: (williamjallen) Much of this can be done in SQL for efficiency and better readability
         foreach ($builds_array as $build_row) {
@@ -394,23 +394,23 @@ final class ProjectOverviewController extends AbstractProjectController
 
         // Now that the data has been collected we can generate the XML.
         // Start with the general build groups.
-        $groups = array();
+        $groups = [];
         foreach ($build_groups as $build_group) {
-            $groups[] = array('name' => $build_group['name']);
+            $groups[] = ['name' => $build_group['name']];
         }
         $response['groups'] = $groups;
 
-        $measurements_response = array();
+        $measurements_response = [];
         foreach ($build_measurements as $measurement) {
             $clean_measurement = $clean_measurements[$measurement];
-            $measurement_response = array();
+            $measurement_response = [];
             $measurement_response['name'] = $measurement;
             $measurement_response['name_clean'] = $clean_measurement;
             $measurement_response['sort'] = $sort[$measurement];
 
-            $groups_response = array();
+            $groups_response = [];
             foreach ($build_groups as $build_group) {
-                $group_response = array();
+                $group_response = [];
                 $group_response['name'] = $build_group['name'];
                 $group_response['name_clean'] = self::sanitize_string($build_group['name']);
                 $value = self::get_current_value($build_group['name'], $measurement, $date_range, $overview_data);
@@ -426,16 +426,16 @@ final class ProjectOverviewController extends AbstractProjectController
         $response['measurements'] = $measurements_response;
 
         // coverage
-        $coverages_response = array();
-        $coverage_buildgroups = array();
+        $coverages_response = [];
+        $coverage_buildgroups = [];
 
         foreach ($coverage_categories as $coverage_category) {
             $category_name = $coverage_category['name'];
-            $coverage_category_response = array();
+            $coverage_category_response = [];
             $coverage_category_response['name_clean'] = self::sanitize_string($category_name);
             $coverage_category_response['name'] = $category_name;
             $coverage_category_response['position'] = $coverage_category['position'];
-            $coverage_category_response['groups'] = array();
+            $coverage_category_response['groups'] = [];
 
             foreach ($coverage_build_group_names as $build_group_name) {
                 // Skip groups that don't have any coverage.
@@ -452,7 +452,7 @@ final class ProjectOverviewController extends AbstractProjectController
                     continue;
                 }
 
-                $coverage_response = array();
+                $coverage_response = [];
 
                 $coverage_response['name'] = $build_group_name;
                 if (!in_array($build_group_name, $coverage_buildgroups)) {
@@ -482,13 +482,13 @@ final class ProjectOverviewController extends AbstractProjectController
         $response['coverage_buildgroups'] = $coverage_buildgroups;
 
         // dynamic analysis
-        $dynamic_analyses_response = array();
+        $dynamic_analyses_response = [];
         foreach ($dynamic_analysis_types as $checker) {
-            $DA_response = array();
+            $DA_response = [];
             $DA_response['name_clean'] = self::sanitize_string($checker);
             $DA_response['name'] = $checker;
 
-            $groups_response = array();
+            $groups_response = [];
             foreach ($build_groups as $build_group) {
                 // Skip groups that don't have any data for this tool.
                 $found = false;
@@ -503,7 +503,7 @@ final class ProjectOverviewController extends AbstractProjectController
                     continue;
                 }
 
-                $group_response = array();
+                $group_response = [];
                 $group_response['name'] = $build_group['name'];
                 $group_response['name_clean'] = self::sanitize_string($build_group['name']);
 
@@ -520,7 +520,7 @@ final class ProjectOverviewController extends AbstractProjectController
         $response['dynamicanalyses'] = $dynamic_analyses_response;
 
         // static analysis
-        $static_analyses_response = array();
+        $static_analyses_response = [];
         foreach ($static_groups as $static_group) {
             // Skip this group if no data was found for it.
             $found = false;
@@ -540,12 +540,12 @@ final class ProjectOverviewController extends AbstractProjectController
                 continue;
             }
 
-            $SA_response = array();
+            $SA_response = [];
             $SA_response['group_name'] = $static_group['name'];
             $SA_response['group_name_clean'] = self::sanitize_string($static_group['name']);
-            $measurements_response = array();
+            $measurements_response = [];
             foreach ($static_measurements as $measurement) {
-                $measurement_response = array();
+                $measurement_response = [];
                 $measurement_response['name'] = $measurement;
                 $measurement_response['name_clean'] = self::sanitize_string($measurement);
                 $measurement_response['sort'] = $sort["build $measurement"];
@@ -661,14 +661,14 @@ final class ProjectOverviewController extends AbstractProjectController
      */
     private static function get_chart_data($group_name, $measurement, $date_range, $overview_data, $beginning_timestamp): string
     {
-        $chart_data = array();
+        $chart_data = [];
 
         for ($i = 0; $i < $date_range; $i++) {
             if (!array_key_exists($measurement, $overview_data[$i][$group_name])) {
                 continue;
             }
             $chart_date = self::get_date_from_index($i, $beginning_timestamp);
-            $chart_data[] = array($chart_date, $overview_data[$i][$group_name][$measurement]);
+            $chart_data[] = [$chart_date, $overview_data[$i][$group_name][$measurement]];
         }
 
         // JSON encode the chart data to make it easier to use on the client side.
@@ -680,7 +680,7 @@ final class ProjectOverviewController extends AbstractProjectController
      */
     private static function get_coverage_chart_data($build_group_name, $coverage_category, $date_range, $coverage_data, $beginning_timestamp): string
     {
-        $chart_data = array();
+        $chart_data = [];
 
         for ($i = 0; $i < $date_range; $i++) {
             $coverage_array =
@@ -691,7 +691,7 @@ final class ProjectOverviewController extends AbstractProjectController
             }
 
             $chart_date = self::get_date_from_index($i, $beginning_timestamp);
-            $chart_data[] = array($chart_date, $coverage_array['percent']);
+            $chart_data[] = [$chart_date, $coverage_array['percent']];
         }
         return json_encode($chart_data);
     }
@@ -717,7 +717,7 @@ final class ProjectOverviewController extends AbstractProjectController
                 $current_value_found = true;
             } else {
                 $previous_value = $coverage_array['percent'];
-                return array($current_value, $previous_value);
+                return [$current_value, $previous_value];
             }
         }
 
@@ -725,7 +725,7 @@ final class ProjectOverviewController extends AbstractProjectController
         // of coverage for these groups.  In this case, we make previous & current
         // hold the same value.  We do this because nvd3's bullet chart implementation
         // does not support leaving the "marker" off of the chart.
-        return array($current_value, $current_value);
+        return [$current_value, $current_value];
     }
 
     /**
@@ -733,7 +733,7 @@ final class ProjectOverviewController extends AbstractProjectController
      */
     private static function get_DA_chart_data($group_name, $checker, $date_range, $dynamic_analysis_data, $beginning_timestamp): string
     {
-        $chart_data = array();
+        $chart_data = [];
 
         for ($i = 0; $i < $date_range; $i++) {
             $dynamic_analysis_array = &$dynamic_analysis_data[$i][$group_name];
@@ -742,7 +742,7 @@ final class ProjectOverviewController extends AbstractProjectController
             }
 
             $chart_date = self::get_date_from_index($i, $beginning_timestamp);
-            $chart_data[] = array($chart_date, $dynamic_analysis_data[$i][$group_name][$checker]);
+            $chart_data[] = [$chart_date, $dynamic_analysis_data[$i][$group_name][$checker]];
         }
         return json_encode($chart_data);
     }

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -27,7 +27,7 @@ final class ProjectOverviewController extends AbstractProjectController
 
         // Handle optional date argument.
         $date = htmlspecialchars($_GET['date'] ?? date(FMT_DATE));
-        list($previousdate, $currentstarttime, $nextdate) = get_dates($date, $this->project->NightlyTime);
+        [$previousdate, $currentstarttime, $nextdate] = get_dates($date, $this->project->NightlyTime);
 
         // Date range is currently hardcoded to two weeks in the past.
         // This could become a configurable value instead.
@@ -463,7 +463,7 @@ final class ProjectOverviewController extends AbstractProjectController
                 $coverage_response['medium'] = $coverage_category['medium'];
                 $coverage_response['satisfactory'] = $coverage_category['satisfactory'];
 
-                list($current_value, $previous_value) =
+                [$current_value, $previous_value] =
                     self::get_recent_coverage_values($build_group_name, $category_name, $date_range, $coverage_data);
                 $coverage_response['current'] = $current_value;
                 $coverage_response['previous'] = $previous_value;

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -744,7 +744,7 @@ final class SiteController extends AbstractController
             'ip' => $ip,
             'latitude' => $latitude,
             'longitude' => $longitude,
-            'outoforder' => $outoforder
+            'outoforder' => $outoforder,
         ]);
 
         add_last_sql_error('update_site');

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -266,7 +266,7 @@ final class SiteController extends AbstractController
             $xml .= '<site>';
             $site_array = $db->executePreparedSingleRow('SELECT * FROM site WHERE id=?', [intval($siteid)]);
 
-            $siteinformation_array = array();
+            $siteinformation_array = [];
             $siteinformation_array['description'] = 'NA';
             $siteinformation_array['processoris64bits'] = 'NA';
             $siteinformation_array['processorvendor'] = 'NA';
@@ -394,7 +394,7 @@ final class SiteController extends AbstractController
             $currenttime = pdo_real_escape_numeric($currenttime);
         }
 
-        $siteinformation_array = array();
+        $siteinformation_array = [];
         $siteinformation_array['description'] = 'NA';
         $siteinformation_array['processoris64bits'] = 'NA';
         $siteinformation_array['processorvendor'] = 'NA';
@@ -542,7 +542,7 @@ final class SiteController extends AbstractController
 
         // Select projects that belong to this site
         $displayPage = 0;
-        $projects = array();
+        $projects = [];
         $site2project = $db->executePrepared('
                             SELECT projectid, max(submittime) AS maxtime
                             FROM build
@@ -749,7 +749,7 @@ final class SiteController extends AbstractController
 
         add_last_sql_error('update_site');
 
-        $names = array();
+        $names = [];
         $names[] = 'processoris64bits';
         $names[] = 'processorvendor';
         $names[] = 'processorvendorid';

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -159,7 +159,7 @@ final class SubProjectController extends AbstractProjectController
             $response['showlastsubmission'] = 1;
         }
 
-        list($previousdate, $currentstarttime, $nextdate) = get_dates($date, $this->project->NightlyTime);
+        [$previousdate, $currentstarttime, $nextdate] = get_dates($date, $this->project->NightlyTime);
 
         // Main dashboard section
         get_dashboard_JSON($this->project->GetName(), $date, $response);

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -144,7 +144,7 @@ final class SubProjectController extends AbstractProjectController
         $response['title'] = $this->project->Name;
         $response['showcalendar'] = 1;
 
-        $banners = array();
+        $banners = [];
         $global_banner = Banner::find(0);
         if ($global_banner !== null && strlen($global_banner->text) > 0) {
             $banners[] = $global_banner->text;
@@ -175,7 +175,7 @@ final class SubProjectController extends AbstractProjectController
         $response['linkparams'] = $linkparams;
 
         // Menu definition
-        $menu_response = array();
+        $menu_response = [];
         $menu_response['subprojects'] = 1;
         $menu_response['previous'] = "viewSubProjects.php?project=$projectname_encoded&date=$previousdate";
         $menu_response['current'] = "viewSubProjects.php?project=$projectname_encoded";
@@ -190,7 +190,7 @@ final class SubProjectController extends AbstractProjectController
         $end_UTCDate = gmdate(FMT_DATETIME, $currentstarttime + 3600 * 24);
 
         // Get some information about the project
-        $project_response = array();
+        $project_response = [];
         $project_response['nbuilderror'] = $this->project->GetNumberOfErrorBuilds($beginning_UTCDate, $end_UTCDate);
         $project_response['nbuildwarning'] = $this->project->GetNumberOfWarningBuilds($beginning_UTCDate, $end_UTCDate);
         $project_response['nbuildpass'] = $this->project->GetNumberOfPassingBuilds($beginning_UTCDate, $end_UTCDate);
@@ -210,11 +210,11 @@ final class SubProjectController extends AbstractProjectController
 
         // Look for the subproject
         $subprojectids = $this->project->GetSubProjects();
-        $subprojProp = array();
+        $subprojProp = [];
         foreach ($subprojectids as $subprojectid) {
             $SubProject = new SubProject();
             $SubProject->SetId($subprojectid);
-            $subprojProp[$subprojectid] = array('name' => $SubProject->GetName());
+            $subprojProp[$subprojectid] = ['name' => $SubProject->GetName()];
         }
 
         // If all of the dates are the same, we can get the results in bulk.  Otherwise, we must query every
@@ -238,15 +238,15 @@ final class SubProjectController extends AbstractProjectController
             }
         }
 
-        $reportArray = array('nbuilderror', 'nbuildwarning', 'nbuildpass',
+        $reportArray = ['nbuilderror', 'nbuildwarning', 'nbuildpass',
             'nconfigureerror', 'nconfigurewarning', 'nconfigurepass',
-            'ntestpass', 'ntestfail', 'ntestnotrun');
-        $subprojects_response = array();
+            'ntestpass', 'ntestfail', 'ntestnotrun'];
+        $subprojects_response = [];
 
         foreach ($subprojectids as $subprojectid) {
             $SubProject = new SubProject();
             $SubProject->SetId($subprojectid);
-            $subproject_response = array();
+            $subproject_response = [];
             $subproject_response['name'] = $SubProject->GetName();
             $subproject_response['name_encoded'] = urlencode($SubProject->GetName());
 

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -140,7 +140,7 @@ final class SubscribeProjectController extends AbstractProjectController
                     $EmailMissingSites,
                     $EmailSuccess,
                     $user->id,
-                    $this->project->Id
+                    $this->project->Id,
                 ]);
 
                 // Update the repository credential
@@ -203,7 +203,7 @@ final class SubscribeProjectController extends AbstractProjectController
                     $EmailMissingSites,
                     $EmailSuccess,
                     $user->id,
-                    $this->project->Id
+                    $this->project->Id,
                 ]);
 
                 // Update the repository credential
@@ -248,7 +248,7 @@ final class SubscribeProjectController extends AbstractProjectController
                     $EmailType,
                     $EmailCategory,
                     $EmailSuccess,
-                    $EmailMissingSites
+                    $EmailMissingSites,
                 ]);
 
                 $UserProject = new UserProject();

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -120,7 +120,7 @@ final class TestController extends AbstractProjectController
         get_dashboard_JSON_by_name($this->project->Name, $date, $response);
         $response['testName'] = $testName;
 
-        list($previousdate, $currentstarttime, $nextdate, $today) = get_dates($date, $this->project->NightlyTime);
+        [$previousdate, $currentstarttime, $nextdate, $today] = get_dates($date, $this->project->NightlyTime);
         $menu = [
             'back' => 'index.php?project=' . urlencode($this->project->Name) . "&date=$date",
             'previous' => "testSummary.php?project={$this->project->Id}&name=$testName&date=$previousdate",

--- a/app/Http/Controllers/UserStatisticsController.php
+++ b/app/Http/Controllers/UserStatisticsController.php
@@ -42,7 +42,7 @@ final class UserStatisticsController extends AbstractProjectController
         $response['range'] = $range;
 
         // Set up links from this page.
-        $menu = array();
+        $menu = [];
         $menu['back'] = "index.php?project={$this->project->Name}&date=$date";
         $nextdate = $response['nextdate'];
         $menu['next'] = "userStatistics.php?project={$this->project->Name}&date=$nextdate&range=$range";
@@ -68,12 +68,12 @@ final class UserStatisticsController extends AbstractProjectController
         $stmt->bindParam(':projectid', $this->project->Id);
         pdo_execute($stmt);
 
-        $users = array();
+        $users = [];
         while ($row = $stmt->fetch()) {
             if (array_key_exists($row['userid'], $users)) {
                 $user = $users[$row['userid']];
             } else {
-                $user = array();
+                $user = [];
                 $user['nfailedwarnings'] = 0;
                 $user['nfixedwarnings'] = 0;
                 $user['nfailederrors'] = 0;
@@ -95,9 +95,9 @@ final class UserStatisticsController extends AbstractProjectController
         }
 
         // Generate the response used to render the main table of this page.
-        $users_response = array();
+        $users_response = [];
         foreach ($users as $key => $user) {
-            $user_response = array();
+            $user_response = [];
             $user_obj = User::where('id', $key)->first();
             $user_response['name'] = $user_obj->full_name;
             $user_response['id'] = $key;

--- a/app/Http/Controllers/ViewTestController.php
+++ b/app/Http/Controllers/ViewTestController.php
@@ -53,7 +53,7 @@ final class ViewTestController extends AbstractController
             return response()->json(cast_data_for_JSON($response));
         } else {
             $headers = [
-                'Content-Type' => 'text/csv'
+                'Content-Type' => 'text/csv',
             ];
             return response()->streamDownload(function () use ($response) {
                 echo $response;

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -19,6 +19,6 @@ class VerifyCsrfToken extends Middleware
      * @var array
      */
     protected $except = [
-        '*.php'
+        '*.php',
     ];
 }

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -80,7 +80,7 @@ class ProcessSubmission implements ShouldQueue
             $response = $client->request('POST', $url, ['query' => [
                     'filename' => $this->filename,
                     'buildid' => $buildid,
-                    'projectid' => $this->projectid
+                    'projectid' => $this->projectid,
                 ]]);
             return $response->getStatusCode() == 200;
         } else {
@@ -140,7 +140,7 @@ class ProcessSubmission implements ShouldQueue
         // Store record for successful job if asynchronously parsing.
         if (config('queue.default') !== 'sync') {
             SuccessfulJob::create([
-                'filename' => $this->filename
+                'filename' => $this->filename,
             ]);
         }
     }

--- a/app/Models/AuthToken.php
+++ b/app/Models/AuthToken.php
@@ -8,13 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class AuthToken extends Model
 {
-    const SCOPE_FULL_ACCESS = 'full_access';
-    const SCOPE_SUBMIT_ONLY = 'submit_only';
+    public const SCOPE_FULL_ACCESS = 'full_access';
+    public const SCOPE_SUBMIT_ONLY = 'submit_only';
 
     // Eloquent requires this since we use a non-default creation date column
     // and have no updated timestamp column at all.
-    const CREATED_AT = 'created';
-    const UPDATED_AT = null;
+    public const CREATED_AT = 'created';
+    public const UPDATED_AT = null;
 
     protected $table = 'authtoken';
 

--- a/app/Models/AuthToken.php
+++ b/app/Models/AuthToken.php
@@ -29,6 +29,6 @@ class AuthToken extends Model
         'expires',
         'description',
         'projectid',
-        'scope'
+        'scope',
     ];
 }

--- a/app/Models/Banner.php
+++ b/app/Models/Banner.php
@@ -24,6 +24,6 @@ class Banner extends Model
 
     protected $fillable = [
         'projectid',
-        'text'
+        'text',
     ];
 }

--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -77,7 +77,7 @@ class BuildTest extends Model
      */
     public static function marshalMissing($name, $buildid, $projectid, $projectshowtesttime, $testtimemaxstatus, $testdate): array
     {
-        $data = array();
+        $data = [];
         $data['name'] = $name;
         $data['status'] = 'missing';
         $data['id'] = '';
@@ -100,10 +100,10 @@ class BuildTest extends Model
 
     public static function marshalStatus($status): array
     {
-        $statuses = array('passed' => array('Passed', 'normal'),
-                          'failed' => array('Failed', 'error'),
-                          'notrun' => array('Not Run', 'warning'),
-                          'missing' => array('Missing', 'missing'));
+        $statuses = ['passed' => ['Passed', 'normal'],
+                          'failed' => ['Failed', 'error'],
+                          'notrun' => ['Not Run', 'warning'],
+                          'missing' => ['Missing', 'missing']];
 
         return $statuses[$status];
     }
@@ -113,7 +113,7 @@ class BuildTest extends Model
     {
         $marshaledStatus = self::marshalStatus($data['status']);
         if ($data['details'] === 'Disabled') {
-            $marshaledStatus = array('Not Run', 'disabled-test');
+            $marshaledStatus = ['Not Run', 'disabled-test'];
         }
         $marshaledData = [
             'id' => $data['id'],

--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -17,7 +17,7 @@ class BuildTest extends Model
 
     protected $attributes = [
         'timemean' => 0.0,
-        'timestd' => 0.0
+        'timestd' => 0.0,
     ];
 
     /**
@@ -127,7 +127,7 @@ class BuildTest extends Model
             'details' => $data['details'],
             'summaryLink' => "testSummary.php?project=$projectid&name=" . urlencode($data['name']) . "&date=$testdate",
             'summary' => 'Summary', /* Default value later replaced by AJAX */
-            'detailsLink' => "test/{$data['buildtestid']}"
+            'detailsLink' => "test/{$data['buildtestid']}",
         ];
 
         if ($data['newstatus']) {

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -11,10 +11,10 @@ class Test extends Model
 
     public $timestamps = false;
 
-    const FAILED = 'failed';
-    const PASSED = 'passed';
-    const OTHER_FAULT = 'OTHER_FAULT';
-    const TIMEOUT = 'Timeout';
-    const NOTRUN = 'notrun';
-    const DISABLED = 'Disabled';
+    public const FAILED = 'failed';
+    public const PASSED = 'passed';
+    public const OTHER_FAULT = 'OTHER_FAULT';
+    public const TIMEOUT = 'Timeout';
+    public const NOTRUN = 'notrun';
+    public const DISABLED = 'Disabled';
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,7 +31,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @var array
      */
     protected $fillable = [
-        'firstname', 'lastname', 'email', 'password', 'institution'
+        'firstname', 'lastname', 'email', 'password', 'institution',
     ];
 
     /**

--- a/app/Services/AuthTokenService.php
+++ b/app/Services/AuthTokenService.php
@@ -79,7 +79,7 @@ class AuthTokenService
         $auth_token = AuthToken::create($params);
         return [
             'raw_token' => $token,
-            'token' => $auth_token
+            'token' => $auth_token,
         ];
     }
 

--- a/app/Services/TestCreator.php
+++ b/app/Services/TestCreator.php
@@ -177,7 +177,7 @@ class TestCreator
         } else {
             DB::insert('INSERT INTO test (projectid, name) VALUES (:projectid, :name)', [
                 ':projectid' => $this->projectid,
-                ':name'      => $this->testName
+                ':name'      => $this->testName,
             ]);
             $testid = DB::getPdo()->lastInsertId();
         }

--- a/app/cdash/app/Controller/Api.php
+++ b/app/cdash/app/Controller/Api.php
@@ -23,7 +23,7 @@ use CDash\Database;
  **/
 abstract class Api
 {
-    const BEGIN_EPOCH = '1980-01-01 00:00:00';
+    public const BEGIN_EPOCH = '1980-01-01 00:00:00';
 
     protected $db;
 

--- a/app/cdash/app/Controller/Api/BuildTestApi.php
+++ b/app/cdash/app/Controller/Api/BuildTestApi.php
@@ -62,7 +62,7 @@ abstract class BuildTestApi extends BuildApi
             ':projectid' => $this->project->Id,
             ':type' => $this->build->Type,
             ':buildname' => $this->build->Name,
-            ':testname' => $this->test->name
+            ':testname' => $this->test->name,
         ];
     }
 

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -1137,7 +1137,7 @@ class Index extends ResultsApi
         // Trim off any filter parameters.  Previously we did this step with a simple
         // strpos check, but since the change to AngularJS query parameters are no
         // longer guaranteed to appear in any particular order.
-        $accepted_parameters = array('project', 'parentid', 'subproject');
+        $accepted_parameters = ['project', 'parentid', 'subproject'];
 
         $parsed_url = parse_url($baseurl);
         $query = $parsed_url['query'];

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -1470,7 +1470,7 @@ class Index extends ResultsApi
         }
 
         // Use the project model to get the bounds of the current testing day.
-        list($beginningOfDay, $endOfDay) =
+        [$beginningOfDay, $endOfDay] =
             $this->project->ComputeTestingDayBounds($this->date);
 
         // Query the database to find the previous testing day

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -223,7 +223,7 @@ class Index extends ResultsApi
                     self::BEGIN_EPOCH,
                     $this->endDate,
                     self::BEGIN_EPOCH,
-                    $this->endDate
+                    $this->endDate,
                 ]);
 
         foreach ($stmt as $rule) {
@@ -1477,7 +1477,7 @@ class Index extends ResultsApi
         // that has build results.
         $query_params = [
             ':projectid' => $this->project->Id,
-            ':time'      => $beginningOfDay
+            ':time'      => $beginningOfDay,
         ];
 
         // Only search for builds from a certain group when buildGroupName is set.

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -210,7 +210,7 @@ class QueryTests extends ResultsApi
 
         get_dashboard_JSON_by_name($this->project->Name, $this->date, $response);
 
-        list($previousdate, $currentstarttime, $nextdate) =
+        [$previousdate, $currentstarttime, $nextdate] =
             get_dates($this->date, $this->project->NightlyTime);
 
         // Filters

--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -90,7 +90,7 @@ abstract class ResultsApi extends ProjectApi
     public function setDate($date)
     {
         $this->project->Fill();
-        list($previousdate, $beginning_timestamp, $nextdate, $d) =
+        [$previousdate, $beginning_timestamp, $nextdate, $d] =
             get_dates($date, $this->project->NightlyTime);
         if (is_null($date)) {
             $date = $d;
@@ -124,7 +124,7 @@ abstract class ResultsApi extends ProjectApi
         if ($begin && $end) {
             // Honor 'begin' & 'end' parameters to specify a range of dates.
             // Compute a date range if both arguments were specified.
-            list($unused, $beginning_timestamp) =
+            [$unused, $beginning_timestamp] =
                 get_dates($begin, $this->project->NightlyTime);
             $this->currentStartTime = $beginning_timestamp;
             $this->beginDate = gmdate(FMT_DATETIME, $beginning_timestamp);
@@ -132,7 +132,7 @@ abstract class ResultsApi extends ProjectApi
 
             $this->date = $end;
             $response['end'] = $this->date;
-            list($previousdate, $end_timestamp, $nextdate) =
+            [$previousdate, $end_timestamp, $nextdate] =
                 get_dates($this->date, $this->project->NightlyTime);
             $this->previousDate = $previousdate;
             $this->nextDate = $nextdate;

--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -157,7 +157,7 @@ class TestDetails extends BuildTestApi
             'priorrevision' => '',
             'path' => '',
             'revisionurl' => '',
-            'revisiondiff' => ''
+            'revisiondiff' => '',
         ];
         $stmt = $this->db->prepare(
             'SELECT status, revision, priorrevision, path

--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -48,22 +48,22 @@ class TestGraph extends BuildTestApi
                 $this->testHistoryQueryExtraColumns = ', b2t.time, b2t.timemean, b2t.timestd';
                 $chart_data[] = [
                     'label' => 'Execution Time (seconds)',
-                    'data' => []
+                    'data' => [],
                 ];
                 $chart_data[] = [
                     'label' => 'Acceptable Range',
-                    'data' => []
+                    'data' => [],
                 ];
                 break;
             case 'status':
                 $this->testHistoryQueryExtraColumns = ', b2t.status';
                 $chart_data[] = [
                     'label' => 'Passed',
-                    'data' => []
+                    'data' => [],
                 ];
                 $chart_data[] = [
                     'label' => 'Failed',
-                    'data' => []
+                    'data' => [],
                 ];
                 break;
             case 'measurement':
@@ -73,7 +73,7 @@ class TestGraph extends BuildTestApi
                 }
                 $chart_data[] = [
                     'label' => $measurement_name,
-                    'data' => []
+                    'data' => [],
                 ];
                 $this->testHistoryQueryExtraColumns = ', tm.value';
                 $this->testHistoryQueryExtraJoins = 'JOIN testmeasurement tm ON (b2t.outputid = tm.outputid)';

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -40,9 +40,9 @@ class Timeline extends Index
     // in Javascript.
     private $timeToDate;
 
-    const ERROR = 0;
-    const FAILURE = 1;
-    const CLEAN = 2;
+    public const ERROR = 0;
+    public const FAILURE = 1;
+    public const CLEAN = 2;
 
     public function __construct(Database $db, Project $project)
     {
@@ -322,7 +322,7 @@ class Timeline extends Index
             // Use this build's starttime to get the beginning of the appropriate
             // testing day.
             $test_date = TestingDay::get($this->project, $build['starttime']);
-            list($unused, $start_of_day) =
+            [$unused, $start_of_day] =
                 get_dates($test_date, $this->project->NightlyTime);
 
             // Convert timestamp to milliseconds for our JS charting library.
@@ -359,9 +359,9 @@ class Timeline extends Index
 
         // Determine the range of the chart that should be selected by default.
         // This is referred to as the extent.
-        list($unused, $begin_extent) = get_dates($this->beginDate, $this->project->NightlyTime);
+        [$unused, $begin_extent] = get_dates($this->beginDate, $this->project->NightlyTime);
         $begin_extent *= 1000;
-        list($unused, $end_extent) = get_dates($this->endDate, $this->project->NightlyTime);
+        [$unused, $end_extent] = get_dates($this->endDate, $this->project->NightlyTime);
         $end_extent *= 1000;
         if ($begin_extent > $end_extent) {
             $begin_extent = $end_extent;
@@ -392,7 +392,7 @@ class Timeline extends Index
             new \DateTime($this->timeToDate[$newest_time_ms]));
         foreach ($period as $datetime) {
             $date = $datetime->format('Y-m-d');
-            list($unused, $start_of_day) = get_dates($date, $this->project->NightlyTime);
+            [$unused, $start_of_day] = get_dates($date, $this->project->NightlyTime);
             $start_of_day_ms = $start_of_day * 1000;
             $this->initializeDate($start_of_day_ms, $date);
         }

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -133,7 +133,7 @@ class Timeline extends Index
             [
                 'name' => 'testfailed',
                 'prettyname' => 'Test Failures',
-            ]
+            ],
         ];
 
         // Query for defects on expected builds only.
@@ -155,7 +155,7 @@ class Timeline extends Index
         $response['colors'] = [
             $this->colors[self::CLEAN],
             $this->colors[self::FAILURE],
-            $this->colors[self::ERROR]
+            $this->colors[self::ERROR],
         ];
         return $response;
     }
@@ -174,7 +174,7 @@ class Timeline extends Index
             [
                 'name' => 'testpassed',
                 'prettyname' => 'Passing Tests',
-            ]
+            ],
         ];
 
         $stmt = $this->db->prepare("
@@ -191,7 +191,7 @@ class Timeline extends Index
         $response['colors'] = [
             $this->colors[self::CLEAN],
             $this->colors[self::FAILURE],
-            $this->colors[self::ERROR]
+            $this->colors[self::ERROR],
         ];
         return $response;
     }
@@ -215,12 +215,12 @@ class Timeline extends Index
             [
                 'name' => 'testfailed',
                 'prettyname' => 'Test Failures',
-            ]
+            ],
         ];
         $colors = [
             $this->colors[self::CLEAN],
             $this->colors[self::FAILURE],
-            $this->colors[self::ERROR]
+            $this->colors[self::ERROR],
         ];
 
         $group_type = $buildgroup->GetType();
@@ -239,7 +239,7 @@ class Timeline extends Index
                     ORDER BY starttime');
             $query_params = [
                 ':projectid'      => $this->project->Id,
-                ':buildgroupname' => $groupname
+                ':buildgroupname' => $groupname,
             ];
             if (!pdo_execute($stmt, $query_params)) {
                 abort(500, 'Failed to load results');
@@ -289,7 +289,7 @@ class Timeline extends Index
                     $error_types = [
                         'countbuilderrors',
                         'countconfigureerrors',
-                        'countupdateerrors'
+                        'countupdateerrors',
                     ];
                     $build['errors'] = 0;
                     foreach ($error_types as $error_type) {
@@ -409,7 +409,7 @@ class Timeline extends Index
         foreach ($this->defectTypes as $defect_type) {
             $chart_keys[] = [
                 'name' => $defect_type['name'],
-                'prettyname' => $defect_type['prettyname']
+                'prettyname' => $defect_type['prettyname'],
             ];
         }
         if ($this->includeCleanBuilds) {

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -369,7 +369,7 @@ class ViewTest extends BuildApi
 
         // Gather date information.
         $testdate = $this->date;
-        list($previousdate, $currentstarttime, $nextdate, $today) =
+        [$previousdate, $currentstarttime, $nextdate, $today] =
             get_dates($this->date, $this->project->NightlyTime);
         $beginning_timestamp = $currentstarttime;
         $end_timestamp = $currentstarttime + 3600 * 24;

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -634,7 +634,7 @@ class ViewTest extends BuildApi
 
         $csv_contents = [];
         // Standard columns.
-        $csv_headers = ['Name', 'Time' ,'Details' , 'Status'];
+        $csv_headers = ['Name', 'Time','Details', 'Status'];
         if ($projectshowtesttime) {
             $csv_headers[] = 'Time Status';
         }

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -634,7 +634,7 @@ class ViewTest extends BuildApi
 
         $csv_contents = [];
         // Standard columns.
-        $csv_headers = array('Name', 'Time' ,'Details' , 'Status');
+        $csv_headers = ['Name', 'Time' ,'Details' , 'Status'];
         if ($projectshowtesttime) {
             $csv_headers[] = 'Time Status';
         }

--- a/app/cdash/app/Controller/Auth/Session.php
+++ b/app/cdash/app/Controller/Auth/Session.php
@@ -23,8 +23,8 @@ use CDash\System;
  */
 class Session
 {
-    const EXTEND_GC_LIFETIME = 600;
-    const CACHE_NOCACHE = 'nocache';
+    public const EXTEND_GC_LIFETIME = 600;
+    public const CACHE_NOCACHE = 'nocache';
 
     private $system;
 

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -38,7 +38,7 @@ use CDash\Model\Project;
  */
 class GitHub implements RepositoryInterface
 {
-    const BASE_URI = 'https://api.github.com';
+    public const BASE_URI = 'https://api.github.com';
 
     /** @var string $installationId */
     private $installationId;
@@ -505,7 +505,7 @@ class GitHub implements RepositoryInterface
         $memcache_enabled = $this->config->get('CDASH_MEMECACHE_ENABLED');
         $memcache_prefix = $this->config->get('CDASH_MEMCACHE_PREFIX');
         if ($memcache_enabled) {
-            list($server, $port) = $this->config->get('CDASH_MEMCACHE_SERVER');
+            [$server, $port] = $this->config->get('CDASH_MEMCACHE_SERVER');
             $memcache = cdash_memcache_connect($server, $port);
             // Disable memcache for this request if it fails to connect.
             if ($memcache === false) {

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -334,7 +334,7 @@ class GitHub implements RepositoryInterface
             'head_sha'    => $head_sha,
             'details_url' => $summary_url,
             'started_at'  => $now,
-            'status'      => 'in_progress'
+            'status'      => 'in_progress',
         ];
 
         // Populate payload with build results.

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -637,7 +637,7 @@ class GitHub implements RepositoryInterface
                         if (!is_array($commit_array) ||
                                 !array_key_exists('files', $commit_array)) {
                             // Skip to the next commit if no list of files was returned.
-                            $cached_commits[$sha] = array();
+                            $cached_commits[$sha] = [];
                             continue;
                         }
 

--- a/app/cdash/app/Middleware/OAuth2.php
+++ b/app/cdash/app/Middleware/OAuth2.php
@@ -176,7 +176,7 @@ abstract class OAuth2 implements OAuth2Interface
         if (!$this->Email) {
             $details = $this->getOwnerDetails();
             $email = (object)[
-                'email' => strtolower($details->getEmail())
+                'email' => strtolower($details->getEmail()),
             ];
             $this->Email = collect([$email]);
         }

--- a/app/cdash/app/Middleware/OAuth2/GitHub.php
+++ b/app/cdash/app/Middleware/OAuth2/GitHub.php
@@ -27,8 +27,8 @@ use League\OAuth2\Client\Provider\Github as GitHubProvider;
  */
 class GitHub extends OAuth2
 {
-    const AUTH_REQUEST_METHOD = 'GET';
-    const AUTH_REQUEST_URI = 'https://api.github.com/user/emails';
+    public const AUTH_REQUEST_METHOD = 'GET';
+    public const AUTH_REQUEST_URI = 'https://api.github.com/user/emails';
 
     /**
      * GitHub constructor

--- a/app/cdash/app/Model/ActionableTypes.php
+++ b/app/cdash/app/Model/ActionableTypes.php
@@ -11,19 +11,19 @@ namespace CDash\Model;
  */
 class ActionableTypes
 {
-    const BUILD_ERROR = 'BuildError';
-    const BUILD_WARNING = 'BuildWarning';
-    const CONFIGURE = 'Configure';
-    const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
-    const TEST = 'TestFailure';
-    const UPDATE = 'UpdateError';
+    public const BUILD_ERROR = 'BuildError';
+    public const BUILD_WARNING = 'BuildWarning';
+    public const CONFIGURE = 'Configure';
+    public const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
+    public const TEST = 'TestFailure';
+    public const UPDATE = 'UpdateError';
 
-    const UPDATE_FIX = 'UpdateFix';
-    const BUILD_WARNING_FIX = 'BuildWarningFix';
-    const BUILD_ERROR_FIX = 'BuildErrorFix';
-    const CONFIGURE_FIX = 'ConfigureFix';
-    const TEST_FIX = 'TestFix';
-    const MISSING_TEST = 'TestMissing';
+    public const UPDATE_FIX = 'UpdateFix';
+    public const BUILD_WARNING_FIX = 'BuildWarningFix';
+    public const BUILD_ERROR_FIX = 'BuildErrorFix';
+    public const CONFIGURE_FIX = 'ConfigureFix';
+    public const TEST_FIX = 'TestFix';
+    public const MISSING_TEST = 'TestMissing';
 
     public static $categories = [
         self::UPDATE => 1,

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -276,7 +276,7 @@ class Build
         // tests.
         $total_proc_time = 0.0;
         foreach ($this->TestCollection as $test) {
-            $exec_time = (double)$test->time;
+            $exec_time = (float)$test->time;
             $num_procs = 1.0;
             foreach ($test->measurements as $measurement) {
                 if ($measurement->name == 'Processors') {

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -2643,7 +2643,7 @@ class Build
                     'buildwarnings'  => $nbuildwarnings,
                     'parentid'       => $this->ParentId,
                     'uuid'           => $this->Uuid,
-                    'changeid'       => $this->PullRequest
+                    'changeid'       => $this->PullRequest,
                 ]);
                 $build_created = true;
                 $this->Id = $new_id;
@@ -3083,7 +3083,7 @@ class Build
                     'Configure' => [
                         'errors' => ($this->BuildConfigure ? $this->BuildConfigure->NumberOfErrors : 0),
                         'warnings' => ($this->BuildConfigure ? $this->BuildConfigure->NumberOfWarnings : 0),
-                    ] ,
+                    ],
                     'TestFailure' => [
                         'passed' => [
                             'new' => $passed,
@@ -3113,11 +3113,11 @@ class Build
                     'Configure' => [
                         'errors' => $diff['configureerrors'],
                         'warnings' => $diff['configurewarnings'],
-                    ] ,
+                    ],
                     'TestFailure' => [
                         'passed' => [
                             'new' => $diff['testpassedpositive'],
-                            'broken' => $diff['testpassednegative']
+                            'broken' => $diff['testpassednegative'],
                         ],
                         'failed' => [
                             'new' => $diff['testfailedpositive'],
@@ -3125,7 +3125,7 @@ class Build
                         ],
                         'notrun' => [
                             'new' => $diff['testnotrunpositive'],
-                            'fixed' => $diff['testnotrunnegative']
+                            'fixed' => $diff['testnotrunnegative'],
                         ],
                     ],
                 ];

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -31,12 +31,12 @@ use PDO;
 
 class Build
 {
-    const TYPE_ERROR = 0;
-    const TYPE_WARN = 1;
-    const STATUS_NEW = 1;
+    public const TYPE_ERROR = 0;
+    public const TYPE_WARN = 1;
+    public const STATUS_NEW = 1;
 
-    const PARENT_BUILD = -1;
-    const STANDALONE_BUILD = 0;
+    public const PARENT_BUILD = -1;
+    public const STANDALONE_BUILD = 0;
 
     public $Id;
     public $SiteId;
@@ -2425,7 +2425,7 @@ class Build
 
         $build_date = $this->GetDate();
         $this->GetProject()->Fill();
-        list($this->BeginningOfDay, $this->EndOfDay) =
+        [$this->BeginningOfDay, $this->EndOfDay] =
             $this->Project->ComputeTestingDayBounds($build_date);
         return true;
     }

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -351,7 +351,7 @@ class BuildConfigure
             'command' => $data['command'],
             'output' => $data['log'],
             'configureerrors' => $data['configureerrors'],
-            'configurewarnings' => $data['configurewarnings']
+            'configurewarnings' => $data['configurewarnings'],
         ];
 
         if (isset($data['subprojectid'])) {

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -346,13 +346,13 @@ class BuildConfigure
 
     public static function marshal($data)
     {
-        $response = array(
+        $response = [
             'status' => $data['status'],
             'command' => $data['command'],
             'output' => $data['log'],
             'configureerrors' => $data['configureerrors'],
             'configurewarnings' => $data['configurewarnings']
-        );
+        ];
 
         if (isset($data['subprojectid'])) {
             $response['subprojectid'] = $data['subprojectid'];

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -148,21 +148,21 @@ class BuildError
 
         // Sets up access to $file and $directory
         extract($builderror->GetSourceFile($data));
-        $marshaled = array(
+        $marshaled = [
             'new' => (isset($data['newstatus'])) ? $data['newstatus'] : -1,
             'logline' => $data['logline'],
             'cvsurl' => get_diff_url($project->Id, $project->CvsUrl, $directory, $file, $revision)
-        );
+        ];
 
         // When building without launchers, CTest truncates the source dir to
         // /.../<project-name>/.  Use this pattern to linkify compiler output.
         $source_dir = "/\.\.\./[^/]+";
-        $marshaled = array_merge($marshaled, array(
+        $marshaled = array_merge($marshaled, [
             'precontext' => linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['precontext']),
             'text' => linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['text']),
             'postcontext' => linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['postcontext']),
             'sourcefile' => $data['sourcefile'],
-            'sourceline' => $data['sourceline']));
+            'sourceline' => $data['sourceline']]);
 
         if (isset($data['subprojectid'])) {
             $marshaled['subprojectid'] = $data['subprojectid'];

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -88,7 +88,7 @@ class BuildError
                      $this->PreContext,
                      $this->PostContext,
                      intval($this->RepeatCount),
-                     $crc32
+                     $crc32,
                  ]);
         if ($query === false) {
             add_last_sql_error('BuildError Insert', 0, $this->BuildId);
@@ -151,7 +151,7 @@ class BuildError
         $marshaled = [
             'new' => (isset($data['newstatus'])) ? $data['newstatus'] : -1,
             'logline' => $data['logline'],
-            'cvsurl' => get_diff_url($project->Id, $project->CvsUrl, $directory, $file, $revision)
+            'cvsurl' => get_diff_url($project->Id, $project->CvsUrl, $directory, $file, $revision),
         ];
 
         // When building without launchers, CTest truncates the source dir to

--- a/app/cdash/app/Model/BuildErrorFilter.php
+++ b/app/cdash/app/Model/BuildErrorFilter.php
@@ -63,7 +63,7 @@ class BuildErrorFilter
         $query_params = [
             ':errors' => $errors,
             ':projectid' => $this->Project->Id,
-            ':warnings' => $warnings
+            ':warnings' => $warnings,
         ];
         if ($this->PDO->execute($stmt, $query_params)) {
             $this->Fill();

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -153,7 +153,7 @@ class BuildFailure
         $id = pdo_insert_id('buildfailure');
 
         // Insert the arguments
-        $argumentids = array();
+        $argumentids = [];
 
         foreach ($this->Arguments as $argument) {
             // Limit the argument to 255
@@ -284,7 +284,7 @@ class BuildFailure
     {
         deepEncodeHTMLEntities($data);
 
-        $marshaled = array_merge(array(
+        $marshaled = array_merge([
             'language' => $data['language'],
             'sourcefile' => $data['sourcefile'],
             'targetname' => $data['targetname'],
@@ -292,7 +292,7 @@ class BuildFailure
             'outputtype' => $data['outputtype'],
             'workingdirectory' => $data['workingdirectory'],
             'exitcondition' => $data['exitcondition']
-        ), $buildfailure->GetBuildFailureArguments($data['id']));
+        ], $buildfailure->GetBuildFailureArguments($data['id']));
 
         $marshaled['stderror'] = $data['stderror'];
         $marshaled['stdoutput'] = $data['stdoutput'];

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -126,7 +126,7 @@ class BuildFailure
                          $targetName,
                          $outputFile,
                          $outputType,
-                         $crc32
+                         $crc32,
                      ]);
             if ($query === false) {
                 add_last_sql_error('BuildFailure InsertDetails', 0, $this->BuildId);
@@ -248,7 +248,7 @@ class BuildFailure
     {
         $response = [
             'argumentfirst' => null,
-            'arguments' => []
+            'arguments' => [],
         ];
 
         $sql = "
@@ -291,7 +291,7 @@ class BuildFailure
             'outputfile' => $data['outputfile'],
             'outputtype' => $data['outputtype'],
             'workingdirectory' => $data['workingdirectory'],
-            'exitcondition' => $data['exitcondition']
+            'exitcondition' => $data['exitcondition'],
         ], $buildfailure->GetBuildFailureArguments($data['id']));
 
         $marshaled['stderror'] = $data['stderror'];

--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -411,7 +411,7 @@ class BuildGroup
                          $this->IncludeSubProjectTotal,
                          $this->EmailCommitters,
                          $this->Type,
-                         $this->Id
+                         $this->Id,
                      ]);
 
             if ($query === false) {
@@ -435,7 +435,7 @@ class BuildGroup
                 $this->SummaryEmail,
                 $this->IncludeSubProjectTotal,
                 $this->EmailCommitters,
-                $this->Type
+                $this->Type,
             ]);
 
             $prepared_array = $this->PDO->createPreparedArray(count($values));

--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -21,8 +21,8 @@ use Illuminate\Support\Facades\Log;
 
 class BuildGroup
 {
-    const NIGHTLY = 'Nightly';
-    const EXPERIMENTAL = 'Experimental';
+    public const NIGHTLY = 'Nightly';
+    public const EXPERIMENTAL = 'Experimental';
 
     private $Id;
     private $ProjectId;

--- a/app/cdash/app/Model/BuildGroupRule.php
+++ b/app/cdash/app/Model/BuildGroupRule.php
@@ -76,7 +76,7 @@ class BuildGroupRule
             ':buildtype'     => $this->BuildType,
             ':buildname'     => $this->BuildName,
             ':siteid'        => $this->SiteId,
-            ':endtime'       => $this->EndTime
+            ':endtime'       => $this->EndTime,
         ];
 
         $this->PDO->execute($stmt, $query_params);
@@ -110,7 +110,7 @@ class BuildGroupRule
                 ':siteid'        => $this->SiteId,
                 ':expected'      => $this->Expected,
                 ':starttime'     => $this->StartTime,
-                ':endtime'       => $this->EndTime
+                ':endtime'       => $this->EndTime,
             ];
             return $this->PDO->execute($stmt, $query_params);
         }
@@ -188,7 +188,7 @@ class BuildGroupRule
             ':buildtype'       => $this->BuildType,
             ':buildname'       => $this->BuildName,
             ':siteid'          => $this->SiteId,
-            ':begin_epoch'     => '1980-01-01 00:00:00'
+            ':begin_epoch'     => '1980-01-01 00:00:00',
         ];
         return $this->PDO->execute($stmt, $query_params);
     }
@@ -214,7 +214,7 @@ class BuildGroupRule
             ':siteid'          => $this->SiteId,
             ':expected'        => $this->Expected,
             ':starttime'       => $this->StartTime,
-            ':endtime'         => $this->EndTime
+            ':endtime'         => $this->EndTime,
         ];
         return $this->PDO->execute($stmt, $query_params);
     }
@@ -281,7 +281,7 @@ class BuildGroupRule
             AND endtime < :endtime");
         $query_params = [
             ':projectid' => $projectid,
-            ':endtime'   => $cutoff_date
+            ':endtime'   => $cutoff_date,
         ];
         $db->execute($stmt, $query_params);
     }

--- a/app/cdash/app/Model/BuildProperties.php
+++ b/app/cdash/app/Model/BuildProperties.php
@@ -77,7 +77,7 @@ class BuildProperties
             VALUES (:buildid, :properties)');
         $query_params = [
             ':buildid' => $this->Build->Id,
-            ':properties' => $properties_str
+            ':properties' => $properties_str,
         ];
         return $this->PDO->execute($stmt, $query_params);
     }

--- a/app/cdash/app/Model/BuildRelationship.php
+++ b/app/cdash/app/Model/BuildRelationship.php
@@ -175,7 +175,7 @@ class BuildRelationship
         return [
             'buildid'      => $this->Build->Id,
             'relatedid'    => $this->RelatedBuild->Id,
-            'relationship' => $this->Relationship
+            'relationship' => $this->Relationship,
         ];
     }
 

--- a/app/cdash/app/Model/BuildUpdate.php
+++ b/app/cdash/app/Model/BuildUpdate.php
@@ -39,7 +39,7 @@ class BuildUpdate
 
     public function __construct()
     {
-        $this->Files = array();
+        $this->Files = [];
         $this->Command = '';
         $this->Append = false;
         $this->PDO = Database::getInstance()->getPdo();

--- a/app/cdash/app/Model/BuildUpdateFile.php
+++ b/app/cdash/app/Model/BuildUpdateFile.php
@@ -79,7 +79,7 @@ class BuildUpdateFile
                      $this->PriorRevision ?? '',
                      $this->Status ?? '',
                      $this->Committer ?? '',
-                     $this->CommitterEmail ?? ''
+                     $this->CommitterEmail ?? '',
                  ]);
 
         if ($query === false) {

--- a/app/cdash/app/Model/BuildUserNote.php
+++ b/app/cdash/app/Model/BuildUserNote.php
@@ -85,7 +85,7 @@ class BuildUserNote
     public function marshal()
     {
         $pdo = get_link_identifier()->getPdo();
-        $marshaledNote = array();
+        $marshaledNote = [];
 
         $user = User::find($this->UserId);
         $marshaledNote['user'] = $user->full_name;
@@ -122,7 +122,7 @@ class BuildUserNote
             'SELECT * FROM buildnote WHERE buildid=? ORDER BY timestamp ASC');
         pdo_execute($stmt, [$buildid]);
 
-        $notes = array();
+        $notes = [];
         while ($row = $stmt->fetch()) {
             $note = new BuildUserNote();
             $note->BuildId = $buildid;

--- a/app/cdash/app/Model/Coverage.php
+++ b/app/cdash/app/Model/Coverage.php
@@ -40,7 +40,7 @@ class Coverage
     public function AddLabel($label)
     {
         if (!isset($this->Labels)) {
-            $this->Labels = array();
+            $this->Labels = [];
         }
 
         $label->CoverageFileId = $this->CoverageFile->Id;

--- a/app/cdash/app/Model/CoverageFileLog.php
+++ b/app/cdash/app/Model/CoverageFileLog.php
@@ -133,7 +133,7 @@ class CoverageFileLog
             if (empty($log_entry)) {
                 continue;
             }
-            list($line, $value) = explode(':', $log_entry);
+            [$line, $value] = explode(':', $log_entry);
             if (is_numeric($line)) {
                 $lines_retrieved[] = intval($line);
             } else {
@@ -159,11 +159,11 @@ class CoverageFileLog
             if (empty($log_entry)) {
                 continue;
             }
-            list($line, $value) = explode(':', $log_entry);
+            [$line, $value] = explode(':', $log_entry);
             if ($line[0] === 'b') {
                 // Branch coverage
                 $line = ltrim($line, 'b');
-                list($covered, $total) = explode('/', $value);
+                [$covered, $total] = explode('/', $value);
                 $this->AddBranch($line, $covered, $total);
             } else {
                 // Line coverage
@@ -196,7 +196,7 @@ class CoverageFileLog
         }
 
         foreach ($this->Branches as $line => $value) {
-            list($timesHit, $total) = explode('/', $value);
+            [$timesHit, $total] = explode('/', $value);
             $stats['branchestested'] += $timesHit;
             $stats['branchesuntested'] += ($total - $timesHit);
         }

--- a/app/cdash/app/Model/CoverageFileLog.php
+++ b/app/cdash/app/Model/CoverageFileLog.php
@@ -91,7 +91,7 @@ class CoverageFileLog
                         ->insert([
                             'buildid' => $this->BuildId,
                             'fileid' => $this->FileId,
-                            'log' => $log
+                            'log' => $log,
                         ]);
                 }
             }
@@ -237,7 +237,7 @@ class CoverageFileLog
                        ', [
                            intval($this->AggregateBuildId),
                            intval($this->Build->ProjectId),
-                           intval($this->Build->SubProjectId)
+                           intval($this->Build->SubProjectId),
                        ]);
                 if (!$row || !array_key_exists('id', $row)) {
                     // An aggregate build for this SubProject doesn't exist yet.

--- a/app/cdash/app/Model/CoverageSummary.php
+++ b/app/cdash/app/Model/CoverageSummary.php
@@ -31,7 +31,7 @@ class CoverageSummary
 
     public function __construct()
     {
-        $this->Coverages = array();
+        $this->Coverages = [];
     }
 
     public function AddCoverage($coverage): void

--- a/app/cdash/app/Model/DailyUpdateFile.php
+++ b/app/cdash/app/Model/DailyUpdateFile.php
@@ -88,7 +88,7 @@ class DailyUpdateFile
                          $this->Revision,
                          $this->PriorRevision,
                          $this->DailyUpdateId,
-                         $this->Filename
+                         $this->Filename,
                      ]);
 
             if ($query === false) {
@@ -114,7 +114,7 @@ class DailyUpdateFile
                          $this->Author,
                          $this->Log,
                          $this->Revision,
-                         $this->PriorRevision
+                         $this->PriorRevision,
                      ]);
 
             if ($query === false) {

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -167,7 +167,7 @@ class DynamicAnalysis
 
         // Handle log decoding/decompression
         if (strtolower($this->LogEncoding ?? '') == 'base64') {
-            $this->Log = str_replace(array("\r\n", "\n", "\r"), '', $this->Log);
+            $this->Log = str_replace(["\r\n", "\n", "\r"], '', $this->Log);
             $this->Log = base64_decode($this->Log);
         }
         if (strtolower($this->LogCompression ?? '') == 'gzip') {

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -199,12 +199,12 @@ class DynamicAnalysis
             $this->Log .= $truncated_msg;
         }
 
-        $this->Status =  $this->Status ?? '';
-        $this->Checker = $this->Checker ?? '';
-        $this->Name = $this->Name ?? '';
+        $this->Status ??= '';
+        $this->Checker ??= '';
+        $this->Name ??= '';
         $path = substr($this->Path, 0, 255);
         $fullCommandLine = substr($this->FullCommandLine, 0, 255);
-        $this->Log = $this->Log ?? '';
+        $this->Log ??= '';
         $this->BuildId = intval($this->BuildId);
 
         $db = Database::getInstance();

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -237,7 +237,7 @@ class DynamicAnalysis
                      $this->Name,
                      $path,
                      $fullCommandLine,
-                     $this->Log
+                     $this->Log,
                  ]));
 
         if ($query === false) {

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -20,9 +20,9 @@ use CDash\Database;
 
 class DynamicAnalysis
 {
-    const PASSED = 'passed';
-    const FAILED = 'failed';
-    const NOTRUN = 'notrun';
+    public const PASSED = 'passed';
+    public const FAILED = 'failed';
+    public const NOTRUN = 'notrun';
 
     public $Id;
     public $Status;

--- a/app/cdash/app/Model/LabelEmail.php
+++ b/app/cdash/app/Model/LabelEmail.php
@@ -136,7 +136,7 @@ class LabelEmail
             return false;
         }
 
-        $labelids = array();
+        $labelids = [];
         foreach ($labels as $labels_array) {
             $labelids[] = intval($labels_array['labelid']);
         }

--- a/app/cdash/app/Model/ModelType.php
+++ b/app/cdash/app/Model/ModelType.php
@@ -16,12 +16,12 @@ namespace CDash\Model;
 
 class ModelType
 {
-    const PROJECT = 1;
-    const BUILD = 2;
-    const UPDATE = 3;
-    const CONFIGURE = 4;
-    const TEST = 5;
-    const COVERAGE = 6;
-    const DYNAMICANALYSIS = 7;
-    const USER = 8;
+    public const PROJECT = 1;
+    public const BUILD = 2;
+    public const UPDATE = 3;
+    public const CONFIGURE = 4;
+    public const TEST = 5;
+    public const COVERAGE = 6;
+    public const DYNAMICANALYSIS = 7;
+    public const USER = 8;
 }

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -548,7 +548,7 @@ class Project
             }
             DB::table('project2repositories')->insert([
                 'projectid' => (int) $this->Id,
-                'repositoryid' => $repositoryid
+                'repositoryid' => $repositoryid,
             ]);
         }
     }
@@ -1064,7 +1064,7 @@ class Project
                       intval($this->Id),
                       $today,
                       intval($this->Id),
-                      $today
+                      $today,
                   ]);
 
         $labelids = [];

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -37,13 +37,13 @@ use RuntimeException;
 /** Main project class */
 class Project
 {
-    const PROJECT_ADMIN = 2;
-    const SITE_MAINTAINER = 1;
-    const PROJECT_USER = 0;
+    public const PROJECT_ADMIN = 2;
+    public const SITE_MAINTAINER = 1;
+    public const PROJECT_USER = 0;
 
-    const ACCESS_PRIVATE = 0;
-    const ACCESS_PUBLIC = 1;
-    const ACCESS_PROTECTED = 2;
+    public const ACCESS_PRIVATE = 0;
+    public const ACCESS_PUBLIC = 1;
+    public const ACCESS_PROTECTED = 2;
 
     public $Name;
     public $Id;
@@ -1454,7 +1454,7 @@ class Project
      */
     public function ComputeTestingDayBounds($date): array
     {
-        list($unused, $beginning_timestamp) = get_dates($date, $this->NightlyTime);
+        [$unused, $beginning_timestamp] = get_dates($date, $this->NightlyTime);
 
         $datetime = new \DateTime();
         $datetime->setTimeStamp($beginning_timestamp);

--- a/app/cdash/app/Model/Repository.php
+++ b/app/cdash/app/Model/Repository.php
@@ -20,29 +20,29 @@ use CDash\Service\RepositoryService;
 
 class Repository
 {
-    const CVS = 0;
-    const SVN = 1;
+    public const CVS = 0;
+    public const SVN = 1;
 
-    const VIEWER_CGIT = 'CGit';
-    const VIEWER_CVSTRAC = 'CVSTrac';
-    const VIEWER_FISHEYE = 'Fisheye';
-    const VIEWER_GITHUB = 'GitHub';
-    const VIEWER_GITLAB = 'GitLab';
-    const VIEWER_GITORIOUS = 'Gitorious';
-    const VIEWER_GITWEB = 'GitWeb';
-    const VIEWER_GITWEB2 = 'GitWeb2';
-    const VIEWER_HGWEB = 'Hgweb';
-    const VIEWER_STASH = 'Atlassian Stash';
-    const VIEWER_LOGGERHEAD = 'Loggerhead';
-    const VIEWER_P4WEB = 'P4Web';
-    const VIEWER_PHAB_GIT = 'Phabricator';
-    const VIEWER_REDMINE = 'Redmine';
-    const VIEWER_ALLURA = 'SourceForge Allura';
-    const VIEWER_TRAC = 'Trac';
-    const VIEWER_VIEWCVS = 'ViewCVS';
-    const VIEWER_VIEWVC = 'ViewVC';
-    const VIEWER_VIEWVC_1_1 = 'ViewVC1.1';
-    const VIEWER_WEBSVN = 'WebSVN';
+    public const VIEWER_CGIT = 'CGit';
+    public const VIEWER_CVSTRAC = 'CVSTrac';
+    public const VIEWER_FISHEYE = 'Fisheye';
+    public const VIEWER_GITHUB = 'GitHub';
+    public const VIEWER_GITLAB = 'GitLab';
+    public const VIEWER_GITORIOUS = 'Gitorious';
+    public const VIEWER_GITWEB = 'GitWeb';
+    public const VIEWER_GITWEB2 = 'GitWeb2';
+    public const VIEWER_HGWEB = 'Hgweb';
+    public const VIEWER_STASH = 'Atlassian Stash';
+    public const VIEWER_LOGGERHEAD = 'Loggerhead';
+    public const VIEWER_P4WEB = 'P4Web';
+    public const VIEWER_PHAB_GIT = 'Phabricator';
+    public const VIEWER_REDMINE = 'Redmine';
+    public const VIEWER_ALLURA = 'SourceForge Allura';
+    public const VIEWER_TRAC = 'Trac';
+    public const VIEWER_VIEWCVS = 'ViewCVS';
+    public const VIEWER_VIEWVC = 'ViewVC';
+    public const VIEWER_VIEWVC_1_1 = 'ViewVC1.1';
+    public const VIEWER_WEBSVN = 'WebSVN';
 
     /**
      * @return array

--- a/app/cdash/app/Model/SubProjectGroup.php
+++ b/app/cdash/app/Model/SubProjectGroup.php
@@ -344,7 +344,7 @@ class SubProjectGroup
                          $this->CoverageThreshold,
                          $starttime,
                          $endtime,
-                         $position
+                         $position,
                      ]));
 
             if ($query === false) {

--- a/app/cdash/app/Model/UserProject.php
+++ b/app/cdash/app/Model/UserProject.php
@@ -30,9 +30,9 @@ class UserProject
     public $ProjectId;
     private $PDO;
 
-    const NORMAL_USER = 0;
-    const SITE_MAINTAINER = 1;
-    const PROJECT_ADMIN = 2;
+    public const NORMAL_USER = 0;
+    public const SITE_MAINTAINER = 1;
+    public const PROJECT_ADMIN = 2;
 
     public function __construct()
     {

--- a/app/cdash/app/Model/UserProject.php
+++ b/app/cdash/app/Model/UserProject.php
@@ -129,7 +129,7 @@ class UserProject
                          $this->EmailSuccess,
                          $this->EmailMissingSites,
                          $this->UserId,
-                         $this->ProjectId
+                         $this->ProjectId,
                      ]);
             if ($query === false) {
                 add_last_sql_error('User2Project Update');
@@ -156,7 +156,7 @@ class UserProject
                          $this->EmailType,
                          $this->EmailCategory,
                          $this->EmailSuccess,
-                         $this->EmailMissingSites
+                         $this->EmailMissingSites,
                      ]);
             if ($query === false) {
                 add_last_sql_error('User2Project Create');

--- a/app/cdash/app/Service/RepositoryService.php
+++ b/app/cdash/app/Service/RepositoryService.php
@@ -49,7 +49,7 @@ class RepositoryService
             'description' => $description,
             'commit_hash' => $revision,
             'state'       => $state,
-            'target_url'  => $target_url
+            'target_url'  => $target_url,
         ];
         $this->repository->setStatus($options);
     }

--- a/app/cdash/include/Messaging/Notification/NotifyOn.php
+++ b/app/cdash/include/Messaging/Notification/NotifyOn.php
@@ -3,21 +3,21 @@ namespace CDash\Messaging\Notification;
 
 class NotifyOn
 {
-    const AUTHORED = 'Authored';
-    const UPDATE_ERROR = 'UpdateError';
-    const UPDATE = 'Update';
-    const CONFIGURE = 'Configure';
-    const BUILD_WARNING = 'BuildWarning';
-    const BUILD_ERROR = 'BuildError';
-    const TEST_FAILURE = 'TestFailure';
-    const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
-    const FIXED = 'Fixed';
-    const FILTERED = 'Filtered';
-    const LABELED = 'Labeled';
-    const SITE_MISSING = 'SiteMissing';
-    const GROUP_NIGHTLY = 'GroupMembership';
-    const ANY = 'Any';
-    const NEVER = 'Never';
-    const REDUNDANT = 'Redundant';
-    const SUMMARY = 'Summary';
+    public const AUTHORED = 'Authored';
+    public const UPDATE_ERROR = 'UpdateError';
+    public const UPDATE = 'Update';
+    public const CONFIGURE = 'Configure';
+    public const BUILD_WARNING = 'BuildWarning';
+    public const BUILD_ERROR = 'BuildError';
+    public const TEST_FAILURE = 'TestFailure';
+    public const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
+    public const FIXED = 'Fixed';
+    public const FILTERED = 'Filtered';
+    public const LABELED = 'Labeled';
+    public const SITE_MISSING = 'SiteMissing';
+    public const GROUP_NIGHTLY = 'GroupMembership';
+    public const ANY = 'Any';
+    public const NEVER = 'Never';
+    public const REDUNDANT = 'Redundant';
+    public const SUMMARY = 'Summary';
 }

--- a/app/cdash/include/Messaging/Preferences/BitmaskNotificationPreferences.php
+++ b/app/cdash/include/Messaging/Preferences/BitmaskNotificationPreferences.php
@@ -3,25 +3,25 @@ namespace CDash\Messaging\Preferences;
 
 class BitmaskNotificationPreferences extends NotificationPreferences
 {
-    const EMAIL_UPDATE = 2;                                      // 2^1
-    const EMAIL_CONFIGURE = 4;                                   // 2^2
-    const EMAIL_WARNING = 8;                                     // 2^3
-    const EMAIL_ERROR = 16;                                      // 2^4
-    const EMAIL_TEST = 32;                                       // 2^5
-    const EMAIL_DYNAMIC_ANALYSIS = 64;                           // 2^6
-    const EMAIL_FIXES = 128;                                     // 2^7
-    const EMAIL_MISSING_SITES = 256;                             // 2^8
+    public const EMAIL_UPDATE = 2;                                      // 2^1
+    public const EMAIL_CONFIGURE = 4;                                   // 2^2
+    public const EMAIL_WARNING = 8;                                     // 2^3
+    public const EMAIL_ERROR = 16;                                      // 2^4
+    public const EMAIL_TEST = 32;                                       // 2^5
+    public const EMAIL_DYNAMIC_ANALYSIS = 64;                           // 2^6
+    public const EMAIL_FIXES = 128;                                     // 2^7
+    public const EMAIL_MISSING_SITES = 256;                             // 2^8
 
     // NEW MASKS
-    const EMAIL_NEVER    = 0;
-    const EMAIL_FILTERED = 1;                                    // 2^0
-    const EMAIL_USER_CHECKIN_ISSUE_ANY_SECTION = 512;            // 2^9
-    const EMAIL_ANY_USER_CHECKIN_ISSUE_NIGHTLY_SECTION = 1024;   // 2^10
-    const EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION = 2048;       // 2^11
-    const EMAIL_SUBSCRIBED_LABELS = 4096;                        // 2^12
-    const EMAIL_NO_REDUNDANT = 8192;                             // 2^13
+    public const EMAIL_NEVER    = 0;
+    public const EMAIL_FILTERED = 1;                                    // 2^0
+    public const EMAIL_USER_CHECKIN_ISSUE_ANY_SECTION = 512;            // 2^9
+    public const EMAIL_ANY_USER_CHECKIN_ISSUE_NIGHTLY_SECTION = 1024;   // 2^10
+    public const EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION = 2048;       // 2^11
+    public const EMAIL_SUBSCRIBED_LABELS = 4096;                        // 2^12
+    public const EMAIL_NO_REDUNDANT = 8192;                             // 2^13
 
-    const DEFAULT_PREFERENCES = 8248;
+    public const DEFAULT_PREFERENCES = 8248;
 
     protected $preferences = [];
 

--- a/app/cdash/include/Messaging/Topic/Topic.php
+++ b/app/cdash/include/Messaging/Topic/Topic.php
@@ -8,14 +8,14 @@ use CDash\Model\SubscriberInterface;
 
 abstract class Topic implements TopicInterface
 {
-    const BUILD_ERROR = 'BuildError';
-    const BUILD_WARNING = 'BuildWarning';
-    const CONFIGURE = 'Configure';
-    const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
-    const LABELED = 'Labeled';
-    const TEST_FAILURE = 'TestFailure';
-    const TEST_MISSING = 'TestMissing';
-    const UPDATE_ERROR = 'UpdateError';
+    public const BUILD_ERROR = 'BuildError';
+    public const BUILD_WARNING = 'BuildWarning';
+    public const CONFIGURE = 'Configure';
+    public const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
+    public const LABELED = 'Labeled';
+    public const TEST_FAILURE = 'TestFailure';
+    public const TEST_MISSING = 'TestMissing';
+    public const UPDATE_ERROR = 'UpdateError';
 
     /** @var  SubscriberInterface $subscriber */
     protected $subscriber;

--- a/app/cdash/include/Test/BuildDiffForTesting.php
+++ b/app/cdash/include/Test/BuildDiffForTesting.php
@@ -37,7 +37,7 @@ trait BuildDiffForTesting
     ];
 
     private $fixed_keys = [
-        'builderrorsnegative' ,
+        'builderrorsnegative',
         'buildwarningsnegative',
         'testfailednegative',
         'testnotrunnegative',

--- a/app/cdash/include/Test/UseCase/BuildUseCase.php
+++ b/app/cdash/include/Test/UseCase/BuildUseCase.php
@@ -8,8 +8,8 @@ use BuildHandler;
 
 class BuildUseCase extends UseCase
 {
-    const WARNING = 0;
-    const ERROR = 1;
+    public const WARNING = 0;
+    public const ERROR = 1;
 
     private $command;
 
@@ -103,7 +103,7 @@ class BuildUseCase extends UseCase
 
     public function createFailure(array $default_properties)
     {
-        list($type, $properties) = $default_properties;
+        [$type, $properties] = $default_properties;
         $properties['type'] = $type === self::ERROR ? 'Error' : 'Warning';
 
         $this->createAction($properties)

--- a/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
+++ b/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
@@ -34,7 +34,7 @@ class DynamicAnalysisUseCase extends UseCase
     {
         parent::__construct('DynamicAnalysis', $properties);
         $faker = parent::getFaker();
-        $this->working_directory = isset($properties['WorkingDirectory']) ? $properties['WorkingDirectory'] :
+        $this->working_directory = $properties['WorkingDirectory'] ??
             "/users/{$faker->firstName}/{$faker->word}";
         $this->checker = '/usr/bin/valgrind';
     }

--- a/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
+++ b/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
@@ -24,8 +24,8 @@ use DynamicAnalysisHandler;
 
 class DynamicAnalysisUseCase extends UseCase
 {
-    const FAILED = 'failed';
-    const PASSED = 'passed';
+    public const FAILED = 'failed';
+    public const PASSED = 'passed';
 
     private $working_directory;
     private $checker;

--- a/app/cdash/include/Test/UseCase/TestUseCase.php
+++ b/app/cdash/include/Test/UseCase/TestUseCase.php
@@ -8,20 +8,20 @@ use TestingHandler;
 
 class TestUseCase extends UseCase
 {
-    const EXIT_CODE = 'Exit Code';
-    const EXIT_VALUE = 'Exit Value';
-    const EXE_TIME = 'Execution Time';
-    const COMPLETION_STATUS = 'Completion Status';
-    const CMD_LINE = 'Command Line';
+    public const EXIT_CODE = 'Exit Code';
+    public const EXIT_VALUE = 'Exit Value';
+    public const EXE_TIME = 'Execution Time';
+    public const COMPLETION_STATUS = 'Completion Status';
+    public const CMD_LINE = 'Command Line';
 
-    const TEXT_STRING = 'text/string';
-    const NUM_DOUBLE = 'numeric/double';
+    public const TEXT_STRING = 'text/string';
+    public const NUM_DOUBLE = 'numeric/double';
 
-    const FAILED = 'failed';
-    const PASSED = 'passed';
-    const OTHERFAULT = 'OTHER_FAULT';
-    const TIMEOUT = 'Timeout';
-    const NOTRUN = 'notrun';
+    public const FAILED = 'failed';
+    public const PASSED = 'passed';
+    public const OTHERFAULT = 'OTHER_FAULT';
+    public const TIMEOUT = 'Timeout';
+    public const NOTRUN = 'notrun';
 
     public function __construct(array $properties = [])
     {

--- a/app/cdash/include/Test/UseCase/TestUseCase.php
+++ b/app/cdash/include/Test/UseCase/TestUseCase.php
@@ -143,8 +143,7 @@ class TestUseCase extends UseCase
         $code_value = $code->appendChild(new DOMElement('Value'));
 
         /** @var DOMElement $exectime */
-        $exectime_text = isset($attributes['Execution Time']) ?
-            $attributes['Execution Time'] : '0.012004';
+        $exectime_text = $attributes['Execution Time'] ?? '0.012004';
 
         $exectime = $results->appendChild(new DOMElement('NamedMeasurement'));
         $exectime->setAttribute('name', 'Execution Time');

--- a/app/cdash/include/Test/UseCase/UpdateUseCase.php
+++ b/app/cdash/include/Test/UseCase/UpdateUseCase.php
@@ -77,7 +77,7 @@ class UpdateUseCase extends UseCase
 
         // create UpdateReturnStatus element
         $status = $update->appendChild(new \DOMElement('UpdateReturnStatus'));
-        $text = isset($prop['UpdateReturnStatus']) ? $prop['UpdateReturnStatus'] : '';
+        $text = $prop['UpdateReturnStatus'] ?? '';
         $status->appendChild(new \DOMText($text));
 
         $xml_str = $xml->saveXML($xml);

--- a/app/cdash/include/Test/UseCase/UpdateUseCase.php
+++ b/app/cdash/include/Test/UseCase/UpdateUseCase.php
@@ -3,8 +3,8 @@ namespace CDash\Test\UseCase;
 
 class UpdateUseCase extends UseCase
 {
-    const TYPE = 'Update';
-    const FAILED = 'FAILED';
+    public const TYPE = 'Update';
+    public const FAILED = 'FAILED';
 
     private $mode;
     private $generator;
@@ -222,7 +222,7 @@ class UpdateUseCase extends UseCase
     public function createPackage(array $properties)
     {
         if ($this->isSequential($properties)) {
-            list($name, $file, $author) = $properties;
+            [$name, $file, $author] = $properties;
             $properties = [
                 'Name' => $name,
                 'File' => $file,

--- a/app/cdash/include/Test/UseCase/UseCase.php
+++ b/app/cdash/include/Test/UseCase/UseCase.php
@@ -10,16 +10,16 @@ use DOMText;
 abstract class UseCase
 {
     /* actionable steps */
-    const TEST = 'Test';
-    const CONFIG = 'Config';
-    const UPDATE = 'Update';
-    const BUILD = 'Build';
-    const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
+    public const TEST = 'Test';
+    public const CONFIG = 'Config';
+    public const UPDATE = 'Update';
+    public const BUILD = 'Build';
+    public const DYNAMIC_ANALYSIS = 'DynamicAnalysis';
 
     /* build types (modes) */
-    const NIGHTLY = 'Nightly';
-    const CONTINUOUS = 'Continuous';
-    const EXPERIMENTAL = 'Experimental';
+    public const NIGHTLY = 'Nightly';
+    public const CONTINUOUS = 'Continuous';
+    public const EXPERIMENTAL = 'Experimental';
 
     private $faker;
     private $ids;

--- a/app/cdash/include/Test/UseCase/UseCase.php
+++ b/app/cdash/include/Test/UseCase/UseCase.php
@@ -217,10 +217,10 @@ abstract class UseCase
         $parser = xml_parser_create();
         xml_set_element_handler(
             $parser,
-            array($handler, 'startElement'),
-            array($handler, 'endElement')
+            [$handler, 'startElement'],
+            [$handler, 'endElement']
         );
-        xml_set_character_data_handler($parser, array($handler, 'text'));
+        xml_set_character_data_handler($parser, [$handler, 'text']);
         xml_parse($parser, $xml, false);
         return $handler;
     }

--- a/app/cdash/include/api_common.php
+++ b/app/cdash/include/api_common.php
@@ -108,7 +108,7 @@ function can_administrate_project($projectid)
  */
 function get_param($name, $required = true)
 {
-    $value = isset($_REQUEST[$name]) ? $_REQUEST[$name] : null;
+    $value = $_REQUEST[$name] ?? null;
     if ($required && !$value) {
         json_error_response(['error' => "Valid $name required"]);
         return null;

--- a/app/cdash/include/autoremove.php
+++ b/app/cdash/include/autoremove.php
@@ -32,7 +32,7 @@ function removeBuildsGroupwise(int $projectid, int $maxbuilds, bool $force = fal
     $db = Database::getInstance();
     $buildgroups = $db->executePrepared('SELECT id, autoremovetimeframe FROM buildgroup WHERE projectid=?', [$projectid]);
 
-    $buildids = array();
+    $buildids = [];
     foreach ($buildgroups as $buildgroup) {
         $days = $buildgroup['autoremovetimeframe'];
 
@@ -103,7 +103,7 @@ function removeFirstBuilds($projectid, $days, $maxbuilds, $force = false, $echo 
                    ', [$startdate, intval($projectid)]);
     add_last_sql_error('dailyupdates::removeFirstBuilds');
 
-    $buildids = array();
+    $buildids = [];
     foreach ($builds as $builds_array) {
         $buildids[] = $builds_array['id'];
     }

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -86,9 +86,9 @@ function generate_XSLT($xml, string $pageName, bool $return_html = false): strin
 
     $xh = new XSLTProcessor();
 
-    $arguments = array(
+    $arguments = [
         '/_xml' => $xml
-    );
+    ];
 
     if (!empty($config->get('CDASH_DEBUG_XML'))) {
         $tmp = preg_replace("#<[A-Za-z0-9\-_.]{1,250}>#", "\\0\n", $xml);
@@ -374,7 +374,7 @@ function get_project_name($projectid): string
  */
 function get_geolocation($ip)
 {
-    $location = array();
+    $location = [];
 
     $lat = '';
     $long = '';
@@ -395,7 +395,7 @@ function get_geolocation($ip)
             ob_end_clean();
             curl_close($curl);
         } elseif (ini_get('allow_url_fopen')) {
-            $options = array('http' => array('timeout' => 5.0));
+            $options = ['http' => ['timeout' => 5.0]];
             $context = stream_context_create($options);
             $httpReply = file_get_contents($url, false, $context);
         } else {
@@ -429,7 +429,7 @@ function get_geolocation($ip)
 
         foreach ($config->get('CDASH_DEFAULT_IP_LOCATIONS') as $defaultlocation) {
             $defaultip = $defaultlocation['IP'];
-            if (preg_match('#^' . strtr(preg_quote($defaultip, '#'), array('\*' => '.*', '\?' => '.')) . '$#i', $ip)) {
+            if (preg_match('#^' . strtr(preg_quote($defaultip, '#'), ['\*' => '.*', '\?' => '.']) . '$#i', $ip)) {
                 $location['latitude'] = $defaultlocation['latitude'];
                 $location['longitude'] = $defaultlocation['longitude'];
             }
@@ -449,7 +449,7 @@ function remove_project_builds($projectid): void
 
     $build = DB::select('SELECT id FROM build WHERE projectid=?', [intval($projectid)]);
 
-    $buildids = array();
+    $buildids = [];
     foreach ($build as $build_array) {
         $buildids[] = (int) $build_array->id;
     }
@@ -982,7 +982,7 @@ function get_dates($date, $nightlytime): array
     $todaydate = mktime(0, 0, 0, intval(date2month($date)), intval(date2day($date)), intval(date2year($date)));
     $previousdate = date(FMT_DATE, $todaydate - 3600 * 24);
     $nextdate = date(FMT_DATE, $todaydate + 3600 * 24);
-    return array($previousdate, $today, $nextdate, $date);
+    return [$previousdate, $today, $nextdate, $date];
 }
 
 function has_next_date($date, $currentstarttime): bool
@@ -1237,10 +1237,10 @@ function begin_XML_for_XSLT(): string
 
 function begin_JSON_response(): array
 {
-    $response = array();
+    $response = [];
     $response['version'] = CDash\Config::getVersion();
 
-    $user_response = array();
+    $user_response = [];
     $userid = Auth::id();
     if ($userid) {
         $user = Auth::user();
@@ -1360,7 +1360,7 @@ function DeleteDirectory(string $dirName): void
         new RecursiveDirectoryIterator($dirName),
         RecursiveIteratorIterator::CHILD_FIRST);
     foreach ($iterator as $file) {
-        if (in_array($file->getBasename(), array('.', '..'))) {
+        if (in_array($file->getBasename(), ['.', '..'])) {
             continue;
         }
         if ($file->isDir()) {

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -87,7 +87,7 @@ function generate_XSLT($xml, string $pageName, bool $return_html = false): strin
     $xh = new XSLTProcessor();
 
     $arguments = [
-        '/_xml' => $xml
+        '/_xml' => $xml,
     ];
 
     if (!empty($config->get('CDASH_DEBUG_XML'))) {

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1033,7 +1033,7 @@ function get_cdash_dashboard_xml_by_name(string $projectname, $date): string
 
     $project_array = array_merge($default, $result);
 
-    list($previousdate, $currentstarttime, $nextdate) = get_dates($date, $project_array['nightlytime']);
+    [$previousdate, $currentstarttime, $nextdate] = get_dates($date, $project_array['nightlytime']);
 
     $xml = '<dashboard>
   <datetime>' . date('l, F d Y H:i:s', time()) . '</datetime>
@@ -1275,7 +1275,7 @@ function get_dashboard_JSON($projectname, $date, &$response)
     if (is_null($date)) {
         $date = date(FMT_DATE);
     }
-    list($previousdate, $currentstarttime, $nextdate) = get_dates($date, $project_array['nightlytime']);
+    [$previousdate, $currentstarttime, $nextdate] = get_dates($date, $project_array['nightlytime']);
 
     $response['datetime'] = date('l, F d Y H:i:s', time());
     $response['date'] = $date;

--- a/app/cdash/include/ctestparserutils.php
+++ b/app/cdash/include/ctestparserutils.php
@@ -77,8 +77,8 @@ function compute_error_difference($buildid, $previousbuildid, $warning)
     // Recurring buildfailures are represented by the buildfailuredetails table.
     // Get a list of buildfailuredetails IDs for the current build and the
     // previous build.
-    $current_failures = array();
-    $previous_failures = array();
+    $current_failures = [];
+    $previous_failures = [];
 
     $stmt = $pdo->prepare(
         'SELECT bf.detailsid FROM buildfailure AS bf

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -35,7 +35,7 @@ use Illuminate\Support\Facades\Storage;
 
 function get_related_dates(string $projectnightlytime, string $basedate): array
 {
-    $dates = array();
+    $dates = [];
     $nightlytime = $projectnightlytime;
 
     if (strlen($basedate) == 0) {
@@ -128,7 +128,7 @@ function is_cvs_root($root): bool
 /** Get the CVS repository commits */
 function get_cvs_repository_commits($cvsroot, $dates): array
 {
-    $commits = array();
+    $commits = [];
 
     // Compute time stamp range expressed as $fromtime and $totime for cvs
     //
@@ -170,7 +170,7 @@ function get_cvs_repository_commits($cvsroot, $dates): array
         $npos = strpos($vv, '--------------------');
         if ($npos !== false && $npos === 0) {
             if ($in_revision_chunk === 1) {
-                $commit = array();
+                $commit = [];
                 $commit['directory'] = $current_directory;
                 $commit['filename'] = $current_filename;
                 $commit['revision'] = $current_revision;
@@ -234,7 +234,7 @@ function get_cvs_repository_commits($cvsroot, $dates): array
             // still $in_revision_chunk?
             $npos = strpos($vv, '====================');
             if ($npos !== false && $npos === 0) {
-                $commit = array();
+                $commit = [];
                 $commit['directory'] = $current_directory;
                 $commit['filename'] = $current_filename;
                 $commit['revision'] = $current_revision;
@@ -266,8 +266,8 @@ function get_cvs_repository_commits($cvsroot, $dates): array
 function get_p4_repository_commits($root, $branch, $dates): array
 {
     $config = Config::getInstance();
-    $commits = array();
-    $users = array();
+    $commits = [];
+    $users = [];
 
     // Add the command line specified by the user in the "Repository" field
     // of the project settings "Repository" tab and set the message language
@@ -292,7 +292,7 @@ function get_p4_repository_commits($root, $branch, $dates): array
             $raw_output = `$p4command describe -s $matches[1]`;
             $describe_lines = explode("\n", $raw_output);
 
-            $commit = array();
+            $commit = [];
 
             // Parse the changelist description and add each file modified to the
             // commits list
@@ -311,7 +311,7 @@ function get_p4_repository_commits($root, $branch, $dates): array
                     } else {
                         $raw_output = `$p4command users -m 1 $user`;
                         if (preg_match("/^(.+) <(.*)> \((.*)\) accessed (.*)$/", $raw_output, $matches)) {
-                            $newuser = array();
+                            $newuser = [];
                             $newuser['username'] = $matches[1];
                             $newuser['email'] = $matches[2];
                             $newuser['name'] = $matches[3];
@@ -344,7 +344,7 @@ function get_p4_repository_commits($root, $branch, $dates): array
 function get_git_repository_commits($gitroot, $dates, $branch, $previousrevision): array
 {
     $config = Config::getInstance();
-    $commits = array();
+    $commits = [];
 
     $gitcommand = $config->get('CDASH_GIT_COMMAND');
     $gitlocaldirectory = $config->get('CDASH_DEFAULT_GIT_DIRECTORY');
@@ -402,7 +402,7 @@ function get_git_repository_commits($gitroot, $dates, $branch, $previousrevision
 
     foreach ($lines as $line) {
         if (substr($line, 0, 6) == 'commit') {
-            $commit = array();
+            $commit = [];
             $commit['revision'] = substr($line, 7);
             $commit['priorrevision'] = '';
             $commit['comment'] = '';
@@ -439,7 +439,7 @@ function get_git_repository_commits($gitroot, $dates, $branch, $previousrevision
 /** Get the SVN repository commits */
 function get_svn_repository_commits($svnroot, $dates, $username = '', $password = ''): array
 {
-    $commits = array();
+    $commits = [];
 
     // To pick up all possible changes, the svn log query has to go back
     // *2* days -- svn log (for date queries) spits out all changes since
@@ -464,7 +464,7 @@ function get_svn_repository_commits($svnroot, $dates, $username = '', $password 
 
     $lines = explode("\n", $raw_output);
 
-    $gathered_file_lines = array();
+    $gathered_file_lines = [];
     $current_author = '';
     $current_comment = '';
     $current_directory = '';
@@ -510,7 +510,7 @@ function get_svn_repository_commits($svnroot, $dates, $username = '', $password 
 
                         $current_directory = remove_directory_from_filename($current_filename);
 
-                        $commit = array();
+                        $commit = [];
                         $commit['directory'] = $current_directory;
                         $commit['filename'] = $current_filename;
                         $commit['revision'] = $current_revision;
@@ -523,7 +523,7 @@ function get_svn_repository_commits($svnroot, $dates, $username = '', $password 
                 } else {
                     //echo "excluding: '" . $current_time . "' (" . gmdate(FMT_DATETIMEMS, $current_time) . ")<br/>";
                 }
-                $gathered_file_lines = array();
+                $gathered_file_lines = [];
             }
             $current_comment = '';
             $last_chunk_line_number = $line_number;
@@ -595,7 +595,7 @@ function get_svn_repository_commits($svnroot, $dates, $username = '', $password 
 /** Get BZR repository commits */
 function get_bzr_repository_commits($bzrroot, $dates): array
 {
-    $commits = array();
+    $commits = [];
 
     $fromtime = gmdate(FMT_DATETIMESTD, $dates['nightly-1'] + 1) . ' GMT';
     $totime = gmdate(FMT_DATETIMESTD, $dates['nightly-0']) . ' GMT';
@@ -619,7 +619,7 @@ function get_bzr_repository_commits($bzrroot, $dates): array
         foreach ($files as $file) {
             $current_filename = $file->nodeValue;
             $current_directory = remove_directory_from_filename($current_filename);
-            $commit = array();
+            $commit = [];
             $commit['directory'] = $current_directory;
             $commit['filename'] = $current_filename;
             $commit['revision'] = $current_revision;
@@ -664,7 +664,7 @@ function get_repository_commits(int $projectid, $dates): array
     $cvsviewer = $cvsviewers_array['cvsviewertype'];
 
     // Start with an empty array:
-    $commits = array();
+    $commits = [];
 
     foreach ($repositories as $repositories_array) {
         $root = $repositories_array['url'];
@@ -907,7 +907,7 @@ function cleanUserTemp(): void
 function sendEmailUnregisteredUsers(int $projectid, $cvsauthors): void
 {
     $config = Config::getInstance();
-    $unregisteredusers = array();
+    $unregisteredusers = [];
     foreach ($cvsauthors as $author) {
         if ($author == 'Local User') {
             continue;
@@ -989,7 +989,7 @@ function addDailyChanges(int $projectid): void
                      AND date=?
              ', [$projectid, $date]);
     if (intval($query['c']) === 0) {
-        $cvsauthors = array();
+        $cvsauthors = [];
 
         $db->executePrepared("
             INSERT INTO dailyupdate (projectid, date, command, type, status)

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -975,7 +975,7 @@ function addDailyChanges(int $projectid): void
     $project = new Project();
     $project->Id = $projectid;
     $project->Fill();
-    list($previousdate, $currentstarttime, $nextdate) = get_dates('now', $project->NightlyTime);
+    [$previousdate, $currentstarttime, $nextdate] = get_dates('now', $project->NightlyTime);
     $date = gmdate(FMT_DATE, $currentstarttime);
 
     $db = Database::getInstance();

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -797,7 +797,7 @@ function sendEmailExpectedBuilds($projectid, $currentstarttime): void
                            $currentEndUTCTime,
                            $projectid,
                            $currentBeginUTCTime,
-                           $currentEndUTCTime
+                           $currentEndUTCTime,
                        ]);
 
     $projectname = get_project_name($projectid);
@@ -1036,7 +1036,7 @@ function addDailyChanges(int $projectid): void
                 $email,
                 $log,
                 $revision,
-                $priorrevision
+                $priorrevision,
             ]);
             add_last_sql_error('addDailyChanges', $projectid);
         }
@@ -1167,7 +1167,7 @@ function addDailyChanges(int $projectid): void
                   endtime < :endtime");
         $query_params = [
             ':projectid' => $project->Id,
-            ':endtime' => $cutoff_date
+            ':endtime' => $cutoff_date,
         ];
         $db->execute($stmt, $query_params);
         while ($row = $stmt->fetch()) {

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -103,7 +103,7 @@ class IndexPhpFilters extends DefaultFilters
                 break;
             }
         }
-        $this->FiltersAffectedBySubProjects = array(
+        $this->FiltersAffectedBySubProjects = [
                 'buildduration',
                 'builderrors',
                 'buildwarnings',
@@ -114,17 +114,17 @@ class IndexPhpFilters extends DefaultFilters
                 'testsfailed',
                 'testsnotrun',
                 'testspassed',
-                'testtimestatus');
+                'testtimestatus'];
     }
 
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'site',
             'fieldtype' => 'string',
             'compare' => 63,
             'value' => '',
-        );
+        ];
     }
 
     public function getFilterDefinitionsXML()
@@ -371,12 +371,12 @@ class QueryTestsPhpFilters extends DefaultFilters
 {
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'testname',
             'fieldtype' => 'string',
             'compare' => 63,
             'value' => '',
-        );
+        ];
     }
 
     public function getFilterDefinitionsXML()
@@ -473,12 +473,12 @@ class ViewCoveragePhpFilters extends DefaultFilters
 {
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'filename',
             'fieldtype' => 'string',
             'compare' => 63,
             'value' => '',
-        );
+        ];
     }
 
     public function getDefaultShowLimit()
@@ -561,12 +561,12 @@ class ViewTestPhpFilters extends DefaultFilters
 {
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'testname',
             'fieldtype' => 'string',
             'compare' => 63,
             'value' => '',
-        );
+        ];
     }
 
     public function getFilterDefinitionsXML()
@@ -634,12 +634,12 @@ class CompareCoveragePhpFilters extends DefaultFilters
 {
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'subproject',
             'fieldtype' => 'string',
             'compare' => 61,
             'value' => ''
-        );
+        ];
     }
 
     public function getFilterDefinitionsXML()
@@ -669,12 +669,12 @@ class TestOverviewPhpFilters extends DefaultFilters
 {
     public function getDefaultFilter()
     {
-        return array(
+        return [
             'field' => 'buildname',
             'fieldtype' => 'string',
             'compare' => 63,
             'value' => ''
-        );
+        ];
     }
 
     public function getFilterDefinitionsXML()
@@ -979,7 +979,7 @@ function get_sql_compare_and_value($compare, $value)
             trigger_error('unknown $compare value: ' . $compare, E_USER_WARNING);
             break;
     }
-    return array($sql_compare, $sql_value);
+    return [$sql_compare, $sql_value];
 }
 
 // Parse a filter's field, compare, and value from the request and return an
@@ -1231,7 +1231,7 @@ function generate_filterdata_sql($filterdata)
 // Return a list of label IDs that match the specified filterdata.
 function get_label_ids_from_filterdata($filterdata)
 {
-    $label_ids = array();
+    $label_ids = [];
     $clauses = 0;
     $label_sql = '';
     $sql_combine = $filterdata['filtercombine'];

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -1062,7 +1062,7 @@ function get_filterdata_from_request($page_id = '')
     $showlimit = intval($_GET['showlimit'] ?? 0);
     $limit = intval($_GET['limit'] ?? 0);
 
-    $clear = isset($_GET['clear']) ? $_GET['clear'] : '';
+    $clear = $_GET['clear'] ?? '';
     if ($clear == 'Clear') {
         $filtercount = 0;
     }

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -362,7 +362,7 @@ class IndexChildrenPhpFilters extends IndexPhpFilters
         return [
             'field' => 'subprojects',
             'compare' => 92,
-            'value' => ''
+            'value' => '',
         ];
     }
 }
@@ -638,7 +638,7 @@ class CompareCoveragePhpFilters extends DefaultFilters
             'field' => 'subproject',
             'fieldtype' => 'string',
             'compare' => 61,
-            'value' => ''
+            'value' => '',
         ];
     }
 
@@ -673,7 +673,7 @@ class TestOverviewPhpFilters extends DefaultFilters
             'field' => 'buildname',
             'fieldtype' => 'string',
             'compare' => 63,
-            'value' => ''
+            'value' => '',
         ];
     }
 
@@ -1020,7 +1020,7 @@ function parse_filter_from_request($field_var, $compare_var, $value_var,
     return [
         'field'   => $field,
         'compare' => $compare,
-        'value'   => $value
+        'value'   => $value,
     ];
 }
 
@@ -1075,7 +1075,7 @@ function get_filterdata_from_request($page_id = '')
             // Handle block of filters.
             $subfiltercount = pdo_real_escape_numeric(@$_GET["field{$i}count"]);
             $filter = [
-                'filters' => []
+                'filters' => [],
             ];
             for ($j = 1; $j <= $subfiltercount; ++$j) {
                 $filter['filters'][] = parse_filter_from_request(

--- a/app/cdash/include/log.php
+++ b/app/cdash/include/log.php
@@ -88,7 +88,7 @@ if (!function_exists('add_log')) {
             $buildid = $GLOBALS['PHP_ERROR_BUILD_ID'];
         }
 
-        $context = array('function' => $function);
+        $context = ['function' => $function];
 
         if ($projectid !== 0 && !is_null($projectid)) {
             $context['project_id'] = $projectid;

--- a/app/cdash/include/repository.php
+++ b/app/cdash/include/repository.php
@@ -804,13 +804,13 @@ function post_github_pull_request_comment(Project $project, $pull_request, $comm
     // Format our comment using Github's comment syntax.
     $message = "[$comment]($cdash_url)";
 
-    $data = array('body' => $message);
+    $data = ['body' => $message];
     $data_string = json_encode($data);
 
     $ch = curl_init($post_url);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
             'Content-Type: application/json',
-            'Content-Length: ' . strlen($data_string))
+            'Content-Length: ' . strlen($data_string)]
     );
     curl_setopt($ch, CURLOPT_HEADER, 1);
     $userpwd = $repo['username'] . ':' . $repo['password'];
@@ -827,7 +827,7 @@ function post_github_pull_request_comment(Project $project, $pull_request, $comm
             'post_github_pull_request_comment',
             LOG_ERR, $project->Id);
     } elseif (config('app.debug')) {
-        $matches = array();
+        $matches = [];
         preg_match("#/comments/(\d+)#", $retval, $matches);
         add_log(
             'Just posted comment #' . $matches[1],

--- a/app/cdash/include/sendemail.php
+++ b/app/cdash/include/sendemail.php
@@ -110,7 +110,7 @@ function check_email_errors(int $buildid, bool $checktesttimeingchanged, int $te
 /** Check for update errors for a given build. */
 function check_email_update_errors(int $buildid): array
 {
-    $errors = array();
+    $errors = [];
     $errors['errors'] = true;
     $errors['hasfixes'] = false;
 

--- a/app/cdash/include/sendemail.php
+++ b/app/cdash/include/sendemail.php
@@ -324,7 +324,7 @@ function get_email_summary(int $buildid, array $errors, $errorkey, int $maxitems
         }
     } elseif ($errorkey === 'missing_tests') {
         // sanity check
-        $missing = isset($errors['missing_tests']['count']) ? $errors['missing_tests']['count'] : 0;
+        $missing = $errors['missing_tests']['count'] ?? 0;
 
         if ($missing) {
             $information .= "\n\n*Missing tests*";

--- a/app/cdash/include/upgrade_functions.php
+++ b/app/cdash/include/upgrade_functions.php
@@ -272,9 +272,9 @@ function ComputeTestTiming($days = 4)
                         ");
                 echo pdo_error();
 
-                $testarray = array();
+                $testarray = [];
                 while ($test_array = pdo_fetch_array($previoustest)) {
-                    $test = array();
+                    $test = [];
                     $test['id'] = $test_array['testid'];
                     $test['name'] = $test_array['name'];
                     $testarray[] = $test;
@@ -658,10 +658,10 @@ function AddUniqueConstraintToSiteTable($site_table)
 
     // Tables with a siteid field that will need to be updated as we prune
     // out duplicate sites.
-    $tables_to_update = array('build', 'build2grouprule', 'site2user',
+    $tables_to_update = ['build', 'build2grouprule', 'site2user',
         'client_job', 'client_site2cmake', 'client_site2compiler',
         'client_site2library', 'client_site2program',
-        'client_site2project');
+        'client_site2project'];
 
     // Find all the rows that will violate this new unique constraint.
     $query = "SELECT name, COUNT(*) FROM $site_table
@@ -690,7 +690,7 @@ function AddUniqueConstraintToSiteTable($site_table)
 
         // Now that we've identified which row to keep, let's find all its
         // duplicates to remove.
-        $ids_to_remove = array();
+        $ids_to_remove = [];
         $dupe_query =
             "SELECT id FROM $site_table
             WHERE id != $id_to_keep AND name = '$name'";

--- a/app/cdash/include/upgrade_functions.php
+++ b/app/cdash/include/upgrade_functions.php
@@ -182,7 +182,7 @@ function AddTablePrimaryKey($table, $field)
     add_log("Adding primarykey $field to $table", 'AddTablePrimaryKey');
     $query = 'ALTER TABLE "' . $table . '" ADD PRIMARY KEY ("' . $field . '")';
     $version = pdo_get_vendor_version();
-    list($major, $minor, $patch) = explode(".", $version);
+    [$major, $minor, $patch] = explode(".", $version);
 
     // As of MySQL 5.7.4, the IGNORE clause for ALTER TABLE is removed and its use produces an error.
     // Retaining original query for backwards compatibility

--- a/app/cdash/public/api/v1/GitHub/webhook.php
+++ b/app/cdash/public/api/v1/GitHub/webhook.php
@@ -34,7 +34,7 @@ if (!is_null($hookSecret)) {
     } elseif (!extension_loaded('hash')) {
         handle_error("Missing 'hash' extension to check the secret code validity.");
     }
-    list($algo, $hash) = explode('=', $_SERVER['HTTP_X_HUB_SIGNATURE'], 2) + ['', ''];
+    [$algo, $hash] = explode('=', $_SERVER['HTTP_X_HUB_SIGNATURE'], 2) + ['', ''];
     if (!in_array($algo, hash_algos(), true)) {
         handle_error("Hash algorithm '$algo' is not supported.");
     }

--- a/app/cdash/public/api/v1/GitHub/webhook.php
+++ b/app/cdash/public/api/v1/GitHub/webhook.php
@@ -34,7 +34,7 @@ if (!is_null($hookSecret)) {
     } elseif (!extension_loaded('hash')) {
         handle_error("Missing 'hash' extension to check the secret code validity.");
     }
-    list($algo, $hash) = explode('=', $_SERVER['HTTP_X_HUB_SIGNATURE'], 2) + array('', '');
+    list($algo, $hash) = explode('=', $_SERVER['HTTP_X_HUB_SIGNATURE'], 2) + ['', ''];
     if (!in_array($algo, hash_algos(), true)) {
         handle_error("Hash algorithm '$algo' is not supported.");
     }

--- a/app/cdash/public/api/v1/build.php
+++ b/app/cdash/public/api/v1/build.php
@@ -122,7 +122,7 @@ function rest_get($build)
             ':type'      => $build->Type,
             ':name'      => $build->Name,
             ':projectid' => $build->ProjectId,
-            ':starttime' => $build->StartTime
+            ':starttime' => $build->StartTime,
         ];
 
         // Prepared statement to find the oldest submission for this build.

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -318,7 +318,7 @@ function rest_post($pdo, $projectid)
             $siteid = $_POST['site']['id'];
         }
 
-        $sql_match = $match = isset($_POST['match']) ? $_POST['match'] : '';
+        $sql_match = $match = $_POST['match'] ?? '';
         if (!empty($match)) {
             $sql_match = $_POST['match'];
         }

--- a/app/cdash/public/api/v1/computeClassifier.php
+++ b/app/cdash/public/api/v1/computeClassifier.php
@@ -73,7 +73,7 @@ $classifiers = [];
 foreach ($allProperties as $propertyName => $propertyData) {
     if ($propertyData['type'] == 'number') {
         // Numerical property.
-        list($classifierName, $score) =
+        [$classifierName, $score] =
             find_numerical_classifier($propertyName, $propertyData, $builds);
         $classifiers[] =
             ['classifier' => $classifierName, 'accuracy' => $score];
@@ -137,8 +137,8 @@ function compute_classifier_score($inGroup, $outGroup)
     }
 
     // Count number of successful and failed samples for the in & out groups.
-    list($numSucceededInGroup, $numFailedInGroup) = count_samples($inGroup);
-    list($numSucceededOutGroup, $numFailedOutGroup) = count_samples($outGroup);
+    [$numSucceededInGroup, $numFailedInGroup] = count_samples($inGroup);
+    [$numSucceededOutGroup, $numFailedOutGroup] = count_samples($outGroup);
 
     // We initially assume that the in group should contain true samples and the
     // out group should contain false samples.

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -52,7 +52,7 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_get')) {
      */
     function rest_get($siteid, $buildgroupid, $buildname, $buildtype, $projectid)
     {
-        $response = array();
+        $response = [];
 
         if (!array_key_exists('currenttime', $_REQUEST)) {
             abort(400, '"currenttime" not specified in request.');
@@ -124,7 +124,7 @@ $rest_json = json_decode(file_get_contents('php://input'), true);
 if (!is_null($rest_json)) {
     $_REQUEST = array_merge($_REQUEST, $rest_json);
 }
-$required_params = array('siteid', 'groupid', 'name', 'type');
+$required_params = ['siteid', 'groupid', 'name', 'type'];
 foreach ($required_params as $param) {
     if (!array_key_exists($param, $_REQUEST)) {
         abort(400, "$param not specified.");

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -75,7 +75,7 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_get')) {
             ':buildtype' => $buildtype,
             ':buildname' => $buildname,
             ':projectid' => $projectid,
-            ':starttime' => $currentUTCtime
+            ':starttime' => $currentUTCtime,
         ];
         $db->execute($stmt, $query_params);
         $lastBuildDate = $stmt->fetchColumn();

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -119,7 +119,7 @@ $response['showtesttime'] = $Project->ShowTestTime;
 $page_id = 'index.php';
 
 // Begin menu definition
-$response['menu'] = array();
+$response['menu'] = [];
 $beginning_UTCDate = $controller->getBeginDate();
 $end_UTCDate = $controller->getEndDate();
 if ($Project->GetNumberOfSubProjects($end_UTCDate) > 0) {
@@ -138,14 +138,14 @@ if (isset($_GET['subproject'])) {
         $controller->setSubProjectId($subprojectid);
         $response['subprojectname'] = $subproject_name;
 
-        $subproject_response = array();
+        $subproject_response = [];
         $subproject_response['name'] = $SubProject->GetName();
 
         $dependencies = $SubProject->GetDependencies();
         if ($dependencies) {
-            $dependencies_response = array();
+            $dependencies_response = [];
             foreach ($dependencies as $dependency) {
-                $dependency_response = array();
+                $dependency_response = [];
                 $DependProject = new SubProject();
                 $DependProject->SetId($dependency);
                 $result = $DependProject->CommonBuildQuery($beginning_UTCDate, $end_UTCDate, false);
@@ -257,7 +257,7 @@ $build_data = array_merge($build_data, $controller->getDynamicBuilds());
 // Check if we need to summarize coverage by subproject groups.
 // This happens when we have subprojects and we're looking at the children
 // of a specific build.
-$coverage_groups = array();
+$coverage_groups = [];
 $groupId = -1;
 if (isset($_GET['parentid']) && (int) $_GET['parentid'] > 0 && $Project->GetNumberOfSubProjects($end_UTCDate) > 0) {
     $groups = $Project->GetSubProjectGroups();
@@ -265,7 +265,7 @@ if (isset($_GET['parentid']) && (int) $_GET['parentid'] > 0 && $Project->GetNumb
         // Keep track of coverage info on a per-group basis.
         $groupId = $group->GetId();
 
-        $coverage_groups[$groupId] = array();
+        $coverage_groups[$groupId] = [];
         $coverageThreshold = $group->GetCoverageThreshold();
         $coverage_groups[$groupId]['thresholdgreen'] = $coverageThreshold;
         $coverage_groups[$groupId]['thresholdyellow'] = $coverageThreshold * 0.7;
@@ -273,11 +273,11 @@ if (isset($_GET['parentid']) && (int) $_GET['parentid'] > 0 && $Project->GetNumb
         $coverage_groups[$groupId]['loctested'] = 0;
         $coverage_groups[$groupId]['locuntested'] = 0;
         $coverage_groups[$groupId]['position'] = $group->GetPosition();
-        $coverage_groups[$groupId]['coverages'] = array();
+        $coverage_groups[$groupId]['coverages'] = [];
     }
     if (count($groups) > 1) {
         // Add a Total group too.
-        $coverage_groups[0] = array();
+        $coverage_groups[0] = [];
         $coverageThreshold = (int) $Project->CoverageThreshold;
         $coverage_groups[0]['thresholdgreen'] = $coverageThreshold;
         $coverage_groups[0]['thresholdyellow'] = $coverageThreshold * 0.7;
@@ -297,8 +297,8 @@ foreach ($build_data as $build_row) {
 }
 
 // Generate the JSON response from the rows of builds.
-$response['coverages'] = array();
-$response['dynamicanalyses'] = array();
+$response['coverages'] = [];
+$response['dynamicanalyses'] = [];
 $num_nightly_coverages_builds = 0;
 $show_aggregate = false;
 $response['comparecoverage'] = 0;
@@ -371,7 +371,7 @@ foreach ($build_rows as $build_array) {
     $loctested = (int) $build_array['loctested'];
     $locuntested = (int) $build_array['locuntested'];
     if ($loctested + $locuntested > 0) {
-        $coverage_response = array();
+        $coverage_response = [];
         $coverage_response['buildid'] = (int) $build_array['id'];
         if ($linkToChildCoverage) {
             $coverage_response['childlink'] = $build_response['multiplebuildshyperlink'] . '##Coverage';
@@ -460,7 +460,7 @@ foreach ($build_rows as $build_array) {
         // of its own.
         $linkToChildrenDA = in_array((int) $build_array['id'], $linkToChildrenDAArray, true);
 
-        $DA_response = array();
+        $DA_response = [];
         $DA_response['site'] = $build_array['sitename'];
         $DA_response['siteid'] = $build_array['siteid'];
         $DA_response['buildname'] = $build_array['name'];
@@ -525,7 +525,7 @@ for ($i = 0; $i < count($controller->buildgroupsResponse); $i++) {
 
 // Create a separate "all buildgroups" section of our response.
 // This is used to allow project admins to move builds between groups.
-$response['all_buildgroups'] = array();
+$response['all_buildgroups'] = [];
 foreach ($controller->buildgroupsResponse as $group) {
     $response['all_buildgroups'][] = [
         'id' => $group['id'],
@@ -624,7 +624,7 @@ if ($response['childview'] === 1) {
 
 // Generate coverage by group here.
 if (count($coverage_groups) > 0) {
-    $response['coveragegroups'] = array();
+    $response['coveragegroups'] = [];
     foreach ($coverage_groups as $groupid => $group) {
         $loctested = $group['loctested'];
         $locuntested = $group['locuntested'];

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -529,7 +529,7 @@ $response['all_buildgroups'] = [];
 foreach ($controller->buildgroupsResponse as $group) {
     $response['all_buildgroups'][] = [
         'id' => $group['id'],
-        'name' => $group['name']
+        'name' => $group['name'],
     ];
 }
 

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -130,11 +130,11 @@ $response['sites'] = $sites;
 $Project = new Project();
 $Project->Id = $projectid;
 $buildgroups = $Project->GetBuildGroups();
-$buildgroups_response = array();
-$dynamics_response = array();
+$buildgroups_response = [];
+$dynamics_response = [];
 /** @var BuildGroup $buildgroup */
 foreach ($buildgroups as $buildgroup) {
-    $buildgroup_response = array();
+    $buildgroup_response = [];
 
     if ($show == $buildgroup->GetId()) {
         $buildgroup_response['selected'] = '1';
@@ -239,9 +239,9 @@ if (!empty($err)) {
     $response['error'] = $err;
 }
 
-$wildcards_response = array();
+$wildcards_response = [];
 foreach ($wildcards as $wildcard_array) {
-    $wildcard_response = array();
+    $wildcard_response = [];
     $wildcard_response['buildgroupname'] = $wildcard_array['name'];
     $wildcard_response['buildgroupid'] = $wildcard_array['id'];
     $wildcard_response['buildtype'] = $wildcard_array['buildtype'];

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -111,10 +111,10 @@ $query = $db->executePrepared('
 
 add_last_sql_error('manageOverview::overviewgroups', $projectid);
 
-$build_response = array();
-$static_response = array();
+$build_response = [];
+$static_response = [];
 foreach ($query as $overviewgroup_row) {
-    $group_response = array();
+    $group_response = [];
     $group_response['id'] = intval($overviewgroup_row['id']);
     $group_response['name'] = $overviewgroup_row['name'];
     $type = $overviewgroup_row['type'];
@@ -148,9 +148,9 @@ $buildgroup_rows = $db->executePrepared('
                    ', [intval($projectid)]);
 add_last_sql_error('manageOverview::buildgroups', $projectid);
 
-$availablegroups_response = array();
+$availablegroups_response = [];
 foreach ($buildgroup_rows as $buildgroup_row) {
-    $buildgroup_response = array();
+    $buildgroup_response = [];
     $buildgroup_response['id'] = intval($buildgroup_row['id']);
     $buildgroup_response['name'] = $buildgroup_row['name'];
     $availablegroups_response[] = $buildgroup_response;

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -272,10 +272,10 @@ function populate_project($Project)
 
     if (isset($project_settings['repositories'])) {
         // Add the repositories.
-        $repo_urls = array();
-        $repo_branches = array();
-        $repo_usernames = array();
-        $repo_passwords = array();
+        $repo_urls = [];
+        $repo_branches = [];
+        $repo_usernames = [];
+        $repo_passwords = [];
         foreach ($project_settings['repositories'] as $repo) {
             $repo_urls[] = $repo['url'];
             $repo_branches[] = $repo['branch'];

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -104,20 +104,20 @@ function rest_get($projectid): bool
     }
 
     $dependencies = $SubProject->GetDependencies();
-    $dependencies_response = array();
-    $available_dependencies_response = array();
+    $dependencies_response = [];
+    $available_dependencies_response = [];
 
     foreach ($query as $row) {
         if (intval($row['id']) === $subprojectid) {
             continue;
         }
         if (is_array($dependencies) && in_array($row['id'], $dependencies)) {
-            $dep = array();
+            $dep = [];
             $dep['id'] = intval($row['id']);
             $dep['name'] = $row['name'];
             $dependencies_response[] = $dep;
         } else {
-            $avail = array();
+            $avail = [];
             $avail['id'] = intval($row['id']);
             $avail['name'] = $row['name'];
             $available_dependencies_response[] = $avail;
@@ -183,7 +183,7 @@ function rest_post($projectid)
         $SubProject->Save();
 
         // Respond with a JSON representation of this new subproject
-        $response = array();
+        $response = [];
         $response['id'] = $SubProject->GetId();
         $response['name'] = $SubProject->GetName();
         $response['group'] = $SubProject->GetGroupId();
@@ -205,7 +205,7 @@ function rest_post($projectid)
         $Group->Save();
 
         // Respond with a JSON representation of this new group
-        $response = array();
+        $response = [];
         $response['id'] = $Group->GetId();
         $response['name'] = $Group->GetName();
         $response['is_default'] = $Group->GetIsDefault();

--- a/app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
@@ -45,7 +45,7 @@ class DynamicAnalysisUseCaseTest extends CDashUseCaseTestCase
             ->createPassedTest(
                 'thirdparty',
                 ['Labels' =>
-                    ['MyThirdPartyDependency', 'NotASubproject']
+                    ['MyThirdPartyDependency', 'NotASubproject'],
                 ]
             );
 

--- a/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -153,11 +153,11 @@ class GitHubTest extends TestCase
             'name' => 'CDash',
             'head_sha' => 'zzz',
             'details_url' => $index_url,
-            'status' => 'in_progress'
+            'status' => 'in_progress',
         ];
         $expected['output'] = [
             'title' => 'Awaiting results',
-            'summary' => "[CDash has not parsed any results for this check yet.]($index_url)"
+            'summary' => "[CDash has not parsed any results for this check yet.]($index_url)",
         ];
         $build_rows = [];
         $actual = $sut->generateCheckPayloadFromBuildRows($build_rows, 'zzz');
@@ -178,7 +178,7 @@ class GitHubTest extends TestCase
             'configureerrors' => 0,
             'builderrors' => 0,
             'testfailed' => 0,
-            'done' => 0
+            'done' => 0,
         ];
         $build_rows[] = $build_row;
         $actual = $sut->generateCheckPayloadFromBuildRows($build_rows, 'zzz');
@@ -213,7 +213,7 @@ class GitHubTest extends TestCase
             'configureerrors' => 5,
             'builderrors' => 0,
             'testfailed' => 0,
-            'done' => 1
+            'done' => 1,
         ];
         $build_rows[] = [
             'name' => 'c',
@@ -222,7 +222,7 @@ class GitHubTest extends TestCase
             'configureerrors' => 0,
             'builderrors' => 1,
             'testfailed' => 0,
-            'done' => 1
+            'done' => 1,
         ];
         $build_rows[] = [
             'name' => 'd',
@@ -231,7 +231,7 @@ class GitHubTest extends TestCase
             'configureerrors' => 0,
             'builderrors' => 0,
             'testfailed' => 7,
-            'done' => 1
+            'done' => 1,
         ];
         $actual = $sut->generateCheckPayloadFromBuildRows($build_rows, 'zzz');
         unset($actual['started_at']);
@@ -258,7 +258,7 @@ class GitHubTest extends TestCase
         $expected = [
             ['id' => 4, 'name' => 'a', 'starttime' => '2019-05-01 18:08:38'],
             ['id' => 6, 'name' => 'b', 'starttime' => '2019-05-01 18:08:40'],
-            ['id' => 1, 'name' => 'c', 'starttime' => '2019-05-01 18:08:35']
+            ['id' => 1, 'name' => 'c', 'starttime' => '2019-05-01 18:08:35'],
         ];
         $this->assertEquals($expected, $actual);
     }
@@ -269,7 +269,7 @@ class GitHubTest extends TestCase
         $repositories = [];
         $repositories[] = [
             'url'      => $github_url,
-            'username' => 12345
+            'username' => 12345,
         ];
         $this->project->CvsUrl = $github_url;
         $this->project->expects($this->once())

--- a/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
@@ -44,7 +44,7 @@ class BuildErrorTest extends CDashTestCase
             'postcontext' => "   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
             'sourcefile'  => 'src/main.cpp',
             'sourceline'  => '2',
-            'text' => '/.../foo/src/main.cpp:2:3: error: `asdf` not declared in this scope'
+            'text' => '/.../foo/src/main.cpp:2:3: error: `asdf` not declared in this scope',
         ];
 
         $this->mock_project->CvsUrl = 'https://github.com/FooCo/foo';
@@ -58,7 +58,7 @@ class BuildErrorTest extends CDashTestCase
             'text' => "<a href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` not declared in this scope",
             'postcontext' => "   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
             'sourcefile' => 'src/main.cpp',
-            'sourceline' => '2'
+            'sourceline' => '2',
         ];
         $this->assertEquals($expected, $marshaled);
     }

--- a/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
@@ -54,7 +54,7 @@ class BuildFailureTest extends CDashTestCase
             'stdoutput'        => '',
             'stderror'         => '/projects/foo/src/main.cpp: In function `int main(int, char**)`:
 /projects/foo/src/main.cpp:2:3: error: `asdf` was not declared in this scope
-   asdf = 0;'
+   asdf = 0;',
         ];
         $this->mock_project->CvsUrl = 'https://github.com/FooCo/foo';
         $marshaled = $this->mock_buildfailure->marshal($input_data, $this->mock_project, '12', true, $this->mock_buildfailure);
@@ -69,7 +69,7 @@ class BuildFailureTest extends CDashTestCase
             'exitcondition'    => '2',
             'stdoutput'        => '',
             'stderror'         => "foo/src/main.cpp: In function `int main(int, char**)`:\n<a href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` was not declared in this scope\n   asdf = 0;",
-            'cvsurl' => 'https://github.com/FooCo/foo/blob/12/src/main.cpp'
+            'cvsurl' => 'https://github.com/FooCo/foo/blob/12/src/main.cpp',
         ];
         $this->assertEquals($expected, $marshaled);
     }

--- a/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
@@ -146,7 +146,7 @@ class BuildRelationshipTest extends CDashTestCase
         $expected = [
             'buildid'      => 1,
             'relatedid'    => 2,
-            'relationship' => 'depends on'
+            'relationship' => 'depends on',
         ];
         $actual = $this->relationship->marshal();
         $this->assertEquals($expected, $actual);

--- a/app/cdash/tests/case/CDash/Model/BuildTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildTest.php
@@ -62,7 +62,7 @@ class BuildTest extends CDashTestCase
                 'testfailedpositive' => 90,
                 'testfailednegative' => 10,
                 'testnotrunpositive' => 11,
-                'testnotrunnegative' => 12
+                'testnotrunnegative' => 12,
 
             ]);
 

--- a/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+++ b/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -191,28 +191,28 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 [
                     'simpletest@localhost',
                     BitmaskNotificationPreferences::EMAIL_TEST |
-                    BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION
+                    BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION,
                 ],
                 [
                     'nox-noemail@noemail',
                     BitmaskNotificationPreferences::EMAIL_TEST |
                     BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                     BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                    ['NOX', 'MyExperimentalFeature']
+                    ['NOX', 'MyExperimentalFeature'],
                 ],
                 [
                     'optika-noemail@noemail',
                     BitmaskNotificationPreferences::EMAIL_TEST |
                     BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                     BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                    ['Optika', 'MyThirdPartyDependency']
+                    ['Optika', 'MyThirdPartyDependency'],
                 ],
                 [
                     'trop-noemail@noemail',
                     BitmaskNotificationPreferences::EMAIL_TEST |
                     BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                     BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                    ['RTOp']
+                    ['RTOp'],
                 ],
             ];
 
@@ -266,28 +266,28 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
             [
                 'simpletest@localhost',
                 BitmaskNotificationPreferences::EMAIL_CONFIGURE |
-                BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION
+                BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION,
             ],
             [
                 'nox-noemail@noemail',
                 BitmaskNotificationPreferences::EMAIL_CONFIGURE |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['NOX', 'MyExperimentalFeature']
+                ['NOX', 'MyExperimentalFeature'],
             ],
             [
                 'optika-noemail@noemail',
                 BitmaskNotificationPreferences::EMAIL_CONFIGURE |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['Optika', 'MyThirdPartyDependency']
+                ['Optika', 'MyThirdPartyDependency'],
             ],
             [
                 'trop-noemail@noemail',
                 BitmaskNotificationPreferences::EMAIL_CONFIGURE |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['RTOp']
+                ['RTOp'],
             ],
         ];
 
@@ -323,7 +323,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 'simpletest@localhost',
                 BitmaskNotificationPreferences::EMAIL_ERROR |
                 BitmaskNotificationPreferences::EMAIL_WARNING |
-                BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION
+                BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION,
             ],
             [
                 'nox-noemail@noemail',
@@ -331,7 +331,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 BitmaskNotificationPreferences::EMAIL_WARNING |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['NOX', 'MyExperimentalFeature']
+                ['NOX', 'MyExperimentalFeature'],
             ],
             [
                 'optika-noemail@noemail',
@@ -339,7 +339,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 BitmaskNotificationPreferences::EMAIL_WARNING |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['Optika', 'MyThirdPartyDependency']
+                ['Optika', 'MyThirdPartyDependency'],
             ],
             [
                 'trop-noemail@noemail',
@@ -347,7 +347,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 BitmaskNotificationPreferences::EMAIL_WARNING |
                 BitmaskNotificationPreferences::EMAIL_ANY_USER_CHECKIN_ISSUE_ANY_SECTION |
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['RTOp']
+                ['RTOp'],
             ],
         ];
 
@@ -383,7 +383,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
             ->createPassedTest(
                 'thirdparty',
                 ['Labels' =>
-                    ['MyThirdPartyDependency', 'NotASubproject']
+                    ['MyThirdPartyDependency', 'NotASubproject'],
                 ]
             )
             ->setStartTime($start)
@@ -393,7 +393,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
             [ // This user should receive email
                 'user_1@company.tld',
                 BitmaskNotificationPreferences::EMAIL_DYNAMIC_ANALYSIS,
-                []
+                [],
             ],
             [
                 // This user should not receive an email as they are not an author
@@ -401,13 +401,13 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 BitmaskNotificationPreferences::EMAIL_WARNING |
                 BitmaskNotificationPreferences::EMAIL_ERROR |
                 BitmaskNotificationPreferences::EMAIL_USER_CHECKIN_ISSUE_ANY_SECTION,
-                []
+                [],
             ],
             [
                 // This user should receive an email, subscribed to two labels, one present
                 'user_3@company.tld',
                 BitmaskNotificationPreferences::EMAIL_SUBSCRIBED_LABELS,
-                ['MyThirdPartyDependency1', 'MyProductionCode']
+                ['MyThirdPartyDependency1', 'MyProductionCode'],
             ],
             [
                 // This user should receive an email, with MyExperimentalFeature appended to subject
@@ -420,7 +420,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                 'user_5@company.tld',
                 BitmaskNotificationPreferences::EMAIL_USER_CHECKIN_ISSUE_ANY_SECTION,
                 [],
-            ]
+            ],
         ];
 
         $notifications = $this->getNotifications($subscribers);

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -281,7 +281,7 @@ class TestUseCaseTest extends CDashUseCaseTestCase
             ->createSite([
                 'Name' => 'Site.Name',
                 'BuildName' => 'SomeOS-SomeBuild',
-                'BuildStamp' => '123456789-2018-Nightly'
+                'BuildStamp' => '123456789-2018-Nightly',
             ])
             ->setStartTime(1235383453)
             ->setEndTime(1235383473)

--- a/app/cdash/tests/case/CDash/UpdateUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/UpdateUseCaseTest.php
@@ -39,8 +39,8 @@ class UpdateUseCaseTest extends CDashUseCaseTestCase
     {
         /** @var \CDash\Test\UseCase\UpdateUseCase $sut */
         $sut = UseCase::createBuilder($this, UseCase::UPDATE);
-        list($date, $time, $tz) = explode(' ', $sut->randomizeCheckinDate());
-        list($y, $m, $d) = explode('-', $date);
+        [$date, $time, $tz] = explode(' ', $sut->randomizeCheckinDate());
+        [$y, $m, $d] = explode('-', $date);
         $yesterday = date('d', strtotime('-1 days'));
         $this->assertEquals($yesterday, $d);
     }

--- a/app/cdash/tests/kwtest/kw_db.php
+++ b/app/cdash/tests/kwtest/kw_db.php
@@ -211,7 +211,7 @@ class dbo_mysql extends dbo
         if (!$resource || $resource === true) {
             return false;
         }
-        $result = array();
+        $result = [];
         while ($row = pdo_fetch_array($resource, PDO::FETCH_ASSOC)) {
             $result[] = $row;
         }
@@ -253,7 +253,7 @@ class dbo_pgsql extends dbo
         if (!$resource) {
             return false;
         }
-        $result = array();
+        $result = [];
         while ($row = pdo_fetch_array($resource, PDO::FETCH_ASSOC)) {
             $result[] = $row;
         }

--- a/app/cdash/tests/kwtest/kw_test_manager.php
+++ b/app/cdash/tests/kwtest/kw_test_manager.php
@@ -67,7 +67,7 @@ class TestManager
         if (!$this->testDir) {
             die("please, set the test directory\n");
         }
-        $testsFile = array();
+        $testsFile = [];
         foreach (glob($this->testDir . '/test_*.php') as $file) {
             $fileinfo = pathinfo($file);
             if (strcmp($fileinfo['basename'], 'test_install.php') != 0 &&

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -456,7 +456,7 @@ class KWWebTestCase extends WebTestCase
                 return false;
             }
             // Specify some default settings.
-            $settings = array(
+            $settings = [
                     'AutoremoveMaxBuilds' => 500,
                     'AutoremoveTimeframe' => 60,
                     'CoverageThreshold' => 70,
@@ -473,7 +473,7 @@ class KWWebTestCase extends WebTestCase
                     'UploadQuota' => 1,
                     'ViewSubProjectsLink' => 1,
                     'WarningsFilter' => '',
-                    'ErrorsFilter' => '');
+                    'ErrorsFilter' => ''];
             $submit_button = 'Submit';
         }
 
@@ -547,7 +547,7 @@ class KWWebTestCase extends WebTestCase
         $client = $this->getGuzzleClient();
 
         // Delete project.
-        $project_array = array('Id' => $projectid);
+        $project_array = ['Id' => $projectid];
         try {
             $response = $client->delete(
                 $this->url . '/api/v1/project.php',

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -732,7 +732,7 @@ class CDashControllerBrowser extends SimpleBrowser
         if (!empty($query)) {
             foreach (explode("&", $query) as $parameter) {
                 if (strpos($parameter, '=') !== false) {
-                    list($key, $value) = explode('=', $parameter);
+                    [$key, $value] = explode('=', $parameter);
                     $this->setRequestKeyValuePair($parameters, $key, $value);
                 } else {
                     $this->setRequestKeyValuePair($parameters, $parameter, '');
@@ -755,13 +755,13 @@ class CDashControllerBrowser extends SimpleBrowser
 
         // Handle key names that represent arrays of values
         if (preg_match('/^(\w+)\[(\w+)\]=?$/', $key, $parts)) {
-            list(, $key, $index) = $parts;
+            [, $key, $index] = $parts;
             if (!isset($parameters[$key])) {
                 $parameters[$key] = [];
             }
             $parameters[$key][$index] = $value;
         } elseif (preg_match('/^(\w+)\[]$/', $key, $parts)) {
-            list(, $key) = $parts;
+            [, $key] = $parts;
             if (!isset($parameters[$key])) {
                 $parameters[$key] = [];
             }

--- a/app/cdash/tests/kwtest/simpletest/arguments.php
+++ b/app/cdash/tests/kwtest/simpletest/arguments.php
@@ -9,7 +9,7 @@
  */
 class SimpleArguments
 {
-    private $all = array();
+    private $all = [];
 
     /**
      * Parses the command line arguments. The usual formats
@@ -44,7 +44,7 @@ class SimpleArguments
         if ($this->$key === false) {
             $this->all[$key] = $value;
         } elseif (!is_array($this->$key)) {
-            $this->all[$key] = array($this->$key, $value);
+            $this->all[$key] = [$this->$key, $value];
         } else {
             $this->all[$key][] = $value;
         }
@@ -62,13 +62,13 @@ class SimpleArguments
     {
         $argument = array_shift($arguments);
         if (preg_match('/^-(\w)=(.+)$/', $argument, $matches)) {
-            return array($matches[1], $matches[2]);
+            return [$matches[1], $matches[2]];
         } elseif (preg_match('/^-(\w)$/', $argument, $matches)) {
-            return array($matches[1], $this->nextNonFlagElseTrue($arguments));
+            return [$matches[1], $this->nextNonFlagElseTrue($arguments)];
         } elseif (preg_match('/^--(\w+)=(.+)$/', $argument, $matches)) {
-            return array($matches[1], $matches[2]);
+            return [$matches[1], $matches[2]];
         } elseif (preg_match('/^--(\w+)$/', $argument, $matches)) {
-            return array($matches[1], $this->nextNonFlagElseTrue($arguments));
+            return [$matches[1], $this->nextNonFlagElseTrue($arguments)];
         }
     }
 
@@ -141,8 +141,8 @@ class SimpleArguments
 class SimpleHelp
 {
     private $overview;
-    private $flag_sets = array();
-    private $explanations = array();
+    private $flag_sets = [];
+    private $explanations = [];
 
     /**
      * Sets up the top level explanation for the program.
@@ -163,7 +163,7 @@ class SimpleHelp
      */
     public function explainFlag($flags, $explanation)
     {
-        $flags = is_array($flags) ? $flags : array($flags);
+        $flags = is_array($flags) ? $flags : [$flags];
         $this->flag_sets[] = $flags;
         $this->explanations[] = $explanation;
     }

--- a/app/cdash/tests/kwtest/simpletest/arguments.php
+++ b/app/cdash/tests/kwtest/simpletest/arguments.php
@@ -26,7 +26,7 @@ class SimpleArguments
     {
         array_shift($arguments);
         while (count($arguments) > 0) {
-            list($key, $value) = $this->parseArgument($arguments);
+            [$key, $value] = $this->parseArgument($arguments);
             $this->assign($key, $value);
         }
     }

--- a/app/cdash/tests/kwtest/simpletest/authentication.php
+++ b/app/cdash/tests/kwtest/simpletest/authentication.php
@@ -140,7 +140,7 @@ class SimpleAuthenticator
      */
     public function restartSession()
     {
-        $this->realms = array();
+        $this->realms = [];
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/autorun.php
+++ b/app/cdash/tests/kwtest/simpletest/autorun.php
@@ -67,7 +67,7 @@ function run_local_tests()
 function tests_have_run()
 {
     if ($context = SimpleTest::getContext()) {
-        return (boolean)$context->getTest();
+        return (bool)$context->getTest();
     }
     return false;
 }

--- a/app/cdash/tests/kwtest/simpletest/autorun.php
+++ b/app/cdash/tests/kwtest/simpletest/autorun.php
@@ -100,5 +100,5 @@ function capture_new_classes()
     global $SIMPLETEST_AUTORUNNER_INITIAL_CLASSES;
     return array_map('strtolower', array_diff(get_declared_classes(),
         $SIMPLETEST_AUTORUNNER_INITIAL_CLASSES ?
-            $SIMPLETEST_AUTORUNNER_INITIAL_CLASSES : array()));
+            $SIMPLETEST_AUTORUNNER_INITIAL_CLASSES : []));
 }

--- a/app/cdash/tests/kwtest/simpletest/browser.php
+++ b/app/cdash/tests/kwtest/simpletest/browser.php
@@ -950,7 +950,7 @@ class SimpleBrowser
      */
     public function isSubmit($label)
     {
-        return (boolean)$this->page->getFormBySubmit(new SimpleByLabel($label));
+        return (bool)$this->page->getFormBySubmit(new SimpleByLabel($label));
     }
 
     /**
@@ -1029,7 +1029,7 @@ class SimpleBrowser
      */
     public function isImage($label)
     {
-        return (boolean)$this->page->getFormByImage(new SimpleByLabel($label));
+        return (bool)$this->page->getFormByImage(new SimpleByLabel($label));
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/browser.php
+++ b/app/cdash/tests/kwtest/simpletest/browser.php
@@ -17,7 +17,7 @@ require_once dirname(__FILE__) . '/selector.php';
 require_once dirname(__FILE__) . '/frames.php';
 require_once dirname(__FILE__) . '/user_agent.php';
 if (!SimpleTest::getParsers()) {
-    SimpleTest::setParsers(array(new SimplePHPPageBuilder()));
+    SimpleTest::setParsers([new SimplePHPPageBuilder()]);
 }
 /**#@-*/
 
@@ -30,7 +30,7 @@ if (!defined('DEFAULT_MAX_NESTED_FRAMES')) {
  */
 class SimpleBrowserHistory
 {
-    private $sequence = array();
+    private $sequence = [];
     private $position = -1;
 
     /**
@@ -70,7 +70,7 @@ class SimpleBrowserHistory
         $this->dropFuture();
         array_push(
             $this->sequence,
-            array('url' => $url, 'parameters' => $parameters));
+            ['url' => $url, 'parameters' => $parameters]);
         $this->position++;
     }
 
@@ -318,7 +318,7 @@ class SimpleBrowser
         if (!$frame || !$this->page->hasFrames() || (strtolower($frame) == '_top')) {
             return $this->loadPage($url, $parameters);
         }
-        return $this->loadFrame(array($frame), $url, $parameters);
+        return $this->loadFrame([$frame], $url, $parameters);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/cookies.php
+++ b/app/cdash/tests/kwtest/simpletest/cookies.php
@@ -332,7 +332,7 @@ class SimpleCookieJar
                 }
             }
         }
-        return (isset($value) ? $value : false);
+        return ($value ?? false);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/cookies.php
+++ b/app/cdash/tests/kwtest/simpletest/cookies.php
@@ -232,7 +232,7 @@ class SimpleCookieJar
      */
     public function __construct()
     {
-        $this->cookies = array();
+        $this->cookies = [];
     }
 
     /**
@@ -242,7 +242,7 @@ class SimpleCookieJar
      */
     public function restartSession($date = false)
     {
-        $surviving_cookies = array();
+        $surviving_cookies = [];
         for ($i = 0; $i < count($this->cookies); $i++) {
             if (!$this->cookies[$i]->getValue()) {
                 continue;
@@ -367,7 +367,7 @@ class SimpleCookieJar
      */
     public function selectAsPairs($url)
     {
-        $pairs = array();
+        $pairs = [];
         foreach ($this->cookies as $cookie) {
             if ($this->isMatch($cookie, $url->getHost(), $url->getPath(), $cookie->getName())) {
                 $pairs[] = $cookie->getName() . '=' . $cookie->getValue();

--- a/app/cdash/tests/kwtest/simpletest/default_reporter.php
+++ b/app/cdash/tests/kwtest/simpletest/default_reporter.php
@@ -20,10 +20,10 @@ require_once dirname(__FILE__) . '/xml.php';
  */
 class SimpleCommandLineParser
 {
-    private $to_property = array(
+    private $to_property = [
         'case' => 'case', 'c' => 'case',
         'test' => 'test', 't' => 'test',
-    );
+    ];
     private $case = '';
     private $test = '';
     private $xml = false;
@@ -137,7 +137,7 @@ class DefaultReporter extends SimpleReporterDecorator
     {
         if (SimpleReporter::inCli()) {
             $parser = new SimpleCommandLineParser($_SERVER['argv']);
-            $interfaces = $parser->isXml() ? array('XmlReporter') : array('TextReporter');
+            $interfaces = $parser->isXml() ? ['XmlReporter'] : ['TextReporter'];
             if ($parser->help()) {
                 // I'm not sure if we should do the echo'ing here -- ezyang
                 echo $parser->getHelpText();

--- a/app/cdash/tests/kwtest/simpletest/default_reporter.php
+++ b/app/cdash/tests/kwtest/simpletest/default_reporter.php
@@ -110,16 +110,16 @@ class SimpleCommandLineParser
     public function getHelpText()
     {
         return <<<HELP
-SimpleTest command line default reporter (autorun)
-Usage: php <test_file> [args...]
+            SimpleTest command line default reporter (autorun)
+            Usage: php <test_file> [args...]
 
-    -c <class>      Run only the test-case <class>
-    -t <method>     Run only the test method <method>
-    -s              Suppress skip messages
-    -x              Return test results in XML
-    -h              Display this help message
+                -c <class>      Run only the test-case <class>
+                -t <method>     Run only the test method <method>
+                -s              Suppress skip messages
+                -x              Return test results in XML
+                -h              Display this help message
 
-HELP;
+            HELP;
     }
 }
 

--- a/app/cdash/tests/kwtest/simpletest/dumper.php
+++ b/app/cdash/tests/kwtest/simpletest/dumper.php
@@ -382,7 +382,7 @@ class SimpleDumper
         $position = 0;
         $step = strlen($first);
         while ($step > 1) {
-            $step = (integer)(($step + 1) / 2);
+            $step = (int)(($step + 1) / 2);
             if (strncmp($first, $second, $position + $step) == 0) {
                 $position += $step;
             }

--- a/app/cdash/tests/kwtest/simpletest/dumper.php
+++ b/app/cdash/tests/kwtest/simpletest/dumper.php
@@ -321,7 +321,7 @@ class SimpleDumper
     protected function getMembers($object)
     {
         $reflection = new ReflectionObject($object);
-        $members = array();
+        $members = [];
         foreach ($reflection->getProperties() as $property) {
             if (method_exists($property, 'setAccessible')) {
                 $property->setAccessible(true);
@@ -377,7 +377,7 @@ class SimpleDumper
             return 0;
         }
         if (strlen($first) < strlen($second)) {
-            list($first, $second) = array($second, $first);
+            list($first, $second) = [$second, $first];
         }
         $position = 0;
         $step = strlen($first);

--- a/app/cdash/tests/kwtest/simpletest/dumper.php
+++ b/app/cdash/tests/kwtest/simpletest/dumper.php
@@ -377,7 +377,7 @@ class SimpleDumper
             return 0;
         }
         if (strlen($first) < strlen($second)) {
-            list($first, $second) = [$second, $first];
+            [$first, $second] = [$second, $first];
         }
         $position = 0;
         $step = strlen($first);

--- a/app/cdash/tests/kwtest/simpletest/eclipse.php
+++ b/app/cdash/tests/kwtest/simpletest/eclipse.php
@@ -74,8 +74,8 @@ class EclipseReporter extends SimpleScorer
      */
     public function escapeVal($raw)
     {
-        $needle = array('\\', '"', '/', "\b", "\f", "\n", "\r", "\t");
-        $replace = array('\\\\', '\"', '\/', '\b', '\f', '\n', '\r', '\t');
+        $needle = ['\\', '"', '/', "\b", "\f", "\n", "\r", "\t"];
+        $replace = ['\\\\', '\"', '\/', '\b', '\f', '\n', '\r', '\t'];
         return str_replace($needle, $replace, $raw);
     }
 

--- a/app/cdash/tests/kwtest/simpletest/encoding.php
+++ b/app/cdash/tests/kwtest/simpletest/encoding.php
@@ -197,7 +197,7 @@ class SimpleEncoding
     public function __construct($query = false)
     {
         if (!$query) {
-            $query = array();
+            $query = [];
         }
         $this->clear();
         $this->merge($query);
@@ -208,7 +208,7 @@ class SimpleEncoding
      */
     public function clear()
     {
-        $this->request = array();
+        $this->request = [];
     }
 
     /**
@@ -276,7 +276,7 @@ class SimpleEncoding
      */
     public function getValue($key)
     {
-        $values = array();
+        $values = [];
         foreach ($this->request as $pair) {
             if ($pair->isKey($key)) {
                 $values[] = $pair->getValue();
@@ -307,7 +307,7 @@ class SimpleEncoding
      */
     protected function encode()
     {
-        $statements = array();
+        $statements = [];
         foreach ($this->request as $pair) {
             if ($statement = $pair->asRequest()) {
                 $statements[] = $statement;
@@ -516,7 +516,7 @@ class SimplePostEncoding extends SimpleEntityEncoding
 
     public function rewriteArrayWithMultipleLevels($query)
     {
-        $query_ = array();
+        $query_ = [];
         foreach ($query as $key => $value) {
             if (is_array($value)) {
                 foreach ($value as $sub_key => $sub_value) {

--- a/app/cdash/tests/kwtest/simpletest/encoding.php
+++ b/app/cdash/tests/kwtest/simpletest/encoding.php
@@ -461,7 +461,7 @@ class SimpleEntityEncoding extends SimpleEncoding
      */
     public function writeHeadersTo(&$socket)
     {
-        $socket->write('Content-Length: ' . (integer)strlen($this->encode()) . "\r\n");
+        $socket->write('Content-Length: ' . (int)strlen($this->encode()) . "\r\n");
         $socket->write('Content-Type: ' . $this->getContentType() . "\r\n");
     }
 
@@ -604,7 +604,7 @@ class SimpleMultipartEncoding extends SimplePostEncoding
      */
     public function writeHeadersTo(&$socket)
     {
-        $socket->write('Content-Length: ' . (integer)strlen($this->encode()) . "\r\n");
+        $socket->write('Content-Length: ' . (int)strlen($this->encode()) . "\r\n");
         $socket->write('Content-Type: multipart/form-data; boundary=' . $this->boundary . "\r\n");
     }
 

--- a/app/cdash/tests/kwtest/simpletest/errors.php
+++ b/app/cdash/tests/kwtest/simpletest/errors.php
@@ -124,11 +124,11 @@ class SimpleErrorQueue
      */
     public function tally()
     {
-        while (list($severity, $message, $file, $line) = $this->extract()) {
+        while ([$severity, $message, $file, $line] = $this->extract()) {
             $severity = $this->getSeverityAsString($severity);
             $this->test->error($severity, $message, $file, $line);
         }
-        while (list($expected, $message) = $this->extractExpectation()) {
+        while ([$expected, $message] = $this->extractExpectation()) {
             $this->test->assert($expected, false, '%s -> Expected error not caught');
         }
     }
@@ -144,7 +144,7 @@ class SimpleErrorQueue
     protected function testLatestError($severity, $content, $filename, $line)
     {
         if ($expectation = $this->extractExpectation()) {
-            list($expected, $message) = $expectation;
+            [$expected, $message] = $expectation;
             $this->test->assert($expected, $content, sprintf(
                 $message,
                 "%s -> PHP error [$content] severity [" .

--- a/app/cdash/tests/kwtest/simpletest/errors.php
+++ b/app/cdash/tests/kwtest/simpletest/errors.php
@@ -79,8 +79,8 @@ class SimpleErrorQueue
      */
     public function clear()
     {
-        $this->queue = array();
-        $this->expectation_queue = array();
+        $this->queue = [];
+        $this->expectation_queue = [];
     }
 
     /**
@@ -102,7 +102,7 @@ class SimpleErrorQueue
      */
     public function expectError($expected, $message)
     {
-        array_push($this->expectation_queue, array($expected, $message));
+        array_push($this->expectation_queue, [$expected, $message]);
     }
 
     /**
@@ -191,7 +191,7 @@ class SimpleErrorQueue
      */
     public static function getSeverityAsString($severity)
     {
-        static $map = array(
+        static $map = [
             E_STRICT => 'E_STRICT',
             E_ERROR => 'E_ERROR',
             E_WARNING => 'E_WARNING',
@@ -203,7 +203,7 @@ class SimpleErrorQueue
             E_COMPILE_WARNING => 'E_COMPILE_WARNING',
             E_USER_ERROR => 'E_USER_ERROR',
             E_USER_WARNING => 'E_USER_WARNING',
-            E_USER_NOTICE => 'E_USER_NOTICE');
+            E_USER_NOTICE => 'E_USER_NOTICE'];
         if (defined('E_RECOVERABLE_ERROR')) {
             $map[E_RECOVERABLE_ERROR] = 'E_RECOVERABLE_ERROR';
         }

--- a/app/cdash/tests/kwtest/simpletest/exceptions.php
+++ b/app/cdash/tests/kwtest/simpletest/exceptions.php
@@ -226,6 +226,6 @@ class SimpleExceptionTrap
     {
         $this->expected = false;
         $this->message = false;
-        $this->ignored = array();
+        $this->ignored = [];
     }
 }

--- a/app/cdash/tests/kwtest/simpletest/expectation.php
+++ b/app/cdash/tests/kwtest/simpletest/expectation.php
@@ -761,7 +761,7 @@ class IsAExpectation extends SimpleExpectation
     protected function canonicalType($type)
     {
         $type = strtolower($type);
-        $map = array('boolean' => 'bool');
+        $map = ['boolean' => 'bool'];
         if (isset($map[$type])) {
             $type = $map[$type];
         }

--- a/app/cdash/tests/kwtest/simpletest/expectation.php
+++ b/app/cdash/tests/kwtest/simpletest/expectation.php
@@ -161,7 +161,7 @@ class TrueExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean)$compare;
+        return (bool)$compare;
     }
 
     /**
@@ -189,7 +189,7 @@ class FalseExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return !(boolean)$compare;
+        return !(bool)$compare;
     }
 
     /**
@@ -622,7 +622,7 @@ class PatternExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean)preg_match($this->getPattern(), $compare);
+        return (bool)preg_match($this->getPattern(), $compare);
     }
 
     /**
@@ -850,7 +850,7 @@ class MethodExistsExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean)(is_object($compare) && method_exists($compare, $this->method));
+        return (bool)(is_object($compare) && method_exists($compare, $this->method));
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/form.php
+++ b/app/cdash/tests/kwtest/simpletest/form.php
@@ -40,11 +40,11 @@ class SimpleForm
         $this->encoding = $this->setEncodingClass($tag);
         $this->default_target = false;
         $this->id = $tag->getAttribute('id');
-        $this->buttons = array();
-        $this->images = array();
-        $this->widgets = array();
-        $this->radios = array();
-        $this->checkboxes = array();
+        $this->buttons = [];
+        $this->images = [];
+        $this->widgets = [];
+        $this->radios = [];
+        $this->checkboxes = [];
     }
 
     /**
@@ -303,7 +303,7 @@ class SimpleForm
      */
     public function submitButton($selector, $additional = false)
     {
-        $additional = $additional ? $additional : array();
+        $additional = $additional ? $additional : [];
         foreach ($this->buttons as $button) {
             if ($selector->isMatch($button)) {
                 $encoding = $this->encode();
@@ -329,7 +329,7 @@ class SimpleForm
      */
     public function submitImage($selector, $x, $y, $additional = false)
     {
-        $additional = $additional ? $additional : array();
+        $additional = $additional ? $additional : [];
         foreach ($this->images as $image) {
             if ($selector->isMatch($image)) {
                 $encoding = $this->encode();

--- a/app/cdash/tests/kwtest/simpletest/frames.php
+++ b/app/cdash/tests/kwtest/simpletest/frames.php
@@ -32,9 +32,9 @@ class SimpleFrameset
     public function __construct($page)
     {
         $this->frameset = $page;
-        $this->frames = array();
+        $this->frames = [];
         $this->focus = false;
-        $this->names = array();
+        $this->names = [];
     }
 
     /**
@@ -81,10 +81,10 @@ class SimpleFrameset
     public function getFrameFocus()
     {
         if ($this->focus === false) {
-            return array();
+            return [];
         }
         return array_merge(
-            array($this->getPublicNameFromIndex($this->focus)),
+            [$this->getPublicNameFromIndex($this->focus)],
             $this->frames[$this->focus]->getFrameFocus());
     }
 
@@ -183,7 +183,7 @@ class SimpleFrameset
      */
     public function getFrames()
     {
-        $report = array();
+        $report = [];
         for ($i = 0; $i < count($this->frames); $i++) {
             $report[$this->getPublicNameFromIndex($i)] =
                 $this->frames[$i]->getFrames();
@@ -393,7 +393,7 @@ class SimpleFrameset
         if (is_integer($this->focus)) {
             return $this->frames[$this->focus]->getUrls();
         }
-        $urls = array();
+        $urls = [];
         foreach ($this->frames as $frame) {
             $urls = array_merge($urls, $frame->getUrls());
         }
@@ -413,7 +413,7 @@ class SimpleFrameset
                 $this->frames[$this->focus]->getUrlsByLabel($label),
                 $this->focus);
         }
-        $urls = array();
+        $urls = [];
         foreach ($this->frames as $index => $frame) {
             $urls = array_merge(
                 $urls,
@@ -453,7 +453,7 @@ class SimpleFrameset
      */
     protected function tagUrlsWithFrame($urls, $frame)
     {
-        $tagged = array();
+        $tagged = [];
         foreach ($urls as $url) {
             if (!$url->getTarget()) {
                 $url->setTarget($this->getPublicNameFromIndex($frame));

--- a/app/cdash/tests/kwtest/simpletest/http.php
+++ b/app/cdash/tests/kwtest/simpletest/http.php
@@ -518,7 +518,7 @@ class SimpleHttpResponse extends SimpleStickyError
             $this->setError('Could not split headers from content');
             $this->headers = new SimpleHttpHeaders($raw);
         } else {
-            list($headers, $this->content) = explode("\r\n\r\n", $raw, 2);
+            [$headers, $this->content] = explode("\r\n\r\n", $raw, 2);
             $this->headers = new SimpleHttpHeaders($headers);
         }
     }

--- a/app/cdash/tests/kwtest/simpletest/http.php
+++ b/app/cdash/tests/kwtest/simpletest/http.php
@@ -463,8 +463,8 @@ class SimpleHttpHeaders
         return new SimpleCookie(
             $cookie[1],
             trim($cookie[2]),
-            isset($cookie['path']) ? $cookie['path'] : '',
-            isset($cookie['expires']) ? $cookie['expires'] : false);
+            $cookie['path'] ?? '',
+            $cookie['expires'] ?? false);
     }
 }
 

--- a/app/cdash/tests/kwtest/simpletest/http.php
+++ b/app/cdash/tests/kwtest/simpletest/http.php
@@ -94,9 +94,9 @@ class SimpleRoute
      */
     protected function createSocket($scheme, $host, $port, $timeout)
     {
-        if (in_array($scheme, array('file'))) {
+        if (in_array($scheme, ['file'])) {
             return new SimpleFileSocket($this->url);
-        } elseif (in_array($scheme, array('https'))) {
+        } elseif (in_array($scheme, ['https'])) {
             return new SimpleSecureSocket($host, $port, $timeout);
         } else {
             return new SimpleSocket($host, $port, $timeout);
@@ -207,8 +207,8 @@ class SimpleHttpRequest
     {
         $this->route = $route;
         $this->encoding = $encoding;
-        $this->headers = array();
-        $this->cookies = array();
+        $this->headers = [];
+        $this->cookies = [];
     }
 
     /**
@@ -308,7 +308,7 @@ class SimpleHttpHeaders
         $this->http_version = false;
         $this->mime_type = '';
         $this->location = false;
-        $this->cookies = array();
+        $this->cookies = [];
         $this->authentication = false;
         $this->realm = false;
         foreach (explode("\r\n", $headers) as $header_line) {
@@ -359,7 +359,7 @@ class SimpleHttpHeaders
      */
     public function isRedirect()
     {
-        return in_array($this->response_code, array(301, 302, 303, 307)) &&
+        return in_array($this->response_code, [301, 302, 303, 307]) &&
         (boolean)$this->getLocation();
     }
 
@@ -453,7 +453,7 @@ class SimpleHttpHeaders
     protected function parseCookie($cookie_line)
     {
         $parts = explode(';', $cookie_line);
-        $cookie = array();
+        $cookie = [];
         preg_match('/\s*(.*?)\s*=(.*)/', array_shift($parts), $cookie);
         foreach ($parts as $part) {
             if (preg_match('/\s*(.*?)\s*=(.*)/', $part, $matches)) {

--- a/app/cdash/tests/kwtest/simpletest/http.php
+++ b/app/cdash/tests/kwtest/simpletest/http.php
@@ -340,7 +340,7 @@ class SimpleHttpHeaders
      */
     public function getResponseCode()
     {
-        return (integer)$this->response_code;
+        return (int)$this->response_code;
     }
 
     /**
@@ -360,7 +360,7 @@ class SimpleHttpHeaders
     public function isRedirect()
     {
         return in_array($this->response_code, [301, 302, 303, 307]) &&
-        (boolean)$this->getLocation();
+        (bool)$this->getLocation();
     }
 
     /**
@@ -371,8 +371,8 @@ class SimpleHttpHeaders
     public function isChallenge()
     {
         return ($this->response_code == 401) &&
-        (boolean)$this->authentication &&
-        (boolean)$this->realm;
+        (bool)$this->authentication &&
+        (bool)$this->realm;
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/mock_objects.php
+++ b/app/cdash/tests/kwtest/simpletest/mock_objects.php
@@ -107,7 +107,7 @@ class ParametersExpectation extends SimpleExpectation
             '] but got ' . count($parameters) .
             ' arguments of [' . $this->renderArguments($parameters) . ']';
         }
-        $messages = array();
+        $messages = [];
         for ($i = 0; $i < count($expected); $i++) {
             $comparison = $this->coerceToExpectation($expected[$i]);
             if (!$comparison->test($parameters[$i])) {
@@ -141,7 +141,7 @@ class ParametersExpectation extends SimpleExpectation
      */
     protected function renderArguments($args)
     {
-        $descriptions = array();
+        $descriptions = [];
         if (is_array($args)) {
             foreach ($args as $arg) {
                 $dumper = new SimpleDumper();
@@ -300,7 +300,7 @@ class SimpleSignatureMap
      */
     public function __construct()
     {
-        $this->map = array();
+        $this->map = [];
     }
 
     /**
@@ -311,7 +311,7 @@ class SimpleSignatureMap
     public function add($parameters, $action)
     {
         $place = count($this->map);
-        $this->map[$place] = array();
+        $this->map[$place] = [];
         $this->map[$place]['params'] = new ParametersExpectation($parameters);
         $this->map[$place]['content'] = $action;
     }
@@ -395,8 +395,8 @@ class SimpleCallSchedule
      */
     public function __construct()
     {
-        $this->always = array();
-        $this->at = array();
+        $this->always = [];
+        $this->at = [];
     }
 
     /**
@@ -431,7 +431,7 @@ class SimpleCallSchedule
         $args = $this->replaceWildcards($args);
         $method = strtolower($method);
         if (!isset($this->at[$method])) {
-            $this->at[$method] = array();
+            $this->at[$method] = [];
         }
         if (!isset($this->at[$method][$step])) {
             $this->at[$method][$step] = new SimpleSignatureMap();
@@ -678,11 +678,11 @@ class SimpleMock
     {
         $this->actions = new SimpleCallSchedule();
         $this->expectations = new SimpleCallSchedule();
-        $this->call_counts = array();
-        $this->expected_counts = array();
-        $this->max_counts = array();
-        $this->expected_args = array();
-        $this->expected_args_at = array();
+        $this->call_counts = [];
+        $this->expected_counts = [];
+        $this->max_counts = [];
+        $this->expected_args = [];
+        $this->expected_args_at = [];
         $this->getCurrentTestCase()->tell($this);
     }
 
@@ -944,7 +944,7 @@ class SimpleMock
         $this->checkArgumentsIsArray($args, 'set expected arguments at time');
         $args = $this->replaceWildcards($args);
         if (!isset($this->expected_args_at[$timing])) {
-            $this->expected_args_at[$timing] = array();
+            $this->expected_args_at[$timing] = [];
         }
         $method = strtolower($method);
         $message .= Mock::getExpectationLine();
@@ -1296,7 +1296,7 @@ class Mock
      */
     public static function getExpectationLine()
     {
-        $trace = new SimpleStackTrace(array('expect'));
+        $trace = new SimpleStackTrace(['expect']);
         return $trace->traceMethod();
     }
 }
@@ -1346,7 +1346,7 @@ class MockGenerator
         if ($mock_reflection->classExistsSansAutoload()) {
             return false;
         }
-        $code = $this->createClassCode($methods ? $methods : array());
+        $code = $this->createClassCode($methods ? $methods : []);
         return eval("$code return \$code;");
     }
 
@@ -1370,10 +1370,10 @@ class MockGenerator
             return false;
         }
         if ($this->reflection->isInterface() || $this->reflection->hasFinal()) {
-            $code = $this->createClassCode($methods ? $methods : array());
+            $code = $this->createClassCode($methods ? $methods : []);
             return eval("$code return \$code;");
         } else {
-            $code = $this->createSubclassCode($methods ? $methods : array());
+            $code = $this->createSubclassCode($methods ? $methods : []);
             return eval("$code return \$code;");
         }
     }
@@ -1409,7 +1409,7 @@ class MockGenerator
     {
         $implements = '';
         $interfaces = $this->reflection->getInterfaces();
-        $interfaces = array_diff($interfaces, array('Traversable'));
+        $interfaces = array_diff($interfaces, ['Traversable']);
         if (count($interfaces) > 0) {
             $implements = 'implements ' . implode(', ', $interfaces);
         }
@@ -1542,7 +1542,7 @@ class MockGenerator
     {
         return in_array(
             strtolower($method),
-            array('__construct', '__destruct'));
+            ['__construct', '__destruct']);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/page.php
+++ b/app/cdash/tests/kwtest/simpletest/page.php
@@ -268,7 +268,7 @@ class SimplePage
     protected function linkIsAbsolute($url)
     {
         $parsed = new SimpleUrl($url);
-        return (boolean)($parsed->getScheme() && $parsed->getHost());
+        return (bool)($parsed->getScheme() && $parsed->getHost());
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/page.php
+++ b/app/cdash/tests/kwtest/simpletest/page.php
@@ -19,12 +19,12 @@ require_once dirname(__FILE__) . '/selector.php';
  */
 class SimplePage
 {
-    private $links = array();
+    private $links = [];
     private $title = false;
     private $last_widget;
     private $label;
-    private $forms = array();
-    private $frames = array();
+    private $forms = [];
+    private $frames = [];
     private $transport_error;
     private $raw;
     private $text = false;
@@ -222,7 +222,7 @@ class SimplePage
      */
     public function getFrameFocus()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -311,7 +311,7 @@ class SimplePage
         if (!$this->hasFrames()) {
             return false;
         }
-        $urls = array();
+        $urls = [];
         for ($i = 0; $i < count($this->frames); $i++) {
             $name = $this->frames[$i]->getAttribute('name');
             $url = new SimpleUrl($this->frames[$i]->getAttribute('src'));
@@ -337,7 +337,7 @@ class SimplePage
      */
     public function getUrls()
     {
-        $all = array();
+        $all = [];
         foreach ($this->links as $link) {
             $url = $this->getUrlFromLink($link);
             $all[] = $url->asString();
@@ -353,7 +353,7 @@ class SimplePage
      */
     public function getUrlsByLabel($label)
     {
-        $matches = array();
+        $matches = [];
         foreach ($this->links as $link) {
             if ($link->getText() == $label) {
                 $matches[] = $this->getUrlFromLink($link);

--- a/app/cdash/tests/kwtest/simpletest/parser.php
+++ b/app/cdash/tests/kwtest/simpletest/parser.php
@@ -7,9 +7,9 @@
 /**#@+
  * Lexer mode stack constants
  */
-foreach (array('LEXER_ENTER', 'LEXER_MATCHED',
+foreach (['LEXER_ENTER', 'LEXER_MATCHED',
              'LEXER_UNMATCHED', 'LEXER_EXIT',
-             'LEXER_SPECIAL') as $i => $constant) {
+             'LEXER_SPECIAL'] as $i => $constant) {
     if (!defined($constant)) {
         define($constant, $i + 1);
     }
@@ -36,8 +36,8 @@ class ParallelRegex
     public function ParallelRegex($case)
     {
         $this->_case = $case;
-        $this->_patterns = array();
-        $this->_labels = array();
+        $this->_patterns = [];
+        $this->_labels = [];
         $this->_regex = null;
     }
 
@@ -94,8 +94,8 @@ class ParallelRegex
         if ($this->_regex == null) {
             for ($i = 0, $count = count($this->_patterns); $i < $count; $i++) {
                 $this->_patterns[$i] = '(' . str_replace(
-                    array('/', '(', ')'),
-                    array('\/', '\(', '\)'),
+                    ['/', '(', ')'],
+                    ['\/', '\(', '\)'],
                     $this->_patterns[$i]) . ')';
             }
             $this->_regex = '/' . implode('|', $this->_patterns) . '/' . $this->_getPerlMatchingFlags();
@@ -126,7 +126,7 @@ class SimpleStateStack
      */
     public function SimpleStateStack($start)
     {
-        $this->_stack = array($start);
+        $this->_stack = [$start];
     }
 
     /**
@@ -190,10 +190,10 @@ class SimpleLexer
     public function SimpleLexer(&$parser, $start = 'accept', $case = false)
     {
         $this->_case = $case;
-        $this->_regexes = array();
+        $this->_regexes = [];
         $this->_parser = &$parser;
         $this->_mode = new SimpleStateStack($start);
-        $this->_mode_handlers = array($start => $start);
+        $this->_mode_handlers = [$start => $start];
     }
 
     /**
@@ -431,7 +431,7 @@ class SimpleLexer
             $unparsed_character_count = strpos($raw, $match);
             $unparsed = substr($raw, 0, $unparsed_character_count);
             $raw = substr($raw, $unparsed_character_count + strlen($match));
-            return array($raw, $unparsed, $match, $action);
+            return [$raw, $unparsed, $match, $action];
         }
         return true;
     }
@@ -465,8 +465,8 @@ class SimpleHtmlLexer extends SimpleLexer
      */
     public function _getParsedTags()
     {
-        return array('a', 'base', 'title', 'form', 'input', 'button', 'textarea', 'select',
-            'option', 'frameset', 'frame', 'label');
+        return ['a', 'base', 'title', 'form', 'input', 'button', 'textarea', 'select',
+            'option', 'frameset', 'frame', 'label'];
     }
 
     /**
@@ -548,7 +548,7 @@ class SimpleHtmlSaxParser
         $this->_listener = &$listener;
         $this->_lexer = &$this->createLexer($this);
         $this->_tag = '';
-        $this->_attributes = array();
+        $this->_attributes = [];
         $this->_current_attribute = '';
     }
 
@@ -596,7 +596,7 @@ class SimpleHtmlSaxParser
                 $this->_tag,
                 $this->_attributes);
             $this->_tag = '';
-            $this->_attributes = array();
+            $this->_attributes = [];
             return $success;
         }
         if ($token != '=') {

--- a/app/cdash/tests/kwtest/simpletest/parser.php
+++ b/app/cdash/tests/kwtest/simpletest/parser.php
@@ -306,7 +306,7 @@ class SimpleLexer
         }
         $length = strlen($raw);
         while (is_array($parsed = $this->_reduce($raw))) {
-            list($raw, $unmatched, $matched, $mode) = $parsed;
+            [$raw, $unmatched, $matched, $mode] = $parsed;
             if (!$this->_dispatchTokens($unmatched, $matched, $mode)) {
                 return false;
             }

--- a/app/cdash/tests/kwtest/simpletest/php_parser.php
+++ b/app/cdash/tests/kwtest/simpletest/php_parser.php
@@ -306,7 +306,7 @@ class SimpleLexer
         }
         $length = strlen($raw);
         while (is_array($parsed = $this->reduce($raw))) {
-            list($raw, $unmatched, $matched, $mode) = $parsed;
+            [$raw, $unmatched, $matched, $mode] = $parsed;
             if (!$this->dispatchTokens($unmatched, $matched, $mode)) {
                 return false;
             }

--- a/app/cdash/tests/kwtest/simpletest/php_parser.php
+++ b/app/cdash/tests/kwtest/simpletest/php_parser.php
@@ -7,9 +7,9 @@
 /**#@+
  * Lexer mode stack constants
  */
-foreach (array('LEXER_ENTER', 'LEXER_MATCHED',
+foreach (['LEXER_ENTER', 'LEXER_MATCHED',
              'LEXER_UNMATCHED', 'LEXER_EXIT',
-             'LEXER_SPECIAL') as $i => $constant) {
+             'LEXER_SPECIAL'] as $i => $constant) {
     if (!defined($constant)) {
         define($constant, $i + 1);
     }
@@ -36,8 +36,8 @@ class ParallelRegex
     public function __construct($case)
     {
         $this->case = $case;
-        $this->patterns = array();
-        $this->labels = array();
+        $this->patterns = [];
+        $this->labels = [];
         $this->regex = null;
     }
 
@@ -94,8 +94,8 @@ class ParallelRegex
         if ($this->regex == null) {
             for ($i = 0, $count = count($this->patterns); $i < $count; $i++) {
                 $this->patterns[$i] = '(' . str_replace(
-                    array('/', '(', ')'),
-                    array('\/', '\(', '\)'),
+                    ['/', '(', ')'],
+                    ['\/', '\(', '\)'],
                     $this->patterns[$i]) . ')';
             }
             $this->regex = '/' . implode('|', $this->patterns) . '/' . $this->getPerlMatchingFlags();
@@ -126,7 +126,7 @@ class SimpleStateStack
      */
     public function __construct($start)
     {
-        $this->stack = array($start);
+        $this->stack = [$start];
     }
 
     /**
@@ -190,10 +190,10 @@ class SimpleLexer
     public function __construct($parser, $start = 'accept', $case = false)
     {
         $this->case = $case;
-        $this->regexes = array();
+        $this->regexes = [];
         $this->parser = $parser;
         $this->mode = new SimpleStateStack($start);
-        $this->mode_handlers = array($start => $start);
+        $this->mode_handlers = [$start => $start];
     }
 
     /**
@@ -431,7 +431,7 @@ class SimpleLexer
             $unparsed_character_count = strpos($raw, $match);
             $unparsed = substr($raw, 0, $unparsed_character_count);
             $raw = substr($raw, $unparsed_character_count + strlen($match));
-            return array($raw, $unparsed, $match, $action);
+            return [$raw, $unparsed, $match, $action];
         }
         return true;
     }
@@ -465,8 +465,8 @@ class SimpleHtmlLexer extends SimpleLexer
      */
     protected function getParsedTags()
     {
-        return array('a', 'base', 'title', 'form', 'input', 'button', 'textarea', 'select',
-            'option', 'frameset', 'frame', 'label');
+        return ['a', 'base', 'title', 'form', 'input', 'button', 'textarea', 'select',
+            'option', 'frameset', 'frame', 'label'];
     }
 
     /**
@@ -548,7 +548,7 @@ class SimpleHtmlSaxParser
         $this->listener = $listener;
         $this->lexer = $this->createLexer($this);
         $this->tag = '';
-        $this->attributes = array();
+        $this->attributes = [];
         $this->current_attribute = '';
     }
 
@@ -594,7 +594,7 @@ class SimpleHtmlSaxParser
                 $this->tag,
                 $this->attributes);
             $this->tag = '';
-            $this->attributes = array();
+            $this->attributes = [];
             return $success;
         }
         if ($token != '=') {
@@ -683,12 +683,12 @@ class SimplePhpPageBuilder
     private $tags;
     private $page;
     private $private_content_tag;
-    private $open_forms = array();
-    private $complete_forms = array();
+    private $open_forms = [];
+    private $complete_forms = [];
     private $frameset = false;
-    private $loading_frames = array();
+    private $loading_frames = [];
     private $frameset_nesting_level = 0;
-    private $left_over_labels = array();
+    private $left_over_labels = [];
 
     /**
      *    Frees up any references so as to allow the PHP garbage
@@ -699,12 +699,12 @@ class SimplePhpPageBuilder
         unset($this->tags);
         unset($this->page);
         unset($this->private_content_tags);
-        $this->open_forms = array();
-        $this->complete_forms = array();
+        $this->open_forms = [];
+        $this->complete_forms = [];
         $this->frameset = false;
-        $this->loading_frames = array();
+        $this->loading_frames = [];
         $this->frameset_nesting_level = 0;
-        $this->left_over_labels = array();
+        $this->left_over_labels = [];
     }
 
     /**
@@ -724,7 +724,7 @@ class SimplePhpPageBuilder
      */
     public function parse($response)
     {
-        $this->tags = array();
+        $this->tags = [];
         $this->page = $this->createPage($response);
         $parser = $this->createParser($this);
         $parser->parse($response->getContent());
@@ -895,7 +895,7 @@ class SimplePhpPageBuilder
     {
         $name = $tag->getTagName();
         if (!in_array($name, array_keys($this->tags))) {
-            $this->tags[$name] = array();
+            $this->tags[$name] = [];
         }
         $this->tags[$name][] = $tag;
     }
@@ -954,7 +954,7 @@ class SimplePhpPageBuilder
      */
     protected function isFormElement($name)
     {
-        return in_array($name, array('input', 'button', 'textarea', 'select'));
+        return in_array($name, ['input', 'button', 'textarea', 'select']);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/recorder.php
+++ b/app/cdash/tests/kwtest/simpletest/recorder.php
@@ -29,7 +29,7 @@ abstract class SimpleResult
     public function __construct($breadcrumb, $message)
     {
         list($this->time, $this->breadcrumb, $this->message) =
-            array(time(), $breadcrumb, $message);
+            [time(), $breadcrumb, $message];
     }
 }
 
@@ -60,7 +60,7 @@ class SimpleResultOfException extends SimpleResult
  */
 class Recorder extends SimpleReporterDecorator
 {
-    public $results = array();
+    public $results = [];
 
     /**
      *    Stashes the pass as a SimpleResultOfPass

--- a/app/cdash/tests/kwtest/simpletest/recorder.php
+++ b/app/cdash/tests/kwtest/simpletest/recorder.php
@@ -28,7 +28,7 @@ abstract class SimpleResult
      */
     public function __construct($breadcrumb, $message)
     {
-        list($this->time, $this->breadcrumb, $this->message) =
+        [$this->time, $this->breadcrumb, $this->message] =
             [time(), $breadcrumb, $message];
     }
 }

--- a/app/cdash/tests/kwtest/simpletest/reflection_php4.php
+++ b/app/cdash/tests/kwtest/simpletest/reflection_php4.php
@@ -79,7 +79,7 @@ class SimpleReflection
      */
     public function getInterfaces()
     {
-        return array();
+        return [];
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/reflection_php5.php
+++ b/app/cdash/tests/kwtest/simpletest/reflection_php5.php
@@ -98,7 +98,7 @@ class SimpleReflection
     {
         $reflection = new ReflectionClass($this->interface);
         if ($reflection->isInterface()) {
-            return array($this->interface);
+            return [$this->interface];
         }
         return $this->onlyParents($reflection->getInterfaces());
     }
@@ -110,7 +110,7 @@ class SimpleReflection
      */
     public function getInterfaceMethods()
     {
-        $methods = array();
+        $methods = [];
         foreach ($this->getInterfaces() as $interface) {
             $methods = array_merge($methods, get_class_methods($interface));
         }
@@ -187,8 +187,8 @@ class SimpleReflection
      */
     protected function onlyParents($interfaces)
     {
-        $parents = array();
-        $blacklist = array();
+        $parents = [];
+        $blacklist = [];
         foreach ($interfaces as $interface) {
             foreach ($interfaces as $possible_parent) {
                 if ($interface->getName() == $possible_parent->getName()) {
@@ -279,7 +279,7 @@ class SimpleReflection
         if ($name == '__call') {
             return 'function __call($method, $arguments)';
         }
-        if (in_array($name, array('__get', '__isset', $name == '__unset'))) {
+        if (in_array($name, ['__get', '__isset', $name == '__unset'])) {
             return "function {$name}(\$key)";
         }
         if ($name == '__toString') {
@@ -327,7 +327,7 @@ class SimpleReflection
      */
     protected function getParameterSignatures($method)
     {
-        $signatures = array();
+        $signatures = [];
         foreach ($method->getParameters() as $parameter) {
             $signature = '';
             $type = $parameter->getClass();
@@ -357,7 +357,7 @@ class SimpleReflection
      */
     protected function suppressSpurious($name)
     {
-        return str_replace(array('[', ']', ' '), '', $name);
+        return str_replace(['[', ']', ' '], '', $name);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/scorer.php
+++ b/app/cdash/tests/kwtest/simpletest/scorer.php
@@ -245,7 +245,7 @@ class SimpleReporter extends SimpleScorer
     public function __construct()
     {
         parent::__construct();
-        $this->test_stack = array();
+        $this->test_stack = [];
         $this->size = null;
         $this->progress = 0;
     }
@@ -452,7 +452,7 @@ class SimpleReporterDecorator
         if (method_exists($this->reporter, 'getTestList')) {
             return $this->reporter->getTestList();
         } else {
-            return array();
+            return [];
         }
     }
 
@@ -627,7 +627,7 @@ class SimpleReporterDecorator
  */
 class MultipleReporter
 {
-    private $reporters = array();
+    private $reporters = [];
 
     /**
      *    Adds a reporter to the subscriber list.

--- a/app/cdash/tests/kwtest/simpletest/simpletest.php
+++ b/app/cdash/tests/kwtest/simpletest/simpletest.php
@@ -89,7 +89,7 @@ class SimpleTest
     public static function preferred($classes)
     {
         if (!is_array($classes)) {
-            $classes = array($classes);
+            $classes = [$classes];
         }
         $registry = &SimpleTest::getRegistry();
         for ($i = count($registry['Preferred']) - 1; $i >= 0; $i--) {
@@ -221,14 +221,14 @@ class SimpleTest
      */
     protected static function getDefaults()
     {
-        return array(
+        return [
             'Parsers' => false,
             'MockBaseClass' => 'SimpleMock',
-            'IgnoreList' => array(),
+            'IgnoreList' => [],
             'DefaultProxy' => false,
             'DefaultProxyUsername' => false,
             'DefaultProxyPassword' => false,
-            'Preferred' => array(new HtmlReporter(), new TextReporter(), new XmlReporter()));
+            'Preferred' => [new HtmlReporter(), new TextReporter(), new XmlReporter()]];
     }
 
     /**
@@ -268,7 +268,7 @@ class SimpleTestContext
      */
     public function clear()
     {
-        $this->resources = array();
+        $this->resources = [];
     }
 
     /**
@@ -407,6 +407,6 @@ class SimpleStackTrace
         if (function_exists('debug_backtrace')) {
             return array_reverse(debug_backtrace());
         }
-        return array();
+        return [];
     }
 }

--- a/app/cdash/tests/kwtest/simpletest/tag.php
+++ b/app/cdash/tests/kwtest/simpletest/tag.php
@@ -730,7 +730,7 @@ class SimpleTextAreaTag extends SimpleWidget
         if ($this->wrapIsEnabled()) {
             return wordwrap(
                 $text,
-                (integer)$this->getAttribute('cols'),
+                (int)$this->getAttribute('cols'),
                 "\r\n");
         }
         return $text;

--- a/app/cdash/tests/kwtest/simpletest/tag.php
+++ b/app/cdash/tests/kwtest/simpletest/tag.php
@@ -27,7 +27,7 @@ class SimpleTagBuilder
      */
     public function createTag($name, $attributes)
     {
-        static $map = array(
+        static $map = [
             'a' => 'SimpleAnchorTag',
             'title' => 'SimpleTitleTag',
             'base' => 'SimpleBaseTag',
@@ -36,7 +36,7 @@ class SimpleTagBuilder
             'option' => 'SimpleOptionTag',
             'label' => 'SimpleLabelTag',
             'form' => 'SimpleFormTag',
-            'frame' => 'SimpleFrameTag');
+            'frame' => 'SimpleFrameTag'];
         $attributes = $this->keysToLowerCase($attributes);
         if (array_key_exists($name, $map)) {
             $tag_class = $map[$name];
@@ -73,7 +73,7 @@ class SimpleTagBuilder
             return new SimpleTextTag($attributes);
         }
         $type = strtolower(trim($attributes['type']));
-        $map = array(
+        $map = [
             'submit' => 'SimpleSubmitTag',
             'image' => 'SimpleImageSubmitTag',
             'checkbox' => 'SimpleCheckboxTag',
@@ -81,7 +81,7 @@ class SimpleTagBuilder
             'text' => 'SimpleTextTag',
             'hidden' => 'SimpleTextTag',
             'password' => 'SimpleTextTag',
-            'file' => 'SimpleUploadTag');
+            'file' => 'SimpleUploadTag'];
         if (array_key_exists($type, $map)) {
             $tag_class = $map[$type];
             return new $tag_class($attributes);
@@ -96,7 +96,7 @@ class SimpleTagBuilder
      */
     protected function keysToLowerCase($map)
     {
-        $lower = array();
+        $lower = [];
         foreach ($map as $key => $value) {
             $lower[strtolower($key)] = $value;
         }
@@ -195,7 +195,7 @@ class SimpleTag
      */
     public function getChildElements()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -802,7 +802,7 @@ class SimpleSelectionTag extends SimpleWidget
     public function __construct($attributes)
     {
         parent::__construct('select', $attributes);
-        $this->options = array();
+        $this->options = [];
         $this->choice = false;
     }
 
@@ -890,7 +890,7 @@ class MultipleSelectionTag extends SimpleWidget
     public function __construct($attributes)
     {
         parent::__construct('select', $attributes);
-        $this->options = array();
+        $this->options = [];
         $this->values = false;
     }
 
@@ -921,7 +921,7 @@ class MultipleSelectionTag extends SimpleWidget
      */
     public function getDefault()
     {
-        $default = array();
+        $default = [];
         for ($i = 0, $count = count($this->options); $i < $count; $i++) {
             if ($this->options[$i]->getAttribute('selected') !== false) {
                 $default[] = $this->options[$i]->getDefault();
@@ -939,7 +939,7 @@ class MultipleSelectionTag extends SimpleWidget
      */
     public function setValue($desired)
     {
-        $achieved = array();
+        $achieved = [];
         foreach ($desired as $value) {
             $success = false;
             for ($i = 0, $count = count($this->options); $i < $count; $i++) {
@@ -1154,7 +1154,7 @@ class SimpleCheckboxTag extends SimpleWidget
  */
 class SimpleTagGroup
 {
-    private $widgets = array();
+    private $widgets = [];
 
     /**
      *    Adds a tag to the group.
@@ -1250,7 +1250,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup
      */
     public function getValue()
     {
-        $values = array();
+        $values = [];
         $widgets = $this->getWidgets();
         for ($i = 0, $count = count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getValue() !== false) {
@@ -1266,7 +1266,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup
      */
     public function getDefault()
     {
-        $values = array();
+        $values = [];
         $widgets = $this->getWidgets();
         for ($i = 0, $count = count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getDefault() !== false) {
@@ -1309,7 +1309,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup
      */
     protected function valuesArePossible($values)
     {
-        $matches = array();
+        $matches = [];
         $widgets = &$this->getWidgets();
         for ($i = 0, $count = count($widgets); $i < $count; $i++) {
             $possible = $widgets[$i]->getAttribute('value');
@@ -1349,10 +1349,10 @@ class SimpleCheckboxGroup extends SimpleTagGroup
     protected function makeArray($value)
     {
         if ($value === false) {
-            return array();
+            return [];
         }
         if (is_string($value)) {
-            return array($value);
+            return [$value];
         }
         return $value;
     }

--- a/app/cdash/tests/kwtest/simpletest/test_case.php
+++ b/app/cdash/tests/kwtest/simpletest/test_case.php
@@ -159,7 +159,7 @@ class SimpleTestCase
      */
     public function getTests()
     {
-        $methods = array();
+        $methods = [];
         foreach (get_class_methods(get_class($this)) as $method) {
             if ($this->isTest($method)) {
                 $methods[] = $method;
@@ -190,7 +190,7 @@ class SimpleTestCase
     public function before($method)
     {
         $this->reporter->paintMethodStart($method);
-        $this->observers = array();
+        $this->observers = [];
     }
 
     /**
@@ -327,7 +327,7 @@ class SimpleTestCase
      */
     public function getAssertionLine()
     {
-        $trace = new SimpleStackTrace(array('assert', 'expect', 'pass', 'fail', 'skip'));
+        $trace = new SimpleStackTrace(['assert', 'expect', 'pass', 'fail', 'skip']);
         return $trace->traceMethod();
     }
 
@@ -426,7 +426,7 @@ class SimpleFileLoader
      */
     public function selectRunnableTests($candidates)
     {
-        $classes = array();
+        $classes = [];
         foreach ($candidates as $class) {
             if (TestSuite::getBaseTestCase($class)) {
                 $reflection = new SimpleReflection($class);
@@ -482,7 +482,7 @@ class TestSuite
     public function __construct($label = false)
     {
         $this->label = $label;
-        $this->test_cases = array();
+        $this->test_cases = [];
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/tidy_parser.php
+++ b/app/cdash/tests/kwtest/simpletest/tidy_parser.php
@@ -10,9 +10,9 @@
 class SimpleTidyPageBuilder
 {
     private $page;
-    private $forms = array();
-    private $labels = array();
-    private $widgets_by_id = array();
+    private $forms = [];
+    private $labels = [];
+    private $widgets_by_id = [];
 
     public function __destruct()
     {
@@ -26,8 +26,8 @@ class SimpleTidyPageBuilder
     private function free()
     {
         unset($this->page);
-        $this->forms = array();
-        $this->labels = array();
+        $this->forms = [];
+        $this->labels = [];
     }
 
     /**
@@ -48,7 +48,7 @@ class SimpleTidyPageBuilder
     {
         $this->page = new SimplePage($response);
         $tidied = tidy_parse_string($input = $this->insertGuards($response->getContent()),
-            array('output-xml' => false, 'wrap' => '0', 'indent' => 'no'),
+            ['output-xml' => false, 'wrap' => '0', 'indent' => 'no'],
             'latin1');
         $this->walkTree($tidied->html());
         $this->attachLabels($this->widgets_by_id, $this->labels);
@@ -116,7 +116,7 @@ class SimpleTidyPageBuilder
     private function insertTextareaSimpleWhitespaceGuards($html)
     {
         return preg_replace_callback('#<textarea([^>]*)>(.*?)</textarea>#is',
-            array($this, 'insertWhitespaceGuards'),
+            [$this, 'insertWhitespaceGuards'],
             $html);
     }
 
@@ -128,8 +128,8 @@ class SimpleTidyPageBuilder
     private function insertWhitespaceGuards($matches)
     {
         return '<textarea' . $matches[1] . '>' .
-        str_replace(array("\n", "\r", "\t", ' '),
-            array('___NEWLINE___', '___CR___', '___TAB___', '___SPACE___'),
+        str_replace(["\n", "\r", "\t", ' '],
+            ['___NEWLINE___', '___CR___', '___TAB___', '___SPACE___'],
             $matches[2]) .
         '</textarea>';
     }
@@ -142,8 +142,8 @@ class SimpleTidyPageBuilder
      */
     private function stripTextareaWhitespaceGuards($html)
     {
-        return str_replace(array('___NEWLINE___', '___CR___', '___TAB___', '___SPACE___'),
-            array("\n", "\r", "\t", ' '),
+        return str_replace(['___NEWLINE___', '___CR___', '___TAB___', '___SPACE___'],
+            ["\n", "\r", "\t", ' '],
             $html);
     }
 
@@ -205,7 +205,7 @@ class SimpleTidyPageBuilder
         if ($node->name == 'a') {
             $this->page->addLink($this->tags()->createTag($node->name, (array)$node->attribute)
                 ->addContent($this->innerHtml($node)));
-        } elseif (in_array($node->name, array('input', 'button', 'textarea', 'select'))) {
+        } elseif (in_array($node->name, ['input', 'button', 'textarea', 'select'])) {
             $this->addWidgetToForm($node, $form, $enclosing_label);
         } elseif ($node->name == 'label') {
             $this->labels[] = $this->tags()->createTag($node->name, (array)$node->attribute)
@@ -267,7 +267,7 @@ class SimpleTidyPageBuilder
             return;
         }
         if (!isset($this->widgets_by_id[$id])) {
-            $this->widgets_by_id[$id] = array();
+            $this->widgets_by_id[$id] = [];
         }
         $this->widgets_by_id[$id][] = $widget;
     }
@@ -279,7 +279,7 @@ class SimpleTidyPageBuilder
      */
     private function collectSelectOptions($node)
     {
-        $options = array();
+        $options = [];
         if ($node->name == 'option') {
             $options[] = $this->tags()->createTag($node->name, $this->attributes($node))
                 ->addContent($this->innerHtml($node));
@@ -301,9 +301,9 @@ class SimpleTidyPageBuilder
     private function attributes($node)
     {
         if (!preg_match('|<[^ ]+\s(.*?)/?>|s', $node->value, $first_tag_contents)) {
-            return array();
+            return [];
         }
-        $attributes = array();
+        $attributes = [];
         preg_match_all('/\S+\s*=\s*\'[^\']*\'|(\S+\s*=\s*"[^"]*")|([^ =]+\s*=\s*[^ "\']+?)|[^ "\']+/', $first_tag_contents[1], $matches);
         foreach ($matches[0] as $unparsed) {
             $attributes = $this->mergeAttribute($attributes, $unparsed);
@@ -321,7 +321,7 @@ class SimpleTidyPageBuilder
     private function mergeAttribute($attributes, $raw)
     {
         $parts = explode('=', $raw);
-        list($name, $value) = count($parts) == 1 ? array($parts[0], $parts[0]) : $parts;
+        list($name, $value) = count($parts) == 1 ? [$parts[0], $parts[0]] : $parts;
         $attributes[trim($name)] = html_entity_decode($this->dequote(trim($value)), ENT_QUOTES);
         return $attributes;
     }
@@ -346,11 +346,11 @@ class SimpleTidyPageBuilder
      */
     private function collectFrames($node)
     {
-        $frames = array();
+        $frames = [];
         if ($node->name == 'frame') {
-            $frames = array($this->tags()->createTag($node->name, (array)$node->attribute));
+            $frames = [$this->tags()->createTag($node->name, (array)$node->attribute)];
         } elseif ($node->hasChildren()) {
-            $frames = array();
+            $frames = [];
             foreach ($node->child as $child) {
                 $frames = array_merge($frames, $this->collectFrames($child));
             }

--- a/app/cdash/tests/kwtest/simpletest/tidy_parser.php
+++ b/app/cdash/tests/kwtest/simpletest/tidy_parser.php
@@ -321,7 +321,7 @@ class SimpleTidyPageBuilder
     private function mergeAttribute($attributes, $raw)
     {
         $parts = explode('=', $raw);
-        list($name, $value) = count($parts) == 1 ? [$parts[0], $parts[0]] : $parts;
+        [$name, $value] = count($parts) == 1 ? [$parts[0], $parts[0]] : $parts;
         $attributes[trim($name)] = html_entity_decode($this->dequote(trim($value)), ENT_QUOTES);
         return $attributes;
     }

--- a/app/cdash/tests/kwtest/simpletest/tidy_parser.php
+++ b/app/cdash/tests/kwtest/simpletest/tidy_parser.php
@@ -334,7 +334,7 @@ class SimpleTidyPageBuilder
     private function dequote($quoted)
     {
         if (preg_match('/^(\'([^\']*)\'|"([^"]*)")$/', $quoted, $matches)) {
-            return isset($matches[3]) ? $matches[3] : $matches[2];
+            return $matches[3] ?? $matches[2];
         }
         return $quoted;
     }

--- a/app/cdash/tests/kwtest/simpletest/url.php
+++ b/app/cdash/tests/kwtest/simpletest/url.php
@@ -39,7 +39,7 @@ class SimpleUrl
      */
     public function __construct($url = '')
     {
-        list($x, $y) = $this->chompCoordinates($url);
+        [$x, $y] = $this->chompCoordinates($url);
         $this->setCoordinates($x, $y);
         $this->scheme = $this->chompScheme($url);
         if ($this->scheme === 'file') {
@@ -50,7 +50,7 @@ class SimpleUrl
             // the scheme is file.
             $url = str_replace('\\', '/', $url);
         }
-        list($this->username, $this->password) = $this->chompLogin($url);
+        [$this->username, $this->password] = $this->chompLogin($url);
         $this->host = $this->chompHost($url);
         $this->port = false;
         if (preg_match('/(.*?):(.*)/', $this->host, $host_parts)) {

--- a/app/cdash/tests/kwtest/simpletest/url.php
+++ b/app/cdash/tests/kwtest/simpletest/url.php
@@ -60,7 +60,7 @@ class SimpleUrl
                 $this->host = false;
             } else {
                 $this->host = $host_parts[1];
-                $this->port = (integer)$host_parts[2];
+                $this->port = (int)$host_parts[2];
             }
         }
         $this->path = $this->chompPath($url);
@@ -79,7 +79,7 @@ class SimpleUrl
     {
         if (preg_match('/(.*)\?(\d+),(\d+)$/', $url, $matches)) {
             $url = $matches[1];
-            return [(integer)$matches[2], (integer)$matches[3]];
+            return [(int)$matches[2], (int)$matches[3]];
         }
         return [false, false];
     }
@@ -320,8 +320,8 @@ class SimpleUrl
             $this->x = $this->y = false;
             return;
         }
-        $this->x = (integer)$x;
-        $this->y = (integer)$y;
+        $this->x = (int)$x;
+        $this->y = (int)$y;
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/url.php
+++ b/app/cdash/tests/kwtest/simpletest/url.php
@@ -79,9 +79,9 @@ class SimpleUrl
     {
         if (preg_match('/(.*)\?(\d+),(\d+)$/', $url, $matches)) {
             $url = $matches[1];
-            return array((integer)$matches[2], (integer)$matches[3]);
+            return [(integer)$matches[2], (integer)$matches[3]];
         }
-        return array(false, false);
+        return [false, false];
     }
 
     /**
@@ -118,12 +118,12 @@ class SimpleUrl
         if (preg_match('#^([^/]*)@(.*)#', $url, $matches)) {
             $url = $prefix . $matches[2];
             $parts = explode(':', $matches[1]);
-            return array(
+            return [
                 urldecode($parts[0]),
-                isset($parts[1]) ? urldecode($parts[1]) : false);
+                isset($parts[1]) ? urldecode($parts[1]) : false];
         }
         $url = $prefix . $url;
-        return array(false, false);
+        return [false, false];
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/url.php
+++ b/app/cdash/tests/kwtest/simpletest/url.php
@@ -250,7 +250,7 @@ class SimpleUrl
     public function getTld()
     {
         $path_parts = pathinfo($this->getHost());
-        return (isset($path_parts['extension']) ? $path_parts['extension'] : false);
+        return ($path_parts['extension'] ?? false);
     }
 
     /**

--- a/app/cdash/tests/kwtest/simpletest/user_agent.php
+++ b/app/cdash/tests/kwtest/simpletest/user_agent.php
@@ -34,7 +34,7 @@ class SimpleUserAgent
     private $proxy_username = false;
     private $proxy_password = false;
     private $connection_timeout = DEFAULT_CONNECTION_TIMEOUT;
-    private $additional_headers = array();
+    private $additional_headers = [];
 
     /**
      *    Starts with no cookies, realms or proxies.

--- a/app/cdash/tests/kwtest/simpletest/web_tester.php
+++ b/app/cdash/tests/kwtest/simpletest/web_tester.php
@@ -206,7 +206,7 @@ class HttpHeaderExpectation extends SimpleExpectation
         if (count($parsed = explode(':', $line, 2)) < 2) {
             return false;
         }
-        list($header, $value) = $parsed;
+        [$header, $value] = $parsed;
         if ($this->normaliseHeader($header) != $this->expected_header) {
             return false;
         }

--- a/app/cdash/tests/kwtest/simpletest/web_tester.php
+++ b/app/cdash/tests/kwtest/simpletest/web_tester.php
@@ -91,7 +91,7 @@ class FieldExpectation extends SimpleExpectation
     protected function testMultiple($compare)
     {
         if (is_string($compare)) {
-            $compare = array($compare);
+            $compare = [$compare];
         }
         if (!is_array($compare)) {
             return false;
@@ -1227,7 +1227,7 @@ class WebTestCase extends SimpleTestCase
      */
     public function assertResponse($responses, $message = '%s')
     {
-        $responses = (is_array($responses) ? $responses : array($responses));
+        $responses = (is_array($responses) ? $responses : [$responses]);
         $code = $this->browser->getResponseCode();
         try {
             $message = sprintf($message, 'Expecting response in [' .
@@ -1247,7 +1247,7 @@ class WebTestCase extends SimpleTestCase
      */
     public function assertMime($types, $message = '%s')
     {
-        $types = (is_array($types) ? $types : array($types));
+        $types = (is_array($types) ? $types : [$types]);
         $type = $this->browser->getMimeType();
         $message = sprintf($message, 'Expecting mime type in [' .
             implode(', ', $types) . "] got [$type]");
@@ -1522,7 +1522,7 @@ class WebTestCase extends SimpleTestCase
      */
     public function getAssertionLine()
     {
-        $trace = new SimpleStackTrace(array('assert', 'click', 'pass', 'fail'));
+        $trace = new SimpleStackTrace(['assert', 'click', 'pass', 'fail']);
         return $trace->traceMethod();
     }
 }

--- a/app/cdash/tests/kwtest/simpletest/xml.php
+++ b/app/cdash/tests/kwtest/simpletest/xml.php
@@ -53,8 +53,8 @@ class XmlReporter extends SimpleReporter
     public function toParsedXml($text)
     {
         return str_replace(
-            array('&', '<', '>', '"', '\''),
-            array('&amp;', '&lt;', '&gt;', '&quot;', '&apos;'),
+            ['&', '<', '>', '"', '\''],
+            ['&amp;', '&lt;', '&gt;', '&quot;', '&apos;'],
             $text);
     }
 
@@ -477,10 +477,10 @@ class SimpleTestXmlParser
     {
         $this->listener = &$listener;
         $this->expat = &$this->createParser();
-        $this->tag_stack = array();
+        $this->tag_stack = [];
         $this->in_content_tag = false;
         $this->content = '';
-        $this->attributes = array();
+        $this->attributes = [];
     }
 
     /**
@@ -551,8 +551,8 @@ class SimpleTestXmlParser
      */
     protected function isLeaf($tag)
     {
-        return in_array($tag, array(
-            'NAME', 'PASS', 'FAIL', 'EXCEPTION', 'SKIP', 'MESSAGE', 'FORMATTED', 'SIGNAL'));
+        return in_array($tag, [
+            'NAME', 'PASS', 'FAIL', 'EXCEPTION', 'SKIP', 'MESSAGE', 'FORMATTED', 'SIGNAL']);
     }
 
     /**
@@ -586,7 +586,7 @@ class SimpleTestXmlParser
     protected function endElement($expat, $tag)
     {
         $this->in_content_tag = false;
-        if (in_array($tag, array('GROUP', 'CASE', 'TEST'))) {
+        if (in_array($tag, ['GROUP', 'CASE', 'TEST'])) {
             $nesting_tag = $this->popNestingTag();
             $nesting_tag->paintEnd($this->listener);
         } elseif ($tag == 'NAME') {

--- a/app/cdash/tests/kwtest/simpletest/xml.php
+++ b/app/cdash/tests/kwtest/simpletest/xml.php
@@ -449,7 +449,7 @@ class NestingGroupTag extends NestingXmlTag
     {
         $attributes = $this->getAttributes();
         if (isset($attributes['SIZE'])) {
-            return (integer)$attributes['SIZE'];
+            return (int)$attributes['SIZE'];
         }
         return 0;
     }

--- a/app/cdash/tests/test_actualtrilinossubmission.php
+++ b/app/cdash/tests/test_actualtrilinossubmission.php
@@ -15,14 +15,14 @@ class ActualTrilinosSubmissionTestCase extends TrilinosSubmissionTestCase
 
     public function createProjectWithName($project)
     {
-        $settings = array(
+        $settings = [
                 'Name' => $project,
                 'Description' => $project . ' project created by test code in file [' . __FILE__ . ']',
                 'EmailBrokenSubmission' => '1',
                 'ShowIPAddresses' => '1',
                 'DisplayLabels' => '1',
                 'NightlyTime' => '21:00:00 America/New_York',
-                'ShareLabelFilters' => '1');
+                'ShareLabelFilters' => '1'];
         return $this->createProject($settings);
     }
 

--- a/app/cdash/tests/test_aggregatecoverage.php
+++ b/app/cdash/tests/test_aggregatecoverage.php
@@ -29,11 +29,11 @@ class AggregateCoverageTestCase extends KWWebTestCase
 
     public function testAggregateCoverage()
     {
-        $files = array(
+        $files = [
             'debug_case/Coverage.xml',
             'debug_case/CoverageLog-0.xml',
             'release_case/Coverage.xml',
-            'release_case/CoverageLog-0.xml');
+            'release_case/CoverageLog-0.xml'];
 
         foreach ($files as $file) {
             if (!$this->submitTestingFile($file)) {

--- a/app/cdash/tests/test_aggregatesubprojectcoverage.php
+++ b/app/cdash/tests/test_aggregatesubprojectcoverage.php
@@ -27,7 +27,7 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
 
     public function testSubmitCoverage()
     {
-        $files = array(
+        $files = [
             'debug_case/experimental/Coverage.xml',
             'debug_case/experimental/CoverageLog-0.xml',
             'debug_case/production/Coverage.xml',
@@ -44,7 +44,7 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
             'release_case/thirdparty/CoverageLog-0.xml',
             'release_case/releaseonly/Coverage.xml',
             'release_case/releaseonly/CoverageLog-0.xml'
-            );
+            ];
         foreach ($files as $filename) {
             $file_to_submit = "$this->DataDir/$filename";
             if (!$this->submission('CrossSubProjectExample', $file_to_submit)) {
@@ -107,82 +107,82 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
         // Verify child results.
 
         // 'debug_coverage'
-        $experimental = array();
-        $experimental['MyExperimentalFeature'] = array();
+        $experimental = [];
+        $experimental['MyExperimentalFeature'] = [];
         $experimental['MyExperimentalFeature']['loctested'] = 5;
         $experimental['MyExperimentalFeature']['locuntested'] = 3;
         $experimental['MyExperimentalFeature']['percentage'] = 62.5;
         $success &= $this->verifyChildResult($debug_buildid, "Experimental", $experimental);
 
-        $third_party = array();
-        $third_party['MyThirdPartyDependency'] = array();
+        $third_party = [];
+        $third_party['MyThirdPartyDependency'] = [];
         $third_party['MyThirdPartyDependency']['loctested'] = 5;
         $third_party['MyThirdPartyDependency']['locuntested'] = 0;
         $third_party['MyThirdPartyDependency']['percentage'] = 100.0;
         $success &= $this->verifyChildResult($debug_buildid, "Third Party", $third_party);
 
-        $production = array();
-        $production['MyEmptyCoverage'] = array();
+        $production = [];
+        $production['MyEmptyCoverage'] = [];
         $production['MyEmptyCoverage']['loctested'] = 0;
         $production['MyEmptyCoverage']['locuntested'] = 0;
         $production['MyEmptyCoverage']['percentage'] = 100.0;
-        $production['MyProductionCode'] = array();
+        $production['MyProductionCode'] = [];
         $production['MyProductionCode']['loctested'] = 10;
         $production['MyProductionCode']['locuntested'] = 6;
         $production['MyProductionCode']['percentage'] = 62.5;
         $success &= $this->verifyChildResult($debug_buildid, "Production", $production);
 
         // 'release_coverage'
-        $experimental = array();
-        $experimental['MyExperimentalFeature'] = array();
+        $experimental = [];
+        $experimental['MyExperimentalFeature'] = [];
         $experimental['MyExperimentalFeature']['loctested'] = 4;
         $experimental['MyExperimentalFeature']['locuntested'] = 4;
         $experimental['MyExperimentalFeature']['percentage'] = 50.0;
         $success &= $this->verifyChildResult($release_buildid, "Experimental", $experimental);
 
-        $third_party = array();
-        $third_party['MyThirdPartyDependency'] = array();
+        $third_party = [];
+        $third_party['MyThirdPartyDependency'] = [];
         $third_party['MyThirdPartyDependency']['loctested'] = 3;
         $third_party['MyThirdPartyDependency']['locuntested'] = 2;
         $third_party['MyThirdPartyDependency']['percentage'] = 60.0;
-        $third_party['MyReleaseOnlyFeature'] = array();
+        $third_party['MyReleaseOnlyFeature'] = [];
         $third_party['MyReleaseOnlyFeature']['loctested'] = 4;
         $third_party['MyReleaseOnlyFeature']['locuntested'] = 4;
         $third_party['MyReleaseOnlyFeature']['percentage'] = 50.0;
         $success &= $this->verifyChildResult($release_buildid, "Third Party", $third_party);
 
-        $production = array();
-        $production['MyProductionCode'] = array();
+        $production = [];
+        $production['MyProductionCode'] = [];
         $production['MyProductionCode']['loctested'] = 8;
         $production['MyProductionCode']['locuntested'] = 8;
         $production['MyProductionCode']['percentage'] = 50.0;
         $success &= $this->verifyChildResult($release_buildid, "Production", $production);
 
         // 'Aggregate Coverage'
-        $experimental = array();
-        $experimental['MyExperimentalFeature'] = array();
+        $experimental = [];
+        $experimental['MyExperimentalFeature'] = [];
         $experimental['MyExperimentalFeature']['loctested'] = 6;
         $experimental['MyExperimentalFeature']['locuntested'] = 2;
         $experimental['MyExperimentalFeature']['percentage'] = 75.0;
         $success &= $this->verifyChildResult($aggregate_buildid, "Experimental", $experimental);
 
-        $third_party = array();
-        $third_party['MyThirdPartyDependency'] = array();
+        $third_party = [];
+        $third_party['MyThirdPartyDependency'] = [];
         $third_party['MyThirdPartyDependency']['loctested'] = 5;
         $third_party['MyThirdPartyDependency']['locuntested'] = 0;
         $third_party['MyThirdPartyDependency']['percentage'] = 100.0;
-        $third_party['MyReleaseOnlyFeature'] = array();
+        $third_party['MyReleaseOnlyFeature'] = [];
         $third_party['MyReleaseOnlyFeature']['loctested'] = 4;
         $third_party['MyReleaseOnlyFeature']['locuntested'] = 4;
         $third_party['MyReleaseOnlyFeature']['percentage'] = 50.0;
         $success &= $this->verifyChildResult($aggregate_buildid, "Third Party", $third_party);
 
-        $production = array();
-        $production['MyEmptyCoverage'] = array();
+        $production = [];
+        $production['MyEmptyCoverage'] = [];
         $production['MyEmptyCoverage']['loctested'] = 0;
         $production['MyEmptyCoverage']['locuntested'] = 0;
         $production['MyEmptyCoverage']['percentage'] = 100.0;
-        $production['MyProductionCode'] = array();
+        $production['MyProductionCode'] = [];
         $production['MyProductionCode']['loctested'] = 12;
         $production['MyProductionCode']['locuntested'] = 4;
         $production['MyProductionCode']['percentage'] = 75.0;
@@ -193,46 +193,46 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
 
     public function testCompareCoverage()
     {
-        $answers = array(
-            'Total' => array(
+        $answers = [
+            'Total' => [
                 'debug' => 68.97,
                 'release' => 51.35,
-                'aggregate' => 72.97),
-            'Third Party' => array(
+                'aggregate' => 72.97],
+            'Third Party' => [
                 'debug' => 100,
                 'release' => 53.85,
-                'aggregate' => 69.23),
-            'Experimental' => array(
+                'aggregate' => 69.23],
+            'Experimental' => [
                 'debug' => 62.5,
                 'release' => 50,
-                'aggregate' => 75),
-            'Production' => array(
+                'aggregate' => 75],
+            'Production' => [
                 'debug' => 62.5,
                 'release' => 50,
-                'aggregate' => 75));
+                'aggregate' => 75]];
         $this->compareCoverageCheck('', $answers);
     }
 
     public function testCompareCoverageWithFilters()
     {
         $extra_url = '&filtercount=1&showfilters=1&field1=subproject&compare1=62&value1=MyReleaseOnlyFeature';
-        $answers = array(
-            'Total' => array(
+        $answers = [
+            'Total' => [
                 'debug' => 68.97,
                 'release' => 51.72,
-                'aggregate' => 79.31),
-            'Third Party' => array(
+                'aggregate' => 79.31],
+            'Third Party' => [
                 'debug' => 100,
                 'release' => 60,
-                'aggregate' => 100),
-            'Experimental' => array(
+                'aggregate' => 100],
+            'Experimental' => [
                 'debug' => 62.5,
                 'release' => 50,
-                'aggregate' => 75),
-            'Production' => array(
+                'aggregate' => 75],
+            'Production' => [
                 'debug' => 62.5,
                 'release' => 50,
-                'aggregate' => 75));
+                'aggregate' => 75]];
         $this->compareCoverageCheck($extra_url, $answers);
     }
 
@@ -250,7 +250,7 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
         }
 
         // Figure out how to distinguish between our coverage builds.
-        $builds = array();
+        $builds = [];
         foreach ($jsonobj['builds'] as $build) {
             switch ($build['name']) {
                 case 'debug_coverage':

--- a/app/cdash/tests/test_aggregatesubprojectcoverage.php
+++ b/app/cdash/tests/test_aggregatesubprojectcoverage.php
@@ -43,7 +43,7 @@ class AggregateSubProjectCoverageTestCase extends KWWebTestCase
             'release_case/thirdparty/Coverage.xml',
             'release_case/thirdparty/CoverageLog-0.xml',
             'release_case/releaseonly/Coverage.xml',
-            'release_case/releaseonly/CoverageLog-0.xml'
+            'release_case/releaseonly/CoverageLog-0.xml',
             ];
         foreach ($files as $filename) {
             $file_to_submit = "$this->DataDir/$filename";

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -45,7 +45,7 @@ class AuthTokenTestCase extends KWWebTestCase
         $settings = [
             'Name' => 'AuthTokenProject',
             'AuthenticateSubmissions' => true,
-            'Public' => 0
+            'Public' => 0,
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
@@ -174,7 +174,7 @@ class AuthTokenTestCase extends KWWebTestCase
             'endtime' => '1475599870',
             'track' => 'Nightly',
             'type' => 'GcovTar',
-            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633'
+            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633',
         ];
 
         $ch = curl_init();

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -110,7 +110,7 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
             VALUES (:groupid, :endtime)');
         $query_params = [
             ':groupid' => $existing_group_id,
-            ':endtime' => '2010-02-25 00:00:00'
+            ':endtime' => '2010-02-25 00:00:00',
         ];
         $db->execute($stmt, $query_params);
 

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -38,7 +38,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 1,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -90,7 +90,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'Name' => 'Bazel',
             'Public' => 1,
             'WarningsFilter' => 'unused variable',
-            'ErrorsFilter' => 'use of undeclared identifier'
+            'ErrorsFilter' => 'use of undeclared identifier',
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
@@ -121,7 +121,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 1,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -140,7 +140,7 @@ class BazelJSONTestCase extends KWWebTestCase
         // Create a new project.
         $settings = [
             'Name' => 'BazelSubProj',
-            'Public' => 1
+            'Public' => 1,
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
@@ -185,7 +185,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 1,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -215,7 +215,7 @@ class BazelJSONTestCase extends KWWebTestCase
                         'testfailed' => 0,
                         'testpassed' => 1,
                         'configureerrors' => 0,
-                        'configurewarnings' => 0
+                        'configurewarnings' => 0,
                     ];
                     break;
                 case 'subproj2':
@@ -225,7 +225,7 @@ class BazelJSONTestCase extends KWWebTestCase
                         'testfailed' => 1,
                         'testpassed' => 0,
                         'configureerrors' => 0,
-                        'configurewarnings' => 0
+                        'configurewarnings' => 0,
                     ];
                     break;
                 default:
@@ -268,7 +268,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 1,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -324,7 +324,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 18,
             'configureerrors' => 0,
-            'configurewarnings' => 1
+            'configurewarnings' => 1,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -380,7 +380,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 0,
             'testpassed' => 0,
             'configureerrors' => 1,
-            'configurewarnings' => 700
+            'configurewarnings' => 700,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -416,7 +416,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 0,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -452,7 +452,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 0,
             'testpassed' => 0,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -498,7 +498,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 0,
             'testpassed' => 1,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -554,7 +554,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 2,
             'testpassed' => 36,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -650,7 +650,7 @@ class BazelJSONTestCase extends KWWebTestCase
             'testfailed' => 1,
             'testpassed' => 0,
             'configureerrors' => 0,
-            'configurewarnings' => 0
+            'configurewarnings' => 0,
         ];
         foreach ($answer_key as $key => $expected) {
             $found = $row[$key];
@@ -732,7 +732,7 @@ class BazelJSONTestCase extends KWWebTestCase
             $response = $client->request('POST',
                 $this->url . '/submit.php',
                 [
-                    'form_params' => $fields
+                    'form_params' => $fields,
                 ]
             );
         } catch (GuzzleHttp\Exception\ClientException $e) {

--- a/app/cdash/tests/test_branchcoverage.php
+++ b/app/cdash/tests/test_branchcoverage.php
@@ -61,7 +61,7 @@ class BranchCoverageTestCase extends KWWebTestCase
             'endtime' => '1422455768',
             'track' => 'Experimental',
             'type' => 'GcovTar',
-            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633'
+            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633',
         ];
 
         $ch = curl_init();

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -18,7 +18,7 @@ class BuildDetailsTestCase extends KWWebTestCase
         parent::__construct();
 
         $this->testDataDir = dirname(__FILE__) . '/data/BuildDetails';
-        $this->testDataFiles = array('Subbuild1.xml', 'Subbuild2.xml', 'Subbuild3.xml');
+        $this->testDataFiles = ['Subbuild1.xml', 'Subbuild2.xml', 'Subbuild3.xml'];
 
         $this->createProject(['Name' => 'BuildDetails']);
 
@@ -29,7 +29,7 @@ class BuildDetailsTestCase extends KWWebTestCase
             }
         }
 
-        $this->builds = array();
+        $this->builds = [];
         $builds = pdo_query("SELECT * FROM build WHERE name = 'linux' ORDER BY id");
         while ($build = pdo_fetch_array($builds)) {
             $this->builds[] = $build;

--- a/app/cdash/tests/test_buildfailuredetails.php
+++ b/app/cdash/tests/test_buildfailuredetails.php
@@ -33,7 +33,7 @@ class BuildFailureDetailsTestCase extends KWWebTestCase
         }
 
         // Get the buildids that we just created so we can delete them later.
-        $buildids = array();
+        $buildids = [];
         $buildid_results = pdo_query(
             "SELECT id FROM build WHERE name='test_buildfailure'");
         while ($buildid_array = pdo_fetch_array($buildid_results)) {

--- a/app/cdash/tests/test_buildgrouprule.php
+++ b/app/cdash/tests/test_buildgrouprule.php
@@ -137,7 +137,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
             $payload = [
                 'buildid'  => $build->Id,
                 'groupid'  => $build->GroupId,
-                'expected' => 1
+                'expected' => 1,
             ];
             try {
                 $response = $client->request('POST',
@@ -155,7 +155,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         $payload = [
             'buildid'    => $build1->Id,
             'expected'   => 1,
-            'newgroupid' => $group->GetId()
+            'newgroupid' => $group->GetId(),
         ];
         try {
             $response = $client->request('POST',

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -25,8 +25,8 @@ class BuildModelTestCase extends KWWebTestCase
         $this->deleteLog($this->logfilename);
 
         $this->testDataDir = dirname(__FILE__) . '/data/BuildModel';
-        $this->testDataFiles = array('build1.xml', 'build2.xml', 'build3.xml', 'build4.xml',
-                                     'build5.xml', 'configure1.xml');
+        $this->testDataFiles = ['build1.xml', 'build2.xml', 'build3.xml', 'build4.xml',
+                                     'build5.xml', 'configure1.xml'];
 
         pdo_query("INSERT INTO project (name) VALUES ('BuildModel')");
 
@@ -37,13 +37,13 @@ class BuildModelTestCase extends KWWebTestCase
             }
         }
 
-        $this->builds = array();
+        $this->builds = [];
         $builds = pdo_query("SELECT * FROM build WHERE name = 'buildmodel-test-build' ORDER BY id");
         while ($build = pdo_fetch_array($builds)) {
             $this->builds[] = $build;
         }
 
-        $this->parentBuilds = array();
+        $this->parentBuilds = [];
         $parentBuilds = pdo_query("SELECT * FROM build WHERE name = 'buildmodel-test-parent-build' AND parentid = -1 ORDER BY id");
         while ($build = pdo_fetch_array($parentBuilds)) {
             $this->parentBuilds[] = $build;
@@ -239,12 +239,12 @@ class BuildModelTestCase extends KWWebTestCase
     {
         // Make sure the first build returns no resolved build failures since it can't have any
         $build = $this->getBuildModel(0);
-        $this->assertTrue($build->GetResolvedBuildFailures(0)->fetchAll() === array());
+        $this->assertTrue($build->GetResolvedBuildFailures(0)->fetchAll() === []);
 
         // The second build resolves the errored failure, but not the warning failure
         $build = $this->getBuildModel(1);
         $this->assertTrue(count($build->GetResolvedBuildFailures(0)->fetchAll()) === 1);
-        $this->assertTrue($build->GetResolvedBuildFailures(1)->fetchAll() === array());
+        $this->assertTrue($build->GetResolvedBuildFailures(1)->fetchAll() === []);
 
         // The third build has a resolved failure of type warning
         $build = $this->getBuildModel(2);

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -212,7 +212,7 @@ class BuildPropertiesTestCase extends KWWebTestCase
                 'POST',
                 config('app.url') . '/submit.php',
                 [
-                    'form_params' => $fields
+                    'form_params' => $fields,
                 ]
             );
         } catch (GuzzleHttp\Exception\ClientException $e) {

--- a/app/cdash/tests/test_buildrelationship.php
+++ b/app/cdash/tests/test_buildrelationship.php
@@ -94,7 +94,7 @@ class BuildRelationshipTestCase extends KWWebTestCase
         $payload = [
             'project'    => 'InsightExample',
             'buildid'    => $build2->Id,
-            'relatedid'  => $build1->Id
+            'relatedid'  => $build1->Id,
         ];
         $response = $client->request('POST',
             $this->url .  '/api/v1/relateBuilds.php',
@@ -109,14 +109,14 @@ class BuildRelationshipTestCase extends KWWebTestCase
                 'project'    => 'InsightExample',
                 'buildid'      => $build2->Id,
                 'relatedid'    => $build1->Id,
-                'relationship' => 'depends on'
+                'relationship' => 'depends on',
             ],
             [
                 'project'    => 'InsightExample',
                 'buildid'      => $build3->Id,
                 'relatedid'    => $build2->Id,
-                'relationship' => 'uses results from'
-            ]
+                'relationship' => 'uses results from',
+            ],
         ];
         foreach ($payloads as $payload) {
             try {

--- a/app/cdash/tests/test_commitauthornotification.php
+++ b/app/cdash/tests/test_commitauthornotification.php
@@ -18,7 +18,7 @@ class CommitAuthorNotificationTestCase extends KWWebTestCase
             'Name' => $this->projectName,
             'Description' => "Project {$this->projectName} test for cdash testing",
             'EmailBrokenSubmission' => 1,
-            'EmailRedundantFailures' => 0
+            'EmailRedundantFailures' => 0,
         ]);
         $group = new BuildGroup();
         $group->SetName('Continuous');

--- a/app/cdash/tests/test_configurewarnings.php
+++ b/app/cdash/tests/test_configurewarnings.php
@@ -52,7 +52,7 @@ class ConfigureWarningTestCase extends KWWebTestCase
         // Create a project for this test.
         $settings = [
             'Name' => 'ConfigureWarningProject',
-            'Description' => 'ConfigureWarningProject'
+            'Description' => 'ConfigureWarningProject',
         ];
         $this->ProjectId = $this->createProject($settings);
         if ($this->ProjectId < 1) {

--- a/app/cdash/tests/test_configurewarnings.php
+++ b/app/cdash/tests/test_configurewarnings.php
@@ -22,17 +22,17 @@ class ConfigureWarningTestCase extends KWWebTestCase
 
     public function testConfigureWarning()
     {
-        $warning_lines = array(
+        $warning_lines = [
             'CMake Warning (dev) at some/file/path:1234 (MESSAGE):',
-            'WARNING: blah blah blah');
+            'WARNING: blah blah blah'];
 
-        $non_warning_lines = array(
+        $non_warning_lines = [
             'warning: blah blah blah',
             'WARNING : blah blah blah',
             'WARNING some other text: blah blah blah',
             'This warning is for project developers. Use -Wno-dev to suppress it.',
             '<<< Configuring library with warnings >>>',
-            'library warnings................. : yes');
+            'library warnings................. : yes'];
 
         foreach ($warning_lines as $line) {
             if (!BuildConfigure::IsConfigureWarning($line)) {

--- a/app/cdash/tests/test_consistenttestingday.php
+++ b/app/cdash/tests/test_consistenttestingday.php
@@ -32,7 +32,7 @@ class ConsistentTestingDayTestCase extends KWWebTestCase
         $this->project = new Project();
         $this->project->Id = $this->createProject([
             'Name' => 'ConsistentTestingDay',
-            'NightlyTime' => '16:30:00 America/New_York'
+            'NightlyTime' => '16:30:00 America/New_York',
         ]);
         $this->project->Fill();
 

--- a/app/cdash/tests/test_coveragedirectories.php
+++ b/app/cdash/tests/test_coveragedirectories.php
@@ -25,16 +25,16 @@ class CoverageDirectoriesTestCase extends KWWebTestCase
             $project->Delete();
         }
 
-        $settings = array(
+        $settings = [
                 'Name' => 'CoverageDirectories',
-                'Description' => 'Test to make sure directories display proper files');
+                'Description' => 'Test to make sure directories display proper files'];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
             $this->fail('Failed to create project');
             return;
         }
 
-        $filesToSubmit = array('prefix-Coverage.xml', 'prefix-CoverageLog-0.xml', 'sort-Coverage.xml', 'sort-CoverageLog-0.xml', 'sort-CoverageLog-1.xml');
+        $filesToSubmit = ['prefix-Coverage.xml', 'prefix-CoverageLog-0.xml', 'sort-Coverage.xml', 'sort-CoverageLog-0.xml', 'sort-CoverageLog-1.xml'];
         $dir = dirname(__FILE__) . '/data/CoverageDirectories';
         foreach ($filesToSubmit as $file) {
             if (!$this->submission('CoverageDirectories', "$dir/$file")) {

--- a/app/cdash/tests/test_createpublicdashboard.php
+++ b/app/cdash/tests/test_createpublicdashboard.php
@@ -15,10 +15,10 @@ class CreatePublicDashboardTestCase extends KWWebTestCase
 
     public function testCreatePublicDashboard()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'PublicDashboard',
                 'Description' => "This project is for CMake dashboards run on this machine to submit to from their test suites... CMake dashboards on this machine should set CMAKE_TESTS_CDASH_SERVER to $this->url",
-                'EmailAdministrator' => 1);
+                'EmailAdministrator' => 1];
         $this->createProject($settings);
     }
 }

--- a/app/cdash/tests/test_crosssubprojectcoverage.php
+++ b/app/cdash/tests/test_crosssubprojectcoverage.php
@@ -30,9 +30,9 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
     public function testCreateProjectTest()
     {
         // Create a new project for this test.
-        $settings = array(
+        $settings = [
                 'Name' => 'CrossSubProjectExample',
-                'Description' => 'Example of coverage across SubProjects');
+                'Description' => 'Example of coverage across SubProjects'];
         $this->createProject($settings);
     }
 
@@ -87,7 +87,7 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
         }
 
         // Do the POST submission to get a pending buildid from CDash.
-        $post_data = array(
+        $post_data = [
             'project' => 'CrossSubProjectExample',
             'subproject' => $subproject,
             'build' => 'subproject_coverage_example',
@@ -97,7 +97,7 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
             'endtime' => $endtime,
             'track' => 'Nightly',
             'type' => 'GcovTar',
-            'datafilesmd5[0]=' => $md5);
+            'datafilesmd5[0]=' => $md5];
         $post_result = $this->post($this->url . '/submit.php', $post_data);
         $post_json = json_decode($post_result, true);
         if ($post_json['status'] != 0) {

--- a/app/cdash/tests/test_deferredsubmissions.php
+++ b/app/cdash/tests/test_deferredsubmissions.php
@@ -135,7 +135,7 @@ class DeferredSubmissionsTestCase extends BranchCoverageTestCase
         $response = $this->post($this->url . '/api/authtokens/create', [
             'description' => 'mytoken',
             'scope' => $scope,
-            'projectid' => $this->project->Id
+            'projectid' => $this->project->Id,
         ]);
         $response = json_decode($response, true);
         $this->token = $response['raw_token'];

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -31,7 +31,7 @@ class DynamicAnalysisSummaryTestCase extends KWWebTestCase
         $this->DataDir = dirname(__FILE__) . '/data/DynamicAnalysisSummary';
         $this->ParentId = 0;
         $this->StandaloneBuildId = 0;
-        $this->ChildIds = array();
+        $this->ChildIds = [];
     }
 
     public function testDynamicAnalysisSummary()

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -21,11 +21,11 @@ class EmailTestCase extends KWWebTestCase
 
     public function testCreateProjectTest()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'EmailProjectExample',
                 'Description' => 'Project EmailProjectExample test for cdash testing',
                 'EmailBrokenSubmission' => 1,
-                'EmailRedundantFailures' => 0);
+                'EmailRedundantFailures' => 0];
         $this->project = $this->createProject($settings);
     }
 

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -124,7 +124,7 @@ class EmailTestCase extends KWWebTestCase
             'Build Time: 2009-02-23 10:02:04',
             'Type: Nightly',
             'Warnings fixed: 6',
-            '-CDash on'
+            '-CDash on',
         ];
         if ($this->assertLogContains($expected, 15)) {
             $this->pass('Passed');
@@ -170,7 +170,7 @@ class EmailTestCase extends KWWebTestCase
             'Build Time: 2009-02-23 10:02:04',
             'Type: Nightly',
             'Test failures fixed: 2',
-            '-CDash on'
+            '-CDash on',
         ];
 
         if ($this->assertLogContains($expected, 15)) {

--- a/app/cdash/tests/test_excludesubprojects.php
+++ b/app/cdash/tests/test_excludesubprojects.php
@@ -240,69 +240,69 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
     {
         $baseurl = "$this->url/api/v1/index.php?project=Trilinos&date=2011-07-22&filtercombine=and&field1=site&compare1=61&value1=hut11.kitware&showfilters=1";
 
-        $test_cases = array(
-            array(
+        $test_cases = [
+            [
                 'filter' => 'buildduration',
                 'compare' => 43,
                 'value' => '10m%2045s',
                 'exclude' => 'Teuchos'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'buildduration',
                 'compare' => 44,
                 'value' => '6m%2026s',
                 'exclude' => 'Sacado',
                 'reverse' => true
-            ),
-            array(
+            ],
+            [
                 'filter' => 'builderrors',
                 'compare' => 43,
                 'value' => 5,
                 'exclude' => 'Mesquite'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'buildwarnings',
                 'compare' => 42,
                 'value' => 29,
                 'exclude' => 'Sacado'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'configureduration',
                 'compare' => 41,
                 'value' => 309,
                 'exclude' => 'Teuchos'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'configureerrors',
                 'compare' => 43,
                 'value' => 21,
                 'exclude' => 'Kokkos'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'configurewarnings',
                 'compare' => 42,
                 'value' => 35,
                 'exclude' => 'Sacado'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'testsfailed',
                 'compare' => 43,
                 'value' => 10,
                 'exclude' => 'TrilinosFramework'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'testsnotrun',
                 'compare' => 42,
                 'value' => 65,
                 'exclude' => 'Didasko'
-            ),
-            array(
+            ],
+            [
                 'filter' => 'testspassed',
                 'compare' => 42,
                 'value' => 33,
                 'exclude' => 'Sacado'
-            )
-        );
+            ]
+        ];
 
         foreach ($test_cases as $test_case) {
             $filter = $test_case['filter'];

--- a/app/cdash/tests/test_excludesubprojects.php
+++ b/app/cdash/tests/test_excludesubprojects.php
@@ -245,63 +245,63 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
                 'filter' => 'buildduration',
                 'compare' => 43,
                 'value' => '10m%2045s',
-                'exclude' => 'Teuchos'
+                'exclude' => 'Teuchos',
             ],
             [
                 'filter' => 'buildduration',
                 'compare' => 44,
                 'value' => '6m%2026s',
                 'exclude' => 'Sacado',
-                'reverse' => true
+                'reverse' => true,
             ],
             [
                 'filter' => 'builderrors',
                 'compare' => 43,
                 'value' => 5,
-                'exclude' => 'Mesquite'
+                'exclude' => 'Mesquite',
             ],
             [
                 'filter' => 'buildwarnings',
                 'compare' => 42,
                 'value' => 29,
-                'exclude' => 'Sacado'
+                'exclude' => 'Sacado',
             ],
             [
                 'filter' => 'configureduration',
                 'compare' => 41,
                 'value' => 309,
-                'exclude' => 'Teuchos'
+                'exclude' => 'Teuchos',
             ],
             [
                 'filter' => 'configureerrors',
                 'compare' => 43,
                 'value' => 21,
-                'exclude' => 'Kokkos'
+                'exclude' => 'Kokkos',
             ],
             [
                 'filter' => 'configurewarnings',
                 'compare' => 42,
                 'value' => 35,
-                'exclude' => 'Sacado'
+                'exclude' => 'Sacado',
             ],
             [
                 'filter' => 'testsfailed',
                 'compare' => 43,
                 'value' => 10,
-                'exclude' => 'TrilinosFramework'
+                'exclude' => 'TrilinosFramework',
             ],
             [
                 'filter' => 'testsnotrun',
                 'compare' => 42,
                 'value' => 65,
-                'exclude' => 'Didasko'
+                'exclude' => 'Didasko',
             ],
             [
                 'filter' => 'testspassed',
                 'compare' => 42,
                 'value' => 33,
-                'exclude' => 'Sacado'
-            ]
+                'exclude' => 'Sacado',
+            ],
         ];
 
         foreach ($test_cases as $test_case) {

--- a/app/cdash/tests/test_expiredbuildrules.php
+++ b/app/cdash/tests/test_expiredbuildrules.php
@@ -31,7 +31,7 @@ class ExpiredBuildRulesTestCase extends KWWebTestCase
             ':siteid' => 0,
             ':parentgroupid' => 0,
             ':starttime' => '2009-02-23 00:00:00',
-            ':endtime' => '2009-02-25 00:00:00'
+            ':endtime' => '2009-02-25 00:00:00',
         ];
         $db->execute($stmt, $query_params);
 

--- a/app/cdash/tests/test_filterbuilderrors.php
+++ b/app/cdash/tests/test_filterbuilderrors.php
@@ -26,9 +26,9 @@ class FilterBuildErrorsTestCase extends KWWebTestCase
             'Name' => 'FilterErrors',
             'Public' => 1,
             'ErrorsFilter' => <<<FILTER
-was not declared in this scope
-No such file or directory
-FILTER
+                was not declared in this scope
+                No such file or directory
+                FILTER,
 ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {

--- a/app/cdash/tests/test_filterbuilderrors.php
+++ b/app/cdash/tests/test_filterbuilderrors.php
@@ -45,7 +45,7 @@ FILTER
         }
 
         // Get the buildid that we just created so we can delete it later.
-        $buildids = array();
+        $buildids = [];
         $buildid_results = pdo_query(
             "SELECT id FROM build WHERE name='test_buildfailure'");
         while ($buildid_array = pdo_fetch_array($buildid_results)) {

--- a/app/cdash/tests/test_filtertestlabels.php
+++ b/app/cdash/tests/test_filtertestlabels.php
@@ -32,7 +32,7 @@ class FilterTestLabelsTestCase extends KWWebTestCase
                 WHERE name='EmailProjectExample'");
 
         // Get the buildid that we just created so we can delete it later.
-        $buildids = array();
+        $buildids = [];
         $buildid_results = pdo_query(
             "SELECT id FROM build WHERE name='labeltest_build'");
         while ($buildid_array = pdo_fetch_array($buildid_results)) {

--- a/app/cdash/tests/test_hidecolumns.php
+++ b/app/cdash/tests/test_hidecolumns.php
@@ -14,7 +14,7 @@ class HideColumnsTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
-        $this->MethodsToTest = array('Update', 'Configure', 'Build', 'Test');
+        $this->MethodsToTest = ['Update', 'Configure', 'Build', 'Test'];
     }
 
     public function testHideColumns()

--- a/app/cdash/tests/test_imagecomparison.php
+++ b/app/cdash/tests/test_imagecomparison.php
@@ -35,7 +35,7 @@ class ImageComparisonTestCase extends KWWebTestCase
             JOIN test2image t2i ON (b2t.outputid=t2i.outputid)
             JOIN image i ON (i.id=t2i.imgid)
             WHERE b.name='image_comparison'");
-        $imgids = array();
+        $imgids = [];
         $buildid = 0;
         while ($row = $stmt->fetch()) {
             $buildid = $row['buildid'];

--- a/app/cdash/tests/test_indexnextprevious.php
+++ b/app/cdash/tests/test_indexnextprevious.php
@@ -40,7 +40,7 @@ class IndexNextPreviousTestCase extends KWWebTestCase
         $build_rows = [
             [$first_date, 1476079800, 'Experimental'],
             [$second_date, 1507637400, 'Nightly'],
-            [$third_date, 1539195000, 'Experimental']
+            [$third_date, 1539195000, 'Experimental'],
         ];
         foreach ($build_rows as $build_row) {
             $date = str_replace('-', '', $build_row[0]);

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -41,7 +41,7 @@ class IssueCreationTestCase extends KWWebTestCase
         foreach ($project_names as $project_name) {
             $settings = [
                 'Name' => $project_name,
-                'Public' => 1
+                'Public' => 1,
             ];
             $projectid = $this->createProject($settings);
             if ($projectid < 1) {
@@ -132,16 +132,16 @@ class IssueCreationTestCase extends KWWebTestCase
         $trackers = [
             [
                 'name' => 'Buganizer',
-                'url' => 'https://buganizer.com/issues/new?component=123&template=456'
+                'url' => 'https://buganizer.com/issues/new?component=123&template=456',
             ],
             [
                 'name' => 'GitHub',
-                'url' => 'https://github.com/Kitware/CDash/issues/new?'
+                'url' => 'https://github.com/Kitware/CDash/issues/new?',
             ],
             [
                 'name' => 'JIRA',
-                'url' => 'http://jira.atlassian.com/secure/CreateIssueDetails!init.jspa?pid=123&issuetype=1'
-            ]
+                'url' => 'http://jira.atlassian.com/secure/CreateIssueDetails!init.jspa?pid=123&issuetype=1',
+            ],
         ];
 
         // Lookup some IDs that we will need in the answer key below.
@@ -170,12 +170,12 @@ class IssueCreationTestCase extends KWWebTestCase
             ],
             'GitHub' => [
                 'Standalone' => "https://github.com/Kitware/CDash/issues/new?title=FAILED+%28w%3D3%2C+t%3D6%2C+d%3D10%29%3A+IssueCreationProject+-+Linux-g%2B%2B-4.1-LesionSizingSandbox_Debug+-+Experimental&body=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid1}%0A%0AProject%3A+IssueCreationProject%0ASite%3A+camelot.kitware%0ABuild+Name%3A+Linux-g%2B%2B-4.1-LesionSizingSandbox_Debug%0ABuild+Time%3A+2009-02-23T07%3A10%3A38+UTC%0AType%3A+Experimental%0AWarnings%3A+3%0ATests+not+passing%3A+6%0ADynamic+analysis+tests+failing%3A+10%0A%0A%0A%2AWarnings%2A+%28first+1%29%0ATesting%5CitkDescoteauxSheetnessImageFilterTest2.cxx+line+187+%28$encoded_base_url%2FviewBuildError.php%3Ftype%3D1%26buildid%3D{$buildid1}%29%0A%5C...%5CSandbox%5CTesting%5CitkDescoteauxSheetnessImageFilterTest2.cxx%3A187%3A+warning%3A+converting+to+%3C-30%3E%3C-128%3E%3C-104%3Emain%3A%3AInputPixelType%3C-30%3E%3C-128%3E%3C-103%3E+from+%3C-30%3E%3C-128%3E%3C-104%3Edouble%3C-30%3E%3C-128%3E%3C-103%3E%0A%0A%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0AitkVectorSegmentationLevelSetFunctionTest1+%7C+Completed+%28OTHER_FAULT%29+%7C+%28$encoded_base_url%2Ftest%2F{$build1failedtestid}%29%0A%0A%0A%0A%2ATests+not+run%2A+%28first+1%29%0AitkVectorFiniteDifferenceFunctionTest1+%7C++%7C+%28$encoded_base_url%2Ftest%2F{$build1notruntestid}%29%0A%0A%0A%0A%2ADynamic+analysis+tests+failing+or+not+run%2A+%28first+1%29%0AitkGeodesicActiveContourLevelSetSegmentationModuleTest1+%28$encoded_base_url%2FviewDynamicAnalysisFile.php%3Fid%3D{$da_id}%29%0A%0A",
-                'SubProject' => "https://github.com/Kitware/CDash/issues/new?title=FAILED+%28t%3D1%29%3A+CDash%2FSubProject1+-+test_PR_comment+-+Experimental&body=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid2}%0A%0AProject%3A+CDash%0ASubProject%3A+SubProject1%0ASite%3A+elysium%0ABuild+Name%3A+test_PR_comment%0ABuild+Time%3A+2015-08-11T20%3A45%3A30+UTC%0AType%3A+Experimental%0ATests+not+passing%3A+1%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0Afoo+%7C+Completed+%28Failed%29+%7C+%28$encoded_base_url%2Ftest%2F{$build2failedtestid}%29%0A%0A%40simpletest+%40user1+"
+                'SubProject' => "https://github.com/Kitware/CDash/issues/new?title=FAILED+%28t%3D1%29%3A+CDash%2FSubProject1+-+test_PR_comment+-+Experimental&body=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid2}%0A%0AProject%3A+CDash%0ASubProject%3A+SubProject1%0ASite%3A+elysium%0ABuild+Name%3A+test_PR_comment%0ABuild+Time%3A+2015-08-11T20%3A45%3A30+UTC%0AType%3A+Experimental%0ATests+not+passing%3A+1%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0Afoo+%7C+Completed+%28Failed%29+%7C+%28$encoded_base_url%2Ftest%2F{$build2failedtestid}%29%0A%0A%40simpletest+%40user1+",
             ],
             'JIRA' => [
                 'Standalone' => "http://jira.atlassian.com/secure/CreateIssueDetails!init.jspa?pid=123&issuetype=1&summary=FAILED+%28w%3D3%2C+t%3D6%2C+d%3D10%29%3A+IssueCreationProject+-+Linux-g%2B%2B-4.1-LesionSizingSandbox_Debug+-+Experimental&description=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid1}%0A%0AProject%3A+IssueCreationProject%0ASite%3A+camelot.kitware%0ABuild+Name%3A+Linux-g%2B%2B-4.1-LesionSizingSandbox_Debug%0ABuild+Time%3A+2009-02-23T07%3A10%3A38+UTC%0AType%3A+Experimental%0AWarnings%3A+3%0ATests+not+passing%3A+6%0ADynamic+analysis+tests+failing%3A+10%0A%0A%0A%2AWarnings%2A+%28first+1%29%0ATesting%5CitkDescoteauxSheetnessImageFilterTest2.cxx+line+187+%28$encoded_base_url%2FviewBuildError.php%3Ftype%3D1%26buildid%3D{$buildid1}%29%0A%5C...%5CSandbox%5CTesting%5CitkDescoteauxSheetnessImageFilterTest2.cxx%3A187%3A+warning%3A+converting+to+%3C-30%3E%3C-128%3E%3C-104%3Emain%3A%3AInputPixelType%3C-30%3E%3C-128%3E%3C-103%3E+from+%3C-30%3E%3C-128%3E%3C-104%3Edouble%3C-30%3E%3C-128%3E%3C-103%3E%0A%0A%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0AitkVectorSegmentationLevelSetFunctionTest1+%7C+Completed+%28OTHER_FAULT%29+%7C+%28$encoded_base_url%2Ftest%2F{$build1failedtestid}%29%0A%0A%0A%0A%2ATests+not+run%2A+%28first+1%29%0AitkVectorFiniteDifferenceFunctionTest1+%7C++%7C+%28$encoded_base_url%2Ftest%2F{$build1notruntestid}%29%0A%0A%0A%0A%2ADynamic+analysis+tests+failing+or+not+run%2A+%28first+1%29%0AitkGeodesicActiveContourLevelSetSegmentationModuleTest1+%28$encoded_base_url%2FviewDynamicAnalysisFile.php%3Fid%3D{$da_id}%29%0A%0A",
-                'SubProject' => "http://jira.atlassian.com/secure/CreateIssueDetails!init.jspa?pid=123&issuetype=1&summary=FAILED+%28t%3D1%29%3A+CDash%2FSubProject1+-+test_PR_comment+-+Experimental&description=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid2}%0A%0AProject%3A+CDash%0ASubProject%3A+SubProject1%0ASite%3A+elysium%0ABuild+Name%3A+test_PR_comment%0ABuild+Time%3A+2015-08-11T20%3A45%3A30+UTC%0AType%3A+Experimental%0ATests+not+passing%3A+1%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0Afoo+%7C+Completed+%28Failed%29+%7C+%28$encoded_base_url%2Ftest%2F{$build2failedtestid}%29%0A%0A%5B%7Esimpletest%5D+%5B%7Euser1%5D+"
-            ]
+                'SubProject' => "http://jira.atlassian.com/secure/CreateIssueDetails!init.jspa?pid=123&issuetype=1&summary=FAILED+%28t%3D1%29%3A+CDash%2FSubProject1+-+test_PR_comment+-+Experimental&description=Details+on+the+submission+can+be+found+at+$encoded_base_url%2Fbuild%2F{$buildid2}%0A%0AProject%3A+CDash%0ASubProject%3A+SubProject1%0ASite%3A+elysium%0ABuild+Name%3A+test_PR_comment%0ABuild+Time%3A+2015-08-11T20%3A45%3A30+UTC%0AType%3A+Experimental%0ATests+not+passing%3A+1%0A%0A%0A%2ATests+failing%2A+%28first+1%29%0Afoo+%7C+Completed+%28Failed%29+%7C+%28$encoded_base_url%2Ftest%2F{$build2failedtestid}%29%0A%0A%5B%7Esimpletest%5D+%5B%7Euser1%5D+",
+            ],
         ];
 
         foreach ($trackers as $tracker) {
@@ -184,7 +184,7 @@ class IssueCreationTestCase extends KWWebTestCase
             $settings = [
                 'Id' => $this->Projects['IssueCreationProject']->Id,
                 'BugTrackerType' => $tracker['name'],
-                'BugTrackerNewIssueUrl' => $tracker['url']
+                'BugTrackerNewIssueUrl' => $tracker['url'],
             ];
             $this->createProject($settings, true);
 

--- a/app/cdash/tests/test_javajsoncoverage.php
+++ b/app/cdash/tests/test_javajsoncoverage.php
@@ -15,7 +15,7 @@ class JavaJSONCoverageTestCase extends KWWebTestCase
     public function testJavaJSONCoverage()
     {
         // Do the POST submission to get a pending buildid.
-        $post_result = $this->post($this->url . '/submit.php', array(
+        $post_result = $this->post($this->url . '/submit.php', [
             'project' => 'SubProjectExample',
             'build' => 'java_json_coverage',
             'site' => 'localhost',
@@ -24,7 +24,7 @@ class JavaJSONCoverageTestCase extends KWWebTestCase
             'endtime' => '1422455768',
             'track' => 'Experimental',
             'type' => 'JavaJSONTar',
-            'datafilesmd5[0]=' => '67b5d3cee7b951ff2981c440b4a515ec'));
+            'datafilesmd5[0]=' => '67b5d3cee7b951ff2981c440b4a515ec']);
 
         $post_json = json_decode($post_result, true);
         if ($post_json['status'] != 0) {

--- a/app/cdash/tests/test_jscovercoverage.php
+++ b/app/cdash/tests/test_jscovercoverage.php
@@ -15,7 +15,7 @@ class JSCoverCoverageTestCase extends KWWebTestCase
     public function testJSCoverCoverage()
     {
         // Do the POST submission to get a pending buildid.
-        $post_result = $this->post($this->url . '/submit.php', array(
+        $post_result = $this->post($this->url . '/submit.php', [
             'project' => 'SubProjectExample',
             'build' => 'jscover_coverage',
             'site' => 'localhost',
@@ -24,7 +24,7 @@ class JSCoverCoverageTestCase extends KWWebTestCase
             'endtime' => '1422455768',
             'track' => 'Experimental',
             'type' => 'JSCoverTar',
-            'datafilesmd5[0]=' => 'e99bdd400ab4643e4fbeef7ec649f04e'));
+            'datafilesmd5[0]=' => 'e99bdd400ab4643e4fbeef7ec649f04e']);
 
         $post_json = json_decode($post_result, true);
         if ($post_json['status'] != 0) {

--- a/app/cdash/tests/test_junithandler.php
+++ b/app/cdash/tests/test_junithandler.php
@@ -33,7 +33,7 @@ class JUnitHandlerTestCase extends KWWebTestCase
         // Create project.
         $settings = [
             'Name' => 'JUnitHandlerProject',
-            'Public' => 1
+            'Public' => 1,
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {

--- a/app/cdash/tests/test_multicoverage.php
+++ b/app/cdash/tests/test_multicoverage.php
@@ -53,7 +53,7 @@ class MultiCoverageTestCase extends KWWebTestCase
 
     public function submitXML()
     {
-        $filesToSubmit = array('Coverage.xml', 'CoverageLog-0.xml');
+        $filesToSubmit = ['Coverage.xml', 'CoverageLog-0.xml'];
         $dir = dirname(__FILE__) . '/data/MultiCoverage';
         foreach ($filesToSubmit as $file) {
             if (!$this->submission('TrilinosDriver', "$dir/$file")) {
@@ -65,7 +65,7 @@ class MultiCoverageTestCase extends KWWebTestCase
 
     public function submitTar()
     {
-        $post_result = $this->post($this->url . '/submit.php', array(
+        $post_result = $this->post($this->url . '/submit.php', [
             'project' => 'TrilinosDriver',
             'build' => 'multi_coverage_example',
             'site' => 'localhost',
@@ -74,7 +74,7 @@ class MultiCoverageTestCase extends KWWebTestCase
             'endtime' => '1462462884',
             'track' => 'Experimental',
             'type' => 'GcovTar',
-            'datafilesmd5[0]=' => '65f385dd8d360e78a35453144c0919ab'));
+            'datafilesmd5[0]=' => '65f385dd8d360e78a35453144c0919ab']);
 
         $post_json = json_decode($post_result, true);
         if ($post_json['status'] != 0) {

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -245,7 +245,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         $pdo = get_link_identifier()->getPdo();
         $parentid = null;
 
-        $subprojects = array("MyThirdPartyDependency", "MyExperimentalFeature", "MyProductionCode", "EmptySubproject");
+        $subprojects = ["MyThirdPartyDependency", "MyExperimentalFeature", "MyProductionCode", "EmptySubproject"];
 
         // Check index.php for this date.
         $this->get($this->url . "/api/v1/index.php?project=SubProjectExample&date=2016-07-28");
@@ -635,7 +635,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
         // Check top-level project results.
         $project = $jsonobj['project'];
-        $project_expected = array(
+        $project_expected = [
             'nbuilderror' => 1,
             'nbuildwarning' => 1,
             'nbuildpass' => 0,
@@ -644,7 +644,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             'nconfigurepass' => 0,
             'ntestpass' => 1,
             'ntestfail' => 5,       // Total number of tests failed
-            'ntestnotrun' => 1);
+            'ntestnotrun' => 1];
         foreach ($project_expected as $key => $expected) {
             $found = $project[$key];
             if ($found !== $expected) {
@@ -653,8 +653,8 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         }
 
         // Check results for each individual SubProject.
-        $subprojects_expected = array(
-            'MyThirdPartyDependency' => array(
+        $subprojects_expected = [
+            'MyThirdPartyDependency' => [
                 'nbuilderror' => 1,
                 'nbuildwarning' => 0,
                 'nbuildpass' => 0,
@@ -663,8 +663,8 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 'nconfigurepass' => 0,
                 'ntestpass' => 0,
                 'ntestfail' => 0,
-                'ntestnotrun' => 1),
-            'MyExperimentalFeature' => array(
+                'ntestnotrun' => 1],
+            'MyExperimentalFeature' => [
                 'nbuilderror' => 0,
                 'nbuildwarning' => 1,
                 'nbuildpass' => 0,
@@ -673,8 +673,8 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 'nconfigurepass' => 0,
                 'ntestpass' => 0,
                 'ntestfail' => 5,
-                'ntestnotrun' => 0),
-            'MyProductionCode' => array(
+                'ntestnotrun' => 0],
+            'MyProductionCode' => [
                 'nbuilderror' => 0,
                 'nbuildwarning' => 1,
                 'nbuildpass' => 0,
@@ -683,7 +683,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
                 'nconfigurepass' => 0,
                 'ntestpass' => 1,
                 'ntestfail' => 0,
-                'ntestnotrun' => 0));
+                'ntestnotrun' => 0]];
         foreach ($jsonobj['subprojects'] as $subproj) {
             $subproj_name = $subproj['name'];
             if (!array_key_exists($subproj_name, $subprojects_expected)) {

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -9,8 +9,8 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 class MultipleSubprojectsTestCase extends KWWebTestCase
 {
-    const EMAIL_NORMAL = 0;
-    const EMAIL_SUMMARY = 1;
+    public const EMAIL_NORMAL = 0;
+    public const EMAIL_SUMMARY = 1;
 
     private $buildIds;
     private $dataDir;
@@ -160,7 +160,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         ";
 
         $stmt = $pdo->query($sql);
-        list($this->summaryEmail, $this->emailMaxChars) = $stmt->fetch();
+        [$this->summaryEmail, $this->emailMaxChars] = $stmt->fetch();
 
         $sql = "
             UPDATE buildgroup

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -783,7 +783,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             'viewBuildError.php',
             'viewDynamicAnalysis.php',
             'viewNotes.php',
-            'viewTest.php'
+            'viewTest.php',
         ];
         $child_buildid = $builds[0]['id'];
 

--- a/app/cdash/tests/test_nobackup.php
+++ b/app/cdash/tests/test_nobackup.php
@@ -37,7 +37,7 @@ class NoBackupTestCase extends KWWebTestCase
         }
 
         // Submit gcov.tar to test the 'PUT' submission path.
-        $post_result = $this->post($this->url . '/submit.php', array(
+        $post_result = $this->post($this->url . '/submit.php', [
             'project' => 'InsightExample',
             'build' => 'nobackup',
             'site' => 'localhost',
@@ -46,7 +46,7 @@ class NoBackupTestCase extends KWWebTestCase
             'endtime' => '1475599870',
             'track' => 'Nightly',
             'type' => 'GcovTar',
-            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633'));
+            'datafilesmd5[0]=' => '5454e16948a1d58d897e174b75cc5633']);
         $post_json = json_decode($post_result, true);
         if ($post_json['status'] != 0) {
             $this->fail(
@@ -75,7 +75,7 @@ class NoBackupTestCase extends KWWebTestCase
             'SELECT b.builderrors, cs.loctested FROM build b
                 JOIN coveragesummary cs ON (cs.buildid=b.id)
                 WHERE b.id=?');
-        $stmt->execute(array($buildid));
+        $stmt->execute([$buildid]);
         $row = $stmt->fetch();
         if ($row['builderrors'] != 0) {
             $this->fail("Unexpected number of build errors found");

--- a/app/cdash/tests/test_notesparsererrormessages.php
+++ b/app/cdash/tests/test_notesparsererrormessages.php
@@ -41,7 +41,7 @@ class NotesParserErrorMessagesTestCase extends KWWebTestCase
             'about to query for builds to remove',
             'removing old buildids for projectid:',
             'removing old buildids for projectid:',
-            'Note missing name for build'
+            'Note missing name for build',
         ];
         $this->assertLogContains($expected, 5);
         $this->deleteLog($this->logfilename);

--- a/app/cdash/tests/test_opencovercoverage.php
+++ b/app/cdash/tests/test_opencovercoverage.php
@@ -22,7 +22,7 @@ class OpenCoverCoverageTestCase extends KWWebTestCase
     public function testOpenCoverCoverage()
     {
         // Do the POST submission to get a pending buildid.
-        $post_result = $this->post($this->url."/submit.php", array(
+        $post_result = $this->post($this->url."/submit.php", [
             "project" => "SubProjectExample",
             "build" => "opencover_coverage",
             "site" => "localhost",
@@ -31,7 +31,7 @@ class OpenCoverCoverageTestCase extends KWWebTestCase
             "endtime" => "1422455768",
             "track" => "Experimental",
             "type" => "OpenCoverTar",
-            "datafilesmd5[0]=" => "c0eeaf6be9838eacc75e652d6c85f925"));
+            "datafilesmd5[0]=" => "c0eeaf6be9838eacc75e652d6c85f925"]);
 
         $post_json = json_decode($post_result, true);
         if ($post_json["status"] != 0) {
@@ -72,7 +72,7 @@ class OpenCoverCoverageTestCase extends KWWebTestCase
     public function testOpenCoverCoverageWithDataJson()
     {
         // Do the POST submission to get a pending buildid.
-        $post_result = $this->post($this->url."/submit.php", array(
+        $post_result = $this->post($this->url."/submit.php", [
             "project" => "SubProjectExample",
             "build" => "opencover_coverage",
             "site" => "localhost",
@@ -81,7 +81,7 @@ class OpenCoverCoverageTestCase extends KWWebTestCase
             "endtime" => "1422455768",
             "track" => "Experimental",
             "type" => "OpenCoverTar",
-            "datafilesmd5[0]=" => "21eb5dff198d703652f8a7c93a290140"));
+            "datafilesmd5[0]=" => "21eb5dff198d703652f8a7c93a290140"]);
 
         $post_json = json_decode($post_result, true);
         if ($post_json["status"] != 0) {

--- a/app/cdash/tests/test_outputcolor.php
+++ b/app/cdash/tests/test_outputcolor.php
@@ -27,9 +27,9 @@ class OutputColorTestCase extends KWWebTestCase
             $project->Delete();
         }
 
-        $settings = array(
+        $settings = [
                 'Name' => 'OutputColor',
-                'Description' => 'Test to make sure test output uses terminal colors');
+                'Description' => 'Test to make sure test output uses terminal colors'];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
             $this->fail('Failed to create project');

--- a/app/cdash/tests/test_projectindb.php
+++ b/app/cdash/tests/test_projectindb.php
@@ -34,18 +34,18 @@ class ProjectInDbTestCase extends KWWebTestCase
         $this->projecttestid = $result[0]['id'];
         $query = "SELECT name,starttime,endtime,description FROM buildgroup WHERE projectid = '" . $this->projecttestid . "' order by name desc";
         $result = $this->db->query($query);
-        $expected = array('0' => array('name' => 'Nightly',
+        $expected = ['0' => ['name' => 'Nightly',
             'starttime' => '1980-01-01 00:00:00',
             'endtime' => '1980-01-01 00:00:00',
-            'description' => 'Nightly builds'),
-            '1' => array('name' => 'Experimental',
+            'description' => 'Nightly builds'],
+            '1' => ['name' => 'Experimental',
                 'starttime' => '1980-01-01 00:00:00',
                 'endtime' => '1980-01-01 00:00:00',
-                'description' => 'Experimental builds'),
-            '2' => array('name' => 'Continuous',
+                'description' => 'Experimental builds'],
+            '2' => ['name' => 'Continuous',
                 'starttime' => '1980-01-01 00:00:00',
                 'endtime' => '1980-01-01 00:00:00',
-                'description' => 'Continuous builds'));
+                'description' => 'Continuous builds']];
         $this->assertEqual($result, $expected);
     }
 
@@ -65,19 +65,19 @@ class ProjectInDbTestCase extends KWWebTestCase
     {
         $query = 'SELECT userid, role, emailtype, emailcategory FROM user2project WHERE projectid=' . $this->projecttestid;
         $result = $this->db->query($query);
-        $expected = array('userid' => 1,
+        $expected = ['userid' => 1,
             'role' => 2,
             'emailtype' => 3,
-            'emailcategory' => 126);
+            'emailcategory' => 126];
         $this->assertEqual($result[0], $expected);
     }
 
     public function createProjectTest4Db()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'ProjectTest4Db',
                 'Description' => 'This is a project test for cdash',
-                'Public' => 0);
+                'Public' => 0];
         $this->createProject($settings);
     }
 }

--- a/app/cdash/tests/test_projectindb.php
+++ b/app/cdash/tests/test_projectindb.php
@@ -22,7 +22,7 @@ class ProjectInDbTestCase extends KWWebTestCase
         $expected = [
             'name' => 'ProjectTest4Db',
             'description' => 'This is a project test for cdash',
-            'public' => 0
+            'public' => 0,
         ];
         $this->assertEqual($result[0], $expected);
     }

--- a/app/cdash/tests/test_projectwebpage.php
+++ b/app/cdash/tests/test_projectwebpage.php
@@ -14,14 +14,14 @@ class ProjectWebPageTestCase extends KWWebTestCase
 
     public function testAccessToWebPageProjectTest()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'BatchmakeExample',
-                'Description' => "Project Batchmake's test for cdash testing");
+                'Description' => "Project Batchmake's test for cdash testing"];
         $this->createProject($settings);
 
-        $settings = array(
+        $settings = [
                 'Name' => 'InsightExample',
-                'Description' => 'Project Insight test for cdash testing');
+                'Description' => 'Project Insight test for cdash testing'];
         $this->createProject($settings);
     }
 
@@ -168,13 +168,13 @@ class ProjectWebPageTestCase extends KWWebTestCase
         // TODO: (williamjallen) This is a terrible test with hardcoded values.  The ID should be determined dynamically.
         $query = 'SELECT id, stamp, name, type, generator, command FROM build WHERE id=7';
         $result = $this->db->query($query);
-        $expected = array('id' => '7',
+        $expected = ['id' => '7',
             'stamp' => '20090223-0100-Nightly',
             'name' => 'Win32-MSVC2009',
             'type' => 'Nightly',
             'generator' => 'ctest2.6-patch 0',
             'command' => 'F:\PROGRA~1\MICROS~1.0\Common7\IDE\VCExpress.exe BatchMake.sln /build Release /project ALL_BUILD'
-        );
+        ];
         $this->assertEqual($result[0], $expected);
     }
 

--- a/app/cdash/tests/test_projectwebpage.php
+++ b/app/cdash/tests/test_projectwebpage.php
@@ -173,7 +173,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
             'name' => 'Win32-MSVC2009',
             'type' => 'Nightly',
             'generator' => 'ctest2.6-patch 0',
-            'command' => 'F:\PROGRA~1\MICROS~1.0\Common7\IDE\VCExpress.exe BatchMake.sln /build Release /project ALL_BUILD'
+            'command' => 'F:\PROGRA~1\MICROS~1.0\Common7\IDE\VCExpress.exe BatchMake.sln /build Release /project ALL_BUILD',
         ];
         $this->assertEqual($result[0], $expected);
     }

--- a/app/cdash/tests/test_projectxmlsequence.php
+++ b/app/cdash/tests/test_projectxmlsequence.php
@@ -27,13 +27,13 @@ class ProjectXmlSequenceTestCase extends KWWebTestCase
 
     public function testProjectXmlSequence()
     {
-        $filenames = array(
+        $filenames = [
             'Trilinos_129273760744.57_Project.xml',
             'Trilinos_129273770005.15_Project.xml',
             'Trilinos_129273771745.07_Project.xml',
             'Trilinos_129273989317.97_Project.xml',
             'Trilinos_129274192973.58_Project.xml',
-        );
+        ];
 
         foreach ($filenames as $filename) {
             echo "submitting $filename\n";

--- a/app/cdash/tests/test_pubproject.php
+++ b/app/cdash/tests/test_pubproject.php
@@ -17,10 +17,10 @@ class PubProjectTestCase extends KWWebTestCase
 
     public function testCreateProject()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'ProjectTest',
                 'Description' => 'This is a project test for cdash',
-                'EmailAdministrator' => 1);
+                'EmailAdministrator' => 1];
         $this->ProjectId = $this->createProject($settings);
     }
 
@@ -31,10 +31,10 @@ class PubProjectTestCase extends KWWebTestCase
         $nameexpected = 'ProjectTest';
         $descriptionexpected = 'This is a project test for cdash';
         $publicexpected = 1;
-        $expected = array(
+        $expected = [
             'name' => $nameexpected,
             'description' => $descriptionexpected,
-            'public' => $publicexpected);
+            'public' => $publicexpected];
 
         $this->assertEqual($result[0], $expected);
     }

--- a/app/cdash/tests/test_putdynamicbuilds.php
+++ b/app/cdash/tests/test_putdynamicbuilds.php
@@ -31,7 +31,7 @@ class PutDynamicBuildsTestCase extends KWWebTestCase
         // Create a project for this test.
         $settings = [
             'Name' => 'PutDynamicBuildsProject',
-            'Description' => 'PutDynamicBuildsProject'
+            'Description' => 'PutDynamicBuildsProject',
         ];
         $this->ProjectId = $this->createProject($settings);
 
@@ -80,7 +80,7 @@ class PutDynamicBuildsTestCase extends KWWebTestCase
         foreach (['%bar%', '%baz%'] as $match) {
             $query_params = [
                 ':buildname'     => $match,
-                ':parentgroupid' => $this->ParentGroupId
+                ':parentgroupid' => $this->ParentGroupId,
             ];
             $this->PDO->execute($starttime_stmt, $query_params);
             $endtime = $starttime_stmt->fetchColumn();
@@ -125,7 +125,7 @@ class PutDynamicBuildsTestCase extends KWWebTestCase
         foreach ($build_rules as $build_rule) {
             $query_params = [
                 ':buildname'     => "%{$build_rule['match']}%",
-                ':parentgroupid' => $build_rule['parentgroupid']
+                ':parentgroupid' => $build_rule['parentgroupid'],
             ];
             $this->PDO->execute($stmt, $query_params);
             $starttime = $stmt->fetchColumn();

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -511,7 +511,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
             $this->fail("Expected $expected for $table, found $num_rows");
         }
         $row = pdo_fetch_array($result);
-        $retval = array();
+        $retval = [];
         foreach ($columns as $c) {
             $retval[] = $row[$c];
         }
@@ -525,7 +525,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         if ($num_rows !== $expected) {
             $this->fail("Expected $expected for $table, found $num_rows");
         }
-        $arr = array();
+        $arr = [];
         while ($row = pdo_fetch_array($result)) {
             $arr[] = $row[$column];
         }

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -389,7 +389,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('subproject2build', 'buildid', '=', $build->Id, 1);
         $this->verify('testdiff', 'buildid', '=', $build->Id, 1);
 
-        list($buildfailureid, $detailsid) =
+        [$buildfailureid, $detailsid] =
             $this->verify_get_columns('buildfailure', ['id', 'detailsid'], 'buildid', '=', $build->Id, 1);
         $this->verify('buildfailure2argument', 'buildfailureid', '=', $buildfailureid, 1);
         $this->verify('buildfailuredetails', 'id', '=', $detailsid, 1);

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -24,7 +24,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Notes',
             'Test',
             'Update',
-            'Upload'
+            'Upload',
         ];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -15,7 +15,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testOriginalOrder()
     {
-        $file_order = array(
+        $file_order = [
             'Build',
             'Configure',
             'Coverage',
@@ -25,7 +25,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Test',
             'Update',
             'Upload'
-        );
+        ];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -33,7 +33,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testReverseOrder()
     {
-        $file_order = array(
+        $file_order = [
             'Upload',
             'Update',
             'Test',
@@ -42,7 +42,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'CoverageLog',
             'Coverage',
             'Configure',
-            'Build');
+            'Build'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -50,7 +50,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testConfigureFirst()
     {
-        $file_order = array(
+        $file_order = [
             'Configure',
             'Test',
             'Notes',
@@ -59,7 +59,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Build',
             'DynamicAnalysis',
             'Upload',
-            'Update');
+            'Update'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -67,7 +67,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testCoverageFirst()
     {
-        $file_order = array(
+        $file_order = [
             'Coverage',
             'DynamicAnalysis',
             'Configure',
@@ -76,7 +76,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Upload',
             'Notes',
             'Update',
-            'Test');
+            'Test'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -84,7 +84,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testCoverageLogFirst()
     {
-        $file_order = array(
+        $file_order = [
             'CoverageLog',
             'Notes',
             'Coverage',
@@ -93,7 +93,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Build',
             'DynamicAnalysis',
             'Update',
-            'Test');
+            'Test'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -101,7 +101,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testDynamicAnalysisFirst()
     {
-        $file_order = array(
+        $file_order = [
             'DynamicAnalysis',
             'Notes',
             'Configure',
@@ -110,7 +110,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Coverage',
             'Update',
             'CoverageLog',
-            'Build');
+            'Build'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -118,7 +118,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testNotesFirst()
     {
-        $file_order = array(
+        $file_order = [
             'Notes',
             'DynamicAnalysis',
             'CoverageLog',
@@ -127,7 +127,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Upload',
             'Build',
             'Test',
-            'Coverage');
+            'Coverage'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -135,7 +135,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testTestFirst()
     {
-        $file_order = array(
+        $file_order = [
             'Test',
             'CoverageLog',
             'DynamicAnalysis',
@@ -144,7 +144,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Notes',
             'Update',
             'Coverage',
-            'Upload');
+            'Upload'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }
@@ -152,7 +152,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
 
     public function testUpdateFirst()
     {
-        $file_order = array(
+        $file_order = [
             'Update',
             'Notes',
             'DynamicAnalysis',
@@ -161,7 +161,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             'Test',
             'CoverageLog',
             'Build',
-            'Coverage');
+            'Coverage'];
         if ($this->PerformOrderTest($file_order)) {
             $this->pass('Passed');
         }

--- a/app/cdash/tests/test_setup_repositories.php
+++ b/app/cdash/tests/test_setup_repositories.php
@@ -22,7 +22,7 @@ class SetupRepositoriesTestCase extends KWWebTestCase
         $insight->Id = $row['id'];
         $insight->Fill();
         $insight->AddRepositories(
-            array(':pserver:anoncvs@itk.org:/cvsroot/Insight'), array('anoncvs'), array(''), array(''));
+            [':pserver:anoncvs@itk.org:/cvsroot/Insight'], ['anoncvs'], [''], ['']);
         $insight->CTestTemplateScript = 'client testing works';
         $insight->Save();
 
@@ -31,7 +31,7 @@ class SetupRepositoriesTestCase extends KWWebTestCase
         $pub->Id = $row['id'];
         $pub->Fill();
         $pub->AddRepositories(
-            array('git://cmake.org/cmake.git'), array(''), array(''), array(''));
+            ['git://cmake.org/cmake.git'], [''], [''], ['']);
         $pub->CvsViewerType = 'gitweb';
         $pub->CvsUrl ='cmake.org/gitweb?p=cmake.git';
         $pub->Save();
@@ -41,7 +41,7 @@ class SetupRepositoriesTestCase extends KWWebTestCase
         $email->Id = $row['id'];
         $email->Fill();
         $email->AddRepositories(
-            array('https://www.kitware.com/svn/CDash/trunk'), array(''), array(''), array(''));
+            ['https://www.kitware.com/svn/CDash/trunk'], [''], [''], ['']);
         $pub->CvsViewerType = 'websvn';
         $email->CvsUrl = 'https://www.kitware.com/svn/CDash/trunk';
         $email->Save();

--- a/app/cdash/tests/test_starttimefromnotes.php
+++ b/app/cdash/tests/test_starttimefromnotes.php
@@ -30,7 +30,7 @@ class StartTimeFromNotesTestCase extends KWWebTestCase
         $this->project = new Project();
         $this->project->Id = $this->createProject([
             'Name' => 'StartTimeFromNotes',
-            'NightlyTime' => '18:00:00 America/Denver'
+            'NightlyTime' => '18:00:00 America/Denver',
         ]);
         $this->project->Fill();
 

--- a/app/cdash/tests/test_submitsortingdata.php
+++ b/app/cdash/tests/test_submitsortingdata.php
@@ -24,8 +24,8 @@ class SubmitSortingDataTestCase extends KWWebTestCase
 
     public function testSubmitSortingData()
     {
-        $builds = array('short', 'medium', 'long');
-        $types = array('Build', 'Configure', 'Test', 'Update', 'Notes');
+        $builds = ['short', 'medium', 'long'];
+        $types = ['Build', 'Configure', 'Test', 'Update', 'Notes'];
         foreach ($builds as $build) {
             foreach ($types as $type) {
                 $this->submitFile($build, $type);

--- a/app/cdash/tests/test_subproject.php
+++ b/app/cdash/tests/test_subproject.php
@@ -26,11 +26,11 @@ class SubProjectTestCase extends KWWebTestCase
 
     public function testAccessToWebPageProjectTest()
     {
-        $settings = array(
+        $settings = [
                 'Name' => 'SubProjectExample',
                 'Description' => 'Project SubProjectExample test for cdash testing',
                 'EmailBrokenSubmission' => 1,
-                'EmailRedundantFailures' => 1);
+                'EmailRedundantFailures' => 1];
         $this->createProject($settings);
     }
 

--- a/app/cdash/tests/test_subproject.php
+++ b/app/cdash/tests/test_subproject.php
@@ -59,7 +59,7 @@ class SubProjectTestCase extends KWWebTestCase
         $url = Config::getInstance()->getBaseUrl();
         $expected = [
             'simpletest@localhost',
-            'FAILED (w=21): SubProjectExample/NOX - Linux-GCC-4.1.2-SERIAL_RELEASE - Nightly' ,
+            'FAILED (w=21): SubProjectExample/NOX - Linux-GCC-4.1.2-SERIAL_RELEASE - Nightly',
             'A submission to CDash for the project SubProjectExample has warnings.',
             "Details on the submission can be found at {$url}/build/",
             'Project: SubProjectExample',

--- a/app/cdash/tests/test_subprojectemail.php
+++ b/app/cdash/tests/test_subprojectemail.php
@@ -45,7 +45,7 @@ class SubProjectEmailTestCase extends KWWebTestCase
             'Name' => 'SubProjectEmails',
             'Public' => 1,
             'EmailBrokenSubmission' => 1,
-            'EmailRedundantFailures' => 0
+            'EmailRedundantFailures' => 0,
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -200,7 +200,7 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
                 $checks = [
                     'nwarningdiffp' => $build['compilation']['nwarningdiffp'],
                     'nnotrundiffn' => $build['test']['nnotrundiffn'],
-                    'npassdiffp' => $build['test']['npassdiffp']
+                    'npassdiffp' => $build['test']['npassdiffp'],
                 ];
                 foreach ($checks as $field => $found) {
                     if ($found != 1) {

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -51,7 +51,7 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
             return 1;
         }
 
-        $buildids = array();
+        $buildids = [];
         while ($row = pdo_fetch_array($result)) {
             $buildids[] = $row['id'];
         }

--- a/app/cdash/tests/test_testhistory.php
+++ b/app/cdash/tests/test_testhistory.php
@@ -31,152 +31,152 @@ class TestHistoryTestCase extends KWWebTestCase
         }
 
         $retval = <<<EOT
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Site BuildName="TestHistory"
-          BuildStamp="20151116-19{$mm}-Experimental"
-          Name="localhost"
-          Generator="ctest"
-          >
-          <Testing>
-            <StartTestTime>{$timestamp}</StartTestTime>
-            <TestList>
-              <Test>./passes</Test>
-              <Test>./fails</Test>
-              <Test>./flaky</Test>
-              <Test>./notrun</Test>
-
-        EOT;
-        if ($include_sporadic) {
-            $retval .= <<<EOT
-                  <Test>./sporadic</Test>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Site BuildName="TestHistory"
+              BuildStamp="20151116-19{$mm}-Experimental"
+              Name="localhost"
+              Generator="ctest"
+              >
+              <Testing>
+                <StartTestTime>{$timestamp}</StartTestTime>
+                <TestList>
+                  <Test>./passes</Test>
+                  <Test>./fails</Test>
+                  <Test>./flaky</Test>
+                  <Test>./notrun</Test>
 
             EOT;
+        if ($include_sporadic) {
+            $retval .= <<<EOT
+                      <Test>./sporadic</Test>
+
+                EOT;
         }
         $retval .= <<<EOT
-            </TestList>
-            <Test Status="passed">
-              <Name>passes</Name>
-              <Path>.</Path>
-              <FullName>./passes</FullName>
-              <FullCommandLine>/bin/true</FullCommandLine>
-              <Results>
-                <NamedMeasurement type="numeric/double" name="Execution Time">
-                  <Value>0</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Completion Status">
-                  <Value>Completed</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Command Line">
-                  <Value>/bin/true</Value>
-                </NamedMeasurement>
-                <Measurement>
-                  <Value></Value>
-                </Measurement>
-              </Results>
-            </Test>
-            <Test Status="failed">
-              <Name>fails</Name>
-              <Path>.</Path>
-              <FullName>./fails</FullName>
-              <FullCommandLine>/bin/false</FullCommandLine>
-              <Results>
-                <NamedMeasurement type="text/string" name="Exit Code">
-                  <Value>Failed</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="numeric/double" name="Execution Time">
-                  <Value>0</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Completion Status">
-                  <Value>Completed</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Command Line">
-                  <Value>/bin/false</Value>
-                </NamedMeasurement>
-                <Measurement>
-                  <Value></Value>
-                </Measurement>
-              </Results>
-            </Test>
-            <Test Status="{$flaky_status}">
-              <Name>flaky</Name>
-              <Path>.</Path>
-              <FullName>./flaky</FullName>
-              <FullCommandLine>/bin/flaky</FullCommandLine>
-              <Results>
-
-        EOT;
-        if (!$flaky_passed) {
-            $retval .= <<<EOT
+                </TestList>
+                <Test Status="passed">
+                  <Name>passes</Name>
+                  <Path>.</Path>
+                  <FullName>./passes</FullName>
+                  <FullCommandLine>/bin/true</FullCommandLine>
+                  <Results>
+                    <NamedMeasurement type="numeric/double" name="Execution Time">
+                      <Value>0</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Completion Status">
+                      <Value>Completed</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Command Line">
+                      <Value>/bin/true</Value>
+                    </NamedMeasurement>
+                    <Measurement>
+                      <Value></Value>
+                    </Measurement>
+                  </Results>
+                </Test>
+                <Test Status="failed">
+                  <Name>fails</Name>
+                  <Path>.</Path>
+                  <FullName>./fails</FullName>
+                  <FullCommandLine>/bin/false</FullCommandLine>
+                  <Results>
                     <NamedMeasurement type="text/string" name="Exit Code">
                       <Value>Failed</Value>
                     </NamedMeasurement>
+                    <NamedMeasurement type="numeric/double" name="Execution Time">
+                      <Value>0</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Completion Status">
+                      <Value>Completed</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Command Line">
+                      <Value>/bin/false</Value>
+                    </NamedMeasurement>
+                    <Measurement>
+                      <Value></Value>
+                    </Measurement>
+                  </Results>
+                </Test>
+                <Test Status="{$flaky_status}">
+                  <Name>flaky</Name>
+                  <Path>.</Path>
+                  <FullName>./flaky</FullName>
+                  <FullCommandLine>/bin/flaky</FullCommandLine>
+                  <Results>
 
             EOT;
+        if (!$flaky_passed) {
+            $retval .= <<<EOT
+                        <NamedMeasurement type="text/string" name="Exit Code">
+                          <Value>Failed</Value>
+                        </NamedMeasurement>
+
+                EOT;
         }
         $retval .= <<<EOT
-                <NamedMeasurement type="numeric/double" name="Execution Time">
-                  <Value>{$flaky_time}</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Completion Status">
-                  <Value>Completed</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Command Line">
-                  <Value>/bin/flaky</Value>
-                </NamedMeasurement>
-                <Measurement>
-                  <Value></Value>
-                </Measurement>
-              </Results>
-            </Test>
-            <Test Status="notrun">
-              <Name>notrun</Name>
-              <Path>.</Path>
-              <FullName>./notrun</FullName>
-              <FullCommandLine></FullCommandLine>
-              <Results>
-                <NamedMeasurement type="text/string" name="Command Line">
-                  <Value></Value>
-                </NamedMeasurement>
-                <Measurement>
-                  <Value>Unable to find executable: /tmp/notrun</Value>
-                </Measurement>
-              </Results>
-            </Test>
+                    <NamedMeasurement type="numeric/double" name="Execution Time">
+                      <Value>{$flaky_time}</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Completion Status">
+                      <Value>Completed</Value>
+                    </NamedMeasurement>
+                    <NamedMeasurement type="text/string" name="Command Line">
+                      <Value>/bin/flaky</Value>
+                    </NamedMeasurement>
+                    <Measurement>
+                      <Value></Value>
+                    </Measurement>
+                  </Results>
+                </Test>
+                <Test Status="notrun">
+                  <Name>notrun</Name>
+                  <Path>.</Path>
+                  <FullName>./notrun</FullName>
+                  <FullCommandLine></FullCommandLine>
+                  <Results>
+                    <NamedMeasurement type="text/string" name="Command Line">
+                      <Value></Value>
+                    </NamedMeasurement>
+                    <Measurement>
+                      <Value>Unable to find executable: /tmp/notrun</Value>
+                    </Measurement>
+                  </Results>
+                </Test>
 
-        EOT;
+            EOT;
         if ($include_sporadic) {
             $retval .= <<<EOT
-            <Test Status="passed">
-              <Name>sporadic</Name>
-              <Path>.</Path>
-              <FullName>./sporadic</FullName>
-              <FullCommandLine>/bin/true</FullCommandLine>
-              <Results>
-                <NamedMeasurement type="numeric/double" name="Execution Time">
-                  <Value>0</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Completion Status">
-                  <Value>Completed</Value>
-                </NamedMeasurement>
-                <NamedMeasurement type="text/string" name="Command Line">
-                  <Value>/bin/true</Value>
-                </NamedMeasurement>
-                <Measurement>
-                  <Value></Value>
-                </Measurement>
-              </Results>
-            </Test>
+                    <Test Status="passed">
+                      <Name>sporadic</Name>
+                      <Path>.</Path>
+                      <FullName>./sporadic</FullName>
+                      <FullCommandLine>/bin/true</FullCommandLine>
+                      <Results>
+                        <NamedMeasurement type="numeric/double" name="Execution Time">
+                          <Value>0</Value>
+                        </NamedMeasurement>
+                        <NamedMeasurement type="text/string" name="Completion Status">
+                          <Value>Completed</Value>
+                        </NamedMeasurement>
+                        <NamedMeasurement type="text/string" name="Command Line">
+                          <Value>/bin/true</Value>
+                        </NamedMeasurement>
+                        <Measurement>
+                          <Value></Value>
+                        </Measurement>
+                      </Results>
+                    </Test>
 
-        EOT;
+                EOT;
         }
         $retval .= <<<EOT
-            <EndDateTime>Nov 16 14:{$mm} EST</EndDateTime>
-            <EndTestTime>{$timestamp}</EndTestTime>
-            <ElapsedMinutes>0</ElapsedMinutes>
-          </Testing>
-        </Site>
+                <EndDateTime>Nov 16 14:{$mm} EST</EndDateTime>
+                <EndTestTime>{$timestamp}</EndTestTime>
+                <ElapsedMinutes>0</ElapsedMinutes>
+              </Testing>
+            </Site>
 
-        EOT;
+            EOT;
         return $retval;
     }
 

--- a/app/cdash/tests/test_testoverview.php
+++ b/app/cdash/tests/test_testoverview.php
@@ -33,7 +33,7 @@ class TestOverviewTestCase extends KWWebTestCase
 
         $content = $this->get($this->url . '/api/v1/testOverview.php?project=InsightExample');
         $jsonobj = json_decode($content, true);
-        if ($jsonobj['tests'] !== array()) {
+        if ($jsonobj['tests'] !== []) {
             $this->fail("Empty list of tests not found when expected");
         }
 

--- a/app/cdash/tests/test_timeline.php
+++ b/app/cdash/tests/test_timeline.php
@@ -26,7 +26,7 @@ class TimelineTestCase extends KWWebTestCase
         $payload = [
             'buildid' => $build->Id,
             'groupid' => $build->GroupId,
-            'expected' => $expected
+            'expected' => $expected,
         ];
         try {
             $response = $client->request('POST',
@@ -81,15 +81,15 @@ class TimelineTestCase extends KWWebTestCase
 
         $answer_key = [
             'index.php' => [
-                'Test Failures' => 1
+                'Test Failures' => 1,
             ],
             'testOverview.php' => [
                 'Failing Tests' => 1,
                 'Not Run Tests' => 1,
-                'Passing Tests' => 1
+                'Passing Tests' => 1,
             ],
             'viewBuildGroup.php' => [
-                'Test Failures' => 1
+                'Test Failures' => 1,
             ],
         ];
         foreach ($pages_to_check as $page) {
@@ -145,8 +145,8 @@ class TimelineTestCase extends KWWebTestCase
                 [
                     'field'   => 'buildname',
                     'compare' => 63,
-                    'value'   => 'vs'
-                ]
+                    'value'   => 'vs',
+                ],
             ],
         ];
 
@@ -155,16 +155,16 @@ class TimelineTestCase extends KWWebTestCase
         $answer_key = [
             'index.php' => [
                 'Errors' => 1,
-                'Test Failures' => 2
+                'Test Failures' => 2,
             ],
             'testOverview.php' => [
                 'Failing Tests' => 2,
                 'Not Run Tests' => 2,
-                'Passing Tests' => 2
+                'Passing Tests' => 2,
             ],
             'viewBuildGroup.php' => [
                 'Errors' => 1,
-                'Test Failures' => 2
+                'Test Failures' => 2,
             ],
         ];
 

--- a/app/cdash/tests/test_timestatus.php
+++ b/app/cdash/tests/test_timestatus.php
@@ -34,7 +34,7 @@ class TimeStatusTestCase extends KWWebTestCase
         $settings = [
             'Name' => 'TimeStatus',
             'Description' => 'Project for test time status',
-            'ShowTestTime' => 1
+            'ShowTestTime' => 1,
         ];
         $projectid = $this->createProject($settings);
         if ($projectid < 1) {
@@ -47,7 +47,7 @@ class TimeStatusTestCase extends KWWebTestCase
             ->createSite([
                 'BuildName' => 'test_timing',
                 'BuildStamp' => '20180127-1723-Experimental',
-                'Name' => 'elysium'
+                'Name' => 'elysium',
             ])
             ->setProjectId($projectid)
             ->setStartTime(1516900999)

--- a/app/cdash/tests/test_updateappend.php
+++ b/app/cdash/tests/test_updateappend.php
@@ -37,7 +37,7 @@ class UppdateAppendTestCase extends KWWebTestCase
         }
 
         // Get the buildid that we just created so we can delete it later.
-        $buildids = array();
+        $buildids = [];
         $buildid_results = pdo_query(
             "SELECT id FROM build WHERE name='test_updateappend'");
         while ($buildid_array = pdo_fetch_array($buildid_results)) {

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -31,7 +31,7 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
         parent::__construct();
         $this->DataDir = dirname(__FILE__) . '/data/UpdateOnlyUserStats';
         $this->ProjectId = null;
-        $this->Users = array();
+        $this->Users = [];
     }
 
     public function testSetup()
@@ -53,19 +53,19 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
         $this->ProjectId = $this->createProject($settings);
 
         // Create some users for the CDash project.
-        $users_details = array(
-                array(
+        $users_details = [
+                [
                     'email' => 'dan.lamanna@kitware.com',
                     'firstname' => 'Dan',
-                    'lastname' => 'LaManna'),
-                array(
+                    'lastname' => 'LaManna'],
+                [
                     'email' => 'jamie.snape@kitware.com',
                     'firstname' => 'Jamie',
-                    'lastname' => 'Snape'),
-                array(
+                    'lastname' => 'Snape'],
+                [
                     'email' => 'zack.galbreath@kitware.com',
                     'firstname' => 'Zack',
-                    'lastname' => 'Galbreath'));
+                    'lastname' => 'Galbreath']];
         $userproject = new UserProject();
         $userproject->ProjectId = $this->ProjectId;
         foreach ($users_details as $user_details) {
@@ -86,8 +86,8 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
     public function testUpdateOnlyUserStats()
     {
         // Submit testing data.
-        $dirs = array('1', '2', '3');
-        $files = array('Build.xml', 'Test.xml', 'Update.xml');
+        $dirs = ['1', '2', '3'];
+        $files = ['Build.xml', 'Test.xml', 'Update.xml'];
         foreach ($dirs as $dir) {
             foreach ($files as $file) {
                 $file_to_submit = "$this->DataDir/$dir/$file";
@@ -109,31 +109,31 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
             $this->fail("Expected stats for 3 users, found $numusers");
         }
 
-        $expected_results = array(
-                'Dan LaManna' => array(
+        $expected_results = [
+                'Dan LaManna' => [
                     'failed_errors' => 0,
                     'fixed_errors' => 0,
                     'failed_warnings' => 0,
                     'fixed_warnings' => 1,
                     'failed_tests' => 0,
                     'fixed_tests' => 0,
-                    'totalupdatedfiles' => 2),
-                'Jamie Snape' => array(
+                    'totalupdatedfiles' => 2],
+                'Jamie Snape' => [
                     'failed_errors' => 0,
                     'fixed_errors' => 1,
                     'failed_warnings' => 0,
                     'fixed_warnings' => 0,
                     'failed_tests' => 0,
                     'fixed_tests' => 0,
-                    'totalupdatedfiles' => 7),
-                'Zack Galbreath' => array(
+                    'totalupdatedfiles' => 7],
+                'Zack Galbreath' => [
                     'failed_errors' => 0,
                     'fixed_errors' => 0,
                     'failed_warnings' => 0,
                     'fixed_warnings' => 0,
                     'failed_tests' => 2,
                     'fixed_tests' => 0,
-                    'totalupdatedfiles' => 3));
+                    'totalupdatedfiles' => 3]];
 
         foreach ($jsonobj['users'] as $user) {
             $name = $user['name'];

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -47,8 +47,8 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
                 'url' => 'https://github.com/Kitware/CDash',
                 'branch' => 'master',
                 'username' => '',
-                'password' => ''
-            ]]
+                'password' => '',
+            ]],
         ];
         $this->ProjectId = $this->createProject($settings);
 

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -111,7 +111,7 @@ class UpgradeTestCase extends KWWebTestCase
 
 
         $version = pdo_get_vendor_version();
-        list($major, $minor, ) = $version? explode(".", $version) : array(null,null,null);
+        list($major, $minor, ) = $version? explode(".", $version) : [null,null,null];
 
         $this->assertTrue(is_numeric($major));
         $this->assertTrue(is_numeric($minor));
@@ -403,8 +403,8 @@ class UpgradeTestCase extends KWWebTestCase
         $row = pdo_single_row_query(
             'SELECT id FROM site ORDER BY id DESC LIMIT 1');
         $i = $row['id'];
-        $dupes = array();
-        $keepers = array();
+        $dupes = [];
+        $keepers = [];
 
         // Insert sites into our testing table that will violate
         // the unique constraint on the name column.
@@ -471,10 +471,10 @@ class UpgradeTestCase extends KWWebTestCase
 
         // We also need to verify that siteids in other tables get updated
         // properly as duplicates are removed.
-        $tables_to_update = array('build', 'build2grouprule', 'site2user',
+        $tables_to_update = ['build', 'build2grouprule', 'site2user',
             'client_job', 'client_site2cmake', 'client_site2compiler',
             'client_site2library', 'client_site2program',
-            'client_site2project');
+            'client_site2project'];
         foreach ($tables_to_update as $table_to_update) {
             foreach ($dupes as $dupe) {
                 if ($table_to_update === 'build') {
@@ -669,7 +669,7 @@ class UpgradeTestCase extends KWWebTestCase
 
         // Insert testing data in configure table.
         // Two rows that duplicate each other
-        $dupe_buildids = array(1, 2);
+        $dupe_buildids = [1, 2];
         foreach ($dupe_buildids as $buildid) {
             pdo_query(
                 "INSERT INTO $configure_table_name
@@ -692,7 +692,7 @@ class UpgradeTestCase extends KWWebTestCase
             VALUES (3, 0, 'unique error')");
 
         // Verify that the right number of testing rows made it into the database.
-        foreach (array($configure_table_name, $error_table_name) as $table_name) {
+        foreach ([$configure_table_name, $error_table_name] as $table_name) {
             $count_query = "
                 SELECT COUNT(*) AS numrows FROM $table_name";
             $count_results = pdo_single_row_query($count_query);

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -111,7 +111,7 @@ class UpgradeTestCase extends KWWebTestCase
 
 
         $version = pdo_get_vendor_version();
-        list($major, $minor, ) = $version? explode(".", $version) : [null,null,null];
+        [$major, $minor, ] = $version? explode(".", $version) : [null,null,null];
 
         $this->assertTrue(is_numeric($major));
         $this->assertTrue(is_numeric($minor));

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -832,7 +832,7 @@ class UpgradeTestCase extends KWWebTestCase
         $expected = [
             1 => 1,
             2 => 2,
-            3 => 0
+            3 => 0,
         ];
         $stmt = $pdo->query(
             "SELECT id, testduration FROM $build_table_name");

--- a/app/cdash/tests/test_usernotes.php
+++ b/app/cdash/tests/test_usernotes.php
@@ -33,7 +33,7 @@ class UserNotesAPICase extends KWWebTestCase
         $buildUserNote = [
             'buildid' => $id,
             'AddNote' => 'testAddNoteRequiresAuth',
-            'Status' => 1
+            'Status' => 1,
         ];
 
         $response = $this->post($endpoint, $buildUserNote);

--- a/app/cdash/tests/test_userstatistics.php
+++ b/app/cdash/tests/test_userstatistics.php
@@ -21,10 +21,10 @@ class UserStatisticsTestCase extends KWWebTestCase
         $this->get($this->url . '/userStatistics.php');
 
         // Cover all date ranges
-        $this->post($this->url . '/userStatistics.php?projectid=1', array('range' => 'lastweek'));
-        $this->post($this->url . '/userStatistics.php?projectid=1', array('range' => 'thismonth'));
-        $this->post($this->url . '/userStatistics.php?projectid=1', array('range' => 'lastmonth'));
-        $this->post($this->url . '/userStatistics.php?projectid=1', array('range' => 'thisyear'));
+        $this->post($this->url . '/userStatistics.php?projectid=1', ['range' => 'lastweek']);
+        $this->post($this->url . '/userStatistics.php?projectid=1', ['range' => 'thismonth']);
+        $this->post($this->url . '/userStatistics.php?projectid=1', ['range' => 'lastmonth']);
+        $this->post($this->url . '/userStatistics.php?projectid=1', ['range' => 'thisyear']);
 
         // Cover no user id case
         $this->logout();

--- a/app/cdash/tests/test_viewsubprojects.php
+++ b/app/cdash/tests/test_viewsubprojects.php
@@ -28,7 +28,7 @@ class ViewSubProjectsTestCase extends KWWebTestCase
         foreach ($jsonobj['subprojects'] as $subproject) {
             if ($subproject['name'] === 'TrilinosFramework') {
                 $found_trilinos_framework = true;
-                $expected_values = array(
+                $expected_values = [
                         'nbuilderror' => 0,
                         'nbuildwarning' => 0,
                         'nbuildpass' => 1,
@@ -38,7 +38,7 @@ class ViewSubProjectsTestCase extends KWWebTestCase
                         'ntestpass' => 90,
                         'ntestfail' => 30,
                         'ntestnotrun' => 0,
-                        'starttime' => '2011-07-22 11:15:59');
+                        'starttime' => '2011-07-22 11:15:59'];
                 foreach ($expected_values as $k => $v) {
                     if ($subproject[$k] !== $v) {
                         $this->fail("Expected $v for TrilinosFramework $k, found " . $subproject[$k]);

--- a/app/cdash/tests/trilinos_submission_test.php
+++ b/app/cdash/tests/trilinos_submission_test.php
@@ -88,7 +88,7 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
             $this->fail('Expected 36 children, found ' . $parent_build['numchildren']);
             return false;
         }
-        $parent_answers = array(
+        $parent_answers = [
             'site' => 'hut11.kitware',
             'buildname' => 'Windows_NT-MSVC10-SERIAL_DEBUG_DEV',
             'uploadfilecount' => 0,
@@ -107,7 +107,7 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
             'testnotrun' => 95,
             'testfail' => 11,
             'testpass' => 303,
-            'testtime' => '48s');
+            'testtime' => '48s'];
         $this->verifyBuild($parent_build, $parent_answers, 'parent');
 
         // Verify details about the children.
@@ -121,8 +121,8 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
             $this->fail('Expected hut11.kitware, found ' . $jsonobj['site']);
         }
 
-        $subproject_answers = array(
-            'Amesos' => array(
+        $subproject_answers = [
+            'Amesos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:29 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -130,9 +130,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'AztecOO' => array(
+            'AztecOO' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:28 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -148,9 +148,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Belos' => array(
+            'Belos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:31 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -158,9 +158,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Claps' => array(
+            'Claps' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:27 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -176,9 +176,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'CTrilinos' => array(
+            'CTrilinos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:34 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -186,9 +186,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Didasko' => array(
+            'Didasko' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:34 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -204,9 +204,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Epetra' => array(
+            'Epetra' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:24 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -222,9 +222,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'EpetraExt' => array(
+            'EpetraExt' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:26 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -232,9 +232,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'FEApp' => array(
+            'FEApp' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:37 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -242,9 +242,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'FEI' => array(
+            'FEI' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:31 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -252,9 +252,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Galeri' => array(
+            'Galeri' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:28 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -262,9 +262,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'GlobiPack' => array(
+            'GlobiPack' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:26 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -272,9 +272,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Ifpack' => array(
+            'Ifpack' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:29 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -282,9 +282,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Intrepid' => array(
+            'Intrepid' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:32 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -292,9 +292,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Kokkos' => array(
+            'Kokkos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:24 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -302,9 +302,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Komplex' => array(
+            'Komplex' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:29 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -312,9 +312,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Mesquite' => array(
+            'Mesquite' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:35 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -326,9 +326,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'buildwarning' => 1,
                 'buildtime' => '2m 11s',
                 'time' => '2m 35s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'ML' => array(
+            'ML' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:29 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -344,9 +344,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Moertel' => array(
+            'Moertel' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:32 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -354,9 +354,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'NOX' => array(
+            'NOX' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:32 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -364,9 +364,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'OptiPack' => array(
+            'OptiPack' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:27 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -374,9 +374,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Piro' => array(
+            'Piro' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:34 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -384,9 +384,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Pliris' => array(
+            'Pliris' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:27 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -402,9 +402,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'RBGen' => array(
+            'RBGen' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:31 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -412,9 +412,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'RTOp' => array(
+            'RTOp' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:23 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -422,9 +422,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Rythmos' => array(
+            'Rythmos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:33 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -432,9 +432,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Sacado' => array(
+            'Sacado' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:18 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -450,9 +450,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 1,
                 'testpass' => 270,
                 'testtime' => '4s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Shards' => array(
+            'Shards' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:25 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -468,9 +468,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 3,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Stokhos' => array(
+            'Stokhos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:33 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -478,9 +478,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '6s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Stratimikos' => array(
+            'Stratimikos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:31 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -488,9 +488,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Teuchos' => array(
+            'Teuchos' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:16 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -502,9 +502,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'buildwarning' => 3,
                 'buildtime' => '1m 27s',
                 'time' => '1m 48s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'ThreadPool' => array(
+            'ThreadPool' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:18 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -520,9 +520,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Thyra' => array(
+            'Thyra' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:27 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -530,9 +530,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'configureerror' => 1,
                 'configurewarning' => 1,
                 'configuretime' => '7s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'TrilinosCouplings' => array(
+            'TrilinosCouplings' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:32 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -548,9 +548,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'TrilinosFramework' => array(
+            'TrilinosFramework' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:15 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -566,9 +566,9 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 10,
                 'testpass' => 30,
                 'testtime' => '44s',
-                'notes' => 2),
+                'notes' => 2],
 
-            'Triutils' => array(
+            'Triutils' => [
                 'builddateelapsed' => 'Jul 22, 2011 - 11:26 EDT',
                 'updatefiles' => '911431',
                 'updateerror' => 0,
@@ -584,7 +584,7 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
                 'testfail' => 0,
                 'testpass' => 0,
                 'testtime' => '0s',
-                'notes' => 2));
+                'notes' => 2]];
 
         foreach ($subproject_answers as $subproject_name => $answer) {
             foreach ($builds as $index => $build) {

--- a/app/cdash/xml_handlers/GcovTar_handler.php
+++ b/app/cdash/xml_handlers/GcovTar_handler.php
@@ -47,7 +47,7 @@ class GCovTarHandler extends NonSaxHandler
         $this->CoverageSummary->BuildId = $this->Build->Id;
         $this->SourceDirectory = '';
         $this->BinaryDirectory = '';
-        $this->Labels = array();
+        $this->Labels = [];
 
         $this->SubProjectPath = '';
 
@@ -60,7 +60,7 @@ class GCovTarHandler extends NonSaxHandler
                 $this->SubProjectPath = $path;
             }
         }
-        $this->SubProjectSummaries = array();
+        $this->SubProjectSummaries = [];
         $this->PreviousAggregateParentId = null;
     }
 
@@ -412,7 +412,7 @@ class GCovTarHandler extends NonSaxHandler
 
         // Parse out any target-wide labels first.  These apply to
         // every source file found below.
-        $target_labels = array();
+        $target_labels = [];
         if (array_key_exists('target', $jsonDecoded)) {
             $target = $jsonDecoded['target'];
             if (array_key_exists('labels', $target)) {

--- a/app/cdash/xml_handlers/JSCoverTar_handler.php
+++ b/app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -34,14 +34,14 @@ class JSCoverTarHandler extends NonSaxHandler
         $this->Build->Id = $buildid;
         $this->Build->FillFromId($this->Build->Id);
 
-        $this->CoverageSummaries = array();
+        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;
 
-        $this->Coverages = array();
-        $this->CoverageFiles = array();
-        $this->CoverageFileLogs = array();
+        $this->Coverages = [];
+        $this->CoverageFiles = [];
+        $this->CoverageFileLogs = [];
     }
 
     /**
@@ -102,7 +102,7 @@ class JSCoverTarHandler extends NonSaxHandler
         }
 
         // Insert coverage summaries
-        $completedSummaries = array();
+        $completedSummaries = [];
         foreach ($this->CoverageSummaries as $coverageSummary) {
             if (in_array($coverageSummary->BuildId, $completedSummaries)) {
                 continue;

--- a/app/cdash/xml_handlers/JavaJSONTar_handler.php
+++ b/app/cdash/xml_handlers/JavaJSONTar_handler.php
@@ -34,7 +34,7 @@ class JavaJSONTarHandler extends NonSaxHandler
         $this->Build->Id = $buildid;
         $this->Build->FillFromId($this->Build->Id);
 
-        $this->CoverageSummaries = array();
+        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;
@@ -79,7 +79,7 @@ class JavaJSONTarHandler extends NonSaxHandler
         }
 
         // Insert coverage summaries
-        $completedSummaries = array();
+        $completedSummaries = [];
         foreach ($this->CoverageSummaries as $coverageSummary) {
             if (in_array($coverageSummary->BuildId, $completedSummaries)) {
                 continue;

--- a/app/cdash/xml_handlers/OpenCoverTar_handler.php
+++ b/app/cdash/xml_handlers/OpenCoverTar_handler.php
@@ -36,14 +36,14 @@ class OpenCoverTarHandler extends AbstractHandler
         $this->Build->Id = $buildid;
         $this->Build->FillFromId($this->Build->Id);
 
-        $this->CoverageSummaries = array();
+        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;
 
-        $this->Coverages = array();
-        $this->CoverageFiles = array();
-        $this->CoverageFileLogs = array();
+        $this->Coverages = [];
+        $this->CoverageFiles = [];
+        $this->CoverageFileLogs = [];
 
         $this->ParseCSFiles = true;
     }
@@ -130,7 +130,7 @@ class OpenCoverTarHandler extends AbstractHandler
         }
         // MODULENAME gives the folder structure that the .cs file belongs in
         if ($element == 'MODULENAME' && (strlen($data))) {
-            $this->currentModule = array($data, strtolower($data));
+            $this->currentModule = [$data, strtolower($data)];
         }
     }
 
@@ -212,7 +212,7 @@ class OpenCoverTarHandler extends AbstractHandler
         }
 
         // Insert coverage summaries
-        $completedSummaries = array();
+        $completedSummaries = [];
         foreach ($this->CoverageSummaries as $coverageSummary) {
             if (in_array($coverageSummary->BuildId, $completedSummaries)) {
                 continue;
@@ -283,8 +283,8 @@ class OpenCoverTarHandler extends AbstractHandler
         $parser = xml_parser_create();
         $fileContents = file_get_contents($fileinfo->getPath() . DIRECTORY_SEPARATOR . $fileinfo->getFilename());
         $parser = xml_parser_create();
-        xml_set_element_handler($parser, array($this,"startElement"), array($this,'endElement'));
-        xml_set_character_data_handler($parser, array($this, 'text'));
+        xml_set_element_handler($parser, [$this,"startElement"], [$this,'endElement']);
+        xml_set_character_data_handler($parser, [$this, 'text']);
         xml_parse($parser, $fileContents, false);
     }
 }

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -117,7 +117,7 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
         } elseif ($name == 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {
-                $this->SubProjects[$this->SubProjectName] = array();
+                $this->SubProjects[$this->SubProjectName] = [];
             }
             if (!array_key_exists($this->SubProjectName, $this->Builds)) {
                 $build = $factory->create(Build::class);

--- a/app/cdash/xml_handlers/coverage_log_handler.php
+++ b/app/cdash/xml_handlers/coverage_log_handler.php
@@ -42,7 +42,7 @@ class CoverageLogHandler extends AbstractHandler
         $this->Build = new Build();
         $this->Site = new Site();
         $this->UpdateEndTime = false;
-        $this->CoverageFiles = array();
+        $this->CoverageFiles = [];
         $this->CurrentLine = "";
     }
 
@@ -149,13 +149,13 @@ class CoverageLogHandler extends AbstractHandler
         } elseif ($name == 'FILE') {
             // Store these objects to be inserted after we're guaranteed
             // to have a valid buildid.
-            $this->CoverageFiles[] = array($this->CurrentCoverageFile,
-                $this->CurrentCoverageFileLog);
+            $this->CoverageFiles[] = [$this->CurrentCoverageFile,
+                $this->CurrentCoverageFileLog];
         } elseif ($name == 'COVERAGELOG') {
             if (empty($this->CoverageFiles)) {
                 // Store these objects to be inserted after we're guaranteed
                 // to have a valid buildid.
-                $this->CoverageFiles[] = array(new CoverageFile(), new CoverageFileLog());
+                $this->CoverageFiles[] = [new CoverageFile(), new CoverageFileLog()];
             }
         }
     }

--- a/app/cdash/xml_handlers/dynamic_analysis_handler.php
+++ b/app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -122,8 +122,8 @@ class DynamicAnalysisHandler extends AbstractHandler implements ActionableBuildI
         } elseif ($name == 'LABEL') {
             $this->Label = $factory->create(Label::class);
         } elseif ($name == 'LOG') {
-            $this->DynamicAnalysis->LogCompression = isset($attributes['COMPRESSION']) ? $attributes['COMPRESSION'] : '';
-            $this->DynamicAnalysis->LogEncoding = isset($attributes['ENCODING']) ? $attributes['ENCODING'] : '';
+            $this->DynamicAnalysis->LogCompression = $attributes['COMPRESSION'] ?? '';
+            $this->DynamicAnalysis->LogEncoding = $attributes['ENCODING'] ?? '';
         }
     }
 

--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -74,7 +74,7 @@ class NoteHandler extends AbstractHandler
         } elseif ($name == 'NOTE') {
             $this->NoteCreator = new NoteCreator;
             $this->NoteCreator->name =
-                isset($attributes['NAME']) ? $attributes['NAME'] : '';
+                $attributes['NAME'] ?? '';
             $this->Timestamp = 0;
         }
     }

--- a/app/cdash/xml_handlers/project_handler.php
+++ b/app/cdash/xml_handlers/project_handler.php
@@ -71,10 +71,10 @@ class ProjectHandler extends AbstractHandler
         }
 
         if ($name == 'PROJECT') {
-            $this->SubProjects = array();
-            $this->Dependencies = array();
+            $this->SubProjects = [];
+            $this->Dependencies = [];
         } elseif ($name == 'SUBPROJECT') {
-            $this->CurrentDependencies = array();
+            $this->CurrentDependencies = [];
             $this->SubProject = new SubProject();
             $this->SubProject->SetProjectId($this->projectid);
             $this->SubProject->SetName($attributes['NAME']);
@@ -184,7 +184,7 @@ class ProjectHandler extends AbstractHandler
             $this->SubProjects[$this->SubProject->GetId()] = $this->SubProject;
 
             // Handle dependencies here too.
-            $this->Dependencies[$this->SubProject->GetId()] = array();
+            $this->Dependencies[$this->SubProject->GetId()] = [];
             foreach ($this->CurrentDependencies as $dependencyid) {
                 $added = false;
 

--- a/app/cdash/xml_handlers/stack.php
+++ b/app/cdash/xml_handlers/stack.php
@@ -16,7 +16,7 @@
 
 class stack
 {
-    private $stack = array();
+    private $stack = [];
 
     public function __construct()
     {

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -390,7 +390,7 @@ class UploadHandler extends AbstractHandler
             switch ($element) {
                 case 'CONTENT':
                     // Write base64 encoded chunch to temporary file
-                    $charsToReplace = array("\r\n", "\n", "\r");
+                    $charsToReplace = ["\r\n", "\n", "\r"];
                     fwrite($this->Base64TmpFileWriteHandle, str_replace($charsToReplace, '', $data));
                     break;
             }

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -183,7 +183,7 @@ class UploadHandler extends AbstractHandler
             $this->UploadFile = new UploadFile();
             $this->UploadFile->Filename = $attributes['FILENAME'];
         } elseif ($name == 'CONTENT') {
-            $fileEncoding = isset($attributes['ENCODING']) ? $attributes['ENCODING'] : 'base64';
+            $fileEncoding = $attributes['ENCODING'] ?? 'base64';
 
             if (strcmp($fileEncoding, 'base64') != 0) {
                 // Only base64 encoding is supported for file upload

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -125,7 +125,7 @@ class UploadHandler extends AbstractHandler
             $build_date =
                 extract_date_from_buildstamp($this->Build->GetStamp());
 
-            list($prev, $nightly_start_time, $next) =
+            [$prev, $nightly_start_time, $next] =
                 get_dates($build_date, $nightly_time);
 
             // If the nightly start time is after noon (server time)

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -194,7 +194,7 @@ class UploadHandler extends AbstractHandler
 
             // Create tmp file
             $this->TmpFilename = tempnam($config->get('CDASH_UPLOAD_DIRECTORY'), 'tmp'); // TODO Handle error
-            chmod($this->TmpFilename, 0644);
+            chmod($this->TmpFilename, 0o644);
 
             if (empty($this->TmpFilename)) {
                 add_log('Failed to create temporary filename', __FILE__ . ':' . __LINE__ . ' - ' . __FUNCTION__, LOG_ERR);

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -26,7 +26,7 @@ return [
     'registration' => [
         'email' => [
             'verify' => env('REGISTRATION_EMAIL_VERIFY', true),
-        ]
+        ],
     ],
     'file' => [
         'path' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -68,7 +68,7 @@ return [
             'driver' => 'local',
             'root' => app_path('cdash/public'),
             'visibility' => 'private',
-        ]
+        ],
     ],
 
 ];

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -5,7 +5,7 @@ $schemas = [
     'activedirectory' => Adldap\Schemas\ActiveDirectory::class,
     'openldap'        => \App\Schemas\OpenLDAP::class,
     'freeipa'         => Adldap\Schemas\FreeIPA::class,
-    ''                => null
+    ''                => null,
 ];
 
 return [

--- a/config/ldap_auth.php
+++ b/config/ldap_auth.php
@@ -10,12 +10,12 @@ return [
         'database' => [
             'guid_column' => 'email',
             'username_column' => 'email',
-        ]
+        ],
     ],
     'sync_attributes' => [
         'email' => env('LDAP_EMAIL_ATTRIBUTE', 'mail'),
         'firstname' => 'givenName',
-        'lastname' => 'sn'
+        'lastname' => 'sn',
     ],
     'logging' => [
         'enabled' => env('LDAP_LOGGING', true),
@@ -34,6 +34,6 @@ return [
         ],
     ],
     'rules' => [
-        App\Rules\LdapFilterRules::class
-    ]
+        App\Rules\LdapFilterRules::class,
+    ],
 ];

--- a/config/logging.php
+++ b/config/logging.php
@@ -50,7 +50,7 @@ return [
             'path' => storage_path('logs/cdash.log'),
             'level' => 'debug',
             'days' => 14,
-            'permission' => 0664,
+            'permission' => 0o664,
         ],
 
         'slack' => [

--- a/config/oauth2.php
+++ b/config/oauth2.php
@@ -24,5 +24,5 @@ return [
         'hostedDomain' => '*',
         'className' => Google::class,
         'enable' => env('GOOGLE_ENABLE', false),
-    ]
+    ],
 ];

--- a/config/saml2.php
+++ b/config/saml2.php
@@ -210,7 +210,7 @@ return [
         */
 
         'singleLogoutService' => [
-            'url' => ''
+            'url' => '',
         ],
     ],
 
@@ -358,11 +358,11 @@ return [
     'contactPerson' => [
         'technical' => [
             'givenName' => env('SAML2_CONTACT_TECHNICAL_NAME', 'name'),
-            'emailAddress' => env('SAML2_CONTACT_TECHNICAL_EMAIL', 'no@reply.com')
+            'emailAddress' => env('SAML2_CONTACT_TECHNICAL_EMAIL', 'no@reply.com'),
         ],
         'support' => [
             'givenName' => env('SAML2_CONTACT_SUPPORT_NAME', 'Support'),
-            'emailAddress' => env('SAML2_CONTACT_SUPPORT_EMAIL', 'no@reply.com')
+            'emailAddress' => env('SAML2_CONTACT_SUPPORT_EMAIL', 'no@reply.com'),
         ],
     ],
 
@@ -379,7 +379,7 @@ return [
         'en-US' => [
             'name' => env('SAML2_ORGANIZATION_NAME', 'Name'),
             'displayname' => env('SAML2_ORGANIZATION_NAME', 'Display Name'),
-            'url' => env('SAML2_ORGANIZATION_URL', 'http://url')
+            'url' => env('SAML2_ORGANIZATION_URL', 'http://url'),
         ],
     ],
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,6 +33,6 @@ $factory->afterCreating(App\Models\User::class, function ($user, $faker) {
     $user->passwords()->insert([
         'userid' => $user->id,
         'date' => now(),
-        'password' => $user->password
+        'password' => $user->password,
     ]);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 
-$routeList = array('verify' => true);
+$routeList = ['verify' => true];
 
 if(config('auth.user_registration_form_enabled') === false) {
     $routeList['register'] = false;

--- a/tests/Feature/CDashTest.php
+++ b/tests/Feature/CDashTest.php
@@ -24,7 +24,7 @@ class CDashTest extends TestCase
         $expected = [
             'driver' => 'local',
             'root' => app_path('cdash/public'),
-            'visibility' => 'private'
+            'visibility' => 'private',
         ];
 
         $actual = Config::get('filesystems.disks.cdash');

--- a/tests/Feature/LdapAuthWithRulesTest.php
+++ b/tests/Feature/LdapAuthWithRulesTest.php
@@ -30,7 +30,7 @@ class LdapAuthWithRulesTest extends LdapTest
             'userprinciplename' => [$email],
             'mail' => $email,
             'sn' => 'Bobby',
-            'givenName' => 'Ricky'
+            'givenName' => 'Ricky',
         ]);
 
         Resolver::shouldReceive('byCredentials')
@@ -70,7 +70,7 @@ class LdapAuthWithRulesTest extends LdapTest
             'userprinciplename' => [$email],
             'mail' => $email,
             'sn' => 'Bobby',
-            'givenName' => 'Ricky'
+            'givenName' => 'Ricky',
         ]);
 
         $mock_ldap_resource = fopen(__FILE__, 'r');

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -174,7 +174,7 @@ class LoginAndRegistration extends TestCase
             'idp_logout_url' => "$saml2_tenant_uri/logout",
             'idp_x509_cert' => base64_encode('asdf'),
             'metadata' => '{}',
-            'name_id_format' => 'persistent'
+            'name_id_format' => 'persistent',
         ];
         $saml2_tenant_id = DB::table('saml2_tenants')->insertGetId($params);
 

--- a/tests/Feature/MeasurementPositionMigration.php
+++ b/tests/Feature/MeasurementPositionMigration.php
@@ -40,7 +40,7 @@ class MeasurementPositionMigration extends TestCase
         // Populate some data to migrate.
         $base_measurement = [
             'projectid'    => $project1->Id,
-            'name'         => 'a'
+            'name'         => 'a',
         ];
         $measurement1 = $base_measurement;
 

--- a/tests/Feature/MigrateConfigCommand.php
+++ b/tests/Feature/MigrateConfigCommand.php
@@ -31,42 +31,42 @@ class MigrateConfigCommand extends TestCase
 
         // Write an example config.local.php file.
         $config_contents = <<<'EOT'
-<?php
-date_default_timezone_set('America/New_York');
-$CDASH_TESTING_MODE = true;
-$CDASH_DB_TYPE = 'mysql';
-$CDASH_DB_NAME = 'cdash4simpletest';
-$CDASH_DB_PASS = 'my_fake_cdash_db_password';
-$CDASH_DB_LOGIN = 'my_fake_cdash_db_user';
-$CDASH_COOKIE_EXPIRATION_TIME = '7200';
-$CDASH_EMAIL_SMTP_HOST = 'cdash_smtp_host';
-$CDASH_EMAIL_SMTP_LOGIN = 'cdash_smtp_user';
-$CDASH_EMAIL_SMTP_PASS = 'cdash_smtp_password';
-$CDASH_BASE_URL = 'https://localhost/CDash';
-$CDASH_LOG_LEVEL = LOG_DEBUG;
-$CDASH_UNLIMITED_PROJECTS = ['Project1', 'Project2'];
-$CDASH_GOOGLE_MAP_API_KEY['cdash.org'] = 'ABC123';
-$OAUTH2_PROVIDERS['GitHub'] = [
-    'clientId'          => 'github_client_id',
-    'clientSecret'      => 'github_client_secret'
-];
-$OAUTH2_PROVIDERS['GitLab'] = [
-    'clientId'          => 'gitlab_client_id',
-    'clientSecret'      => 'gitlab_client_secret',
-    'domain'            => 'https://gitlab.kitware.com'
-];
-$OAUTH2_PROVIDERS['Google'] = [
-    'clientId'          => 'google_client_id',
-    'clientSecret'      => 'google_client_secret'
-];
+            <?php
+            date_default_timezone_set('America/New_York');
+            $CDASH_TESTING_MODE = true;
+            $CDASH_DB_TYPE = 'mysql';
+            $CDASH_DB_NAME = 'cdash4simpletest';
+            $CDASH_DB_PASS = 'my_fake_cdash_db_password';
+            $CDASH_DB_LOGIN = 'my_fake_cdash_db_user';
+            $CDASH_COOKIE_EXPIRATION_TIME = '7200';
+            $CDASH_EMAIL_SMTP_HOST = 'cdash_smtp_host';
+            $CDASH_EMAIL_SMTP_LOGIN = 'cdash_smtp_user';
+            $CDASH_EMAIL_SMTP_PASS = 'cdash_smtp_password';
+            $CDASH_BASE_URL = 'https://localhost/CDash';
+            $CDASH_LOG_LEVEL = LOG_DEBUG;
+            $CDASH_UNLIMITED_PROJECTS = ['Project1', 'Project2'];
+            $CDASH_GOOGLE_MAP_API_KEY['cdash.org'] = 'ABC123';
+            $OAUTH2_PROVIDERS['GitHub'] = [
+                'clientId'          => 'github_client_id',
+                'clientSecret'      => 'github_client_secret'
+            ];
+            $OAUTH2_PROVIDERS['GitLab'] = [
+                'clientId'          => 'gitlab_client_id',
+                'clientSecret'      => 'gitlab_client_secret',
+                'domain'            => 'https://gitlab.kitware.com'
+            ];
+            $OAUTH2_PROVIDERS['Google'] = [
+                'clientId'          => 'google_client_id',
+                'clientSecret'      => 'google_client_secret'
+            ];
 
-EOT;
+            EOT;
         file_put_contents($this->config_file, $config_contents);
 
         file_put_contents($this->test_file, <<<'EOT'
-MIX_APP_URL="${APP_URL}"
-DB_PASSWORD=my_db_password
-EOT, FILE_APPEND);
+            MIX_APP_URL="${APP_URL}"
+            DB_PASSWORD=my_db_password
+            EOT, FILE_APPEND);
 
         // Run the migration command.
         $this->artisan('config:migrate', ['output' => $this->test_file]);
@@ -77,8 +77,8 @@ EOT, FILE_APPEND);
         $this::assertStringContainsString('APP_URL=https://localhost/CDash', $actual);
         $this::assertStringContainsString('APP_ENV=production', $actual);
         $expected = <<<'EOT'
-MIX_APP_URL="${APP_URL}"
-EOT;
+            MIX_APP_URL="${APP_URL}"
+            EOT;
         $this::assertStringContainsString($expected, $actual);
         $this::assertStringContainsString('SESSION_LIFETIME=120', $actual);
         $this::assertStringContainsString('MAIL_HOST=cdash_smtp_host', $actual);

--- a/tests/Feature/Monitor.php
+++ b/tests/Feature/Monitor.php
@@ -72,7 +72,7 @@ class Monitor extends TestCase
         // Verify default (empty) JSON result.
         $this->actingAs($this->admin_user)->get('/api/monitor')->assertJsonFragment([
             'backlog_length' => 0,
-            'backlog_time' => null
+            'backlog_time' => null,
         ]);
 
         // Populate some testing data.
@@ -82,14 +82,14 @@ class Monitor extends TestCase
             'payload' => '1',
             'attempts' => 0,
             'available_at' => $now,
-            'created_at' => $now
+            'created_at' => $now,
         ]);
 
         DB::table('failed_jobs')->insert([
             'connection' => 'database',
             'queue' => 'default',
             'payload' => '2',
-            'exception' => 'problem'
+            'exception' => 'problem',
         ]);
 
         DB::table('successful_jobs')->insert(['filename' => 'Build.xml']);
@@ -101,7 +101,7 @@ class Monitor extends TestCase
         $response = $this->actingAs($this->admin_user)->getJson('/api/monitor');
         $response->assertJsonFragment([
             'backlog_length' => 1,
-            'backlog_time' => 'just now'
+            'backlog_time' => 'just now',
         ]);
         $response_json = $response->json();
         $this::assertTrue(array_key_exists('time_chart_data', $response_json));

--- a/tests/Feature/OpenLdapAuthWithOverrides.php
+++ b/tests/Feature/OpenLdapAuthWithOverrides.php
@@ -32,7 +32,7 @@ class OpenLdapAuthWithOverrides extends LdapTest
                 'uid' => [$uid],
                 'mail' => $email,
                 'sn' => 'Bobby',
-                'givenName' => 'Ricky'
+                'givenName' => 'Ricky',
         ]);
 
         Resolver::shouldReceive('byCredentials')
@@ -71,7 +71,7 @@ class OpenLdapAuthWithOverrides extends LdapTest
                 'uid' => [$uid],
                 'mail' => $email,
                 'sn' => 'Bobby',
-                'givenName' => 'Ricky'
+                'givenName' => 'Ricky',
         ]);
 
         $this::assertEquals($email, $user->getConvertedGuid());

--- a/tests/Feature/ProjectPermissions.php
+++ b/tests/Feature/ProjectPermissions.php
@@ -102,7 +102,7 @@ class ProjectPermissions extends TestCase
         $response = $this->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PublicProject',
-            'public' => Project::ACCESS_PUBLIC
+            'public' => Project::ACCESS_PUBLIC,
         ]);
 
         // Verify that viewProjects.php only lists the public project.
@@ -138,7 +138,7 @@ class ProjectPermissions extends TestCase
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PublicProject',
-            'public' => Project::ACCESS_PUBLIC
+            'public' => Project::ACCESS_PUBLIC,
         ]);
 
         // Verify that we can access the protected project when logged in
@@ -147,7 +147,7 @@ class ProjectPermissions extends TestCase
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'ProtectedProject',
-            'public' => Project::ACCESS_PROTECTED
+            'public' => Project::ACCESS_PROTECTED,
         ]);
 
         // Add the user to PrivateProject1.
@@ -167,7 +167,7 @@ class ProjectPermissions extends TestCase
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PrivateProject1',
-            'public' => Project::ACCESS_PRIVATE
+            'public' => Project::ACCESS_PRIVATE,
         ]);
 
         // Verify that she cannot access PrivateProject2.
@@ -198,25 +198,25 @@ class ProjectPermissions extends TestCase
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PublicProject',
-            'public' => Project::ACCESS_PUBLIC
+            'public' => Project::ACCESS_PUBLIC,
         ]);
         $_GET['project'] = 'ProtectedProject';
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'ProtectedProject',
-            'public' => Project::ACCESS_PROTECTED
+            'public' => Project::ACCESS_PROTECTED,
         ]);
         $_GET['project'] = 'PrivateProject1';
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PrivateProject1',
-            'public' => Project::ACCESS_PRIVATE
+            'public' => Project::ACCESS_PRIVATE,
         ]);
         $_GET['project'] = 'PrivateProject2';
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
             'projectname' => 'PrivateProject2',
-            'public' => Project::ACCESS_PRIVATE
+            'public' => Project::ACCESS_PRIVATE,
         ]);
 
         // Verify that admin sees all four projects on viewProjects.php

--- a/tests/Feature/TestSchemaMigration.php
+++ b/tests/Feature/TestSchemaMigration.php
@@ -82,7 +82,7 @@ class TestSchemaMigration extends TestCase
             'path'      => '/tmp',
             'command'   => 'ls',
             'details'   => 'Completed',
-            'output'    => '0'
+            'output'    => '0',
         ];
         $test1 = $base_test;
 
@@ -108,7 +108,7 @@ class TestSchemaMigration extends TestCase
             'timemean' => 0.00,
             'timestd' => 0.00,
             'timestatus' => 0,
-            'newstatus' => 1
+            'newstatus' => 1,
         ];
 
         $buildtest1 = $base_buildtest;
@@ -123,7 +123,7 @@ class TestSchemaMigration extends TestCase
         $base_testlabel = [
             'labelid' => 1,
             'buildid' => 1,
-            'testid' => 1
+            'testid' => 1,
         ];
         $testlabel1 = $base_testlabel;
         $testlabel2 = $base_testlabel;
@@ -137,7 +137,7 @@ class TestSchemaMigration extends TestCase
         $base_testimage = [
             'imgid' => 1,
             'testid' => 1,
-            'role' => 'BaseImage'
+            'role' => 'BaseImage',
         ];
         $testimage1 = $base_testimage;
         $testimage2 = $base_testimage;
@@ -154,7 +154,7 @@ class TestSchemaMigration extends TestCase
             'testid' => 1,
             'name' => 'WallTime',
             'type' => 'numeric/double',
-            'value' => 0.1
+            'value' => 0.1,
         ];
         $testmeasurement1 = $base_testmeasurement;
         $testmeasurement2 = $base_testmeasurement;
@@ -199,19 +199,19 @@ class TestSchemaMigration extends TestCase
                 'crc32' => 123,
                 'path' => '/tmp',
                 'command' => 'ls',
-                'output' => '0'
+                'output' => '0',
             ],
             [
                 'crc32' => 456,
                 'path' => '/tmp',
                 'command' => 'ls',
-                'output' => '0 0 0'
+                'output' => '0 0 0',
             ],
             [
                 'crc32' => 789,
                 'path' => '/tmp',
                 'command' => 'ls',
-                'output' => 'something else'
+                'output' => 'something else',
             ],
         ];
         foreach ($expected_testoutputs as $expected_testoutput) {

--- a/tests/Unit/app/Validators/PasswordTest.php
+++ b/tests/Unit/app/Validators/PasswordTest.php
@@ -25,11 +25,11 @@ use Illuminate\Validation\Validator;
 
 class PasswordTest extends TestCase
 {
-    const LOWERCASE = 'abc';
-    const UPPERCASE = 'YYZ';
-    const DIGITS = '246';
-    const SYMBOLS = '+!#';
-    const UNDERSCORE = '_';
+    public const LOWERCASE = 'abc';
+    public const UPPERCASE = 'YYZ';
+    public const DIGITS = '246';
+    public const SYMBOLS = '+!#';
+    public const UNDERSCORE = '_';
 
     public function testGetComplexityConfigurationGivenDefault()
     {


### PR DESCRIPTION
PHP-CS-Fixer provides a ruleset for most major and minor PHP versions which flags deprecated functions and ensures that our code style keeps up with modern PHP style guidelines.  This PR is part of a series of improvements in which I intend to gradually turn on more style check rules as we modernize the codebase.