### PR TITLE
Treat autoremove builds query parameter as integer

### DIFF
--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -72,12 +72,12 @@ class AutoRemoveBuilds extends Command
                 removeFirstBuilds(
                     $project_array['id'],
                     $project_array['autoremovetimeframe'],
-                    $project_array['autoremovemaxbuilds'],
+                    (int) $project_array['autoremovemaxbuilds'],
                     true // force the autoremove
                 );
                 removeBuildsGroupwise(
-                    $project_array['id'],
-                    $project_array['autoremovemaxbuilds'],
+                    (int) $project_array['id'],
+                    (int) $project_array['autoremovemaxbuilds'],
                     true // force the autoremove
                 );
             }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -397,8 +397,8 @@ final class UserController extends AbstractController
 
             if ($password_is_good && config('cdash.password.expires') > 0) {
                 $query = 'SELECT password FROM password WHERE userid=?';
-                $unique_count = config('cdash.password.unique');
-                if ($unique_count) {
+                $unique_count = (int) config('cdash.password.unique');
+                if ($unique_count > 0) {
                     $query .= " ORDER BY date DESC LIMIT $unique_count";
                 }
                 $stmt = $pdo->prepare($query);

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -77,7 +77,7 @@ class Project
     public $AuthenticateSubmissions;
     public $ShowCoverageCode;
     public $AutoremoveTimeframe;
-    public $AutoremoveMaxBuilds;
+    public int $AutoremoveMaxBuilds;
     public $UploadQuota;
     public $RobotName;
     public $RobotRegex;
@@ -494,7 +494,7 @@ class Project
                      intval($this->AuthenticateSubmissions),
                      intval($this->ShowCoverageCode),
                      intval($this->AutoremoveTimeframe),
-                     intval($this->AutoremoveMaxBuilds),
+                     $this->AutoremoveMaxBuilds,
                      intval($this->UploadQuota),
                      $this->WebApiKey
                  ]));
@@ -626,7 +626,7 @@ class Project
             $this->AuthenticateSubmissions = $project_array['authenticatesubmissions'];
             $this->ShowCoverageCode = $project_array['showcoveragecode'];
             $this->AutoremoveTimeframe = $project_array['autoremovetimeframe'];
-            $this->AutoremoveMaxBuilds = $project_array['autoremovemaxbuilds'];
+            $this->AutoremoveMaxBuilds = (int) $project_array['autoremovemaxbuilds'];
             $this->UploadQuota = $project_array['uploadquota'];
             $this->CvsViewerType = $project_array['cvsviewertype'];
             $this->TestTimeStd = $project_array['testtimestd'];

--- a/app/cdash/include/autoremove.php
+++ b/app/cdash/include/autoremove.php
@@ -15,9 +15,10 @@
 =========================================================================*/
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 /** Remove builds by their group-specific auto-remove timeframe setting */
-function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
+function removeBuildsGroupwise(int $projectid, int $maxbuilds, bool $force = false): void
 {
 
 
@@ -38,26 +39,26 @@ function removeBuildsGroupwise($projectid, $maxbuilds, $force = false)
         if ($days < 2) {
             continue;
         }
-        $groupid = $buildgroup['id'];
+        $groupid = (int) $buildgroup['id'];
 
         $cutoff = time() - 3600 * 24 * $days;
 
         $cutoffdate = date(FMT_DATETIME, $cutoff);
 
-        $builds = $db->executePrepared('
+        $builds = DB::select('
                       SELECT build.id AS id
                       FROM build, build2group
                       WHERE
                           build.parentid IN (0, -1)
-                          AND build.starttime<?
-                          AND build2group.buildid=build.id
-                          AND build2group.groupid=?
+                          AND build.starttime < ?
+                          AND build2group.buildid = build.id
+                          AND build2group.groupid = ?
                       ORDER BY build.starttime ASC
                       LIMIT ?
                   ', [$cutoffdate, $groupid, $maxbuilds]);
 
         foreach ($builds as $build) {
-            $buildids[] = $build['id'];
+            $buildids[] = (int) $build->id;
         }
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8111,11 +8111,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$AutoremoveMaxBuilds has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$AutoremoveTimeframe has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -11724,27 +11719,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
-			path: app/cdash/include/autoremove.php
-
-		-
-			message: "#^Function removeBuildsGroupwise\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/autoremove.php
-
-		-
-			message: "#^Function removeBuildsGroupwise\\(\\) has parameter \\$force with no type specified\\.$#"
-			count: 1
-			path: app/cdash/include/autoremove.php
-
-		-
-			message: "#^Function removeBuildsGroupwise\\(\\) has parameter \\$maxbuilds with no type specified\\.$#"
-			count: 1
-			path: app/cdash/include/autoremove.php
-
-		-
-			message: "#^Function removeBuildsGroupwise\\(\\) has parameter \\$projectid with no type specified\\.$#"
-			count: 1
+			count: 2
 			path: app/cdash/include/autoremove.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1284,7 +1284,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 4
+			count: 3
 			path: app/Http/Controllers/UserController.php
 
 		-


### PR DESCRIPTION
The query parameter for the limit clause in one of the build autoremoval scripts is currently being passed to the database as a string.  This is problematic, and prints the following message to the logs:
`production.ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''500'' at line 9`

MySQL does a limited amount of type conversion, but does not extend the type conversion to limit clauses.  By passing the query parameter as an integer, the problem will be resolved.

I also addressed the only other case of this type of bug, even though it's not directly related to the bug report per se.

This PR is a good example of why passing numeric strings around is a bad idea...