### PR TITLE
Display build start time on `viewConfigure.php` and `viewTest.php`

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1044,13 +1044,14 @@ final class BuildController extends AbstractBuildController
 
         // Build
         $site = $this->build->GetSite();
-        $build_response = [];
-        $build_response['site'] = $site->name;
-        $build_response['siteid'] = $site->id;
-        $build_response['buildname'] = $this->build->Name;
-        $build_response['buildid'] = $this->build->Id;
-        $build_response['hassubprojects'] = $has_subprojects;
-        $response['build'] = $build_response;
+        $response['build'] = [
+            'site' => $site->name,
+            'siteid' => $site->id,
+            'buildname' => $this->build->Name,
+            'buildid' => $this->build->Id,
+            'buildstarttime' => $this->build->StartTime,
+            'hassubprojects' => $has_subprojects,
+        ];
 
         $pageTimer->end($response);
         return response()->json(cast_data_for_JSON($response));

--- a/app/cdash/public/views/viewBuildError.html
+++ b/app/cdash/public/views/viewBuildError.html
@@ -15,7 +15,7 @@
         </tr>
         <tr>
           <td align="left">
-            <b>Build Time: </b>
+            <b>Build Start Time: </b>
             {{cdash.build.starttime}}
           </td>
         </tr>

--- a/resources/js/components/BuildConfigure.vue
+++ b/resources/js/components/BuildConfigure.vue
@@ -30,6 +30,12 @@
         </tr>
         <tr>
           <td align="left">
+            <b>Build Start Time: </b>
+            {{ cdash.build.buildstarttime }}
+          </td>
+        </tr>
+        <tr>
+          <td align="left">
             <b>Configure Command: </b>
             <pre class="pre-wrap">{{ cdash.configures[0].command }}</pre>
           </td>

--- a/resources/views/test/view-test.blade.php
+++ b/resources/views/test/view-test.blade.php
@@ -42,6 +42,15 @@
 
                 <tr>
                     <td>
+                        <b>Build Start Time:</b>
+                    </td>
+                    <td>
+                        {{::cdash.build.starttime}}
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
                         <b>Total time:</b>
                     </td>
                     <td>

--- a/tests/Spec/build-configure.spec.js
+++ b/tests/Spec/build-configure.spec.js
@@ -20,6 +20,7 @@ beforeEach(() => {
       siteid: 1,
       buildname: "my build",
       buildid: 2,
+      buildstarttime: "2023-08-21 12:30:48",
       hassubprojects: 0
     },
     configures: [{
@@ -48,6 +49,7 @@ test('BuildConfigure handles API response', async () => {
   var html = component.html();
   expect(html).toContain('mysite');
   expect(html).toContain('my build');
+  expect(html).toContain('2023-08-21 12:30:48');
   expect(html).toContain('Configuring done');
   expect(html).toContain('written to: /tmp/bin/');
 });


### PR DESCRIPTION
The build start time has been added to the info table at the top of `viewConfigure.php` and `viewTest.php`.

I will add Cypress tests for the angular-based pages once I get Cypress set up.