### PR TITLE
Deprecate legacy `Config` class

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -27,6 +27,11 @@ abstract class AbstractController extends BaseController
         return $result;
     }
 
+    public static function getCDashVersion(): string
+    {
+        return file_get_contents(public_path('VERSION'));
+    }
+
     /**
      * Returns the version used to find compiled css and javascript files
      *

--- a/app/cdash/include/CDash/Config.php
+++ b/app/cdash/include/CDash/Config.php
@@ -3,7 +3,7 @@ namespace CDash;
 
 class Config extends Singleton
 {
-    private $_config;
+    private array $_config;
 
     protected function __construct()
     {
@@ -12,6 +12,9 @@ class Config extends Singleton
         $this->_config = get_defined_vars();
     }
 
+    /**
+     * @deprecated 09/04/2023  Use config() instead.
+     */
     public function get($name)
     {
         if (isset($this->_config[$name])) {
@@ -19,16 +22,17 @@ class Config extends Singleton
         }
     }
 
+    /**
+     * @deprecated 09/04/2023  Use config() instead.
+     */
     public function set($name, $value)
     {
         $this->_config[$name] = $value;
     }
 
-    public static function getVersion(): string
-    {
-        return file_get_contents(public_path('VERSION'));
-    }
-
+    /**
+     * @deprecated 09/04/2023  Use url() instead.
+     */
     public function getServer(): string
     {
         $server = $this->get('CDASH_SERVER_NAME');
@@ -42,6 +46,9 @@ class Config extends Singleton
         return $server;
     }
 
+    /**
+     * @deprecated 09/04/2023  Use url() instead.
+     */
     public function getProtocol(): string
     {
         $protocol = 'http';
@@ -53,18 +60,19 @@ class Config extends Singleton
     }
 
     /**
-     * @return string
+     * @deprecated 09/04/2023  Use url() instead.
      */
-    public function getServerPort()
+    public function getServerPort(): ?string
     {
         if (isset($_SERVER['SERVER_PORT'])
             && $_SERVER['SERVER_PORT'] != 80
             && $_SERVER['SERVER_PORT'] != 443) {
             return $_SERVER['SERVER_PORT'];
         }
+        return null;
     }
 
-    public function getPath(): string
+    private function getPath(): string
     {
         $path = config('cdash.curl_localhost_prefix') ?: $_SERVER['REQUEST_URI'];
         if (!str_starts_with($path, '/')) {
@@ -73,6 +81,9 @@ class Config extends Singleton
         return $path;
     }
 
+    /**
+     * @deprecated 09/04/2023  Use url() instead.
+     */
     public function getBaseUrl(): string
     {
         $uri = config('app.url');
@@ -80,7 +91,7 @@ class Config extends Singleton
         if (!$uri) {
             $protocol = $this->getProtocol();
             $host = $this->getServer();
-            $port = $this->getServerPort() ? ":{$this->getServerPort()}" : '';
+            $port = $this->getServerPort() !== null ? ":{$this->getServerPort()}" : '';
             $path = $this->getPath();
 
             // Trim any known subdirectories off of the path.
@@ -93,7 +104,7 @@ class Config extends Singleton
             }
 
             // Also trim any .php files from the path.
-            if (strpos($path, '.php') !== false) {
+            if (str_contains($path, '.php')) {
                 $path = dirname($path);
             }
 

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1229,7 +1229,7 @@ function begin_XML_for_XSLT(): string
 
     $xml = '<?xml version="1.0" encoding="UTF-8"?><cdash>';
     $xml .= add_XML_value('cssfile', $css_file);
-    $xml .= add_XML_value('version', CDash\Config::getVersion());
+    $xml .= add_XML_value('version', \App\Http\Controllers\AbstractController::getCDashVersion());
     $xml .= add_XML_value('_token', csrf_token());
 
     return $xml;
@@ -1238,7 +1238,7 @@ function begin_XML_for_XSLT(): string
 function begin_JSON_response(): array
 {
     $response = [];
-    $response['version'] = CDash\Config::getVersion();
+    $response['version'] = \App\Http\Controllers\AbstractController::getCDashVersion();
 
     $user_response = [];
     $userid = Auth::id();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -246,6 +246,14 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 12
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
@@ -531,6 +539,22 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 10
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -827,6 +851,22 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 8
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -890,6 +930,14 @@ parameters:
 			message: "#^Variable \\$project_array might not be defined\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/Http/Controllers/ManageUsersController.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
@@ -1708,6 +1756,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -2192,6 +2248,14 @@ parameters:
 			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$labels has no type specified\\.$#"
 			count: 1
 			path: app/Models/BuildTest.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/Models/Site.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -3524,6 +3588,14 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
 		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/app/Controller/Api/ViewProjects.php
@@ -3798,6 +3870,14 @@ parameters:
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
+			"""
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
 			"""
 			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
@@ -4751,6 +4831,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
+			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -5047,6 +5135,14 @@ parameters:
 			path: app/cdash/app/Model/BuildError.php
 
 		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/BuildError.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/app/Model/BuildError.php
@@ -5292,6 +5388,14 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/app/Model/BuildFailure.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
 			path: app/cdash/app/Model/BuildFailure.php
 
 		-
@@ -6178,6 +6282,14 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 3
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
@@ -7163,6 +7275,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/DynamicAnalysis.php
+
+		-
+			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -7839,6 +7959,22 @@ parameters:
 			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: """
+				#^Call to deprecated method getServer\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
 			"""
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -9103,11 +9239,6 @@ parameters:
 			path: app/cdash/include/CDash/Config.php
 
 		-
-			message: "#^Method CDash\\\\Config\\:\\:getServerPort\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: app/cdash/include/CDash/Config.php
-
-		-
 			message: "#^Method CDash\\\\Config\\:\\:set\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Config.php
@@ -9128,12 +9259,7 @@ parameters:
 			path: app/cdash/include/CDash/Config.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 1
-			path: app/cdash/include/CDash/Config.php
-
-		-
-			message: "#^Property CDash\\\\Config\\:\\:\\$_config has no type specified\\.$#"
+			message: "#^Property CDash\\\\Config\\:\\:\\$_config type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Config.php
 
@@ -9176,6 +9302,14 @@ parameters:
 			message: "#^Method CDash\\\\Database\\:\\:prepare\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/include/CDash/ServiceContainer.php
 
 		-
 			message: "#^Method CDash\\\\ServiceContainer\\:\\:create\\(\\) has parameter \\$class_name with no type specified\\.$#"
@@ -9838,6 +9972,14 @@ parameters:
 			path: app/cdash/include/Messaging/Subscription/CommitAuthorSubscriptionBuilder.php
 
 		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/cdash/include/Messaging/Subscription/Subscription.php
@@ -10471,6 +10613,14 @@ parameters:
 			message: "#^Method CDash\\\\Submission\\\\CommitAuthorHandlerInterface\\:\\:GetCommitAuthors\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/Submission/CommitAuthorHandlerInterface.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
 			message: """
@@ -11884,6 +12034,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 6
+			path: app/cdash/include/common.php
+
+		-
+			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -11894,6 +12052,14 @@ parameters:
 			message: """
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
+			"""
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
 			"""
 			count: 1
 			path: app/cdash/include/common.php
@@ -12338,6 +12504,14 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/cdash/include/ctestparser.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
 			path: app/cdash/include/ctestparser.php
@@ -12582,6 +12756,30 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 8
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 3
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: """
+				#^Call to deprecated method getServer\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 2
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -12850,6 +13048,14 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 5
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
@@ -13320,6 +13526,14 @@ parameters:
 		-
 			message: "#^Access to undefined constant Memcached\\:\\:OPT_CLIENT_MODE\\.$#"
 			count: 1
+			path: app/cdash/include/memcache_functions.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
 			path: app/cdash/include/memcache_functions.php
 
 		-
@@ -14768,6 +14982,22 @@ parameters:
 			path: app/cdash/include/sendemail.php
 
 		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 3
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: """
+				#^Call to deprecated method getServer\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
@@ -15320,6 +15550,14 @@ parameters:
 			message: """
 				#^Call to deprecated function json_error_response\\(\\)\\:
 				15/06/2023 Use abort\\(\\) to exit cleanly instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
 			"""
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
@@ -16149,6 +16387,14 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
+
+		-
+			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
@@ -16229,6 +16475,54 @@ parameters:
 			message: "#^Method BuildUseCaseTest\\:\\:testUseCaseCreateBuilderReturnsInstanceOfBuildUseCase\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/BuildUseCaseTest.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 5
+			path: app/cdash/tests/case/CDash/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/cdash/tests/case/CDash/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getProtocol\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 3
+			path: app/cdash/tests/case/CDash/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getServer\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/cdash/tests/case/CDash/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method getServerPort\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 3
+			path: app/cdash/tests/case/CDash/ConfigTest.php
+
+		-
+			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 11
+			path: app/cdash/tests/case/CDash/ConfigTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
@@ -16553,6 +16847,22 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+
+		-
+			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+
+		-
+			message: """
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
@@ -16653,6 +16963,14 @@ parameters:
 			message: "#^Method LinkifyCompilerOutputTest\\:\\:testLinkifyCompilerOutput\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
+
+		-
+			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/MessengerTest.php
 
 		-
 			message: "#^Call to method send\\(\\) on an unknown class CDash\\\\Messaging\\\\Messenger\\.$#"
@@ -18687,6 +19005,14 @@ parameters:
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
 
 		-
+			message: """
+				#^Call to deprecated method set\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\)\\.$#"
 			count: 4
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -19905,6 +20231,14 @@ parameters:
 				04/22/2023$#
 			"""
 			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 2
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
@@ -22774,6 +23108,14 @@ parameters:
 			path: app/cdash/tests/test_email.php
 
 		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 4
+			path: app/cdash/tests/test_email.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 5
 			path: app/cdash/tests/test_email.php
@@ -24804,6 +25146,14 @@ parameters:
 			path: app/cdash/tests/test_submitsortingdata.php
 
 		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 2
+			path: app/cdash/tests/test_subproject.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 3
 			path: app/cdash/tests/test_subproject.php
@@ -25318,6 +25668,14 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
+			message: """
+				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use url\\(\\) instead\\.$#
+			"""
+			count: 2
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
 		-
@@ -29141,6 +29499,14 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: """
+				#^Call to deprecated method get\\(\\) of class CDash\\\\Config\\:
+				09/04/2023  Use config\\(\\) instead\\.$#
+			"""
+			count: 3
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-

--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -2,6 +2,7 @@
     use App\Http\Controllers\AbstractController;
 
     $js_version = AbstractController::getJsVersion();
+    $cdash_version = AbstractController::getCDashVersion();
 @endphp
 
 <!DOCTYPE html>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,9 +1,3 @@
-@php
-use CDash\Config;
-
-$version = Config::getVersion();
-@endphp
-
 {{-- Fill the space between the content and the footer to push the footer to the bottom of the page --}}
 <div style="flex:1;"></div>
 
@@ -19,7 +13,7 @@ $version = Config::getVersion();
             <img src="{{ asset('img/cdash_logo_full.svg?rev=2023-05-31') }}" height="30" alt="CDash logo">
         </a>
         <span id="footertext" class="pull-right">
-            CDash {{ $version }} ©&nbsp; <a href="https://www.kitware.com">Kitware</a>
+            CDash {{ $cdash_version }} ©&nbsp; <a href="https://www.kitware.com">Kitware</a>
             | <a href="https://github.com/Kitware/CDash/issues" target="_blank">Report problems</a>
 
             @if(isset($angular) && $angular === true)


### PR DESCRIPTION
Everything the legacy `Config` class does can be done by an equivalent Laravel helper function.  As such, there is no longer a need for the `Config` class, and it has been marked as deprecated.  I tried to simply replace each of the deprecated functions with laravel equivalents, but a few quirks with our testing suite make it a nontrivial task.

I created a new function for getting the current CDash version in the base controller class.  This is now the preferred method to use for getting the version.  I intend to make a separate PR once this is merged to simplify our versioning logic.