### PR TITLE
Update handler: Ignore empty site field

### DIFF
--- a/app/cdash/xml_handlers/abstract_handler.php
+++ b/app/cdash/xml_handlers/abstract_handler.php
@@ -31,8 +31,7 @@ abstract class AbstractHandler implements SaxHandler, CDashSubmissionHandlerInte
     protected $Append;
     /** @var  Build $Build */
     protected $Build;
-    /** @var  Site $Site */
-    protected $Site;
+    protected Site $Site;
     protected $SubProjectName;
 
     protected $ModelFactory;

--- a/app/cdash/xml_handlers/update_handler.php
+++ b/app/cdash/xml_handlers/update_handler.php
@@ -78,7 +78,11 @@ class UpdateHandler extends AbstractHandler implements ActionableBuildInterface,
     {
         parent::endElement($parser, $name);
         if ($name == 'SITE') {
-            $this->Site->save();
+            if (!isset($this->Site)) {
+                $this->Site = Site::firstOrCreate(['name' => '(unknown)']);
+            } else {
+                $this->Site->save();
+            }
         } elseif ($name == 'UPDATE') {
             $this->Build->SiteId = $this->Site->id;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30546,6 +30546,11 @@ parameters:
 			path: app/cdash/xml_handlers/abstract_handler.php
 
 		-
+			message: "#^Class AbstractHandler has an uninitialized property \\$Site\\. Give it default value or assign it in the constructor\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/abstract_handler.php
+
+		-
 			message: "#^Class stack referenced with incorrect case\\: Stack\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_handler.php


### PR DESCRIPTION
The update handler currently fails when a submission with a blank `<site>` tag is present.

If a blank site tag is included in an update XML file, CDash will now ignore it gracefully.