### PR TITLE
Convert backend of `Build` model to Eloquent

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $siteid
+ * @property int $projectid
+ * @property int $parentid
+ * @property string $stamp
+ * @property string $name
+ * @property string $type
+ * @property string $generator
+ * @property Carbon $starttime
+ * @property Carbon $endtime
+ * @property Carbon $submittime
+ * @property string $command
+ * @property string $log
+ * @property int $configureerrors
+ * @property int $configurewarnings
+ * @property int $configureduration
+ * @property int $builderrors
+ * @property int $buildwarnings
+ * @property int $buildduration
+ * @property int $testnotrun
+ * @property int $testfailed
+ * @property int $testpassed
+ * @property int $testtimestatusfailed
+ * @property int $testduration
+ * @property bool $notified
+ * @property bool $done
+ * @property string $uuid
+ * @property string $changeid
+ *
+ * @mixin Builder<Build>
+ */
+class Build extends Model
+{
+    protected $table = 'build';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'id',
+        'siteid',
+        'projectid',
+        'parentid',
+        'stamp',
+        'name',
+        'type',
+        'generator',
+        'starttime',
+        'endtime',
+        'submittime',
+        'command',
+        'log',
+        'configureerrors',
+        'configurewarnings',
+        'configureduration',
+        'builderrors',
+        'buildwarnings',
+        'buildduration',
+        'testnotrun',
+        'testfailed',
+        'testpassed',
+        'testtimestatusfailed',
+        'testduration',
+        'notified',
+        'done',
+        'uuid',
+        'changeid',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'siteid' => 'integer',
+        'projectid' => 'integer',
+        'parentid' => 'integer',
+        'starttime' => 'datetime',
+        'endtime' => 'datetime',
+        'submittime' => 'datetime',
+        'configureerrors' => 'integer',
+        'configurewarnings' => 'integer',
+        'configureduration' => 'integer',
+        'builderrors' => 'integer',
+        'buildwarnings' => 'integer',
+        'buildduration' => 'integer',
+        'testnotrun' => 'integer',
+        'testfailed' => 'integer',
+        'testpassed' => 'integer',
+        'testduration' => 'integer',
+        'notified' => 'boolean',
+        'done' => 'boolean',
+    ];
+}

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -176,7 +176,7 @@ function pdo_real_escape_numeric(mixed $unescaped_string): float|int|string
  *
  * @deprecated v2.5.0 01/22/2018
  */
-function pdo_execute(PDOStatement $stmt, array|null $input_parameters=null): bool|null
+function pdo_execute(PDOStatement $stmt, array|null $input_parameters=null): bool
 {
     $db = Database::getInstance();
     return $db->execute($stmt, $input_parameters);

--- a/app/cdash/public/api/v1/build.php
+++ b/app/cdash/public/api/v1/build.php
@@ -101,7 +101,7 @@ function rest_post($build)
 
     // Should we change the 'done' setting for this build?
     if (isset($_POST['done'])) {
-        $build->MarkAsDone($_POST['done']);
+        $build->MarkAsDone((bool) $_POST['done']);
     }
 }
 

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -77,7 +77,7 @@ class DoneHandlerTestCase extends KWWebTestCase
         $this->assertTrue($build->GetDone());
 
         // Mark the build as "not done" again.
-        $build->MarkAsDone(0);
+        $build->MarkAsDone(false);
 
         // Clean backup directory.
         $this->removeParsedFiles();

--- a/app/cdash/xml_handlers/done_handler.php
+++ b/app/cdash/xml_handlers/done_handler.php
@@ -63,7 +63,7 @@ class DoneHandler extends AbstractHandler
             }
 
             $this->Build->UpdateBuild($this->Build->Id, -1, -1);
-            $this->Build->MarkAsDone(1);
+            $this->Build->MarkAsDone(true);
 
             // Should we re-run any checks that were previously marked
             // as pending?

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4108,7 +4108,7 @@ parameters:
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
-			count: 24
+			count: 20
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4116,7 +4116,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 52
+			count: 31
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4132,7 +4132,7 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4206,6 +4206,16 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Build\\>\\:\\:count\\(\\)\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Build\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/app/Model/Build.php
@@ -4266,13 +4276,13 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FillFromId\\(\\) has no return type specified\\.$#"
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FillFromId\\(\\) has parameter \\$buildid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FillFromId\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:FillFromId\\(\\) throws checked exception TypeError but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 3
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4356,11 +4366,6 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetIdFromUuid\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetIdFromUuid\\(\\) has parameter \\$uuid with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4417,11 +4422,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetTests\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:MarkAsDone\\(\\) has parameter \\$done with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4492,11 +4492,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuild\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Build\\:\\:UpdateBuild\\(\\) has parameter \\$lock with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4637,6 +4632,11 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Build\\:\\:\\$TestCollection has no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Variable property access on App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -13232,11 +13232,6 @@ parameters:
 
 		-
 			message: "#^Function pdo_execute\\(\\) has parameter \\$input_parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_execute\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 


### PR DESCRIPTION
This PR follows #1674 and converts the parts of the `Build` model which interact directly with the `build` table to Eloquent wherever feasible.  I intend to slowly switch more parts of the codebase to the Eloquent-based model, but that work will happen in separate PRs.  By simply having an Eloquent `Build` model present, we can do significantly more in other Eloquent models.