### PR TITLE
Bump default Debian version from bullseye to bookworm in Docker

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM php:8.1-apache-bullseye AS cdash-common
+FROM php:8.1-apache-bookworm AS cdash-common
 LABEL MAINTAINER="Kitware, Inc. <cdash@public.kitware.com>"
 
 ARG CDASH_DB_HOST=localhost


### PR DESCRIPTION
The latest "stable" Debian version is Debian bookworm, [released](https://www.debian.org/News/2023/20230722) on July 22, 2023.  I have bumped our base Docker image to a bookworm-based image.