### PR TITLE
Re-enable CTEST_DROP_* information for older CTests

### DIFF
--- a/resources/views/project/ctest-configuration.blade.php
+++ b/resources/views/project/ctest-configuration.blade.php
@@ -9,7 +9,13 @@
 set(CTEST_PROJECT_NAME {{ $project->Name }})
 set(CTEST_NIGHTLY_START_TIME {{ $project->NightlyTime }})
 
-set(CTEST_SUBMIT_URL {{ env('APP_URL') }}/submit.php?project={{ urlencode($project->Name) }})
+if(CMAKE_VERSION VERSION_GREATER 3.14)
+  set(CTEST_SUBMIT_URL {{ config('app.url') }}/submit.php?project={{ urlencode($project->Name) }})
+else()
+  set(CTEST_DROP_METHOD "{{ explode("://", config('app.url'))[0] }}")
+  set(CTEST_DROP_SITE "{{ explode("://", config('app.url'))[1] }}")
+  set(CTEST_DROP_LOCATION "/submit.php?project={{ urlencode($project->Name) }}")
+endif()
 
 set(CTEST_DROP_SITE_CDASH TRUE)
 


### PR DESCRIPTION
Recreate the variables used in the older method of building the submit site for a CDash submission.  Hide these variables behind a proper version check, as the new style of "CTEST_SUBMIT_URL" was introduced in version 3.14

Fixes #1714 