### PR TITLE
`queryTests.php`: Optimize testmeasurement query

### DIFF
--- a/app/Models/TestMeasurement.php
+++ b/app/Models/TestMeasurement.php
@@ -3,11 +3,30 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @property int $outputid
+ * @property string $name
+ * @property string $type
+ * @property string $value
+ *
+ * @mixin Builder<TestMeasurement>
+ */
 class TestMeasurement extends Model
 {
     protected $table = 'testmeasurement';
-    protected $fillable = ['outputid', 'name', 'type', 'value'];
+
+    protected $fillable = [
+        'outputid',
+        'name',
+        'type',
+        'value',
+    ];
+
+    protected $casts = [
+        'outputid' => 'integer',
+    ];
 
     public $timestamps = false;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3111,21 +3111,11 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 9
+			count: 8
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\QueryTests\\:\\:addExtraMeasurements\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/QueryTests.php
-
-		-
-			message: "#^Method CDash\\\\Controller\\\\Api\\\\QueryTests\\:\\:addExtraMeasurements\\(\\) has parameter \\$outputid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/QueryTests.php
-
-		-
-			message: "#^Method CDash\\\\Controller\\\\Api\\\\QueryTests\\:\\:addExtraMeasurements\\(\\) has parameter \\$test with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
 


### PR DESCRIPTION
`queryTests.php` currently executes a query to check for test measurements for each row in the table.  This contributes to the slowness observed on this page for bigger projects.

The offensive query has been moved outside the loop and now only runs a larger aggregate query once.