### PR TITLE
Bump PHPStan to level 8

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,6 +17,11 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Console/Commands/AutoRemoveBuilds.php
@@ -32,8 +37,23 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
 			message: "#^PHPDoc type string of property App\\\\Console\\\\Commands\\\\AutoRemoveBuilds\\:\\:\\$description is not the same as PHPDoc type string\\|null of overridden property Illuminate\\\\Console\\\\Command\\:\\:\\$description\\.$#"
 			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Part \\$projectname \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
@@ -57,8 +77,58 @@ parameters:
 			path: app/Console/Commands/MigrateConfig.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, resource\\|false given\\.$#"
+			count: 2
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
 			message: "#^PHPDoc type string of property App\\\\Console\\\\Commands\\\\MigrateConfig\\:\\:\\$description is not the same as PHPDoc type string\\|null of overridden property Illuminate\\\\Console\\\\Command\\:\\:\\$description\\.$#"
 			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, array\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, array\\|bool\\|string\\|null given\\.$#"
+			count: 2
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_writable expects string, array\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$from of function copy expects string, array\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fgets expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/Console/Commands/MigrateConfig.php
+
+		-
+			message: "#^Part \\$output_filename \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 4
 			path: app/Console/Commands/MigrateConfig.php
 
 		-
@@ -97,6 +167,11 @@ parameters:
 			path: app/Console/Commands/RemoveUser.php
 
 		-
+			message: "#^Part \\$email \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/Console/Commands/RemoveUser.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Console/Commands/SaveUser.php
@@ -112,12 +187,52 @@ parameters:
 			path: app/Console/Commands/SaveUser.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
 			message: "#^PHPDoc type string of property App\\\\Console\\\\Commands\\\\SaveUser\\:\\:\\$description is not the same as PHPDoc type string\\|null of overridden property Illuminate\\\\Console\\\\Command\\:\\:\\$description\\.$#"
 			count: 1
 			path: app/Console/Commands/SaveUser.php
 
 		-
+			message: "#^Parameter \\#1 \\$password of function password_hash expects string, array\\|bool\\|string given\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Part \\$email \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/Console/Commands/SaveUser.php
+
+		-
 			message: "#^Property App\\\\Models\\\\User\\:\\:\\$admin \\(int\\) does not accept array\\|string\\|true\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$email \\(string\\) does not accept array\\|bool\\|string\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$firstname \\(string\\) does not accept array\\|bool\\|string\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$institution \\(string\\) does not accept array\\|bool\\|string\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$lastname \\(string\\) does not accept array\\|bool\\|string\\.$#"
+			count: 1
+			path: app/Console/Commands/SaveUser.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$password \\(string\\) does not accept array\\|bool\\|string\\.$#"
 			count: 1
 			path: app/Console/Commands/SaveUser.php
 
@@ -129,6 +244,11 @@ parameters:
 		-
 			message: "#^Method App\\\\Console\\\\Commands\\\\UpdateDependencies\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/Console/Commands/UpdateDependencies.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, array\\|bool\\|string\\|null given\\.$#"
+			count: 2
 			path: app/Console/Commands/UpdateDependencies.php
 
 		-
@@ -167,9 +287,29 @@ parameters:
 			path: app/Http/Controllers/AbstractBuildController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\AbstractController\\:\\:getCDashVersion\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractController.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractController.php
+
+		-
 			message: "#^Class App\\\\Http\\\\Controllers\\\\AbstractProjectController has an uninitialized property \\$project\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/Http/Controllers/AbstractProjectController.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: app/Http/Controllers/AdminController.php
 
 		-
 			message: "#^Call to an undefined static method App\\\\Models\\\\User\\:\\:PasswordHash\\(\\)\\.$#"
@@ -249,6 +389,56 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Cannot access offset 'groupid' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'major' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'minor' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'projectid' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'submittime' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 'type' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
@@ -284,6 +474,11 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 4
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
@@ -294,8 +489,18 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 11
+			path: app/Http/Controllers/AdminController.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -310,6 +515,11 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property App\\\\Http\\\\Controllers\\\\Auth\\\\LoginController\\:\\:\\$maxAttempts\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/LoginController.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$uuid\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/LoginController.php
 
@@ -339,6 +549,66 @@ parameters:
 			path: app/Http/Controllers/AuthTokenController.php
 
 		-
+			message: "#^Parameter \\#1 \\$user_id of static method App\\\\Services\\\\AuthTokenService\\:\\:generateToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AuthTokenController.php
+
+		-
+			message: "#^Parameter \\#2 \\$expected_user_id of static method App\\\\Services\\\\AuthTokenService\\:\\:deleteToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AuthTokenController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$compilername\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$compilerversion\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osname\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osplatform\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osrelease\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osversion\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Argument of an invalid type array\\<CDash\\\\Model\\\\UploadFile\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 7
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\<isurl\\>' and 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:notes\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -356,6 +626,16 @@ parameters:
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
 
@@ -450,12 +730,52 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function XMLStrFormat expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
+			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 9
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\|false given\\.$#"
+			count: 3
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: "#^Variable \\$buildupdate in isset\\(\\) is never defined\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Note\\:\\:\\$pivot\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildNoteController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:notes\\(\\)\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildNoteController.php
 
@@ -491,6 +811,11 @@ parameters:
 			path: app/Http/Controllers/BuildPropertiesController.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Http/Controllers/CDash.php
@@ -511,9 +836,44 @@ parameters:
 			path: app/Http/Controllers/CDash.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, bool\\|int given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CDash.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of method Symfony\\\\Component\\\\HttpFoundation\\\\Response\\:\\:setStatusCode\\(\\) expects int, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|true given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CDash.php
+
+		-
+			message: "#^Parameter \\#2 \\$status of function response expects int, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|true given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CDash.php
+
+		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: app/Http/Controllers/CDash.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$full_name\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 9
+			path: app/Http/Controllers/CoverageController.php
 
 		-
 			message: """
@@ -544,6 +904,36 @@ parameters:
 				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
 				09/04/2023  Use url\\(\\) instead\\.$#
 			"""
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'branchestested' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'branchesuntested' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'loctested' on array\\|false\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'locuntested' on array\\|false\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'text' on array\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -590,6 +980,11 @@ parameters:
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:ajaxGetViewCoverage\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 3
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:apiCompareCoverage_create_subproject\\(\\) should return array\\<string, mixed\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -683,12 +1078,117 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Offset 'branchcoveragemetric' might not exist on array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: \\(float\\|int\\), covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: numeric\\-string, branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: numeric\\-string, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: 0, covered\\: 0, locuntested\\: 0, loctested\\: 0, branchesuntested\\: 0, branchestested\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'branchcoveragemetric' might not exist on array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: \\(float\\|int\\), covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: numeric\\-string, branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: numeric\\-string, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'branchcoveragemetric' might not exist on array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'branchpercentcovera…' might not exist on array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: \\(float\\|int\\), covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: numeric\\-string, branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: numeric\\-string, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: 0, covered\\: 0, locuntested\\: 0, loctested\\: 0, branchesuntested\\: 0, branchestested\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'functionstested' might not exist on array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: \\(float\\|int\\), covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: numeric\\-string, branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: numeric\\-string, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'functionsuntested' might not exist on array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: \\(float\\|int\\), covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: \\(float\\|int\\), branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: 0, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{branchcoveragemetric\\: numeric\\-string, branchestested\\: \\(float\\|int\\), branchesuntested\\: \\(float\\|int\\), branchpercentcoverage\\: numeric\\-string, coveragemetric\\: numeric\\-string, covered\\: 1, directory\\: 1, fileid\\: 0, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\|array\\{filename\\: string, fullpath\\: mixed, fileid\\: mixed, locuntested\\: mixed, loctested\\: mixed, covered\\: 1, branchesuntested\\: mixed, branchestested\\: mixed, \\.\\.\\.\\}\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'id' might not exist on array\\{\\}\\|array\\{name\\: 'Aggregate Coverage', key\\: non\\-falsy\\-string, id\\: mixed\\}\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Offset 'key' might not exist on array\\{\\}\\|array\\{name\\: 'Aggregate Coverage', key\\: non\\-falsy\\-string, id\\: mixed\\}\\.$#"
+			count: 3
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Only numeric types are allowed in /, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^PHPDoc tag @var with type App\\\\Models\\\\User is not subtype of type Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function rsort expects TArray of array, array\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function sort expects TArray of array, array\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, int\\|string given\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, int\\|false given\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -753,6 +1253,11 @@ parameters:
 			path: app/Http/Controllers/ManageBannerController.php
 
 		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
+			count: 2
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Measurement\\>\\:\\:delete\\(\\)\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
@@ -790,6 +1295,16 @@ parameters:
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$Id\\.$#"
 			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 4
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\{\\}\\|float\\|int\\|string\\|false\\|null and int results in an error\\.$#"
+			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -912,6 +1427,46 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
+			count: 3
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Variable \\$project_array might not be defined\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -938,6 +1493,16 @@ parameters:
 			message: "#^Variable \\$post_user might not be defined\\.$#"
 			count: 8
 			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\<date\\>' and 0\\|0\\.0\\|array\\{\\}\\|string\\|false\\|null results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/MapController.php
 
 		-
 			message: """
@@ -981,6 +1546,11 @@ parameters:
 			path: app/Http/Controllers/MapController.php
 
 		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/MapController.php
+
+		-
 			message: "#^Parameter \\#3 \\$second of function gmmktime expects int\\|null, string given\\.$#"
 			count: 2
 			path: app/Http/Controllers/MapController.php
@@ -998,6 +1568,11 @@ parameters:
 		-
 			message: "#^Parameter \\#6 \\$year of function gmmktime expects int\\|null, string given\\.$#"
 			count: 2
+			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Part \\$date \\(0\\|0\\.0\\|array\\{\\}\\|string\\|false\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
 			path: app/Http/Controllers/MapController.php
 
 		-
@@ -1111,6 +1686,11 @@ parameters:
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_DA_chart_data\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_build_group_name\\(\\) has parameter \\$build_groups with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -1146,6 +1726,11 @@ parameters:
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_chart_data\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_coverage_chart_data\\(\\) has parameter \\$beginning_timestamp with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -1167,6 +1752,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_coverage_chart_data\\(\\) has parameter \\$date_range with no type specified\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\ProjectOverviewController\\:\\:get_coverage_chart_data\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
 
@@ -1291,6 +1881,36 @@ parameters:
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
+			message: "#^Offset 'loctested' might not exist on array\\{\\}\\|array\\{loctested\\?\\: \\(array\\|float\\|int\\), locuntested\\?\\: \\(array\\|float\\|int\\)\\}\\.$#"
+			count: 6
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Offset 'locuntested' might not exist on \\(array\\{\\}&mixed\\)\\|array\\{loctested\\: \\(float\\|int\\), locuntested\\?\\: \\(array\\|float\\|int\\)\\}\\.$#"
+			count: 2
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Offset 'locuntested' might not exist on array\\{loctested\\: \\(float\\|int\\), locuntested\\?\\: \\(array\\|float\\|int\\)\\}\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Offset 'locuntested' might not exist on array\\{\\}\\|array\\{loctested\\?\\: \\(array\\|float\\|int\\), locuntested\\?\\: \\(array\\|float\\|int\\)\\}\\.$#"
+			count: 2
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float given\\.$#"
 			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -1299,6 +1919,16 @@ parameters:
 			message: "#^Variable property access on mixed\\.$#"
 			count: 4
 			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Binary operation \"\\+\" between array\\{\\}\\|float\\|int\\|string\\|false\\|null and 86400 results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
 
 		-
 			message: """
@@ -1346,6 +1976,46 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 6
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'ip' on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'latitude' on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'longitude' on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 'outoforder' on array\\|false\\.$#"
+			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -1509,6 +2179,16 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
+			count: 3
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
@@ -1609,10 +2289,60 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Banner\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Banner\\>\\:\\:\\$text\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'nbuilderrors' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'nbuildwarnings' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'nconfigureerrors' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'nconfigurewarnings' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'npassingbuilds' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'npassingconfigures' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'ntestsfailed' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'ntestsnotrun' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Cannot access offset 'ntestspassed' on array\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubProjectController.php
 
@@ -1647,6 +2377,11 @@ parameters:
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
@@ -1658,6 +2393,21 @@ parameters:
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
 			message: """
@@ -1696,10 +2446,30 @@ parameters:
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$test\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
 			message: """
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
 
@@ -1722,6 +2492,26 @@ parameters:
 			message: "#^Method App\\\\Http\\\\Controllers\\\\TestController\\:\\:details\\(\\) has parameter \\$buildtest_id with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$id\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$outoforder\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
 
 		-
 			message: "#^Call to an undefined static method App\\\\Models\\\\User\\:\\:PasswordHash\\(\\)\\.$#"
@@ -1786,14 +2576,44 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 6
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 2
 			path: app/Http/Controllers/UserController.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed and 'subscribedtoproject' will always evaluate to false\\.$#"
 			count: 1
 			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, array\\|string given\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserNoteController.php
 
 		-
 			message: """
@@ -1870,7 +2690,22 @@ parameters:
 			path: app/Http/Middleware/CheckDatabaseConnection.php
 
 		-
+			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckDirectoryPermissions.php
+
+		-
+			message: "#^Cannot access offset 'uid' on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckDirectoryPermissions.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Middleware\\\\CheckDirectoryPermissions\\:\\:handle\\(\\) throws checked exception UnexpectedValueException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckDirectoryPermissions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, bool\\|string given\\.$#"
 			count: 1
 			path: app/Http/Middleware/CheckDirectoryPermissions.php
 
@@ -1946,6 +2781,11 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$backupFileName\\.$#"
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$backupFileName\\.$#"
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
@@ -2077,6 +2917,11 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 3
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Parameter \\#1 \\$from of function rename expects string, string\\|false given\\.$#"
+			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
 		-
@@ -2253,6 +3098,21 @@ parameters:
 			path: app/Models/Site.php
 
 		-
+			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$description \\(string\\) does not accept int\\|string\\.$#"
+			count: 1
+			path: app/Models/SiteInformation.php
+
+		-
+			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$processorvendor \\(string\\) does not accept int\\|string\\.$#"
+			count: 1
+			path: app/Models/SiteInformation.php
+
+		-
+			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$processorvendorid \\(string\\) does not accept int\\|string\\.$#"
+			count: 1
+			path: app/Models/SiteInformation.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:orWhere\\(\\)\\.$#"
 			count: 1
 			path: app/Models/SubProject.php
@@ -2279,6 +3139,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: app/Models/TestOutput.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/Models/TestOutput.php
 
@@ -2331,6 +3196,11 @@ parameters:
 			message: "#^Variable method call on CDash\\\\Model\\\\User\\.$#"
 			count: 1
 			path: app/Models/User.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: app/Providers/AppServiceProvider.php
 
 		-
 			message: "#^PHPDoc type array of property App\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies is not the same as PHPDoc type array\\<class\\-string, class\\-string\\> of overridden property Illuminate\\\\Foundation\\\\Support\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies\\.$#"
@@ -2443,6 +3313,16 @@ parameters:
 			path: app/Services/AuthTokenService.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/Services/AuthTokenService.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int given\\.$#"
+			count: 1
+			path: app/Services/AuthTokenService.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
@@ -2536,6 +3416,26 @@ parameters:
 			path: app/Services/TestCreator.php
 
 		-
+			message: "#^Parameter \\#1 \\$image of function imagegif expects GdImage, GdImage\\|false given\\.$#"
+			count: 1
+			path: app/Services/TestCreator.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagejpeg expects GdImage, GdImage\\|false given\\.$#"
+			count: 1
+			path: app/Services/TestCreator.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagepng expects GdImage, GdImage\\|false given\\.$#"
+			count: 1
+			path: app/Services/TestCreator.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function crc32 expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Services/TestCreator.php
+
+		-
 			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$time \\(float\\) does not accept string\\.$#"
 			count: 1
 			path: app/Services/TestCreator.php
@@ -2601,7 +3501,32 @@ parameters:
 			path: app/Services/TestCreator.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$difference_negative\\.$#"
+			count: 1
+			path: app/Services/TestDiffService.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$difference_positive\\.$#"
+			count: 1
+			path: app/Services/TestDiffService.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/Services/TestDiffService.php
+
+		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: app/Services/TestDiffService.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 2
+			path: app/Services/TestDiffService.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_column expects array, array\\|false given\\.$#"
 			count: 2
 			path: app/Services/TestDiffService.php
 
@@ -2614,6 +3539,16 @@ parameters:
 			message: "#^Method App\\\\Services\\\\TestingDay\\:\\:get\\(\\) has parameter \\$date with no type specified\\.$#"
 			count: 1
 			path: app/Services/TestingDay.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$authenticatesubmissions\\.$#"
+			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -2636,8 +3571,23 @@ parameters:
 			path: app/Services/UnparsedSubmissionProcessor.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
 			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Parameter \\#2 \\$contents of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:put\\(\\) expects resource\\|string, string\\|false given\\.$#"
+			count: 2
 			path: app/Services/UnparsedSubmissionProcessor.php
 
 		-
@@ -2776,6 +3726,11 @@ parameters:
 			path: app/Validators/Password.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Validators/Password.php
+
+		-
 			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\:\\:\\$pageTimer\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api.php
@@ -2856,6 +3811,21 @@ parameters:
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Binary operation \"\\+\" between int\\|string\\|false and 1 results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Binary operation \"\\.\\=\" between list\\<string\\>\\|string and string results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
 			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -2879,6 +3849,16 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 5
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Cannot access offset 'a' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Cannot access offset 'query' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\|false\\.$#"
+			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
@@ -2967,6 +3947,31 @@ parameters:
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 3
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 4
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
 			message: "#^Property CDash\\\\Controller\\\\Api\\\\Index\\:\\:\\$buildStartTimes type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
@@ -2988,6 +3993,11 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Controller\\\\Api\\\\Index\\:\\:\\$labelIds type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
+			message: "#^Property CDash\\\\Controller\\\\Api\\\\Index\\:\\:\\$numChildrenForBuildCache \\(array\\<int, int\\>\\|null\\) does not accept array\\<int\\|string, mixed\\>\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
 
@@ -3092,6 +4102,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
 				04/01/2023$#
@@ -3166,6 +4181,36 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\QueryTests\\:\\:rowSurvivesTestOutputFilter\\(\\) has parameter \\$row with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\<\\-1, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<\\-1, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, float\\|int given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
@@ -3260,6 +4305,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/ResultsApi.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_sum expects array, array\\<string, array\\<int, string\\>\\|int\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ResultsApi.php
+
+		-
 			message: "#^Property CDash\\\\Controller\\\\Api\\\\ResultsApi\\:\\:\\$beginDate has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ResultsApi.php
@@ -3320,6 +4370,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
 		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/cdash/app/Controller/Api/TestDetails.php
@@ -3376,6 +4431,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\TestDetails\\:\\:utf8_for_xml\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
@@ -3441,6 +4501,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\TestOverview\\:\\:getResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestOverview.php
+
+		-
+			message: "#^Offset 'subproject' might not exist on array\\{failed\\: int\\<0, max\\>, name\\: mixed, passed\\: int\\<0, max\\>, subproject\\?\\: mixed, time\\: mixed, timeout\\: int\\<0, max\\>\\}\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestOverview.php
 
@@ -3606,9 +4671,49 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
 		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
 			message: "#^Property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$projectids has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$compilername\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$compilerversion\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osname\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osplatform\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osrelease\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildInformation\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildInformation\\>\\:\\:\\$osversion\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
 			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewTest\\:\\:\\$build\\.$#"
@@ -3622,6 +4727,16 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewTest\\:\\:\\$pageTimer\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$projectid\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
@@ -3778,6 +4893,26 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fputcsv expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function stream_get_contents expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
@@ -4154,6 +5289,16 @@ parameters:
 			path: app/cdash/app/Middleware/OAuth2.php
 
 		-
+			message: "#^Cannot call method query\\(\\) on array\\|Illuminate\\\\Http\\\\Request\\|string\\.$#"
+			count: 2
+			path: app/cdash/app/Middleware/OAuth2.php
+
+		-
+			message: "#^Cannot call method session\\(\\) on array\\|Illuminate\\\\Http\\\\Request\\|string\\.$#"
+			count: 2
+			path: app/cdash/app/Middleware/OAuth2.php
+
+		-
 			message: "#^Method CDash\\\\Middleware\\\\OAuth2\\:\\:getEmail\\(\\) return type with generic class Illuminate\\\\Support\\\\Collection does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: app/cdash/app/Middleware/OAuth2.php
@@ -4244,6 +5389,96 @@ parameters:
 			path: app/cdash/app/Model/ActionableTypes.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timemean\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timestatus\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timestd\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$builderrors\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$buildwarnings\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$configureerrors\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$configurewarnings\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$done\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$notified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$testfailed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$testnotrun\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$testpassed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$difference\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$groupid\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$time\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:save\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:save\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -4282,6 +5517,66 @@ parameters:
 
 		-
 			message: "#^Call to method CDash\\\\Model\\\\Build\\:\\:IsParentBuild\\(\\) with incorrect case\\: isParentBuild$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'builderrorsnegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'builderrorspositive' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'buildwarningsnegati…' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'buildwarningspositi…' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'configureerrors' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'configurewarnings' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testfailednegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testfailedpositive' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testnotrunnegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testnotrunpositive' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testpassednegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access offset 'testpassedpositive' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4462,6 +5757,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetDiffWithPreviousBuild\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetErrorDifferences\\(\\) should return array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false but returns array\\<'builderrorsnegative'\\|'builderrorspositive'\\|'buildwarningsnegati…'\\|'buildwarningspositi…'\\|'configureerrors'\\|'configurewarnings'\\|'testfailednegative'\\|'testfailedpositive'\\|'testnotrunnegative'\\|'testnotrunpositive'\\|'testpassednegative'\\|'testpassedpositive', int\\>\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -4681,6 +5981,11 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
+			message: "#^Only booleans are allowed in &&, string\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -4688,6 +5993,56 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 4
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\*, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 7
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -4931,6 +6286,11 @@ parameters:
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\BuildConfigure\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
@@ -5002,6 +6362,16 @@ parameters:
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
+			count: 5
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
@@ -5057,6 +6427,11 @@ parameters:
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
+			message: "#^Only booleans are allowed in a ternary operator condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
@@ -5064,6 +6439,11 @@ parameters:
 		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$notification$#"
 			count: 1
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
@@ -5220,6 +6600,11 @@ parameters:
 		-
 			message: "#^Access to an undefined property CDash\\\\Model\\\\BuildErrorFilter\\:\\:\\$PDO\\.$#"
 			count: 8
+			path: app/cdash/app/Model/BuildErrorFilter.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
 			path: app/cdash/app/Model/BuildErrorFilter.php
 
 		-
@@ -5457,6 +6842,11 @@ parameters:
 			path: app/cdash/app/Model/BuildFailure.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|false\\|null given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildFailure.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\BuildFailure\\:\\:\\$Arguments has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildFailure.php
@@ -5542,6 +6932,16 @@ parameters:
 			path: app/cdash/app/Model/BuildGroup.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$groupid\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -5602,6 +7002,11 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroup.php
 
@@ -5732,6 +7137,16 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroup\\:\\:SetType\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 4
+			path: app/cdash/app/Model/BuildGroup.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroup.php
 
@@ -5901,6 +7316,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:SoftDeleteExpiredRules\\(\\) has parameter \\$now with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildGroupRule.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
 
@@ -6086,6 +7506,26 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$nfiles\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$parentid\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$updateid\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$warnings\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -6142,6 +7582,11 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
 			path: app/cdash/app/Model/BuildUpdate.php
@@ -6173,6 +7618,21 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildUpdate\\:\\:GetUpdateForBuild\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 2
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 3
+			path: app/cdash/app/Model/BuildUpdate.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdate.php
 
@@ -6268,6 +7728,11 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
 		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUpdateFile.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\BuildUpdateFile\\:\\:\\$Author has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdateFile.php
@@ -6323,6 +7788,11 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$full_name\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUserNote.php
+
+		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -6371,6 +7841,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildUserNote\\:\\:marshal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildUserNote.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUserNote.php
 
@@ -6597,6 +8072,11 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function base64_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFile.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\CoverageFile\\:\\:\\$Crc32 has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile.php
@@ -6625,6 +8105,16 @@ parameters:
 			message: "#^Property CDash\\\\Model\\\\CoverageFile\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/app/Model/CoverageFile2User.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
 			message: """
@@ -6659,6 +8149,11 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/app/Model/CoverageFile2User.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
 			path: app/cdash/app/Model/CoverageFile2User.php
@@ -6670,6 +8165,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\CoverageFile2User\\:\\:GetCoverageFileId\\(\\) has parameter \\$buildid with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFile2User.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
 
@@ -6699,6 +8199,11 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$log\\.$#"
+			count: 2
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
 			message: "#^Binary operation \"\\-\" between string and string results in an error\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
@@ -6717,6 +8222,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 3
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Cannot access offset 'fullpath' on array\\|false\\.$#"
+			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
@@ -6800,6 +8310,21 @@ parameters:
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|false\\|null given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\CoverageFileLog\\:\\:\\$AggregateBuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
@@ -6835,6 +8360,26 @@ parameters:
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$loctested\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$locuntested\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$parentid\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -6864,6 +8409,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 4
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
@@ -6909,6 +8459,16 @@ parameters:
 		-
 			message: "#^Method CDash\\\\Model\\\\CoverageSummary\\:\\:Insert\\(\\) has parameter \\$append with no type specified\\.$#"
 			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 2
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 2
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
@@ -7077,6 +8637,11 @@ parameters:
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/DynamicAnalysis.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/app/Model/DynamicAnalysis.php
@@ -7134,6 +8699,11 @@ parameters:
 		-
 			message: "#^Method CDash\\\\Model\\\\DynamicAnalysis\\:\\:Insert\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/app/Model/DynamicAnalysis.php
+
+		-
+			message: "#^Parameter \\#1 \\$context of function inflate_add expects InflateContext, InflateContext\\|false given\\.$#"
+			count: 2
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -7346,6 +8916,21 @@ parameters:
 			path: app/cdash/app/Model/Image.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
+			count: 11
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
@@ -7362,6 +8947,26 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 4
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fread expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<0, max\\>, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
 
@@ -7480,12 +9085,27 @@ parameters:
 			path: app/cdash/app/Model/LabelEmail.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/LabelEmail.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/app/Model/LabelEmail.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\LabelEmail\\:\\:UpdateLabels\\(\\) has parameter \\$labels with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/LabelEmail.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/LabelEmail.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/LabelEmail.php
 
@@ -7644,7 +9264,32 @@ parameters:
 			path: app/cdash/app/Model/PendingSubmissions.php
 
 		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: "#^Access to an uninitialized property CDash\\\\Model\\\\Project\\:\\:\\$AutoremoveMaxBuilds\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:fill\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:save\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -7695,6 +9340,21 @@ parameters:
 
 		-
 			message: "#^Call to method DateTime\\:\\:setTimestamp\\(\\) with incorrect case\\: setTimeStamp$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -7839,7 +9499,27 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
+			message: "#^Only numeric types are allowed in \\-, float\\|int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects 0\\|2, false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects non\\-empty\\-string, string given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -8101,6 +9781,11 @@ parameters:
 			path: app/cdash/app/Model/Repository.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Repository.php
+
+		-
 			message: "#^Method CDash\\\\Model\\\\Repository\\:\\:compareCommits\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Repository.php
@@ -8167,6 +9852,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$repository of class CDash\\\\Service\\\\RepositoryService constructor expects CDash\\\\Lib\\\\Repository\\\\RepositoryInterface, CDash\\\\Model\\\\RepositoryInterface given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Repository.php
 
@@ -8303,6 +9993,11 @@ parameters:
 			path: app/cdash/app/Model/SubProject.php
 
 		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProject.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -8348,6 +10043,11 @@ parameters:
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProjectGroup.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 6
 			path: app/cdash/app/Model/SubProjectGroup.php
@@ -8369,6 +10069,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getUserCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getUserCredentials\\(\\) should return array but returns array\\|bool\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
 
@@ -8730,6 +10435,11 @@ parameters:
 			path: app/cdash/app/Model/UserProject.php
 
 		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/app/Model/UserProject.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/app/Model/UserProject.php
@@ -8865,6 +10575,16 @@ parameters:
 			path: app/cdash/bootstrap/cdash_autoload.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_slice expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/bootstrap/cdash_autoload.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/bootstrap/cdash_autoload.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Config.php
@@ -8920,6 +10640,16 @@ parameters:
 			path: app/cdash/include/CDash/Config.php
 
 		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
 			message: "#^Method CDash\\\\Database\\:\\:execute\\(\\) has parameter \\$input_parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
@@ -8947,6 +10677,16 @@ parameters:
 		-
 			message: "#^Method CDash\\\\Database\\:\\:prepare\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/include/CDash/Database.php
 
 		-
@@ -9786,6 +11526,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
+
+		-
 			message: "#^Property CDash\\\\Messaging\\\\Topic\\\\BuildErrorTopic\\:\\:\\$collection has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/BuildErrorTopic.php
@@ -10016,6 +11761,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/MissingTestTopic.php
 
 		-
+			message: "#^Method CDash\\\\Messaging\\\\Topic\\\\MissingTestTopic\\:\\:getTopicCollection\\(\\) should return CDash\\\\Messaging\\\\Topic\\\\Illuminate\\\\Support\\\\Collection but returns CDash\\\\Messaging\\\\Topic\\\\Illuminate\\\\Support\\\\Collection\\|Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\), mixed\\>\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/MissingTestTopic.php
+
+		-
 			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$test is not writable\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/MissingTestTopic.php
@@ -10106,6 +11856,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, array\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
+
+		-
 			message: "#^Parameter \\#2 \\$item \\(App\\\\Models\\\\Test\\) of method CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:itemHasTopicSubject\\(\\) should be contravariant with parameter \\$item \\(mixed\\) of method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:itemHasTopicSubject\\(\\)$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
@@ -10117,6 +11872,11 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:\\$collection with generic class Illuminate\\\\Support\\\\Collection does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
+
+		-
+			message: "#^Property CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:\\$diff \\(array\\) does not accept array\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
@@ -10402,12 +12162,27 @@ parameters:
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashTestCase.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, CDash\\\\Database given\\.$#"
 			count: 1
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashTestCase.php
+
+		-
+			message: "#^Property CDash\\\\Test\\\\CDashTestCase\\:\\:\\$endpoint \\(string\\) does not accept string\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/Test/CDashTestCase.php
 
@@ -10449,6 +12224,16 @@ parameters:
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$Id\\.$#"
 			count: 2
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$Name\\.$#"
+			count: 1
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$SubProjectName\\.$#"
+			count: 1
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
 
 		-
@@ -10865,6 +12650,11 @@ parameters:
 			path: app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
+
+		-
 			message: "#^Property CDash\\\\Test\\\\UseCase\\\\DynamicAnalysisUseCase\\:\\:\\$checker has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
@@ -10971,6 +12761,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Test\\\\UseCase\\\\TestUseCase\\:\\:setTestStatus\\(\\) has parameter \\$status with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/TestUseCase.php
+
+		-
+			message: "#^Offset 'dirname' might not exist on array\\{dirname\\?\\: string, basename\\: string, extension\\?\\: string, filename\\: string\\}\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/TestUseCase.php
 
@@ -11145,6 +12940,11 @@ parameters:
 			path: app/cdash/include/Test/UseCase/UpdateUseCase.php
 
 		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/UpdateUseCase.php
+
+		-
 			message: "#^Property CDash\\\\Test\\\\UseCase\\\\UpdateUseCase\\:\\:\\$generator has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/UpdateUseCase.php
@@ -11196,6 +12996,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Test\\\\UseCase\\\\UseCase\\:\\:createBuilder\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/UseCase.php
+
+		-
+			message: "#^Method CDash\\\\Test\\\\UseCase\\\\UseCase\\:\\:createBuilder\\(\\) should return CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\|CDash\\\\Test\\\\UseCase\\\\ConfigUseCase\\|CDash\\\\Test\\\\UseCase\\\\TestUseCase\\|CDash\\\\Test\\\\UseCase\\\\UpdateUseCase but returns CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\|CDash\\\\Test\\\\UseCase\\\\ConfigUseCase\\|CDash\\\\Test\\\\UseCase\\\\DynamicAnalysisUseCase\\|CDash\\\\Test\\\\UseCase\\\\TestUseCase\\|CDash\\\\Test\\\\UseCase\\\\UpdateUseCase\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/UseCase.php
 
@@ -11506,6 +13311,11 @@ parameters:
 			path: app/cdash/include/api_common.php
 
 		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/include/autoremove.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -11618,6 +13428,16 @@ parameters:
 			path: app/cdash/include/cdashmail.php
 
 		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Call to an undefined method Archive_Tar\\:\\:setErrorHandling\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -11712,6 +13532,11 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -12086,8 +13911,28 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 3
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
 			path: app/cdash/include/common.php
 
 		-
@@ -12097,6 +13942,91 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 3
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset expects array\\|object, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, array\\<int, string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function stripos expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 4
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$num of function is_infinite expects float, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$num of function is_nan expects float, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$source of method DOMDocument\\:\\:loadXML\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#2 \\$baseTimestamp of function strtotime expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function fwrite expects string, array\\<int, string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -12112,6 +14042,16 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property BuildHandler\\|ConfigureHandler\\|CoverageHandler\\|CoverageJUnitHandler\\|CoverageLogHandler\\|DoneHandler\\|DynamicAnalysisHandler\\|NoteHandler\\|ProjectHandler\\|TestingHandler\\|TestingJUnitHandler\\|UpdateHandler\\|UploadHandler\\:\\:\\$backupFileName\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$backupFileName\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:Parse\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/include/ctestparser.php
 
@@ -12243,6 +14183,16 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|false given\\.$#"
+			count: 13
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function xml_parse expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/include/ctestparser.php
+
+		-
 			message: """
 				#^Call to deprecated function get_link_identifier\\(\\)\\:
 				04/22/2023$#
@@ -12332,6 +14282,21 @@ parameters:
 			path: app/cdash/include/ctestparserutils.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparserutils.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\<0, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparserutils.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 6
+			path: app/cdash/include/dailyupdates.php
+
+		-
 			message: "#^Backtick operator is not allowed\\. Use shell_exec\\(\\) instead\\.$#"
 			count: 10
 			path: app/cdash/include/dailyupdates.php
@@ -12418,6 +14383,26 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			count: 4
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot access offset 'status' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
@@ -12592,7 +14577,87 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
+			message: "#^Offset 'comment' might not exist on array\\{author\\?\\: string, comment\\?\\: string, directory\\?\\: string, email\\?\\: string, filename\\?\\: string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Offset 'comment' might not exist on array\\{\\}\\|array\\{author\\?\\: string, comment\\?\\: string, directory\\?\\: string, email\\?\\: string, filename\\?\\: string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
 			message: "#^Offset 'filename' on array\\{author\\?\\: string, comment\\?\\: string, directory\\: string, email\\?\\: string, filename\\: string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Offset 'revision' might not exist on array\\{author\\?\\: string, comment\\?\\: string, directory\\: string, email\\?\\: string, filename\\: non\\-empty\\-string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Offset 'revision' might not exist on array\\{author\\?\\: string, comment\\?\\: string, directory\\: string, email\\?\\: string, filename\\: string, priorrevision\\?\\: '', revision\\?\\: string, time\\?\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 3
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 3
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 4
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the right side\\.$#"
+			count: 2
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, int\\|false given\\.$#"
+			count: 7
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\<0, max\\>\\|false given\\.$#"
+			count: 2
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#3 \\$offset of function strpos expects int, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
@@ -13075,6 +15140,21 @@ parameters:
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strrpos expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 8
 			path: app/cdash/include/filterdataFunctions.php
@@ -13244,6 +15324,11 @@ parameters:
 			path: app/cdash/include/pdo.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/pdo.php
+
+		-
 			message: "#^Function pdo_execute\\(\\) has parameter \\$input_parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
@@ -13289,6 +15374,11 @@ parameters:
 			path: app/cdash/include/pdo.php
 
 		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, int\\|string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/pdo.php
+
+		-
 			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
 			count: 2
 			path: app/cdash/include/repository.php
@@ -13330,6 +15420,16 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Cannot access offset 'cvsurl' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/repository.php
 
@@ -14564,6 +16664,51 @@ parameters:
 			path: app/cdash/include/repository.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_close expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_error expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_exec expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_setopt expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 7
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|true given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
 			count: 2
 			path: app/cdash/include/repository.php
@@ -14574,8 +16719,23 @@ parameters:
 			path: app/cdash/include/sendemail.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$log\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$status\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
 			message: "#^Anonymous function has an unused use \\$buildid\\.$#"
 			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 6
 			path: app/cdash/include/sendemail.php
 
 		-
@@ -14620,6 +16780,41 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'builderrorsnegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'buildwarningsnegati…' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 2
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'buildwarningspositi…' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'configureerrors' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'configurewarnings' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'testfailednegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot access offset 'testnotrunnegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
 
@@ -14682,6 +16877,36 @@ parameters:
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetErrorDifferences\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_slice expects array, array\\|false given\\.$#"
+			count: 4
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
+			count: 6
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Argument of an invalid type PDOStatement\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
 
 		-
 			message: """
@@ -14777,6 +17002,51 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 5
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'configureduration' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'duration' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'timemean' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 'timestd' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
 			path: app/cdash/include/upgrade_functions.php
 
 		-
@@ -15150,13 +17420,48 @@ parameters:
 			path: app/cdash/include/upgrade_functions.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|false\\|null given on the left side\\.$#"
+			count: 2
+			path: app/cdash/include/upgrade_functions.php
+
+		-
 			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 7
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, PDOStatement\\|false given\\.$#"
+			count: 3
+			path: app/cdash/include/upgrade_functions.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|string\\|false\\|null given\\.$#"
+			count: 2
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Only numeric types are allowed in /, int\\|false given on the right side\\.$#"
+			count: 3
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 4
 			path: app/cdash/include/upgrade_functions.php
 
 		-
@@ -15200,6 +17505,11 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function hash_hmac expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
@@ -15281,6 +17591,21 @@ parameters:
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
+			path: app/cdash/public/api/v1/build.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/build.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/build.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 2
 			path: app/cdash/public/api/v1/build.php
 
 		-
@@ -15462,6 +17787,11 @@ parameters:
 			path: app/cdash/public/api/v1/deleteSubmissionFile.php
 
 		-
+			message: "#^Binary operation \"\\-\" between float\\|int\\|string and int\\|false results in an error\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -15498,6 +17828,11 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/expectedbuild.php
 
@@ -15587,9 +17922,49 @@ parameters:
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/expectedbuild.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/getSubmissionFile.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Banner\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Banner\\>\\:\\:\\$text\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
 
 		-
 			message: """
@@ -15597,6 +17972,51 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 3
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'nbuilderrors' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'nbuildwarnings' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'nconfigureerrors' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'nconfigurewarnings' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'npassingbuilds' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'npassingconfigures' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'ntestsfailed' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'ntestsnotrun' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot access offset 'ntestspassed' on array\\|false\\.$#"
+			count: 1
 			path: app/cdash/public/api/v1/index.php
 
 		-
@@ -15613,6 +18033,46 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Measurement\\>\\:\\:where\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Offset 'loctested' might not exist on array\\{\\}\\|array\\{thresholdgreen\\?\\: int\\|null, thresholdyellow\\?\\: float, label\\?\\: string\\|false, loctested\\?\\: mixed, locuntested\\?\\: int, position\\?\\: int, coverages\\?\\: list\\<array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, datefull\\: int\\|false, date\\: string, dateelapsed\\: string, \\.\\.\\.\\}\\|array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, percentagediff\\: float, locuntesteddiff\\: int, loctesteddiff\\: int\\<1, max\\>, \\.\\.\\.\\}\\>\\}\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Offset 'locuntested' might not exist on array\\{thresholdgreen\\?\\: int\\|null, thresholdyellow\\?\\: float, label\\?\\: string\\|false, loctested\\: \\(float\\|int\\), locuntested\\?\\: int, position\\?\\: int, coverages\\?\\: list\\<array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, datefull\\: int\\|false, date\\: string, dateelapsed\\: string, \\.\\.\\.\\}\\|array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, percentagediff\\: float, locuntesteddiff\\: int, loctesteddiff\\: int\\<1, max\\>, \\.\\.\\.\\}\\>\\}\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Offset 'locuntested' might not exist on array\\{\\}\\|array\\{thresholdgreen\\?\\: int\\|null, thresholdyellow\\?\\: float, label\\?\\: string\\|false, loctested\\?\\: mixed, locuntested\\?\\: int, position\\?\\: int, coverages\\?\\: list\\<array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, datefull\\: int\\|false, date\\: string, dateelapsed\\: string, \\.\\.\\.\\}\\|array\\{buildid\\: int, childlink\\?\\: non\\-falsy\\-string, percentage\\: float, locuntested\\: int, loctested\\: int, percentagediff\\: float, locuntesteddiff\\: int, loctesteddiff\\: int\\<1, max\\>, \\.\\.\\.\\}\\>\\}\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 6
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
+			count: 4
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$name\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
 			message: """
@@ -15660,6 +18120,21 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 6
 			path: app/cdash/public/api/v1/manageBuildGroup.php
@@ -15680,9 +18155,24 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|float\\|int\\|string\\|false\\|null given on the left side\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
 			message: "#^Variable \\$user2project might not be defined\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/manageOverview.php
 
 		-
 			message: """
@@ -15714,6 +18204,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 4
+			path: app/cdash/public/api/v1/manageOverview.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
 			path: app/cdash/public/api/v1/manageOverview.php
 
 		-
@@ -15835,6 +18330,31 @@ parameters:
 			path: app/cdash/public/api/v1/project.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, int\\|string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Trying to invoke non\\-falsy\\-string but it might not be a callable\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Variable \\$filetype might not be defined\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
@@ -15925,6 +18445,11 @@ parameters:
 
 		-
 			message: "#^Function CDash\\\\Api\\\\v1\\\\SubProject\\\\rest_put\\(\\) has parameter \\$projectid with no type specified\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/subproject.php
 
@@ -18420,6 +20945,26 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 
 		-
+			message: "#^Cannot access offset 'BuildError' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
+			message: "#^Cannot access offset 'BuildWarning' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
+			message: "#^Cannot access offset 'Configure' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
+			message: "#^Cannot access offset 'TestFailure' on array\\|false\\.$#"
+			count: 6
+			path: app/cdash/tests/case/CDash/Model/BuildTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 12
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
@@ -19647,6 +22192,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_db.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 4
+			path: app/cdash/tests/kwtest/kw_db.php
+
+		-
 			message: "#^Property database\\:\\:\\$dbo has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
@@ -19697,6 +22247,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_db.php
 
 		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_test_manager.php
+
+		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_test_manager.php
@@ -19732,8 +22287,18 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_test_manager.php
 
 		-
+			message: "#^Offset 'dirname' might not exist on array\\{dirname\\?\\: string, basename\\: string, extension\\?\\: string, filename\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_test_manager.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\<\\-1, 1\\> given\\.$#"
 			count: 2
+			path: app/cdash/tests/kwtest/kw_test_manager.php
+
+		-
+			message: "#^Parameter \\#1 \\$reporter of method TestSuite\\:\\:run\\(\\) expects SimpleReporter, object given\\.$#"
+			count: 1
 			path: app/cdash/tests/kwtest/kw_test_manager.php
 
 		-
@@ -19760,6 +22325,11 @@ parameters:
 			message: "#^Function cdash_testsuite_unlink\\(\\) has parameter \\$filename with no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_unlink.php
+
+		-
+			message: "#^Argument of an invalid type array\\|string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
 			message: "#^Call to an undefined method Psr\\\\Log\\\\LoggerInterface\\:\\:getHandlers\\(\\)\\.$#"
@@ -20226,6 +22796,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Only booleans are allowed in &&, string given on the left side\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -20236,8 +22811,58 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, object given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
 			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_close expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_exec expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_getinfo expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$handle of function curl_setopt expects CurlHandle, CurlHandle\\|false given\\.$#"
+			count: 7
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$message of class Exception constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$mystring of method KWWebTestCase\\:\\:findString\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
@@ -20247,6 +22872,21 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$responses of method WebTestCase\\:\\:assertResponse\\(\\) expects array, int given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$socket of class SimpleHttpResponse constructor expects SimpleSocket, object given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -20261,7 +22901,32 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects int, int\\<0, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#3 \\$value of function curl_setopt expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#7 \\$content of static method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:create\\(\\) expects resource\\|string\\|null, string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Part \\$page \\(object\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -20380,8 +23045,18 @@ parameters:
 			path: app/cdash/tests/manageCoverageTest.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/manageCoverageTest.php
+
+		-
 			message: "#^Method ManageCoverageTestCase\\:\\:testManageCoverageTest\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/manageCoverageTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/manageCoverageTest.php
 
 		-
@@ -20605,6 +23280,11 @@ parameters:
 			path: app/cdash/tests/simple2.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/singletest.php
+
+		-
 			message: "#^Method ActualBranchCoverageTestCase\\:\\:testBranchCoverage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_actualbranchcoverage.php
@@ -20635,6 +23315,11 @@ parameters:
 				#^Call to deprecated method query\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_actualtrilinossubmission.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
@@ -20675,6 +23360,11 @@ parameters:
 
 		-
 			message: "#^Method ActualTrilinosSubmissionTestCase\\:\\:testSubProjectBuildErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_actualtrilinossubmission.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
@@ -20749,6 +23439,16 @@ parameters:
 
 		-
 			message: "#^Method AggregateCoverageTestCase\\:\\:testAggregateCoverage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|true given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatecoverage.php
 
@@ -20874,7 +23574,22 @@ parameters:
 			path: app/cdash/tests/test_attachedfiles.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_attachedfiles.php
+
+		-
 			message: "#^Method AttachedFilesTestCase\\:\\:testAttachedFiles\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_attachedfiles.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_attachedfiles.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_attachedfiles.php
 
@@ -21018,6 +23733,11 @@ parameters:
 			path: app/cdash/tests/test_authtoken.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool\\|string given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
@@ -21083,6 +23803,11 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_autoremovebuilds.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
@@ -21136,6 +23861,26 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Cannot call method bindValue\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 4
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -21153,6 +23898,21 @@ parameters:
 		-
 			message: "#^Method AutoRemoveBuildsOnSubmitTestCase\\:\\:testBuildsRemovedOnSubmission\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|string\\|false\\|null given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 4
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
@@ -21301,6 +24061,11 @@ parameters:
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 3
 			path: app/cdash/tests/test_branchcoverage.php
@@ -21336,12 +24101,27 @@ parameters:
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool\\|string given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects bool, int given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
+			message: "#^Part \\$this\\-\\>buildid \\(0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
@@ -21377,6 +24157,16 @@ parameters:
 			path: app/cdash/tests/test_buildconfigure.php
 
 		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildconfigure.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildconfigure.php
+
+		-
 			message: "#^Method BuildConfigureTestCase\\:\\:testBuildConfigure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildconfigure.php
@@ -21389,6 +24179,16 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
+			path: app/cdash/tests/test_buildconfigure.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildconfigure.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_buildconfigure.php
 
 		-
@@ -21418,6 +24218,11 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 4
 			path: app/cdash/tests/test_builddetails.php
 
 		-
@@ -21471,6 +24276,11 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
 			message: "#^Property BuildDetailsTestCase\\:\\:\\$builds has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_builddetails.php
@@ -21512,6 +24322,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_buildfailuredetails.php
+
+		-
+			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			count: 6
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
@@ -21682,6 +24497,11 @@ parameters:
 			path: app/cdash/tests/test_buildmodel.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildmodel.php
+
+		-
 			message: "#^Property BuildModelTestCase\\:\\:\\$builds has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildmodel.php
@@ -21820,6 +24640,11 @@ parameters:
 			path: app/cdash/tests/test_buildproperties.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
 			message: "#^Property BuildPropertiesTestCase\\:\\:\\$Builds has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildproperties.php
@@ -21876,6 +24701,11 @@ parameters:
 			path: app/cdash/tests/test_buildusernote.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildusernote.php
+
+		-
 			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -21892,7 +24722,17 @@ parameters:
 			path: app/cdash/tests/test_changeid.php
 
 		-
+			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_changeid.php
+
+		-
 			message: "#^Method ChangeIdTestCase\\:\\:testChangeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_changeid.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_changeid.php
 
@@ -21924,6 +24764,11 @@ parameters:
 		-
 			message: "#^Method CommitAuthorNotificationTestCase\\:\\:testCommitAuthorsReceiveTestFailureNotifications\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_commitauthornotification.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of static method Illuminate\\\\Support\\\\Str\\:\\:contains\\(\\) expects string, string\\|false given\\.$#"
+			count: 9
 			path: app/cdash/tests/test_commitauthornotification.php
 
 		-
@@ -22013,6 +24858,11 @@ parameters:
 			path: app/cdash/tests/test_configurewarnings.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 4
+			path: app/cdash/tests/test_configurewarnings.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_configurewarnings.php
@@ -22025,6 +24875,11 @@ parameters:
 		-
 			message: "#^Method ConfigureWarningTestCase\\:\\:testConfigureWarningDiff\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_configurewarnings.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 3
 			path: app/cdash/tests/test_configurewarnings.php
 
 		-
@@ -22049,7 +24904,17 @@ parameters:
 			path: app/cdash/tests/test_consistenttestingday.php
 
 		-
+			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
 			message: "#^Method ConsistentTestingDayTestCase\\:\\:testConsistentTestingDay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_consistenttestingday.php
 
@@ -22082,6 +24947,16 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 3
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
 			path: app/cdash/tests/test_createprojectpermissions.php
 
 		-
@@ -22134,6 +25009,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
@@ -22242,6 +25122,11 @@ parameters:
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
 			message: "#^Property CoverageAcrossSubProjectsTestCase\\:\\:\\$DataDir has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
@@ -22255,9 +25140,44 @@ parameters:
 			path: app/cdash/tests/test_csvexport.php
 
 		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_csvexport.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_csvexport.php
+
+		-
 			message: "#^Method ExportToCSVTestCase\\:\\:testExportToCSV\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_csvexport.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$builderrors\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$buildwarnings\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 4
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$testfailed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$testpassed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
 
 		-
 			message: "#^Method DeferredSubmissionsTestCase\\:\\:getToken\\(\\) has no return type specified\\.$#"
@@ -22325,6 +25245,16 @@ parameters:
 			path: app/cdash/tests/test_deferredsubmissions.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 4
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
 			message: "#^Property DeferredSubmissionsTestCase\\:\\:\\$ConfigFile has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_deferredsubmissions.php
@@ -22381,8 +25311,18 @@ parameters:
 			path: app/cdash/tests/test_disabledtests.php
 
 		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
 			message: "#^Method DisabledTestsTestCase\\:\\:testDisabledTests\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_disabledtests.php
 
 		-
@@ -22420,6 +25360,31 @@ parameters:
 
 		-
 			message: "#^Method DoneHandlerTestCase\\:\\:testDoneHandlerRemote\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function unlink expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_donehandler.php
 
@@ -22496,6 +25461,16 @@ parameters:
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_dynamicanalysissummary.php
+
+		-
+			message: "#^Cannot access offset 'numdefects' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_dynamicanalysissummary.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 5
 			path: app/cdash/tests/test_dynamicanalysissummary.php
@@ -22533,6 +25508,11 @@ parameters:
 		-
 			message: "#^Method DynamicAnalysisSummaryTestCase\\:\\:testSubProjectDynamicAnalysisSummary\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_dynamicanalysissummary.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
@@ -22576,6 +25556,11 @@ parameters:
 			path: app/cdash/tests/test_edituser.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
 			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -22602,6 +25587,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -22647,6 +25637,11 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -22802,6 +25797,11 @@ parameters:
 			path: app/cdash/tests/test_expiredbuildrules.php
 
 		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expiredbuildrules.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
 				04/01/2023$#
@@ -22815,6 +25815,11 @@ parameters:
 			path: app/cdash/tests/test_externallinksfromtests.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
 			message: "#^Method ExternalLinksFromTestsTestCase\\:\\:testExternalLinksFromTests\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_externallinksfromtests.php
@@ -22822,6 +25827,11 @@ parameters:
 		-
 			message: "#^Method ExtractTarTestCase\\:\\:testExtractTarArchiveTarWithInvalidFile\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_extracttar.php
+
+		-
+			message: "#^Parameter \\#1 \\$mystring of method KWWebTestCase\\:\\:findString\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_extracttar.php
 
 		-
@@ -22956,6 +25966,11 @@ parameters:
 			path: app/cdash/tests/test_hidecolumns.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 16
 			path: app/cdash/tests/test_hidecolumns.php
@@ -23013,6 +26028,11 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_imagecomparison.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_imagecomparison.php
 
@@ -23262,6 +26282,16 @@ parameters:
 		-
 			message: "#^Method LotsOfSubProjectsTestCase\\:\\:testLotsOfSubProjects\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_lotsofsubprojects.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 5
+			path: app/cdash/tests/test_lotsofsubprojects.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function fwrite expects string, string\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_lotsofsubprojects.php
 
 		-
@@ -23545,6 +26575,16 @@ parameters:
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplesubprojects.php
@@ -23635,7 +26675,22 @@ parameters:
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, int\\|string\\|false\\|null given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplesubprojects.php
 
@@ -23834,7 +26889,17 @@ parameters:
 			path: app/cdash/tests/test_outputcolor.php
 
 		-
+			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/cdash/tests/test_parallelsubmissions.php
+
+		-
 			message: "#^Method ParallelSubmissionsTestCase\\:\\:testParallelSubmissions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_parallelsubmissions.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_parallelsubmissions.php
 
@@ -23910,6 +26975,11 @@ parameters:
 		-
 			message: "#^Method PdoExecuteLogsErrorsTestCase\\:\\:testPdoExecuteLogsErrors\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_pdoexecutelogserrors.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|false given\\.$#"
+			count: 2
 			path: app/cdash/tests/test_pdoexecutelogserrors.php
 
 		-
@@ -24243,6 +27313,16 @@ parameters:
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_removebuilds.php
+
+		-
+			message: "#^Cannot access offset mixed on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_removebuilds.php
+
+		-
 			message: "#^Method RemoveBuildsTestCase\\:\\:testBuildRemovalWorksAsExpected\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_removebuilds.php
@@ -24358,6 +27438,16 @@ parameters:
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_removebuilds.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_removebuilds.php
+
+		-
 			message: "#^Property App\\\\Models\\\\TestMeasurement\\:\\:\\$value \\(string\\) does not accept int\\.$#"
 			count: 2
 			path: app/cdash/tests/test_removebuilds.php
@@ -24397,7 +27487,27 @@ parameters:
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
+			message: "#^Cannot access offset 'generator' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_replacebuild.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_replacebuild.php
+
+		-
 			message: "#^Method ReplaceBuildTestCase\\:\\:testReplaceBuild\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_replacebuild.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_replacebuild.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_replacebuild.php
 
@@ -24466,6 +27576,41 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 9
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'filename' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'loctested' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'nfiles' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'numdefects' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'numfiles' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'starttime' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
+			message: "#^Cannot access offset 'time' on array\\|false\\.$#"
+			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -24544,6 +27689,11 @@ parameters:
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 7
+			path: app/cdash/tests/test_sequenceindependence.php
+
+		-
 			message: "#^Access to an undefined property CDash\\\\Model\\\\Project\\:\\:\\$CTestTemplateScript\\.$#"
 			count: 1
 			path: app/cdash/tests/test_setup_repositories.php
@@ -24553,6 +27703,11 @@ parameters:
 				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
 				04/01/2023$#
 			"""
+			count: 3
+			path: app/cdash/tests/test_setup_repositories.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
 			count: 3
 			path: app/cdash/tests/test_setup_repositories.php
 
@@ -24638,6 +27793,11 @@ parameters:
 			message: "#^Method SubProjectTestCase\\:\\:testSubmissionSubProjectTest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subproject.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectemail.php
 
 		-
 			message: """
@@ -24740,7 +27900,17 @@ parameters:
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
 		-
+			message: "#^Cannot access offset 'parentid' on array\\|false\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
 			message: "#^Method SubProjectNextPreviousTestCase\\:\\:testSubProjectNextPrevious\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
@@ -24761,7 +27931,17 @@ parameters:
 			path: app/cdash/tests/test_subprojectorder.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
 			message: "#^Method SubProjectOrderTestCase\\:\\:testSubProjectOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectorder.php
 
@@ -24880,6 +28060,16 @@ parameters:
 			path: app/cdash/tests/test_testgraphpermissions.php
 
 		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_testgraphpermissions.php
@@ -24991,9 +28181,24 @@ parameters:
 			path: app/cdash/tests/test_testoverview.php
 
 		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testoverview.php
+
+		-
 			message: "#^Method TestOverviewTestCase\\:\\:testTestOverview\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testoverview.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testoverview.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeline.php
 
 		-
 			message: """
@@ -25112,6 +28317,11 @@ parameters:
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
 		-
@@ -25254,6 +28464,11 @@ parameters:
 			path: app/cdash/tests/test_truncateoutput.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_truncateoutput.php
@@ -25318,6 +28533,11 @@ parameters:
 			path: app/cdash/tests/test_uniquediffs.php
 
 		-
+			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
+			count: 9
+			path: app/cdash/tests/test_uniquediffs.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uniquediffs.php
@@ -25368,6 +28588,11 @@ parameters:
 			path: app/cdash/tests/test_uniquediffs.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uniquediffs.php
+
+		-
 			message: "#^Property UniqueDiffsTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uniquediffs.php
@@ -25390,6 +28615,16 @@ parameters:
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateappend.php
+
+		-
+			message: "#^Cannot access offset 'nfiles' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_updateappend.php
+
+		-
+			message: "#^Cannot access offset 'updateid' on array\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_updateappend.php
 
@@ -25505,6 +28740,56 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
+			message: "#^Cannot access offset 'buildduration' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'configureduration' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'numdetails' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'numrows' on array\\|false\\.$#"
+			count: 8
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'numsites' on array\\|false\\.$#"
+			count: 8
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot access offset 'testduration' on array\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 2
+			path: app/cdash/tests/test_upgrade.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 17
 			path: app/cdash/tests/test_upgrade.php
@@ -25590,6 +28875,16 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
+			count: 14
+			path: app/cdash/tests/test_upgrade.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_upgrade.php
+
+		-
 			message: "#^Property UpgradeTestCase\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_upgrade.php
@@ -25656,6 +28951,11 @@ parameters:
 			path: app/cdash/tests/test_usernotes.php
 
 		-
+			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/tests/test_usernotes.php
+
+		-
 			message: "#^Method UserStatisticsTestCase\\:\\:testUserStatistics\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_userstatistics.php
@@ -25701,6 +29001,11 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_viewdynamicanalysisfile.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewdynamicanalysisfile.php
 
@@ -25815,12 +29120,32 @@ parameters:
 			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
+			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
 			message: "#^Variable \\$found might not be defined\\.$#"
 			count: 1
 			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$details\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:subprojects\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
@@ -26002,6 +29327,16 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
 			message: "#^Property BazelJSONHandler\\:\\:\\$BuildErrorFilter has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
@@ -26140,9 +29475,24 @@ parameters:
 			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+
+		-
 			message: "#^Method CDashSubmissionHandlerInterface\\:\\:getBuilds\\(\\) has invalid return type Build\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/CDashSubmissionHandlerInterface.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Binary operation \"\\-\" between 0\\|string and 1 results in an error\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
 			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
@@ -26233,6 +29583,31 @@ parameters:
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, array\\|string\\|false given\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, array\\|string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, array\\|string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
 			message: "#^Property GCovTarHandler\\:\\:\\$AggregateBuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
@@ -26314,6 +29689,11 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
+			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
 			message: "#^Foreach overwrites \\$coverageSummary with its value variable\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -26350,6 +29730,21 @@ parameters:
 
 		-
 			message: "#^Method JSCoverTarHandler\\:\\:__construct\\(\\) has parameter \\$buildid with no type specified\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
@@ -26430,6 +29825,21 @@ parameters:
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
+			message: "#^Only booleans are allowed in &&, array\\|false\\|null given on the left side\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
 			message: "#^Property JavaJSONTarHandler\\:\\:\\$CoverageSummaries has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
@@ -26482,6 +29892,16 @@ parameters:
 		-
 			message: "#^Access to an undefined property OpenCoverTarHandler\\:\\:\\$tarDir\\.$#"
 			count: 3
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and list\\<string\\>\\|string results in an error\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
 
 		-
@@ -26635,6 +30055,36 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in &&, int\\<0, max\\> given on the right side\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int\\|false given on the right side\\.$#"
+			count: 7
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function xml_parse expects string, string\\|false given\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
 
 		-
@@ -26976,6 +30426,11 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
+			message: "#^Cannot access offset '' on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
 			message: "#^Class BuildHandler has an uninitialized property \\$BuildInformation\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
@@ -27186,6 +30641,11 @@ parameters:
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
+			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/configure_handler.php
+
+		-
 			message: "#^Class ConfigureHandler has an uninitialized property \\$BuildInformation\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/configure_handler.php
@@ -27272,6 +30732,11 @@ parameters:
 
 		-
 			message: "#^Method ConfigureHandler\\:\\:text\\(\\) has parameter \\$parser with no type specified\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/configure_handler.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/configure_handler.php
 
@@ -27561,6 +31026,11 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
 		-
+			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/coverage_log_handler.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
 			path: app/cdash/xml_handlers/coverage_log_handler.php
@@ -27782,6 +31252,11 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access offset mixed on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
@@ -28041,6 +31516,31 @@ parameters:
 			path: app/cdash/xml_handlers/note_handler.php
 
 		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 5
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 5
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
 			message: "#^Property NoteHandler\\:\\:\\$AdjustStartTime has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/note_handler.php
@@ -28147,6 +31647,11 @@ parameters:
 			path: app/cdash/xml_handlers/project_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/project_handler.php
+
+		-
 			message: "#^Property ProjectHandler\\:\\:\\$CurrentDependencies has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/project_handler.php
@@ -28180,6 +31685,16 @@ parameters:
 			message: "#^Property ProjectHandler\\:\\:\\$SubProjects has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/project_handler.php
+
+		-
+			message: "#^Cannot access offset 'retries' on SimpleXMLElement\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/retry_handler.php
+
+		-
+			message: "#^Cannot call method attributes\\(\\) on SimpleXMLElement\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/retry_handler.php
 
 		-
 			message: "#^Class RetryHandler has an uninitialized property \\$Retries\\. Give it default value or assign it in the constructor\\.$#"
@@ -28537,6 +32052,11 @@ parameters:
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
 			message: "#^Property TestingHandler\\:\\:\\$BuildName has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
@@ -28689,6 +32209,16 @@ parameters:
 		-
 			message: "#^Method TestingJUnitHandler\\:\\:text\\(\\) has parameter \\$parser with no type specified\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/testing_junit_handler.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_junit_handler.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
+			count: 3
 			path: app/cdash/xml_handlers/testing_junit_handler.php
 
 		-
@@ -28906,6 +32436,11 @@ parameters:
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
+			message: "#^Cannot access offset 'nightlytime' on array\\|false\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/cdash/xml_handlers/upload_handler.php
@@ -28976,7 +32511,62 @@ parameters:
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
+			message: "#^Offset 'extension' might not exist on array\\{dirname\\?\\: string, basename\\: string, extension\\?\\: string, filename\\: string\\}\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, bool\\|int given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function chmod expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function feof expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fread expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php
 
@@ -29014,6 +32604,11 @@ parameters:
 			message: "#^Property UploadHandler\\:\\:\\$UploadFile has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: config/cdash.php
 
 		-
 			message: "#^Class App\\\\Password not found\\.$#"
@@ -29166,6 +32761,26 @@ parameters:
 			path: routes/console.php
 
 		-
+			message: "#^Part \\$buildid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: routes/web.php
+
+		-
+			message: "#^Part \\$imgid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: routes/web.php
+
+		-
+			message: "#^Part \\$siteid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: routes/web.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urldecode expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: server.php
+
+		-
 			message: "#^Access to an undefined property CDash\\\\Model\\\\Build\\:\\:\\$Endime\\.$#"
 			count: 2
 			path: tests/Feature/AutoRemoveBuildsCommand.php
@@ -29184,6 +32799,16 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: tests/Feature/AutoRemoveBuildsCommand.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 3
+			path: tests/Feature/AutoRemoveBuildsCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 3
 			path: tests/Feature/AutoRemoveBuildsCommand.php
 
 		-
@@ -29245,6 +32870,16 @@ parameters:
 			message: "#^Missing call to parent\\:\\:tearDown\\(\\) method\\.$#"
 			count: 1
 			path: tests/Feature/LoginAndRegistration.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, string\\|false given\\.$#"
+			count: 23
+			path: tests/Feature/MigrateConfigCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringNotContainsString\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Feature/MigrateConfigCommand.php
 
 		-
 			message: "#^Property Tests\\\\Feature\\\\MigrateConfigCommand\\:\\:\\$config_file has no type specified\\.$#"
@@ -29383,6 +33018,11 @@ parameters:
 			message: "#^Method Tests\\\\LdapTest\\:\\:makeLdapUser\\(\\) throws checked exception Adldap\\\\AdldapException but it's missing from the PHPDoc @throws tag\\.$#"
 			count: 1
 			path: tests/LdapTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: tests/Unit/app/ControllerNameTest.php
 
 		-
 			message: """

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -52,7 +52,7 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
-			message: "#^Part \\$projectname \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$projectname \\(array\\|bool\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 2
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
@@ -127,7 +127,7 @@ parameters:
 			path: app/Console/Commands/MigrateConfig.php
 
 		-
-			message: "#^Part \\$output_filename \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$output_filename \\(array\\|bool\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 4
 			path: app/Console/Commands/MigrateConfig.php
 
@@ -389,52 +389,52 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'groupid' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'groupid' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'major' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'major' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'minor' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'minor' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'name' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'projectid' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'projectid' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'siteid' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'siteid' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'submittime' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'submittime' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 'type' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'type' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			message: "#^Cannot access offset 0 on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/AdminController.php
 
@@ -524,6 +524,16 @@ parameters:
 			path: app/Http/Controllers/Auth/LoginController.php
 
 		-
+			message: "#^Cannot access property \\$password on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: "#^Cannot call method passwords\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:create\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
@@ -535,6 +545,16 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:validator\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: "#^Parameter \\#1 \\$user of class Illuminate\\\\Auth\\\\Events\\\\Registered constructor expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: "#^Parameter \\#1 \\$user of method Illuminate\\\\Contracts\\\\Auth\\\\StatefulGuard\\:\\:login\\(\\) expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
 
@@ -627,6 +647,16 @@ parameters:
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 3
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 5
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -780,6 +810,11 @@ parameters:
 			path: app/Http/Controllers/BuildNoteController.php
 
 		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildNoteController.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -856,11 +891,6 @@ parameters:
 			path: app/Http/Controllers/CDash.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$email\\.$#"
-			count: 1
-			path: app/Http/Controllers/CoverageController.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$full_name\\.$#"
 			count: 2
 			path: app/Http/Controllers/CoverageController.php
@@ -908,32 +938,42 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'branchestested' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'branchestested' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'branchesuntested' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'branchesuntested' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'loctested' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'loctested' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'locuntested' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'locuntested' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Cannot access offset 'text' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'text' on array\\|false\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access property \\$email on App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -1123,6 +1163,11 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Only numeric types are allowed in \\*, int\\|null given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
@@ -1213,6 +1258,11 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 2
+			path: app/Http/Controllers/DynamicAnalysisController.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
 			count: 1
 			path: app/Http/Controllers/DynamicAnalysisController.php
@@ -1255,6 +1305,31 @@ parameters:
 		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 2
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Measurement\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Measurement\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access property \\$position on App\\\\Models\\\\Measurement\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access property \\$projectid on App\\\\Models\\\\Measurement\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot call method save\\(\\) on App\\\\Models\\\\Measurement\\|null\\.$#"
+			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
 		-
@@ -1372,6 +1447,11 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 8
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -1480,6 +1560,26 @@ parameters:
 			path: app/Http/Controllers/ManageUsersController.php
 
 		-
+			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Cannot access property \\$full_name on App\\\\Models\\\\User\\|null\\.$#"
+			count: 3
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Cannot call method delete\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Cannot call method save\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageUsersController.php
@@ -1571,9 +1671,14 @@ parameters:
 			path: app/Http/Controllers/MapController.php
 
 		-
-			message: "#^Part \\$date \\(0\\|0\\.0\\|array\\{\\}\\|string\\|false\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$date \\(0\\|0\\.0\\|array\\{\\}\\|string\\|false\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Http/Controllers/MapController.php
+
+		-
+			message: "#^Cannot access property \\$truncated_time on stdClass\\|null\\.$#"
+			count: 8
+			path: app/Http/Controllers/MonitorController.php
 
 		-
 			message: "#^Call to an undefined method CDash\\\\Middleware\\\\OAuth2\\\\OAuth2Interface\\:\\:getPrimaryEmail\\(\\)\\.$#"
@@ -1911,6 +2016,11 @@ parameters:
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
+			message: "#^Only numeric types are allowed in \\*, int\\|null given on the right side\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float given\\.$#"
 			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -1979,42 +2089,47 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'ip' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'ip' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'latitude' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'latitude' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'longitude' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'longitude' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'name' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'outoforder' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'outoforder' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
 			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
@@ -2469,7 +2584,12 @@ parameters:
 			path: app/Http/Controllers/TestController.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot access property \\$projectid on App\\\\Models\\\\Test\\|null\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
 
@@ -2490,6 +2610,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\TestController\\:\\:details\\(\\) has parameter \\$buildtest_id with no type specified\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Parameter \\#1 \\$projectid of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectById\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
 
@@ -2640,6 +2765,16 @@ parameters:
 			path: app/Http/Controllers/UserStatisticsController.php
 
 		-
+			message: "#^Cannot access property \\$full_name on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$build of class CDash\\\\Controller\\\\Api\\\\ViewTest constructor expects CDash\\\\Model\\\\Build, CDash\\\\Model\\\\Build\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ViewTestController.php
+
+		-
 			message: "#^PHPDoc type array of property App\\\\Http\\\\Kernel\\:\\:\\$middleware is not the same as PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Foundation\\\\Http\\\\Kernel\\:\\:\\$middleware\\.$#"
 			count: 1
 			path: app/Http/Kernel.php
@@ -2678,6 +2813,11 @@ parameters:
 			message: "#^Property App\\\\Http\\\\Kernel\\:\\:\\$routeMiddleware type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Http/Kernel.php
+
+		-
+			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Middleware/Admin.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Middleware\\\\Admin\\:\\:handle\\(\\) has no return type specified\\.$#"
@@ -3203,6 +3343,11 @@ parameters:
 			path: app/Providers/AppServiceProvider.php
 
 		-
+			message: "#^Cannot access property \\$test on App\\\\Models\\\\TestOutput\\|null\\.$#"
+			count: 1
+			path: app/Providers/AuthServiceProvider.php
+
+		-
 			message: "#^PHPDoc type array of property App\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies is not the same as PHPDoc type array\\<class\\-string, class\\-string\\> of overridden property Illuminate\\\\Foundation\\\\Support\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies\\.$#"
 			count: 1
 			path: app/Providers/AuthServiceProvider.php
@@ -3294,6 +3439,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: app/Rules/LdapFilterRules.php
+
+		-
+			message: "#^Parameter \\#1 \\$dn of method Adldap\\\\Connections\\\\ConnectionInterface\\:\\:search\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: app/Rules/LdapFilterRules.php
 
@@ -3586,6 +3736,11 @@ parameters:
 			path: app/Services/UnparsedSubmissionProcessor.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|null given\\.$#"
+			count: 1
+			path: app/Services/UnparsedSubmissionProcessor.php
+
+		-
 			message: "#^Parameter \\#2 \\$contents of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:put\\(\\) expects resource\\|string, string\\|false given\\.$#"
 			count: 2
 			path: app/Services/UnparsedSubmissionProcessor.php
@@ -3852,7 +4007,7 @@ parameters:
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
-			message: "#^Cannot access offset 'a' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'a' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
 
@@ -4731,11 +4886,6 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$projectid\\.$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/ViewTest.php
-
-		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
@@ -4758,6 +4908,11 @@ parameters:
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Cannot access property \\$projectid on object\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
@@ -5324,6 +5479,11 @@ parameters:
 			path: app/cdash/app/Middleware/OAuth2.php
 
 		-
+			message: "#^Parameter \\#1 \\$pattern of static method Illuminate\\\\Support\\\\Str\\:\\:is\\(\\) expects iterable\\<string\\>\\|string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Middleware/OAuth2.php
+
+		-
 			message: "#^Parameter \\#1 \\$token of method League\\\\OAuth2\\\\Client\\\\Provider\\\\AbstractProvider\\:\\:getResourceOwner\\(\\) expects League\\\\OAuth2\\\\Client\\\\Token\\\\AccessToken, League\\\\OAuth2\\\\Client\\\\Token\\\\AccessTokenInterface given\\.$#"
 			count: 1
 			path: app/cdash/app/Middleware/OAuth2.php
@@ -5389,21 +5549,6 @@ parameters:
 			path: app/cdash/app/Model/ActionableTypes.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timemean\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timestatus\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:\\$timestd\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Build\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Build\\>\\:\\:\\$builderrors\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
@@ -5465,11 +5610,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$time\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Build.php
-
-		-
-			message: "#^Call to an undefined method App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\:\\:save\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -5577,6 +5717,36 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'testpassedpositive' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Build\\|null\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Test\\|null\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access property \\$timemean on App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\|null\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access property \\$timestatus on App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\|null\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot access property \\$timestd on App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\|null\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Cannot call method save\\(\\) on App\\\\Models\\\\BuildTest\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\BuildTest\\>\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -7582,7 +7752,7 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildUpdate.php
 
@@ -7788,11 +7958,6 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\:\\:\\$full_name\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildUserNote.php
-
-		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -7822,6 +7987,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 3
+			path: app/cdash/app/Model/BuildUserNote.php
+
+		-
+			message: "#^Cannot access property \\$full_name on App\\\\Models\\\\User\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\User\\>\\|null\\.$#"
+			count: 1
 			path: app/cdash/app/Model/BuildUserNote.php
 
 		-
@@ -8149,7 +8319,7 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/app/Model/CoverageFile2User.php
 
@@ -8165,6 +8335,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\CoverageFile2User\\:\\:GetCoverageFileId\\(\\) has parameter \\$buildid with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFile2User.php
+
+		-
+			message: "#^Offset 'c' might not exist on array\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
 
@@ -8225,7 +8400,7 @@ parameters:
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
-			message: "#^Cannot access offset 'fullpath' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'fullpath' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
 
@@ -8412,7 +8587,7 @@ parameters:
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageSummary.php
 
@@ -8637,7 +8812,7 @@ parameters:
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
@@ -8916,7 +9091,7 @@ parameters:
 			path: app/cdash/app/Model/Image.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
 
@@ -8999,6 +9174,11 @@ parameters:
 			message: "#^Property CDash\\\\Model\\\\Image\\:\\:\\$Name has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Label\\|null\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Label.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -9085,7 +9265,7 @@ parameters:
 			path: app/cdash/app/Model/LabelEmail.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/LabelEmail.php
 
@@ -9340,6 +9520,11 @@ parameters:
 
 		-
 			message: "#^Call to method DateTime\\:\\:setTimestamp\\(\\) with incorrect case\\: setTimeStamp$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -10043,13 +10228,18 @@ parameters:
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 6
+			path: app/cdash/app/Model/SubProjectGroup.php
+
+		-
+			message: "#^Offset 'c' might not exist on array\\|null\\.$#"
+			count: 2
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
@@ -10104,6 +10294,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, CDash\\\\Model\\\\User\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
+			message: "#^Property CDash\\\\Model\\\\Subscriber\\:\\:\\$topics \\(CDash\\\\Messaging\\\\Topic\\\\TopicCollection\\) does not accept CDash\\\\Messaging\\\\Topic\\\\TopicCollection\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
 
@@ -10435,7 +10630,7 @@ parameters:
 			path: app/cdash/app/Model/UserProject.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/app/Model/UserProject.php
 
@@ -10513,6 +10708,11 @@ parameters:
 			message: "#^Property CDash\\\\Model\\\\UserProject\\:\\:\\$UserId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/UserProject.php
+
+		-
+			message: "#^Cannot access property \\$Revision on CDash\\\\Model\\\\BuildUpdate\\|null\\.$#"
+			count: 2
+			path: app/cdash/app/Service/RepositoryService.php
 
 		-
 			message: "#^Method CDash\\\\Service\\\\RepositoryService\\:\\:setStatus\\(\\) has no return type specified\\.$#"
@@ -10646,6 +10846,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
+			message: "#^Cannot call method prepare\\(\\) on PDO\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
 
@@ -10859,6 +11064,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\System\\:\\:trimNullArguments\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/System.php
+
+		-
+			message: "#^Parameter \\#3 \\$response_code of function header expects int, int\\|null given\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/System.php
 
@@ -12440,6 +12650,11 @@ parameters:
 			path: app/cdash/include/Test/UseCase/BuildUseCase.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/BuildUseCase.php
+
+		-
 			message: "#^Property CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\:\\:\\$command has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/BuildUseCase.php
@@ -13180,6 +13395,11 @@ parameters:
 			path: app/cdash/include/Test/UseCase/UseCase.php
 
 		-
+			message: "#^Parameter \\#1 \\$useCase of method CDash\\\\Test\\\\CDashUseCaseTestCase\\:\\:setUseCaseModelFactory\\(\\) expects CDash\\\\Test\\\\UseCase\\\\UseCase, CDash\\\\Test\\\\UseCase\\\\BuildUseCase\\|CDash\\\\Test\\\\UseCase\\\\ConfigUseCase\\|CDash\\\\Test\\\\UseCase\\\\DynamicAnalysisUseCase\\|CDash\\\\Test\\\\UseCase\\\\TestUseCase\\|CDash\\\\Test\\\\UseCase\\\\UpdateUseCase\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/Test/UseCase/UseCase.php
+
+		-
 			message: "#^Property CDash\\\\Test\\\\UseCase\\\\UseCase\\:\\:\\$authors has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Test/UseCase/UseCase.php
@@ -13536,6 +13756,16 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -13562,6 +13792,11 @@ parameters:
 
 		-
 			message: "#^Function DeleteDirectory\\(\\) throws checked exception UnexpectedValueException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Function XMLStrFormat\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -14031,6 +14266,11 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, array\\<int, string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Parameter \\#4 \\$resultcontainer of function xslt_process expects string, null given\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -14387,18 +14627,23 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Cannot access offset 'c' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Cannot access offset 'status' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'status' on array\\|false\\|null\\.$#"
 			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot access property \\$nodeValue on DOMElement\\|null\\.$#"
+			count: 4
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -14637,7 +14882,22 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
+			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
@@ -15424,12 +15684,12 @@ parameters:
 			path: app/cdash/include/repository.php
 
 		-
-			message: "#^Cannot access offset 'cvsurl' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'cvsurl' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/repository.php
 
 		-
-			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/repository.php
 
@@ -16704,6 +16964,11 @@ parameters:
 			path: app/cdash/include/repository.php
 
 		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/repository.php
+
+		-
 			message: "#^Parameter \\#3 \\$value of function curl_setopt expects array\\|string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/repository.php
@@ -17005,37 +17270,37 @@ parameters:
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'configureduration' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'configureduration' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'duration' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'duration' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numfails' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'timemean' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'timemean' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 'timestd' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'timestd' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			message: "#^Cannot access offset 0 on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
@@ -18020,6 +18285,21 @@ parameters:
 			path: app/cdash/public/api/v1/index.php
 
 		-
+			message: "#^Cannot call method GetCurrentBuildId\\(\\) on CDash\\\\Model\\\\Build\\|null\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot call method GetNextBuildId\\(\\) on CDash\\\\Model\\\\Build\\|null\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
+			message: "#^Cannot call method GetPreviousBuildId\\(\\) on CDash\\\\Model\\\\Build\\|null\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/cdash/public/api/v1/index.php
@@ -18050,6 +18330,11 @@ parameters:
 			path: app/cdash/public/api/v1/index.php
 
 		-
+			message: "#^Only numeric types are allowed in \\*, int\\|null given on the left side\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
 			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
 			count: 6
 			path: app/cdash/public/api/v1/index.php
@@ -18063,11 +18348,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
 			count: 4
 			path: app/cdash/public/api/v1/index.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$name\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
@@ -18120,8 +18400,23 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\|null\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 2
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
@@ -21430,6 +21725,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-
+			message: "#^Cannot access property \\$mostRecentInformation on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -22327,7 +22627,7 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_unlink.php
 
 		-
-			message: "#^Argument of an invalid type array\\|string supplied for foreach, only iterables are supported\\.$#"
+			message: "#^Argument of an invalid type array\\|string\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -22362,6 +22662,11 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot call method getAttribute\\(\\) on DOMElement\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -23861,7 +24166,7 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\|false\\.$#"
+			message: "#^Cannot access offset 0 on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
@@ -24121,7 +24426,7 @@ parameters:
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
-			message: "#^Part \\$this\\-\\>buildid \\(0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$this\\-\\>buildid \\(0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
@@ -24221,7 +24526,7 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/cdash/tests/test_builddetails.php
 
@@ -24325,7 +24630,7 @@ parameters:
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
-			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numfails' on array\\|false\\|null\\.$#"
 			count: 6
 			path: app/cdash/tests/test_buildfailuredetails.php
 
@@ -25012,7 +25317,7 @@ parameters:
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
@@ -25155,27 +25460,32 @@ parameters:
 			path: app/cdash/tests/test_csvexport.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$builderrors\\.$#"
-			count: 1
-			path: app/cdash/tests/test_deferredsubmissions.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$buildwarnings\\.$#"
-			count: 1
-			path: app/cdash/tests/test_deferredsubmissions.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
-			count: 4
-			path: app/cdash/tests/test_deferredsubmissions.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$testfailed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_deferredsubmissions.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$testpassed\\.$#"
+			message: "#^Cannot access property \\$builderrors on object\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Cannot access property \\$buildwarnings on object\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Cannot access property \\$id on object\\|null\\.$#"
+			count: 3
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Cannot access property \\$testfailed on object\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Cannot access property \\$testpassed on object\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_deferredsubmissions.php
 
@@ -25344,6 +25654,16 @@ parameters:
 			path: app/cdash/tests/test_donehandler.php
 
 		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_donehandler.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 2
+			path: app/cdash/tests/test_donehandler.php
+
+		-
 			message: "#^Method DoneHandlerTestCase\\:\\:performTest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_donehandler.php
@@ -25461,12 +25781,12 @@ parameters:
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
-			message: "#^Cannot access offset 'numdefects' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numdefects' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
@@ -25556,11 +25876,6 @@ parameters:
 			path: app/cdash/tests/test_edituser.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
 			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -25587,6 +25902,16 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 2
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$id on object\\|null\\.$#"
+			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -25815,7 +26140,7 @@ parameters:
 			path: app/cdash/tests/test_externallinksfromtests.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_externallinksfromtests.php
 
@@ -25966,7 +26291,7 @@ parameters:
 			path: app/cdash/tests/test_hidecolumns.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_hidecolumns.php
 
@@ -26097,6 +26422,11 @@ parameters:
 			path: app/cdash/tests/test_indexfilters.php
 
 		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
 			message: "#^Method IndexNextPreviousTestCase\\:\\:testIndexNextPrevious\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_indexnextprevious.php
@@ -26132,6 +26462,11 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_issuecreation.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_issuecreation.php
 
@@ -26537,6 +26872,16 @@ parameters:
 			message: "#^Property MultiCoverageTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\BuildTest\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
+			message: "#^Cannot call method getLabels\\(\\) on App\\\\Models\\\\BuildTest\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
 
 		-
 			message: "#^Method MultipleLabelsForTestsTestCase\\:\\:testMultipleLabelsForTests\\(\\) has no return type specified\\.$#"
@@ -27113,6 +27458,11 @@ parameters:
 			path: app/cdash/tests/test_projectwebpage.php
 
 		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
 			message: "#^Method ProjectXmlSequenceTestCase\\:\\:submitFile\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_projectxmlsequence.php
@@ -27157,6 +27507,16 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_putdynamicbuilds.php
 
@@ -27266,6 +27626,16 @@ parameters:
 			path: app/cdash/tests/test_registeruser.php
 
 		-
+			message: "#^Cannot access property \\$password on App\\\\Models\\\\User\\|null\\.$#"
+			count: 3
+			path: app/cdash/tests/test_rehashpassword.php
+
+		-
+			message: "#^Cannot call method save\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_rehashpassword.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_rehashpassword.php
@@ -27313,12 +27683,12 @@ parameters:
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
-			message: "#^Cannot access offset mixed on array\\|false\\.$#"
+			message: "#^Cannot access offset mixed on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_removebuilds.php
 
@@ -27487,12 +27857,12 @@ parameters:
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
-			message: "#^Cannot access offset 'generator' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'generator' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_replacebuild.php
 
@@ -27579,37 +27949,37 @@ parameters:
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'filename' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'filename' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'loctested' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'loctested' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'nfiles' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'nfiles' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'numdefects' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numdefects' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'numfiles' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numfiles' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'starttime' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'starttime' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'time' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'time' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
@@ -27707,7 +28077,7 @@ parameters:
 			path: app/cdash/tests/test_setup_repositories.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 3
 			path: app/cdash/tests/test_setup_repositories.php
 
@@ -27823,6 +28193,11 @@ parameters:
 			path: app/cdash/tests/test_subprojectemail.php
 
 		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectemail.php
+
+		-
 			message: "#^Cannot access property \\$id on null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectemail.php
@@ -27900,7 +28275,7 @@ parameters:
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
 		-
-			message: "#^Cannot access offset 'parentid' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'parentid' on array\\|false\\|null\\.$#"
 			count: 3
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
@@ -28320,7 +28695,7 @@ parameters:
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
@@ -28464,7 +28839,7 @@ parameters:
 			path: app/cdash/tests/test_truncateoutput.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_truncateoutput.php
 
@@ -28619,12 +28994,12 @@ parameters:
 			path: app/cdash/tests/test_updateappend.php
 
 		-
-			message: "#^Cannot access offset 'nfiles' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'nfiles' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_updateappend.php
 
 		-
-			message: "#^Cannot access offset 'updateid' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'updateid' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_updateappend.php
 
@@ -28740,42 +29115,42 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'buildduration' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'buildduration' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'configureduration' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'configureduration' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'numdetails' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numdetails' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'numfails' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numfails' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'numrows' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numrows' on array\\|false\\|null\\.$#"
 			count: 8
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'numsites' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'numsites' on array\\|false\\|null\\.$#"
 			count: 8
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Cannot access offset 'testduration' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'testduration' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
@@ -28951,7 +29326,7 @@ parameters:
 			path: app/cdash/tests/test_usernotes.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_usernotes.php
 
@@ -29337,6 +29712,16 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|null given\\.$#"
+			count: 7
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
 			message: "#^Property BazelJSONHandler\\:\\:\\$BuildErrorFilter has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
@@ -29588,13 +29973,28 @@ parameters:
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 2
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, array\\|string\\|false given\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, string\\|null given\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
@@ -29605,6 +30005,11 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, array\\|string\\|false given\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
@@ -30426,7 +30831,7 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
-			message: "#^Cannot access offset '' on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\.$#"
+			message: "#^Cannot access offset '' on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
 
@@ -30641,7 +31046,7 @@ parameters:
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
-			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\.$#"
+			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/configure_handler.php
 
@@ -31026,7 +31431,7 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
 		-
-			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\.$#"
+			message: "#^Cannot access an offset on array\\|float\\|int\\|string\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
@@ -31139,6 +31544,11 @@ parameters:
 			message: "#^Property CoverageLogHandler\\:\\:\\$UpdateEndTime is never read, only written\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/coverage_log_handler.php
+
+		-
+			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/done_handler.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
@@ -31256,7 +31666,7 @@ parameters:
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
-			message: "#^Cannot access offset mixed on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\.$#"
+			message: "#^Cannot access offset mixed on 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
@@ -32436,7 +32846,7 @@ parameters:
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
-			message: "#^Cannot access offset 'nightlytime' on array\\|false\\.$#"
+			message: "#^Cannot access offset 'nightlytime' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php
 
@@ -32761,17 +33171,17 @@ parameters:
 			path: routes/console.php
 
 		-
-			message: "#^Part \\$buildid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$buildid \\(array\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 5
 			path: routes/web.php
 
 		-
-			message: "#^Part \\$imgid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$imgid \\(array\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: routes/web.php
 
 		-
-			message: "#^Part \\$siteid \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#"
+			message: "#^Part \\$siteid \\(array\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: routes/web.php
 
@@ -32867,8 +33277,23 @@ parameters:
 			path: tests/Feature/LdapAuthWithRulesTest.php
 
 		-
+			message: "#^Cannot call method delete\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: tests/Feature/LoginAndRegistration.php
+
+		-
 			message: "#^Missing call to parent\\:\\:tearDown\\(\\) method\\.$#"
 			count: 1
+			path: tests/Feature/LoginAndRegistration.php
+
+		-
+			message: "#^Parameter \\#1 \\$model of method Illuminate\\\\Foundation\\\\Testing\\\\TestCase\\:\\:assertModelExists\\(\\) expects Illuminate\\\\Database\\\\Eloquent\\\\Model, App\\\\Models\\\\User\\|null given\\.$#"
+			count: 2
+			path: tests/Feature/LoginAndRegistration.php
+
+		-
+			message: "#^Parameter \\#1 \\$user of method Illuminate\\\\Foundation\\\\Testing\\\\TestCase\\:\\:assertAuthenticatedAs\\(\\) expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
+			count: 3
 			path: tests/Feature/LoginAndRegistration.php
 
 		-
@@ -32905,6 +33330,21 @@ parameters:
 			message: "#^Method Tests\\\\Feature\\\\OpenLdapAuthWithOverrides\\:\\:testOpenLdapUnmodifiedGuid\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Feature/OpenLdapAuthWithOverrides.php
+
+		-
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
+			count: 4
+			path: tests/Feature/PasswordRotation.php
+
+		-
+			message: "#^Cannot access property \\$institution on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: tests/Feature/PasswordRotation.php
+
+		-
+			message: "#^Parameter \\#1 \\$user of method Illuminate\\\\Foundation\\\\Testing\\\\TestCase\\:\\:actingAs\\(\\) expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
+			count: 5
+			path: tests/Feature/PasswordRotation.php
 
 		-
 			message: "#^Property Tests\\\\Feature\\\\PasswordRotation\\:\\:\\$user has no type specified\\.$#"
@@ -32998,6 +33438,16 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Http\\\\Response\\:\\:content\\(\\)\\.$#"
 			count: 1
 			path: tests/Feature/SlowPageTest.php
+
+		-
+			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: tests/Feature/UserCommand.php
+
+		-
+			message: "#^Cannot access property \\$institution on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: tests/Feature/UserCommand.php
 
 		-
 			message: "#^Property Tests\\\\Feature\\\\UserCommand\\:\\:\\$user has no type specified\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,7 +39,7 @@ parameters:
     checkUninitializedProperties: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
 
-    level: 7
+    level: 8
 
 includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,7 +39,7 @@ parameters:
     checkUninitializedProperties: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
 
-    level: 6
+    level: 7
 
 includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon


### PR DESCRIPTION
PHPStan provides a set of [rule levels](https://phpstan.org/user-guide/rule-levels) which provide increasingly strict code analysis.  We currently use level 6.

PHPStan level 8 checks nullable types in greater detail, which will prevent a few common types of bugs, including the one fixed in #1725.  I was forced to also turn on level 7.  Level 7 checks union types, which will significantly improve our error detection abilities, but comes with the caveat that checking for all of the error cases for functions which return false instead of throwing an exception will cause additional developer overhead.

Eventually, we should turn on level 9, but it would be pointless to do so without turning on `treatPhpDocTypesAsCertain`.  PHPStan cannot currently understand Laravel's type casting system, which means that we'd have to rely upon the PHPDoc types for level 9 to be of any practical use.