### PR TITLE
Fix typo in `getPreviousBuilds.php` API endpoint

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1110,7 +1110,7 @@ final class BuildController extends AbstractBuildController
         if ($this->build->SubProjectId > 0) {
             $subproj_table = 'INNER JOIN subproject2build AS sp2b ON (b.id=sp2b.buildid)';
             $subproj_criteria = 'AND sp2b.subprojectid=:subprojectid';
-            $query_params = $this->build->SubProjectId;
+            $query_params[] = $this->build->SubProjectId;
         }
 
         // Get details about previous builds.


### PR DESCRIPTION
I forgot to wrap a query parameter in an array in https://github.com/Kitware/CDash/pull/1550.

Thanks to @sbelsk for spotting this bug!