### PR TITLE
Migrate backend of `BuildError` model to Eloquent

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -890,7 +890,7 @@ final class BuildController extends AbstractBuildController
             $resolvedBuildErrors = $this->build->GetResolvedBuildErrors($type);
             if ($resolvedBuildErrors !== false) {
                 while ($resolvedBuildError = $resolvedBuildErrors->fetch()) {
-                    $this->addErrorResponse(BuildError::marshal($resolvedBuildError, $this->project, $revision, $builderror), $response);
+                    $this->addErrorResponse(BuildError::marshal($resolvedBuildError, $this->project, $revision), $response);
                 }
             }
 
@@ -930,7 +930,7 @@ final class BuildController extends AbstractBuildController
             $buildErrors = $this->build->GetErrors($filter_error_properties);
 
             foreach ($buildErrors as $error) {
-                $this->addErrorResponse(BuildError::marshal($error, $this->project, $revision, $builderror), $response);
+                $this->addErrorResponse(BuildError::marshal($error, $this->project, $revision), $response);
             }
 
             // Build failure table

--- a/app/Models/BuildError.php
+++ b/app/Models/BuildError.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $buildid
+ * @property int $type
+ * @property int $ogline
+ * @property string $text
+ * @property string $sourcefile
+ * @property int $sourceline
+ * @property string $precontext
+ * @property string $postcontext
+ * @property int $repeatcount
+ * @property int $crc32
+ * @property int $newstatus
+ *
+ * @mixin Builder<BuildError>
+ */
+class BuildError extends Model
+{
+    protected $table = 'builderror';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'type',
+        'logline',
+        'text',
+        'sourcefile',
+        'sourceline',
+        'precontext',
+        'postcontext',
+        'repeatcount',
+        'crc32',
+        'newstatus',
+    ];
+}

--- a/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
@@ -48,7 +48,7 @@ class BuildErrorTest extends CDashTestCase
         ];
 
         $this->mock_project->CvsUrl = 'https://github.com/FooCo/foo';
-        $marshaled = $this->mock_builderror->marshal($input_data, $this->mock_project, '12', $this->mock_builderror);
+        $marshaled = $this->mock_builderror->marshal($input_data, $this->mock_project, '12');
 
         $expected = [
             'new' => '1',

--- a/database/migrations/2023_08_22_125134_builderror_primary_key.php
+++ b/database/migrations/2023_08_22_125134_builderror_primary_key.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('builderror', function (Blueprint $table) {
+            $table->integer('id', true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('builderror', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5498,24 +5498,8 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function add_last_sql_error\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
-			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_execute\\(\\)\\:
-				v2\\.5\\.0 01/22/2018$#
 			"""
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
@@ -5526,22 +5510,17 @@ parameters:
 			path: app/cdash/app/Model/BuildError.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\BuildError\\>\\:\\:orderBy\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildError.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\BuildError\\:\\:GetErrorsForBuild\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildError\\:\\:GetSourceFile\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildError\\:\\:GetSourceFile\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildError\\:\\:marshal\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 
@@ -5567,11 +5546,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\BuildError\\:\\:\\$LogLine has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\BuildError\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 
@@ -18867,7 +18841,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property BuildErrorTest\\:\\:\\$mock_builderror\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/tests/case/CDash/Model/BuildErrorTest.php
 
 		-


### PR DESCRIPTION
All database queries in the legacy `BuildError` model are handled by a new Eloquent `BuildError` model.  Since the eloquent isn't a 1:1 swap for the legacy model, I have turned the legacy model into an adapter for the new Eloquent model.  Future usages of the `BuildError` model should use the new Eloquent model if possible.