### PR TITLE
Clean up `Build` model

### DIFF
--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -100,7 +100,7 @@ class BuildError
     /**
      * Returns all errors from builderror for current build
      */
-    public function GetErrorsForBuild(int $fetchStyle = PDO::FETCH_ASSOC): array|bool
+    public function GetErrorsForBuild(int $fetchStyle = PDO::FETCH_ASSOC): array|false
     {
         if (!$this->BuildId) {
             add_log('BuildId not set', 'BuildError::GetErrorsForBuild', LOG_WARNING);

--- a/app/cdash/include/ctestparserutils.php
+++ b/app/cdash/include/ctestparserutils.php
@@ -1,9 +1,10 @@
 <?php
 
+use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
 
 /** Add a new build */
-function add_build($build)
+function add_build(Build $build)
 {
     if (!is_numeric($build->ProjectId) || !is_numeric($build->SiteId)) {
         return;
@@ -34,16 +35,6 @@ function add_build($build)
     }
 
     return $build->Id;
-}
-
-/** Extract the type from the build stamp */
-function extract_type_from_buildstamp($buildstamp)
-{
-    // We assume that the time stamp is always of the form
-    // 20080912-1810-this-is-a-type
-    if (!empty($buildstamp)) {
-        return substr($buildstamp, strpos($buildstamp, '-', strpos($buildstamp, '-') + 1) + 1);
-    }
 }
 
 /** Extract the date from the build stamp */

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -142,7 +142,7 @@ function pdo_query(string $query): PDOStatement|false
  *
  * @deprecated 04/01/2023
  */
-function pdo_real_escape_string(mixed $unescaped_string): string|false
+function pdo_real_escape_string(mixed $unescaped_string): string
 {
     $str = get_link_identifier()->getPdo()->quote($unescaped_string ?? '');
     return substr($str, 1, strlen($str) - 2); // remove enclosing quotes

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -128,12 +128,12 @@ class BuildModelTestCase extends KWWebTestCase
             return 1;
         }
 
-        if ($build->ComputeDifferences() !== false) {
+        if ($build->ComputeDifferences()) {
             $this->fail("ComputeDifferences didn't return false for empty build id");
             return 1;
         }
 
-        if ($build->ComputeConfigureDifferences() !== false) {
+        if ($build->ComputeConfigureDifferences()) {
             $this->fail("ComputeConfigureDifferences didn't return false for empty build id");
             return 1;
         }
@@ -153,7 +153,7 @@ class BuildModelTestCase extends KWWebTestCase
             return 1;
         }
 
-        if ($build->SaveTotalTestsTime('100') !== false) {
+        if ($build->SaveTotalTestsTime() !== false) {
             $this->fail("SaveTotalTestsTime didn't return false for empty build id");
             return 1;
         }

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -74,7 +74,7 @@ class DoneHandlerTestCase extends KWWebTestCase
         $this->assertEqual($build->Id, $received_buildid);
 
         // Verify that the build is marked as done.
-        $this->assertEqual($build->GetDone(), 1);
+        $this->assertTrue($build->GetDone());
 
         // Mark the build as "not done" again.
         $build->MarkAsDone(0);

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -149,7 +149,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $shared_note->create();
 
         // buildtesttime
-        $build->SaveTotalTestsTime(8);
+        $build->SaveTotalTestsTime();
 
         // BuildUpdate
         $updatefile = new BuildUpdateFile();

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -128,7 +128,7 @@ class BazelJSONHandler extends NonSaxHandler
                 $this->NumTestsFailed[$subproject_name];
             $num_notrun = $build->GetNumberOfNotRunTests() +
                 $this->NumTestsNotRun[$subproject_name];
-            $build->UpdateTestNumbers($num_passed, $num_failed, $num_notrun);
+            $build->UpdateTestNumbers((int) $num_passed, (int) $num_failed, (int) $num_notrun);
         }
 
         // Save configure information.
@@ -152,16 +152,16 @@ class BazelJSONHandler extends NonSaxHandler
 
                 // Record the number of warnings & errors with the build.
                 $build->SetNumberOfConfigureWarnings(
-                    $configure->NumberOfWarnings);
+                    (int) $configure->NumberOfWarnings);
                 $build->SetNumberOfConfigureErrors(
-                    $configure->NumberOfErrors);
+                    (int) $configure->NumberOfErrors);
                 $build->ComputeConfigureDifferences();
 
                 // Update the tally of warnings & errors in the parent build,
                 // if applicable.
                 if (!empty($subproject_name)) {
                     $build->UpdateParentConfigureNumbers(
-                        $configure->NumberOfWarnings, $configure->NumberOfErrors);
+                        (int) $configure->NumberOfWarnings, (int) $configure->NumberOfErrors);
                 }
             }
         }
@@ -660,7 +660,7 @@ class BazelJSONHandler extends NonSaxHandler
         // Initialize the child build.
         $child_build = new Build();
         $child_build->Generator = $this->ParentBuild->Generator;
-        $child_build->GroupId = $this->ParentBuild->GroupId;
+        $child_build->GroupId = (int) $this->ParentBuild->GroupId;
         $child_build->Name = $this->ParentBuild->Name;
         $child_build->ProjectId = $this->ParentBuild->ProjectId;
         $child_build->SiteId = $this->ParentBuild->SiteId;

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -181,6 +181,9 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
             // XML file represents multiple "all-at-once" SubProject builds.
             $all_at_once = count($this->Builds) > 1;
             $parent_duration_set = false;
+            /**
+             * @var Build $build
+             */
             foreach ($this->Builds as $subproject => $build) {
                 $build->ProjectId = $this->projectid;
                 $build->StartTime = $start_time;
@@ -203,7 +206,7 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
                 $duration = $this->EndTimeStamp - $this->StartTimeStamp;
                 $build->UpdateBuildDuration($duration, !$all_at_once);
                 if ($all_at_once && !$parent_duration_set) {
-                    $parent_build = $factory->create(Build::class);
+                    $parent_build = new Build();
                     $parent_build->Id = $build->GetParentId();
                     $parent_build->UpdateBuildDuration($duration, false);
                     $parent_duration_set = true;

--- a/app/cdash/xml_handlers/configure_handler.php
+++ b/app/cdash/xml_handlers/configure_handler.php
@@ -206,10 +206,8 @@ class ConfigureHandler extends AbstractHandler implements ActionableBuildInterfa
                 }
 
                 // Record the number of warnings & errors with the build.
-                $build->SetNumberOfConfigureWarnings(
-                    $this->Configure->NumberOfWarnings);
-                $build->SetNumberOfConfigureErrors(
-                    $this->Configure->NumberOfErrors);
+                $build->SetNumberOfConfigureWarnings((int) $this->Configure->NumberOfWarnings);
+                $build->SetNumberOfConfigureErrors((int) $this->Configure->NumberOfErrors);
 
                 $build->ComputeConfigureDifferences();
 
@@ -232,7 +230,7 @@ class ConfigureHandler extends AbstractHandler implements ActionableBuildInterfa
             // All subprojects share the same configure file and parent build,
             // so only need to do this once
             $build->UpdateParentConfigureNumbers(
-                $this->Configure->NumberOfWarnings, $this->Configure->NumberOfErrors);
+                (int) $this->Configure->NumberOfWarnings, (int) $this->Configure->NumberOfErrors);
         } elseif ($name == 'LABEL' && $parent == 'LABELS') {
             if (isset($this->Configure)) {
                 $this->Configure->AddLabel($this->Label);

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -226,9 +226,9 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
                 $build->UpdateBuild($build->Id, -1, -1);
 
                 // Update the number of tests in the Build table
-                $build->UpdateTestNumbers($this->NumberTestsPassed[$subproject],
-                    $this->NumberTestsFailed[$subproject],
-                    $this->NumberTestsNotRun[$subproject]);
+                $build->UpdateTestNumbers((int) $this->NumberTestsPassed[$subproject],
+                    (int) $this->NumberTestsFailed[$subproject],
+                    (int) $this->NumberTestsNotRun[$subproject]);
 
                 // Is it really necessary to have to load the build from the db here?
                 $build->ComputeTestTiming();
@@ -328,6 +328,7 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
             $this->NumberTestsPassed[$this->SubProjectName] = 0;
         }
         $factory = $this->getModelFactory();
+        /** @var Build $build */
         $build = $factory->create(Build::class);
         $build->SetSite($this->Site);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1469,7 +1469,7 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string given\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
@@ -3693,6 +3693,16 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
+			message: "#^Only booleans are allowed in &&, string given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Only booleans are allowed in &&, string given on the right side\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
 			message: "#^Only booleans are allowed in an elseif condition, int given\\.$#"
 			count: 5
 			path: app/cdash/app/Controller/Api/ViewTest.php
@@ -4174,7 +4184,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 53
+			count: 52
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4204,42 +4214,72 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$BeginningOfDay\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$BuildEmailCollection\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$BuildErrorCount\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$Done\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$DynamicAnalysisCollection\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$EndOfDay\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$ErrorDifferences\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$Information\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$MissingTests\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$Project\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Class CDash\\\\Model\\\\Build has an uninitialized property \\$TestFailedCount\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 21
 			path: app/cdash/app/Model/Build.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 12
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 34
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddBuild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddBuild\\(\\) has parameter \\$nbuilderrors with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddBuild\\(\\) has parameter \\$nbuildwarnings with no type specified\\.$#"
-			count: 1
+			count: 2
 			path: app/cdash/app/Model/Build.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddBuild\\(\\) throws checked exception Error but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddError\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4249,17 +4289,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddLabel\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddLabel\\(\\) has parameter \\$label with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddUpdateStatistics\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4284,11 +4314,6 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddUpdateStatistics\\(\\) has parameter \\$firstbuild with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AddUpdateStatistics\\(\\) has parameter \\$testdiff with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4299,62 +4324,12 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:AssignToGroup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ComputeConfigureDifferences\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ComputeDifferences\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ComputeTestTiming\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ComputeTestingDayBounds\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ComputeUpdateStatistics\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ConvertMissingToZero\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:ConvertMissingToZero\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:CreateParentBuild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:CreateParentBuild\\(\\) has parameter \\$numErrors with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:CreateParentBuild\\(\\) has parameter \\$numWarnings with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:Exists\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4369,32 +4344,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FindRealErrors\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FindRealErrors\\(\\) has parameter \\$author with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FindRealErrors\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FindRealErrors\\(\\) has parameter \\$filename with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FindRealErrors\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GenerateUuid\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4424,32 +4374,12 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetBuildEmailCollection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetCommitAuthors\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetDate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetDiffWithPreviousBuild\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetDone\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetErrorDifferences\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4469,6 +4399,16 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetFailedTests\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetFailedTimeStatusTests\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetFailures\\(\\) has parameter \\$propertyFilters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4484,16 +4424,6 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetIdFromName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetIdFromName\\(\\) has parameter \\$subproject with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetIdFromUuid\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4504,12 +4434,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetLabelCollection\\(\\) has invalid return type CDash\\\\Model\\\\Collection\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetLabels\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetLabelCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4519,52 +4444,17 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetName\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetLabels\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfErrors\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNotRunTests\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfFailedTests\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfNotRunTests\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfPassedTests\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfTestsByField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfTestsByField\\(\\) has parameter \\$field with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfWarnings\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetParentId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetPullRequest\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetPassedTests\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4574,22 +4464,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetResolvedBuildErrors\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetResolvedBuildFailures\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetResolvedBuildFailures\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetSubProjectBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4604,27 +4479,12 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetSubProjectName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetTestCollection\\(\\) has invalid return type CDash\\\\Model\\\\TestCollection\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetUploadedFilesOrUrls\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:LookupParentBuildId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:MarkAsDone\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetTests\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4674,52 +4534,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:QuerySubProjectId\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:RemoveIfDone\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:Save\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SaveInformation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SaveTotalTestsTime\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SaveTotalTestsTime\\(\\) has parameter \\$update_parent with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetBuildConfigure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetBuildEmailCollection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetBuildUpdate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetConfigureDuration\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4729,42 +4544,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetNumberOfConfigureErrors\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetNumberOfConfigureErrors\\(\\) has parameter \\$numErrors with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetNumberOfConfigureWarnings\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetNumberOfConfigureWarnings\\(\\) has parameter \\$numWarnings with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetParentId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetParentId\\(\\) has parameter \\$parentid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetProject\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetPullRequest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4774,22 +4554,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetSite\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetSubProject\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:SetSubProject\\(\\) has parameter \\$subproject with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuild\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4814,72 +4579,12 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuildDuration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuildDuration\\(\\) has parameter \\$duration with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuildTestTime\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuildTestTime\\(\\) has parameter \\$test_exec_time with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateDuration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateDuration\\(\\) has parameter \\$duration with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateDuration\\(\\) has parameter \\$field with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateDuration\\(\\) has parameter \\$update_parent with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateEndTime\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateEndTime\\(\\) has parameter \\$end_time with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateParentConfigureNumbers\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateParentConfigureNumbers\\(\\) has parameter \\$newErrors with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateParentConfigureNumbers\\(\\) has parameter \\$newWarnings with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateParentTestNumbers\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4899,37 +4604,12 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestDuration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestDuration\\(\\) has parameter \\$duration with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestDuration\\(\\) has parameter \\$update_parent with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestNumbers\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestNumbers\\(\\) has parameter \\$numberTestsFailed with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestNumbers\\(\\) has parameter \\$numberTestsNotRun with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateTestNumbers\\(\\) has parameter \\$numberTestsPassed with no type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:extract_type_from_buildstamp\\(\\) has parameter \\$buildstamp with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4944,47 +4624,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$test$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^PHPDoc tag @return has invalid value \\(BuildEmailCollection;\\)\\: Unexpected token \";\", expected TOKEN_HORIZONTAL_WS at offset 196 on line 6$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$ActionableType has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Append has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$BeginningOfDay has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$BuildConfigure has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$BuildEmailCollection has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$BuildErrorCount has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4994,67 +4634,22 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Command has no type specified\\.$#"
+			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$CommitAuthors type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$CommitAuthors has no type specified\\.$#"
+			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$ErrorDifferences type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Done has no type specified\\.$#"
+			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Errors type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$DynamicAnalysisCollection has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$EndOfDay has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$EndTime has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$ErrorDifferences has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$ErrorDiffs has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Errors has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Failures has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Filled has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Generator has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$GroupId has no type specified\\.$#"
+			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Failures type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -5064,47 +4659,17 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Information has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$InsertErrors has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$LabelCollection has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Log has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$MissingTests has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Name has no type specified\\.$#"
+			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$MissingTests type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$PDO has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$ParentId has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -5129,16 +4694,6 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Stamp has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$StartTime has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$SubProjectId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -5149,27 +4704,7 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$SubmitTime has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$TestCollection has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$TestFailedCount has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Type has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$Uuid has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -9832,6 +9367,11 @@ parameters:
 			path: app/cdash/include/Collection/BuildCollection.php
 
 		-
+			message: "#^Parameter \\#2 \\$name of method CDash\\\\Collection\\\\Collection\\:\\:addItem\\(\\) expects null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/BuildCollection.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/cdash/include/Collection/BuildEmailCollection.php
@@ -10463,7 +10003,7 @@ parameters:
 
 		-
 			message: "#^Iterating over an object of an unknown class CDash\\\\Model\\\\Collection\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/include/Messaging/Topic/ConfigureTopic.php
 
 		-
@@ -10798,6 +10338,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:itemHasTopicSubject\\(\\) has parameter \\$item with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/Topic.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/Topic.php
 
@@ -12857,21 +12402,6 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$Id\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$Name\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:GetStamp\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
 			message: """
 				#^Call to deprecated function get_link_identifier\\(\\)\\:
 				04/22/2023$#
@@ -12907,16 +12437,11 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: "#^Function add_build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/ctestparserutils.php
 
 		-
-			message: "#^Function add_build\\(\\) has parameter \\$build with no type specified\\.$#"
+			message: "#^Function add_build\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/ctestparserutils.php
 
@@ -12952,16 +12477,6 @@ parameters:
 
 		-
 			message: "#^Function extract_date_from_buildstamp\\(\\) has parameter \\$buildstamp with no type specified\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: "#^Function extract_type_from_buildstamp\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: "#^Function extract_type_from_buildstamp\\(\\) has parameter \\$buildstamp with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/ctestparserutils.php
 
@@ -13874,11 +13389,6 @@ parameters:
 
 		-
 			message: "#^Function pdo_real_escape_numeric\\(\\) never returns float so it can be removed from the return type\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_real_escape_string\\(\\) never returns false so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
@@ -15223,11 +14733,6 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/cdash/include/sendemail.php
-
-		-
-			message: "#^Comparison operation \"\\=\\=\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
 
@@ -19024,6 +18529,11 @@ parameters:
 
 		-
 			message: "#^Call to method GetDiffWithPreviousBuild\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'CDash\\\\\\\\Collection\\\\\\\\BuildEmailCollection' and CDash\\\\Collection\\\\BuildEmailCollection will always evaluate to true\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 


### PR DESCRIPTION
We eventually want to convert all of the models to Eloquent.  The `Build` model is the largest, and most complicated, model in the CDash codebase, and it is not feasible to simply swap it out for an Eloquent-based model.  In preparation for a gradual conversion to an Eloquent backend via the adapter pattern used in #1556, I have tightened the parameter and return type constraints on the legacy Build model wherever possible.  By ensuring that all of the parameter and return types are known, the process of converting individual methods to Eloquent equivalents will be easier and less bug prone.

While the automated test suite passes, and I didn't see any issues during some manual testing, it is quite possible that bugs associated with this PR will pop up.  By opening this PR early in the release cycle, I hope to be able to catch any resulting bugs before the CDash 3.3 release comes out.