### PR TITLE
Delete unused `buildgroup.php` GET endpoint

### DIFF
--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -17,13 +17,12 @@
 namespace CDash\Api\v1\BuildGroup;
 
 require_once 'include/api_common.php';
-require_once 'include/version.php';
 
-use App\Services\PageTimer;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
 use App\Models\Site;
+use Symfony\Component\HttpFoundation\Response;
 
 // Require administrative access to view this page.
 init_api_request();
@@ -53,61 +52,8 @@ switch ($method) {
     case 'PUT':
         rest_put($projectid);
         break;
-    case 'GET':
     default:
-        rest_get($pdo, $projectid);
-        break;
-}
-
-/** Handle GET requests */
-function rest_get($pdo, $projectid)
-{
-    if (!isset($_GET['buildgroupid'])) {
-        abort(400, 'buildgroupid not specified');
-    }
-    $buildgroupid = pdo_real_escape_numeric($_GET['buildgroupid']);
-
-    $pageTimer = new PageTimer();
-    $response = begin_JSON_response();
-    $response['projectid'] = $projectid;
-    $response['buildgroupid'] = $buildgroupid;
-
-    $BuildGroup = new BuildGroup();
-    $BuildGroup->SetId($buildgroupid);
-    $response['name'] = $BuildGroup->GetName();
-    $response['group'] = $BuildGroup->GetGroupId();
-
-    $stmt = $pdo->prepare(
-        "SELECT id, name FROM buildgroup
-        WHERE projectid = ? AND endtime = '1980-01-01 00:00:00'");
-    pdo_execute($stmt, [$projectid]);
-
-    $dependencies = $BuildGroup->GetDependencies();
-    $dependencies_response = [];
-    $available_dependencies_response = [];
-
-    while ($row = $stmt->fetch()) {
-        if ($row['id'] == $buildgroupid) {
-            continue;
-        }
-        if (is_array($dependencies) && in_array($row['id'], $dependencies)) {
-            $dep = [];
-            $dep['id'] = $row['id'];
-            $dep['name'] = $row['name'];
-            $dependencies_response[] = $dep;
-        } else {
-            $avail = [];
-            $avail['id'] = $row['id'];
-            $avail['name'] = $row['name'];
-            $available_dependencies_response[] = $avail;
-        }
-    }
-
-    $response['dependencies'] = $dependencies_response;
-    $response['available_dependencies'] = $available_dependencies_response;
-
-    $pageTimer->end($response);
-    echo json_encode(cast_data_for_JSON($response));
+        abort(Response::HTTP_NOT_IMPLEMENTED);
 }
 
 /** Handle DELETE requests */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15884,16 +15884,6 @@ parameters:
 			path: app/cdash/public/api/v1/build.php
 
 		-
-			message: "#^Call to an undefined method CDash\\\\Model\\\\BuildGroup\\:\\:GetDependencies\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: "#^Call to an undefined method CDash\\\\Model\\\\BuildGroup\\:\\:GetGroupId\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
 			message: """
 				#^Call to deprecated function get_link_identifier\\(\\)\\:
 				04/22/2023$#
@@ -15906,7 +15896,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
@@ -15914,7 +15904,7 @@ parameters:
 				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 10
+			count: 9
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
@@ -15930,11 +15920,6 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/buildgroup.php
 
@@ -15955,21 +15940,6 @@ parameters:
 
 		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\BuildGroup\\\\rest_delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\BuildGroup\\\\rest_get\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\BuildGroup\\\\rest_get\\(\\) has parameter \\$pdo with no type specified\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: "#^Function CDash\\\\Api\\\\v1\\\\BuildGroup\\\\rest_get\\(\\) has parameter \\$projectid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/buildgroup.php
 
@@ -16000,7 +15970,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 5
+			count: 4
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-


### PR DESCRIPTION
The GET method for the endpoint `/api/v1/buildgroup.php` is currently broken, and is not used anywhere in the codebase.  I plan to refactor this entire file eventually, but I'm waiting for #1666 to be fixed and merged before doing so.