### PR TITLE
Drop unused `random_compat` polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "league/oauth2-google": "4.0.1",
     "nyholm/psr7": "1.8.0",
     "omines/oauth2-gitlab": "3.5.0",
-    "paragonie/random_compat": "2.0.4",
     "pear/archive_tar": "1.4.14",
     "php-di/php-di": "7.0.2",
     "ramsey/uuid": "4.7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03ae95c94bd25831a8a0c2b26ee60fa2",
+    "content-hash": "c11af109c298a00c1b4f819fbca6db47",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -3669,33 +3669,29 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.4",
+            "version": "v9.99.100",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "php": ">= 7"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
             },
             "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -3710,6 +3706,7 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
@@ -3718,7 +3715,7 @@
                 "issues": "https://github.com/paragonie/random_compat/issues",
                 "source": "https://github.com/paragonie/random_compat"
             },
-            "time": "2016-11-07T23:38:38+00:00"
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "pear/archive_tar",


### PR DESCRIPTION
The `random_compat` polyfill is used to port a handful of functions introduced in PHP 7 to PHP 5.  Since we do not support PHP 5, we don't need this dependency.

I have removed `random_compat` from our `composer.json`, but it is still a required dependency for `league/oauth2-client` and is still in our lock file.