### PR TITLE
Eliminate `pdo_real_escape_numeric()` function

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -493,11 +493,8 @@ final class AdminController extends AbstractController
 
         // Compute the testtime
         if ($ComputeTestTiming) {
-            @$TestTimingDays = $_POST['TestTimingDays'];
-            if ($TestTimingDays != null) {
-                $TestTimingDays = pdo_real_escape_numeric($TestTimingDays);
-            }
-            if (is_numeric($TestTimingDays) && $TestTimingDays > 0) {
+            $TestTimingDays = (int) ($_POST['TestTimingDays'] ?? 0);
+            if ($TestTimingDays > 0) {
                 ComputeTestTiming($TestTimingDays);
                 $xml .= add_XML_value('alert', 'Timing for tests has been computed successfully.');
             } else {
@@ -507,11 +504,8 @@ final class AdminController extends AbstractController
 
         // Compute the user statistics
         if ($ComputeUpdateStatistics) {
-            @$UpdateStatisticsDays = $_POST['UpdateStatisticsDays'];
-            if ($UpdateStatisticsDays != null) {
-                $UpdateStatisticsDays = pdo_real_escape_numeric($UpdateStatisticsDays);
-            }
-            if (is_numeric($UpdateStatisticsDays) && $UpdateStatisticsDays > 0) {
+            $UpdateStatisticsDays = (int) ($_POST['UpdateStatisticsDays'] ?? 0);
+            if ($UpdateStatisticsDays > 0) {
                 ComputeUpdateStatistics($UpdateStatisticsDays);
                 $xml .= add_XML_value('alert', 'User statistics has been computed successfully.');
             } else {

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -61,19 +61,19 @@ final class ManageProjectRolesController extends AbstractProjectController
         @$adduser = $_POST['adduser'];
         @$removeuser = $_POST['removeuser'];
 
-        @$userid = $_POST['userid'];
-        if ($userid != null) {
-            $userid = pdo_real_escape_numeric($userid);
+        $userid = $_POST['userid'] ?? null;
+        if ($userid !== null) {
+            $userid = (int) $userid;
         }
 
-        @$role = $_POST['role'];
-        if ($role != null) {
-            $role = pdo_real_escape_numeric($role);
+        $role = $_POST['role'] ?? null;
+        if ($role !== null) {
+            $role = (int) $role;
         }
 
-        @$emailtype = $_POST['emailtype'];
-        if ($emailtype != null) {
-            $emailtype = pdo_real_escape_numeric($emailtype);
+        $emailtype = $_POST['emailtype'] ?? null;
+        if ($emailtype !== null) {
+            $emailtype = (int) $emailtype;
         }
 
         @$credentials = $_POST['credentials'];

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -213,12 +213,12 @@ final class SiteController extends AbstractController
         }
 
         // If we have a projectid that means we should list all the sites
-        @$projectid = $_GET['projectid'];
-        if ($projectid != null) {
-            $projectid = pdo_real_escape_numeric($projectid);
+        $projectid = $_GET['projectid'] ?? null;
+        if ($projectid !== null) {
+            $projectid = (int) $projectid;
         }
-        if (isset($projectid) && is_numeric($projectid)) {
-            $project_array = $db->executePreparedSingleRow('SELECT name FROM project WHERE id=?', [intval($projectid)]);
+        if ($projectid !== null) {
+            $project_array = $db->executePreparedSingleRow('SELECT name FROM project WHERE id=?', [$projectid]);
             $xml .= '<project>';
             $xml .= add_XML_value('id', $projectid);
             $xml .= add_XML_value('name', $project_array['name']);
@@ -234,7 +234,7 @@ final class SiteController extends AbstractController
                                     AND build.starttime>?
                                     AND site.id=build.siteid
                                 ORDER BY site.name ASC
-                            ', [intval($projectid), $beginUTCTime]);
+                            ', [$projectid, $beginUTCTime]);
 
             foreach ($site2project as $site2project_array) {
                 $siteid = intval($site2project_array['id']);
@@ -256,14 +256,14 @@ final class SiteController extends AbstractController
         }
 
         // If we have a siteid we look if the user has claimed the site or not
-        @$siteid = $_GET['siteid'];
-        if ($siteid != null) {
-            $siteid = pdo_real_escape_numeric($siteid);
+        $siteid = $_GET['siteid'] ?? null;
+        if ($siteid !== null) {
+            $siteid = (int) $siteid;
         }
-        if (isset($siteid) && is_numeric($siteid)) {
+        if ($siteid !== null) {
             $xml .= '<user>';
             $xml .= '<site>';
-            $site_array = $db->executePreparedSingleRow('SELECT * FROM site WHERE id=?', [intval($siteid)]);
+            $site_array = $db->executePreparedSingleRow('SELECT * FROM site WHERE id=?', [$siteid]);
 
             $siteinformation_array = [];
             $siteinformation_array['description'] = 'NA';
@@ -287,7 +287,7 @@ final class SiteController extends AbstractController
                          WHERE siteid=?
                          ORDER BY timestamp DESC
                          LIMIT 1
-                     ', [intval($siteid)]);
+                     ', [$siteid]);
             if (!empty($query)) {
                 $siteinformation_array = $query;
                 if ($siteinformation_array['processoris64bits'] == -1) {
@@ -353,7 +353,7 @@ final class SiteController extends AbstractController
                                  AND up.role>0
                                  AND su.siteid=?
                                  AND su.userid=?
-                         ', [intval($siteid), intval($userid)]);
+                         ', [$siteid, $userid]);
             echo pdo_error();
             if (!empty($user2site)) {
                 $xml .= add_XML_value('siteclaimed', '0');
@@ -378,25 +378,26 @@ final class SiteController extends AbstractController
         $site_array = $db->executePreparedSingleRow("SELECT * FROM site WHERE id=?", [$siteid]);
         $sitename = $site_array['name'];
 
-        @$currenttime = $_GET['currenttime'];
-        if ($currenttime != null) {
-            $currenttime = pdo_real_escape_numeric($currenttime);
+        $currenttime = $_GET['currenttime'] ?? null;
+        if ($currenttime !== null) {
+            $currenttime = (int) $currenttime;
         }
 
-        $siteinformation_array = [];
-        $siteinformation_array['description'] = 'NA';
-        $siteinformation_array['processoris64bits'] = 'NA';
-        $siteinformation_array['processorvendor'] = 'NA';
-        $siteinformation_array['processorvendorid'] = 'NA';
-        $siteinformation_array['processorfamilyid'] = 'NA';
-        $siteinformation_array['processormodelid'] = 'NA';
-        $siteinformation_array['processorcachesize'] = 'NA';
-        $siteinformation_array['numberlogicalcpus'] = 'NA';
-        $siteinformation_array['numberphysicalcpus'] = 'NA';
-        $siteinformation_array['totalvirtualmemory'] = 'NA';
-        $siteinformation_array['totalphysicalmemory'] = 'NA';
-        $siteinformation_array['logicalprocessorsperphysical'] = 'NA';
-        $siteinformation_array['processorclockfrequency'] = 'NA';
+        $siteinformation_array = [
+            'description' => 'NA',
+            'processoris64bits' => 'NA',
+            'processorvendor' => 'NA',
+            'processorvendorid' => 'NA',
+            'processorfamilyid' => 'NA',
+            'processormodelid' => 'NA',
+            'processorcachesize' => 'NA',
+            'numberlogicalcpus' => 'NA',
+            'numberphysicalcpus' => 'NA',
+            'totalvirtualmemory' => 'NA',
+            'totalphysicalmemory' => 'NA',
+            'logicalprocessorsperphysical' => 'NA',
+            'processorclockfrequency' => 'NA',
+        ];
 
         // Current timestamp is the beginning of the dashboard and we want the end
         $currenttimestamp = gmdate(FMT_DATETIME, $currenttime + 3600 * 24);
@@ -447,8 +448,8 @@ final class SiteController extends AbstractController
 
         $xml = begin_XML_for_XSLT();
 
-        @$projectid = pdo_real_escape_numeric($_GET['project']);
-        if ($projectid) {
+        $projectid = (int) $_GET['project'];
+        if ($projectid > 0) {
             $project = new Project();
             $project->Id = $projectid;
             $project->Fill();
@@ -503,7 +504,7 @@ final class SiteController extends AbstractController
         $xml .= add_XML_value('logicalprocessorsperphysical', $siteinformation_array['logicalprocessorsperphysical']);
         $xml .= add_XML_value('processorclockfrequency', getByteValueWithExtension($processor_clock_frequency, 1000) . 'Hz');
         $xml .= add_XML_value('outoforder', $site_array['outoforder']);
-        if ($projectid && $project->ShowIPAddresses) {
+        if ($projectid > 0 && $project->ShowIPAddresses) {
             $xml .= add_XML_value('ip', $site_array['ip']);
             $xml .= add_XML_value('latitude', $site_array['latitude']);
             $xml .= add_XML_value('longitude', $site_array['longitude']);

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -204,9 +204,8 @@ class QueryTests extends ResultsApi
         // If parentid is set we need to lookup the date for this build
         // because it is not specified as a query string parameter.
         if (isset($_GET['parentid'])) {
-            $parentid = pdo_real_escape_numeric($_GET['parentid']);
             $parent_build = new Build();
-            $parent_build->Id = $parentid;
+            $parent_build->Id = (int) $_GET['parentid'];
             $this->setDate($parent_build->GetDate());
         } else {
             // Handle the optional arguments that dictate our time range.

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -23,6 +23,7 @@ use CDash\Config;
 use CDash\Database;
 use CDash\Model\Build;
 use App\Models\BuildInformation;
+use Illuminate\Support\Facades\DB;
 
 require_once 'include/filterdataFunctions.php';
 
@@ -557,16 +558,16 @@ class ViewTest extends BuildApi
             return;
         }
 
-        $projectid = pdo_real_escape_numeric($_GET['projectid']);
+        $projectid = (int) $_GET['projectid'];
 
         $previous_buildids = [];
         if (array_key_exists('previous_builds', $_GET)) {
             foreach (explode(', ', $_GET['previous_builds']) as $previous_buildid) {
                 if (is_numeric($previous_buildid) && $previous_buildid > 1) {
-                    $previous_build_row = \DB::table('build')
+                    $previous_build_row = DB::table('build')
                         ->where('id', $previous_buildid)
                         ->first();
-                    if ($previous_build_row->projectid == $projectid) {
+                    if ((int) $previous_build_row->projectid === $projectid) {
                         $previous_buildids[] = $previous_buildid;
                     }
                 }
@@ -581,7 +582,7 @@ class ViewTest extends BuildApi
         if (array_key_exists('time_end', $_GET)) {
             $time_end = pdo_real_escape_string($_GET['time_end']);
         }
-        $groupid = pdo_real_escape_numeric($_GET['groupid']);
+        $groupid = (int) $_GET['groupid'];
 
         $response = [];
         $tests_response = [];

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -92,7 +92,7 @@ class IndexPhpFilters extends DefaultFilters
         // If so, we won't add SQL clauses for some other filters.
         // Instead we handle them in PHP code via build_survives_filter().
         $this->HasSubProjectsFilter = false;
-        $filtercount = pdo_real_escape_numeric(@$_REQUEST['filtercount']);
+        $filtercount = (int) ($_REQUEST['filtercount'] ?? 0);
         for ($i = 1; $i <= $filtercount; ++$i) {
             if (empty($_REQUEST['field' . $i])) {
                 continue;
@@ -104,17 +104,18 @@ class IndexPhpFilters extends DefaultFilters
             }
         }
         $this->FiltersAffectedBySubProjects = [
-                'buildduration',
-                'builderrors',
-                'buildwarnings',
-                'configureduration',
-                'configureerrors',
-                'configurewarnings',
-                'testsduration',
-                'testsfailed',
-                'testsnotrun',
-                'testspassed',
-                'testtimestatus'];
+            'buildduration',
+            'builderrors',
+            'buildwarnings',
+            'configureduration',
+            'configureerrors',
+            'configurewarnings',
+            'testsduration',
+            'testsfailed',
+            'testsnotrun',
+            'testspassed',
+            'testtimestatus',
+        ];
     }
 
     public function getDefaultFilter()
@@ -1073,7 +1074,7 @@ function get_filterdata_from_request($page_id = '')
     for ($i = 1; $i <= $filtercount; ++$i) {
         if (array_key_exists("field{$i}count", $_GET)) {
             // Handle block of filters.
-            $subfiltercount = pdo_real_escape_numeric(@$_GET["field{$i}count"]);
+            $subfiltercount = (int) ($_GET["field{$i}count"] ?? 0);
             $filter = [
                 'filters' => [],
             ];

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -149,27 +149,6 @@ function pdo_real_escape_string(mixed $unescaped_string): string
 }
 
 /**
- * Case for numeric empty string in Postgres.
- *
- * @deprecated 04/01/2023
- */
-function pdo_real_escape_numeric(mixed $unescaped_string): float|int|string
-{
-    if (config('database.default') === 'pgsql' && $unescaped_string == '') {
-        // MySQL interprets an empty string as zero when assigned to a numeric field,
-        // for PostgreSQL this must be done explicitly:
-        $unescaped_string = '0';
-    }
-
-    // Return zero if we don't end up with a numeric value.
-    $escaped_string = pdo_real_escape_string($unescaped_string);
-    if (!is_numeric($escaped_string)) {
-        return 0;
-    }
-    return $escaped_string;
-}
-
-/**
  * DEPRECATED - use Database::getInstance()->execute(...)
  *
  * Execute a prepared statement and log any errors that occur.

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -27,8 +27,8 @@ use Symfony\Component\HttpFoundation\Response;
 // Require administrative access to view this page.
 init_api_request();
 
-if (array_key_exists('projectid', $_REQUEST)) {
-    $projectid = pdo_real_escape_numeric($_REQUEST['projectid']);
+if (isset($_REQUEST['projectid'])) {
+    $projectid = (int) $_REQUEST['projectid'];
 } else {
     $project = get_project_from_request();
     $projectid = $project->Id;
@@ -61,7 +61,7 @@ function rest_delete()
 {
     if (isset($_GET['buildgroupid'])) {
         // Delete the specified BuildGroup.
-        $buildgroupid = pdo_real_escape_numeric($_GET['buildgroupid']);
+        $buildgroupid = (int) $_GET['buildgroupid'];
         $Group = new BuildGroup();
         $Group->SetId($buildgroupid);
         $Group->Delete();
@@ -197,8 +197,7 @@ function rest_post($pdo, $projectid)
             $groupid = $group['id'];
 
             $Build = new Build();
-            $buildid = pdo_real_escape_numeric($buildinfo['id']);
-            $Build->Id = $buildid;
+            $Build->Id = (int) $buildinfo['id'];
             $Build->FillFromId($Build->Id);
             $prevgroupid = $Build->GroupId;
 
@@ -208,7 +207,7 @@ function rest_post($pdo, $projectid)
                 SET groupid = :groupid
                 WHERE groupid = :prevgroupid AND
                       buildid = :buildid');
-            pdo_execute($stmt, [$groupid, $prevgroupid, $buildid]);
+            pdo_execute($stmt, [$groupid, $prevgroupid, $Build->Id]);
 
             // Soft delete any previous rules.
             $buildgrouprule = new BuildGroupRule($Build);
@@ -315,18 +314,14 @@ function rest_put($projectid)
         }
 
         $BuildGroup = new BuildGroup();
-        $BuildGroup->SetId(pdo_real_escape_numeric($buildgroup['id']));
+        $BuildGroup->SetId((int) $buildgroup['id']);
         $BuildGroup->SetName(pdo_real_escape_string($buildgroup['name']));
         $BuildGroup->SetDescription(
             pdo_real_escape_string($buildgroup['description']));
-        $BuildGroup->SetSummaryEmail(
-            pdo_real_escape_numeric($buildgroup['summaryemail']));
-        $BuildGroup->SetEmailCommitters(
-            pdo_real_escape_numeric($buildgroup['emailcommitters']));
-        $BuildGroup->SetIncludeSubProjectTotal(
-            pdo_real_escape_numeric($buildgroup['includesubprojecttotal']));
-        $BuildGroup->SetAutoRemoveTimeFrame(
-            pdo_real_escape_numeric($buildgroup['autoremovetimeframe']));
+        $BuildGroup->SetSummaryEmail((int) $buildgroup['summaryemail']);
+        $BuildGroup->SetEmailCommitters((int) $buildgroup['emailcommitters']);
+        $BuildGroup->SetIncludeSubProjectTotal((int) $buildgroup['includesubprojecttotal']);
+        $BuildGroup->SetAutoRemoveTimeFrame((int) $buildgroup['autoremovetimeframe']);
 
         if (!$BuildGroup->Save()) {
             abort(500, 'Failed to save BuildGroup');
@@ -335,7 +330,7 @@ function rest_put($projectid)
 
     if (isset($_REQUEST['dynamiclist']) && !empty($_REQUEST['dynamiclist'])) {
         // Update a list of dynamic builds.
-        $buildgroupid = pdo_real_escape_numeric($_REQUEST['buildgroupid']);
+        $buildgroupid = (int) $_REQUEST['buildgroupid'];
         $build_group = new BuildGroup();
         $build_group->SetId($buildgroupid);
         $old_rules = $build_group->GetRules();

--- a/app/cdash/public/api/v1/expectedbuild.php
+++ b/app/cdash/public/api/v1/expectedbuild.php
@@ -54,10 +54,10 @@ if (!function_exists('CDash\Api\v1\ExpectedBuild\rest_get')) {
     {
         $response = [];
 
-        if (!array_key_exists('currenttime', $_REQUEST)) {
+        if (!isset($_REQUEST['currenttime'])) {
             abort(400, '"currenttime" not specified in request.');
         }
-        $currenttime = pdo_real_escape_numeric($_REQUEST['currenttime']);
+        $currenttime = (int) $_REQUEST['currenttime'];
         $currentUTCtime = gmdate(FMT_DATETIME, $currenttime);
 
         // Find the last time this expected build submitted.
@@ -130,8 +130,8 @@ foreach ($required_params as $param) {
         abort(400, "$param not specified.");
     }
 }
-$siteid = pdo_real_escape_numeric($_REQUEST['siteid']);
-$buildgroupid = pdo_real_escape_numeric($_REQUEST['groupid']);
+$siteid = (int) $_REQUEST['siteid'];
+$buildgroupid = (int) $_REQUEST['groupid'];
 $buildname = htmlspecialchars(pdo_real_escape_string($_REQUEST['name']));
 $buildtype = htmlspecialchars(pdo_real_escape_string($_REQUEST['type']));
 

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -36,23 +36,17 @@ if (!Auth::check()) {
 }
 
 // Make sure a project was specified.
-$projectid_ok = false;
-@$projectid = $_GET['projectid'];
-if (!isset($projectid)) {
+$projectid = $_GET['projectid'] ?? null;
+if ($projectid === null) {
     $rest_json = file_get_contents('php://input');
     $_POST = json_decode($rest_json, true);
     $projectid = $_POST['projectid'];
 }
-if (isset($projectid)) {
-    $projectid = pdo_real_escape_numeric($projectid);
-    if (is_numeric($projectid)) {
-        $projectid_ok = true;
-    }
-}
-if (!$projectid_ok) {
+if (!is_numeric($projectid)) {
     $response['error'] = "Please specify a project";
     return json_encode($response);
 }
+$projectid = (int) $projectid;
 
 $Project = new Project();
 $Project->Id = $projectid;

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -41,7 +41,7 @@ if (!isset($projectid)) {
     echo_error('projectid not specified.');
     return;
 }
-$projectid = pdo_real_escape_numeric($projectid);
+$projectid = (int) $projectid;
 
 // Make sure the user has access to this page.
 $project = new Project;
@@ -138,9 +138,8 @@ function rest_delete(): void
 {
     if (isset($_GET['groupid'])) {
         // Delete subproject group.
-        $groupid = pdo_real_escape_numeric($_GET['groupid']);
         $Group = new SubProjectGroup();
-        $Group->SetId(intval($groupid));
+        $Group->SetId((int) $_GET['groupid']);
         $Group->Delete();
         return;
     }

--- a/app/cdash/public/api/v1/testGraph.php
+++ b/app/cdash/public/api/v1/testGraph.php
@@ -30,10 +30,11 @@ if (is_null($build)) {
     return;
 }
 
-$testid = pdo_real_escape_numeric($_GET['testid']);
-if (!isset($testid) || !is_numeric($testid)) {
+$testid = $_GET['testid'] ?? null;
+if (!is_numeric($testid)) {
     abort(400, 'A valid test was not specified.');
 }
+$testid = (int) $testid;
 
 $buildtest = BuildTest::where('buildid', '=', $build->Id)
     ->where('testid', '=', $testid)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -366,14 +366,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -450,7 +442,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 11
+			count: 9
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -1378,11 +1370,6 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
-			message: "#^Binary operation \"\\.\" between array\\{\\}\\|float\\|int\\|string\\|false\\|null and int results in an error\\.$#"
-			count: 2
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -1401,14 +1388,6 @@ parameters:
 		-
 			message: """
 				#^Call to deprecated function pdo_error\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
 				04/01/2023$#
 			"""
 			count: 3
@@ -1453,7 +1432,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 8
+			count: 5
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -2036,11 +2015,6 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Binary operation \"\\+\" between array\\{\\}\\|float\\|int\\|string\\|false\\|null and 86400 results in an error\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -2054,14 +2028,6 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 4
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2141,11 +2107,6 @@ parameters:
 		-
 			message: "#^Foreach overwrites \\$projectid with its value variable\\.$#"
 			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 3
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2259,18 +2220,8 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Only booleans are allowed in &&, float\\|int\\|string given on the left side\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, float\\|int\\|string given\\.$#"
-			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2289,6 +2240,11 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
 			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string given\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
@@ -2296,11 +2252,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
 			count: 3
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -4262,14 +4213,6 @@ parameters:
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Controller/Api/QueryTests.php
-
-		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
@@ -4882,14 +4825,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/app/Controller/Api/ViewTest.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -4928,7 +4863,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 10
+			count: 9
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
@@ -14972,14 +14907,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/include/filterdataFunctions.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -15589,11 +15516,6 @@ parameters:
 			path: app/cdash/include/pdo.php
 
 		-
-			message: "#^Function pdo_real_escape_numeric\\(\\) never returns float so it can be removed from the return type\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
 			message: "#^Function pdo_single_row_query\\(\\) has parameter \\$qry with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
@@ -15605,11 +15527,6 @@ parameters:
 
 		-
 			message: "#^Instanceof between PDOStatement and PDOStatement will always evaluate to true\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
@@ -17876,14 +17793,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 9
-			path: app/cdash/public/api/v1/buildgroup.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -18037,24 +17946,11 @@ parameters:
 			path: app/cdash/public/api/v1/deleteSubmissionFile.php
 
 		-
-			message: "#^Binary operation \"\\-\" between float\\|int\\|string and int\\|false results in an error\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/expectedbuild.php
-
-		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
 			count: 1
-			path: app/cdash/public/api/v1/expectedbuild.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
@@ -18194,11 +18090,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
 			count: 2
-			path: app/cdash/public/api/v1/expectedbuild.php
-
-		-
-			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int\\|string given\\.$#"
-			count: 1
 			path: app/cdash/public/api/v1/expectedbuild.php
 
 		-
@@ -18472,14 +18363,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/public/api/v1/manageOverview.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -18669,14 +18552,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/public/api/v1/subproject.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -18732,19 +18607,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/subproject.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_numeric\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/public/api/v1/testGraph.php
-
-		-
-			message: "#^Variable \\$testid in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/testGraph.php
 
 		-
 			message: "#^Call to an undefined method CDash\\\\Middleware\\\\OAuth2\\\\GitHub\\:\\:auth\\(\\)\\.$#"


### PR DESCRIPTION
Integers are always safe to insert in SQL queries.  Thus, we can eliminate the `pdo_real_escape_numeric()` function and replace all of the existing usages with integer casts.  In the vast majority of cases, this function was no longer being used to sanitize values for SQL queries anyway.