### PR TITLE
Change nodejs install command

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -12,8 +12,13 @@ ARG DEVELOPMENT_BUILD
 ENV DEVELOPMENT_BUILD=$DEVELOPMENT_BUILD
 
 RUN apt-get update                                                         \
- && apt-get install -y gnupg                                               \
- && curl -fsSL https://deb.nodesource.com/setup_19.x | bash                \
+ && apt-get install -y ca-certificates curl gnupg                          \
+ && mkdir -p /etc/apt/keyrings                                             \
+ && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key   \
+     | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg              \
+ && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+     | tee /etc/apt/sources.list.d/nodesource.list                         \
+ && apt-get update                                                         \
  && apt-get install -y apt-utils git libbz2-dev libfreetype6-dev           \
     libjpeg62-turbo-dev libldap2-dev libmcrypt-dev libpng-dev libpq-dev    \
     libxslt-dev libxss1 nodejs unzip vim wget zip                          \


### PR DESCRIPTION
The nodejs installation script we currently use is [deprecated](https://github.com/nodesource/distributions?tab=readme-ov-file#new-update-%EF%B8%8F), and results in a warning message when building our docker image.  The install process has been updated to reflect the current nodesource recommendations.

I also bumped nodejs to version 20.x.  This change should not affect our codebase.