### PR TITLE
Convert backend of `SubProject` model to Eloquent

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int $id
@@ -95,4 +96,12 @@ class Project extends Model
         'authenticatesubmissions',
         'viewsubprojectslink',
     ];
+
+    /**
+     * @return HasMany<SubProject>
+     */
+    public function subprojects(): HasMany
+    {
+        return $this->hasMany(SubProject::class, 'projectid', 'id');
+    }
 }

--- a/app/Models/SubProject.php
+++ b/app/Models/SubProject.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property int $projectid
+ * @property int $groupid
+ * @property string $path
+ * @property int $position
+ * @property Carbon $starttime
+ * @property Carbon $endtime
+ *
+ * @mixin Builder<SubProject>
+ */
+class SubProject extends Model
+{
+    protected $table = 'subproject';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'projectid',
+        'groupid',
+        'path',
+        'position',
+        'starttime',
+        'endtime',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'projectid' => 'integer',
+        'groupid' => 'integer',
+        'position' => 'integer',
+        'starttime' => 'datetime',
+        'endtime' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Project, self>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'id', 'projectid');
+    }
+
+    /**
+     * Return the subprojects which depended upon this subproject on the specified date.
+     * If no date is provided, the current date is used.
+     *
+     * @return BelongsToMany<self>
+     */
+    public function children(?Carbon $date = null): BelongsToMany
+    {
+        if ($date === null) {
+            $date = Carbon::now()->setTimezone('UTC');
+        }
+
+        return $this->belongsToMany(SubProject::class, 'subproject2subproject', 'subprojectid', 'dependsonid')
+            ->wherePivot('starttime', '<=', Carbon::now()->setTimezone('UTC'))
+            ->where(function ($query) use ($date) {
+                $query->where('subproject2subproject.endtime', '>', $date)
+                    ->orWhere('subproject2subproject.endtime', '=', Carbon::create(1980));
+            });
+    }
+}

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -142,7 +142,7 @@ if (isset($_GET['subproject'])) {
         $subproject_response['name'] = $SubProject->GetName();
 
         $dependencies = $SubProject->GetDependencies();
-        if ($dependencies) {
+        if ($dependencies !== []) {
             $dependencies_response = [];
             foreach ($dependencies as $dependency) {
                 $dependency_response = [];

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -111,7 +111,7 @@ function rest_get($projectid): bool
         if (intval($row['id']) === $subprojectid) {
             continue;
         }
-        if (is_array($dependencies) && in_array($row['id'], $dependencies)) {
+        if (in_array((int) $row['id'], $dependencies, true)) {
             $dep = [];
             $dep['id'] = intval($row['id']);
             $dep['name'] = $row['name'];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2154,6 +2154,16 @@ parameters:
 			path: app/Models/Site.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:orWhere\\(\\)\\.$#"
+			count: 1
+			path: app/Models/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:where\\(\\)\\.$#"
+			count: 2
+			path: app/Models/SubProject.php
+
+		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
 			count: 2
 			path: app/Models/TestOutput.php
@@ -8210,45 +8220,13 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 8
+			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
 		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 4
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_error\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_execute\\(\\)\\:
-				v2\\.5\\.0 01/22/2018$#
-			"""
-			count: 7
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
 			"""
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
@@ -8258,7 +8236,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 9
+			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
 		-
@@ -8266,24 +8244,46 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 8
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 3
+			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SubProject\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:where\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SubProject\\>\\:\\:first\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SubProject\\>\\:\\:where\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:AddDependency\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
@@ -8308,7 +8308,22 @@ parameters:
 			path: app/cdash/app/Model/SubProject.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetDependencies\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:Exists\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:Fill\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:GetDependencies\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:Save\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
@@ -8318,52 +8333,17 @@ parameters:
 			path: app/cdash/app/Model/SubProject.php
 
 		-
+			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:SetId\\(\\) throws checked exception Carbon\\\\Exceptions\\\\InvalidFormatException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\SubProject\\:\\:SetProjectId\\(\\) has parameter \\$projectid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$GroupId has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$Id has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$Name has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$PDO has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$Path has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$Position has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\SubProject\\:\\:\\$ProjectId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProject.php
 
@@ -15839,11 +15819,6 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
-			path: app/cdash/public/api/v1/subproject.php
-
-		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
 			path: app/cdash/public/api/v1/subproject.php
 
 		-
@@ -25710,7 +25685,7 @@ parameters:
 				#^Call to deprecated function get_link_identifier\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 1
+			count: 2
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
@@ -25718,7 +25693,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 1
+			count: 2
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
@@ -25726,7 +25701,7 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 1
+			count: 2
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-


### PR DESCRIPTION
This PR is part of our ongoing effort to switch all of our models to Laravel's Eloquent ORM library.  The legacy `SubProject` model has been turned into an adapter for the Eloquent-based model, using the same approach taken in #1556.