### PR TITLE
Increase token length from 128 bits to 512 bits

### DIFF
--- a/app/Services/AuthTokenService.php
+++ b/app/Services/AuthTokenService.php
@@ -28,7 +28,8 @@ class AuthTokenService
      */
     public static function generateToken(int $user_id, int $project_id, string $scope, string $description): array
     {
-        $token = bin2hex(random_bytes(16));
+        // 86 characters generates more than 512 bits of entropy (and is thus limited by the entropy of the hash)
+        $token = generate_password(86);
         $params['hash'] = hash('sha512', $token);
 
         $params['userid'] = $user_id;


### PR DESCRIPTION
Authentication tokens currently only contain 128 bits of entropy.  This PR increases the entropy to 512 bits, which is the maximum value we can use without changing the hashing algorithm.  If we limit the available character set to the 62 upper- and lower-case alphanumeric characters, 86 characters are necessary to exceed 512 bits of entropy, assuming my calculations are correct.