### PR TITLE
Add additional information to failed submission log message

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -150,7 +150,7 @@ class ProcessSubmission implements ShouldQueue
      */
     public function failed(\Throwable $exception) : void
     {
-        \Log::warning("Failed to process {$this->filename}");
+        \Log::warning("Failed to process {$this->filename} with message: {$exception->getMessage()}");
         $this->renameSubmissionFile("inprogress/{$this->filename}", "failed/{$this->filename}");
     }
 


### PR DESCRIPTION
We only log the filename for failing submissions currently, and information about *why* a submission failed is lost.

This PR adds the specific error message to the logging statement.