### PR TITLE
Remove lingering reference to defunct submission table

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -742,7 +742,6 @@ final class AdminController extends AbstractController
             delete_unused_rows('project2repositories', 'projectid', 'project');
             delete_unused_rows('dailyupdate', 'projectid', 'project');
             delete_unused_rows('projectrobot', 'projectid', 'project');
-            delete_unused_rows('submission', 'projectid', 'project');
             delete_unused_rows('subproject', 'projectid', 'project');
             delete_unused_rows('coveragefilepriority', 'projectid', 'project');
             delete_unused_rows('test', 'projectid', 'project');


### PR DESCRIPTION
This table was removed in #1258, but we accidentally retained a reference to it in the admin-only "Cleanup database" functionality.