### PR TITLE
Disable git repo ownership check

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -71,6 +71,9 @@ fi
 # Assign www-data ownership of apache2 configuration files
 RUN chown -R www-data:www-data /etc/apache2
 
+# Disable git repo ownership check system wide
+RUN git config --system --add safe.directory '*'
+
 # Run the rest of the commands as www-data
 USER www-data
 


### PR DESCRIPTION
On systems where the user is not the default `www-data` user, the installation process may fail with the message `fatal: detected dubious ownership in repository`.

As a workaround, this PR simply disables the `safe.directory` Git configuration setting globally.