### PR TITLE
Enable PHPStan analysis of `Collection.php`

### DIFF
--- a/app/cdash/include/Collection/Collection.php
+++ b/app/cdash/include/Collection/Collection.php
@@ -39,10 +39,9 @@ abstract class Collection implements CollectionInterface
     /**
      * Return the current element
      * @link http://php.net/manual/en/iterator.current.php
-     * @return mixed Can return any type.
      * @since 5.0.0
      */
-    public function current()
+    public function current(): mixed
     {
         if ($this->valid()) {
             return $this->collection[$this->key()];
@@ -53,10 +52,9 @@ abstract class Collection implements CollectionInterface
     /**
      * Move forward to next element
      * @link http://php.net/manual/en/iterator.next.php
-     * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -67,7 +65,7 @@ abstract class Collection implements CollectionInterface
      * @return mixed scalar on success, or null on failure.
      * @since 5.0.0
      */
-    public function key()
+    public function key(): mixed
     {
         if (isset($this->keys[$this->position])) {
             return $this->keys[$this->position];
@@ -82,7 +80,7 @@ abstract class Collection implements CollectionInterface
      * Returns true on success or false on failure.
      * @since 5.0.0
      */
-    public function valid()
+    public function valid(): bool
     {
         $key = $this->key();
         // a call to key may result in null, e.g. !isset. To prevent endless loop in the event
@@ -98,21 +96,17 @@ abstract class Collection implements CollectionInterface
     /**
      * Rewind the Iterator to the first element
      * @link http://php.net/manual/en/iterator.rewind.php
-     * @return void Any returned value is ignored.
      * @since 5.0.0
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
 
     /**
-     * @param $item
-     * @param null $name
-     * @return $this|mixed
      * TODO: Watch this in a debugger when integration testing
      */
-    public function addItem($item, $name = null)
+    public function addItem($item, $name = null): self
     {
         $ptr = count($this->collection);
         $key = is_null($name) ? $ptr : $name;
@@ -126,9 +120,8 @@ abstract class Collection implements CollectionInterface
 
     /**
      * Returns true if the collection has items, and false if not.
-     * @return boolean
      */
-    public function hasItems()
+    public function hasItems(): bool
     {
         return count($this->collection) > 0;
     }
@@ -136,13 +129,13 @@ abstract class Collection implements CollectionInterface
     /**
      * Count elements of an object
      * @link http://php.net/manual/en/countable.count.php
-     * @return int The custom count as an integer.
+     * @return int<0,max> The custom count as an integer.
      * </p>
      * <p>
      * The return value is cast to an integer.
      * @since 5.1.0
      */
-    public function count()
+    public function count(): int
     {
         return count($this->collection);
     }
@@ -182,10 +175,7 @@ abstract class Collection implements CollectionInterface
         return $item;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         return array_values($this->collection);
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9847,6 +9847,61 @@ parameters:
 			path: app/cdash/include/Collection/BuildErrorCollection.php
 
 		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 3
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:__construct\\(\\) has parameter \\$collection with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:addItem\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:get\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:has\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:remove\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Method CDash\\\\Collection\\\\Collection\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Property CDash\\\\Collection\\\\Collection\\:\\:\\$collection type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Property CDash\\\\Collection\\\\Collection\\:\\:\\$keys type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/Collection.php
+
+		-
 			message: "#^Parameter \\#2 \\$name of method CDash\\\\Collection\\\\Collection\\:\\:addItem\\(\\) expects null, class\\-string\\<CDash\\\\Collection\\\\CollectionInterface\\> given\\.$#"
 			count: 1
 			path: app/cdash/include/Collection/CollectionCollection.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,7 +15,6 @@ parameters:
             # Don't analyze these files because they cause PHPStan to crash
             - app/cdash/tests/kwtest/simpletest
             - app/cdash/tests/selenium/cdash_selenium_test_case.php
-            - app/cdash/include/Collection/Collection.php
 
     exceptions:
         uncheckedExceptionRegexes:


### PR DESCRIPTION
The `Collection` class was ignored when I first set up PHPStan.  By specifying a few function return types, I was able to get PHPStan to successfully analyze the `Collection` class.