### PR TITLE
Move include of global functions to `AppServiceProvider`

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -8,10 +8,6 @@ use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
-require_once 'include/common.php';
-require_once 'include/pdo.php';
-require_once 'include/defines.php';
-
 abstract class AbstractController extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 
+require_once 'include/common.php';
+require_once 'include/pdo.php';
+require_once 'include/defines.php';
+
 class AppServiceProvider extends ServiceProvider
 {
     /**


### PR DESCRIPTION
#1621 reduced the number of repetitive `require_once` commands, but made the faulty assumption that the global functions being included were not necessary in any of the middleware.  A more appropriate spot for these includes is Laravel's `AppServiceProvider`, which runs before the middleware does, and is generally the place to change global settings.

Fixes #1630.