### PR TITLE
Add missing final/abstract keywords

### DIFF
--- a/app/Http/Controllers/AbstractBuildController.php
+++ b/app/Http/Controllers/AbstractBuildController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 use App\Services\TestingDay;
 use CDash\Model\Build;
 
-class AbstractBuildController extends AbstractProjectController
+abstract class AbstractBuildController extends AbstractProjectController
 {
     protected Build $build;
 

--- a/app/Http/Controllers/FilterController.php
+++ b/app/Http/Controllers/FilterController.php
@@ -5,7 +5,7 @@ use Illuminate\Http\JsonResponse;
 
 include_once 'include/filterdataFunctions.php';
 
-class FilterController extends AbstractController
+final class FilterController extends AbstractController
 {
     public function getFilterDataArray(): JsonResponse
     {


### PR DESCRIPTION
The `FilterController` class was created before https://github.com/Kitware/CDash/pull/1587 was merged, and is thus missing the `final` designation.

`AbstractBuildController ` was missed amidst some logical conflicts when previous PRs were merged and has been designated as `abstract`.

In the future, it might be interesting to create a PHPStan plugin which ensures that all future controllers follow our naming and designation conventions.