### PR TITLE
Finish transition from CDASH_USER_CREATE_PROJECTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,3 +248,6 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # Whether or not to automatically register new users upon first login
 #SAML2_AUTO_REGISTER_NEW_USERS=false
+
+# Should normal user allowed to create projects
+# USER_CREATE_PROJECTS = false

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -59,7 +59,7 @@ final class UserController extends AbstractController
         $response['user_is_admin'] = $user->admin;
         $response['show_monitor'] = config('queue.default') === 'database';
 
-        if ($config->get('CDASH_USER_CREATE_PROJECTS')) {
+        if (boolval(config('cdash.user_create_projects'))) {
             $response['user_can_create_projects'] = 1;
         } else {
             $response['user_can_create_projects'] = 0;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1241,7 +1241,9 @@ class Project
         }
         $response['name_encoded'] = urlencode($this->Name ?? '');
 
-        if (!$config->get('CDASH_USER_CREATE_PROJECTS') || (Auth::check() && Auth::user()->IsAdmin())) {
+        $includeQuota = !boolval(config('cdash.user_create_projects')) || (Auth::check() && Auth::user()->IsAdmin());
+
+        if ($includeQuota) {
             $uploadQuotaGB = 0;
 
             if ($this->UploadQuota > 0) {

--- a/app/cdash/config/config.php
+++ b/app/cdash/config/config.php
@@ -46,8 +46,6 @@ $CDASH_LOG_DIRECTORY = $CDASH_ROOT_DIR . '/log';
 $CDASH_LOG_FILE = $CDASH_LOG_DIRECTORY . '/cdash.log';
 // Upload directory (absolute or relative)
 $CDASH_UPLOAD_DIRECTORY = $CDASH_ROOT_DIR . '/public/upload';
-// Should normal user allowed to create projects
-$CDASH_USER_CREATE_PROJECTS = false;
 // Request full email address to add new users
 // instead of displaying a list
 $CDASH_FULL_EMAIL_WHEN_ADDING_USER = '0';


### PR DESCRIPTION
Finish the replacement of the query for CDASH_USER_CREATE_PROJECTS environment variable with the checking of the config singleton.

With the UserController transition, the link for project creation will appear for each user when the variable is set.

All project creation by users is controlled by the `.env` variable USER_CREATE_PROJECTS.

Finishes work started in  #1604