### PR TITLE
Finish transition from CDASH_USER_CREATE_PROJECTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,3 +248,6 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 # Whether or not to automatically register new users upon first login
 #SAML2_AUTO_REGISTER_NEW_USERS=false
+
+# Should normal user allowed to create projects
+# USER_CREATE_PROJECTS = false

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -59,7 +59,7 @@ final class UserController extends AbstractController
         $response['user_is_admin'] = $user->admin;
         $response['show_monitor'] = config('queue.default') === 'database';
 
-        if ($config->get('CDASH_USER_CREATE_PROJECTS')) {
+        if (boolval(config('cdash.user_create_projects'))) {
             $response['user_can_create_projects'] = 1;
         } else {
             $response['user_can_create_projects'] = 0;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1735,7 +1735,7 @@ class Project
         }
         $response['name_encoded'] = urlencode($this->Name ?? '');
 
-        $includeQuota = !$config->get('CDASH_USER_CREATE_PROJECTS') || $user->IsAdmin();
+        $includeQuota = !boolval(config('cdash.user_create_projects')) ||  $user->IsAdmin();
 
         if ($includeQuota) {
             $uploadQuotaGB = 0;

--- a/app/cdash/config/config.php
+++ b/app/cdash/config/config.php
@@ -46,8 +46,6 @@ $CDASH_LOG_DIRECTORY = $CDASH_ROOT_DIR . '/log';
 $CDASH_LOG_FILE = $CDASH_LOG_DIRECTORY . '/cdash.log';
 // Upload directory (absolute or relative)
 $CDASH_UPLOAD_DIRECTORY = $CDASH_ROOT_DIR . '/public/upload';
-// Should normal user allowed to create projects
-$CDASH_USER_CREATE_PROJECTS = false;
 // Request full email address to add new users
 // instead of displaying a list
 $CDASH_FULL_EMAIL_WHEN_ADDING_USER = '0';


### PR DESCRIPTION
This MR cherry-picks the commit merged to `master` already onto the `releases/3.2` branch

Previous message: 
Finish the replacement of the query for CDASH_USER_CREATE_PROJECTS environment variable with the checking of the config singleton.

All creation by users is controlled by the environment variable USER_CREATE_PROJECTS.

Finishes work started in  #1604