### PR TITLE
Migrate `BuildProperties` model backend to Eloquent

### DIFF
--- a/app/Models/BuildProperties.php
+++ b/app/Models/BuildProperties.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This table has a one-to-one relationship with the build table.  The buildid is the primary key.
+ * In the future, we should consider whether this table should simply be converted to a column on
+ * the build table.
+ *
+ * @property int $buildid
+ * @property string $properties
+ *
+ * @mixin Builder<BuildProperties>
+ */
+class BuildProperties extends Model
+{
+    protected $table = 'buildproperties';
+
+    protected $primaryKey = 'buildid';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'properties',
+    ];
+}

--- a/app/cdash/app/Model/BuildProperties.php
+++ b/app/cdash/app/Model/BuildProperties.php
@@ -15,51 +15,31 @@
 =========================================================================*/
 namespace CDash\Model;
 
-use CDash\Database;
+use App\Models\BuildProperties as EloquentBuildProperties;
 
 /** BuildProperties class */
 class BuildProperties
 {
-    public $Build;
-    public $Properties;
-    private $Filled;
-    private $PDO;
+    public Build $Build;
+    /** @var array<mixed> */
+    public array $Properties = [];
+    private bool $Filled = false;
 
     public function __construct(Build $build)
     {
         $this->Build = $build;
-        $this->Properties = [];
-        $this->Filled = false;
-        $this->PDO = Database::getInstance();
     }
 
     /** Return true if this build already has properties. */
-    public function Exists()
+    public function Exists(): bool
     {
-        if (!$this->Build) {
-            return false;
-        }
-        $stmt = $this->PDO->prepare(
-            'SELECT COUNT(*) FROM buildproperties WHERE buildid = :buildid');
-        $this->PDO->execute($stmt, [':buildid' => $this->Build->Id]);
-        if ($stmt->fetchColumn() > 0) {
-            return true;
-        }
-        return false;
+        return EloquentBuildProperties::where('buildid', (int) $this->Build->Id)->exists();
     }
 
     /** Save these build properties to the database,
         overwriting any existing content. */
-    public function Save()
+    public function Save(): bool
     {
-        $required_params = ['Build', 'Properties'];
-        foreach ($required_params as $param) {
-            if (!$this->$param) {
-                add_log("$param not set", 'BuildProperties::Save', LOG_ERR);
-                return false;
-            }
-        }
-
         // Delete any previously existing properties for this build.
         if ($this->Exists()) {
             $this->Delete();
@@ -67,64 +47,37 @@ class BuildProperties
 
         $properties_str = json_encode($this->Properties);
         if ($properties_str === false) {
-            add_log('Failed to encode JSON: ' . json_last_error_msg(),
-                'BuildProperties::Save', LOG_ERR);
-            return false;
+            abort(500, 'Failed to encode JSON: ' . json_last_error_msg());
         }
 
-        $stmt = $this->PDO->prepare(
-            'INSERT INTO buildproperties (buildid, properties)
-            VALUES (:buildid, :properties)');
-        $query_params = [
-            ':buildid' => $this->Build->Id,
-            ':properties' => $properties_str,
-        ];
-        return $this->PDO->execute($stmt, $query_params);
+        return EloquentBuildProperties::create([
+            'buildid' => (int) $this->Build->Id,
+            'properties' => $properties_str,
+        ]) !== null;
     }
 
     /** Delete this record from the database. */
-    public function Delete()
+    public function Delete(): bool
     {
-        if (!$this->Build) {
-            add_log('Build not set', 'BuildProperties::Delete', LOG_ERR);
-            return false;
-        }
         if (!$this->Exists()) {
-            add_log('No properties exist for this build',
-                'BuildProperties::Delete', LOG_ERR);
-            return false;
+            abort(500, 'No properties exist for this build');
         }
 
-        $stmt = $this->PDO->prepare(
-            'DELETE FROM buildproperties WHERE buildid = :buildid');
-        return $this->PDO->execute($stmt, [':buildid' => $this->Build->Id]);
+        return (bool) EloquentBuildProperties::where('buildid', (int) $this->Build->Id)->delete();
     }
 
     /** Retrieve properties for a given build. */
-    public function Fill()
+    public function Fill(): void
     {
-        if (!$this->Build) {
-            add_log('Build not set', 'BuildProperties::Fill', LOG_ERR);
-            return false;
+        $model = EloquentBuildProperties::find((int) $this->Build->Id);
+        if ($model === null) {
+            return;
         }
 
-        $stmt = $this->PDO->prepare(
-            'SELECT properties FROM buildproperties
-             WHERE buildid = :buildid');
-        if (!$this->PDO->execute($stmt, [':buildid' => $this->Build->Id])) {
-            return false;
-        }
-
-        $row = $stmt->fetch();
-        if (!is_array($row)) {
-            return true;
-        }
-
-        $properties = json_decode($row['properties'], true);
+        $properties = json_decode($model->properties, true);
         if (is_array($properties)) {
             $this->Properties = $properties;
+            $this->Filled = true;
         }
-        $this->Filled = true;
-        return true;
     }
 }

--- a/app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+++ b/app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
@@ -35,7 +35,7 @@ class BuildPropertiesJSONHandler extends NonSaxHandler
     public function Parse($filename)
     {
         // Test that this file contains valid JSON that PHP can decode.
-        $json_obj = json_decode(file_get_contents($filename));
+        $json_obj = json_decode(file_get_contents($filename), true);
         if ($json_obj === null) {
             $err = json_last_error_msg();
             add_log("Failed to parse $filename: $err", 'BuildPropertiesJSONHandler::Parse', LOG_ERR);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6448,60 +6448,12 @@ parameters:
 			path: app/cdash/app/Model/BuildInformation.php
 
 		-
-			message: """
-				#^Call to deprecated function add_log\\(\\)\\:
-				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 5
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildProperties\\:\\:Delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildProperties\\:\\:Exists\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildProperties\\:\\:Fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildProperties\\:\\:Save\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$Build has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$Filled has no type specified\\.$#"
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\BuildProperties\\>\\:\\:exists\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildProperties.php
 
 		-
 			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$Filled is never read, only written\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$PDO has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$Properties has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildProperties.php
-
-		-
-			message: "#^Variable property access on \\$this\\(CDash\\\\Model\\\\BuildProperties\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildProperties.php
 


### PR DESCRIPTION
This PR is part of our ongoing effort to migrate our models to Laravel's Eloquent ORM library.

As noted in a comment, we should eventually consider whether the `buildproperties` table should simply be a column on the `build` table , given that it has a one-to-one relationship with a corresponding build.  Performing such a refactor should be relatively straightforward.