### PR TITLE
Use Laravel query builder for DELETE statements when possible

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -192,7 +192,7 @@ final class AdminController extends AbstractController
             // We need to move the buildupdate build ids to the build2update table
             $query = pdo_query('SELECT buildid FROM buildupdate');
             while ($query_array = pdo_fetch_array($query)) {
-                pdo_query("INSERT INTO build2update (buildid,updateid) VALUES ('" . $query_array['buildid'] . "','" . $query_array['buildid'] . "')");
+                DB::insert("INSERT INTO build2update (buildid,updateid) VALUES ('" . $query_array['buildid'] . "','" . $query_array['buildid'] . "')");
             }
             RemoveTableIndex('buildupdate', 'buildid');
             RenameTableField('buildupdate', 'buildid', 'id', 'int(11)', 'bigint', '0');
@@ -678,7 +678,7 @@ final class AdminController extends AbstractController
                 $buildgroup_array = pdo_fetch_array(pdo_query("SELECT id FROM buildgroup WHERE name='$buildtype' AND projectid='$projectid'"));
 
                 $groupid = $buildgroup_array['id'];
-                pdo_query("INSERT INTO build2group(buildid,groupid) VALUES ('$buildid','$groupid')");
+                DB::insert("INSERT INTO build2group(buildid,groupid) VALUES ('$buildid','$groupid')");
             }
 
             $xml .= add_XML_value('alert', 'Builds have been added to default groups successfully.');

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -177,9 +177,8 @@ final class ManageProjectRolesController extends AbstractProjectController
 
         // Remove the user
         if ($removeuser) {
-            $db->executePrepared('DELETE FROM user2project WHERE userid=? AND projectid=?', [$userid. $projectid]);
-            $db->executePrepared('DELETE FROM user2repository WHERE userid=? AND projectid=?', [$userid. $projectid]);
-            echo pdo_error();
+            DB::delete('DELETE FROM user2project WHERE userid=? AND projectid=?', [$userid, $projectid]);
+            DB::delete('DELETE FROM user2repository WHERE userid=? AND projectid=?', [$userid, $projectid]);
         }
 
         // Update the user

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -133,7 +133,7 @@ final class SiteController extends AbstractController
         $db = Database::getInstance();
 
         if (isset($_POST['unclaimsite']) && isset($_GET['siteid'])) {
-            $db->executePrepared('
+            DB::delete('
                     DELETE FROM site2user
                     WHERE siteid=? AND userid=?
                 ', [intval($_GET['siteid']), $userid]);
@@ -660,8 +660,7 @@ final class SiteController extends AbstractController
         $db = Database::getInstance();
         $site2user = $db->executePrepared('SELECT * FROM site2user WHERE siteid=? AND userid=?', [intval($siteid), intval($userid)]);
         if (!empty($site2user)) {
-            $db->executePrepared('INSERT INTO site2user (siteid, userid) VALUES (?, ?)', [$siteid, $userid]);
-            add_last_sql_error('add_site2user');
+            DB::insert('INSERT INTO site2user (siteid, userid) VALUES (?, ?)', [$siteid, $userid]);
         }
     }
 
@@ -670,9 +669,7 @@ final class SiteController extends AbstractController
      */
     private static function remove_site2user(int $siteid, int $userid): void
     {
-        $db = Database::getInstance();
-        $db->executePrepared('DELETE FROM site2user WHERE siteid=? AND userid=?', [$siteid, $userid]);
-        add_last_sql_error('remove_site2user');
+        DB::delete('DELETE FROM site2user WHERE siteid=? AND userid=?', [$siteid, $userid]);
     }
 
     /**

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -9,6 +9,7 @@ use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 final class SubscribeProjectController extends AbstractProjectController
@@ -92,11 +93,11 @@ final class SubscribeProjectController extends AbstractProjectController
         $LabelEmail->UserId = $user->id;
 
         if ($Unsubscribe) {
-            $db->executePrepared('DELETE FROM user2project WHERE userid=? AND projectid=?', [$user->id, $this->project->Id]);
-            $db->executePrepared('DELETE FROM user2repository WHERE userid=? AND projectid=?', [$user->id, $this->project->Id]);
+            DB::delete('DELETE FROM user2project WHERE userid=? AND projectid=?', [$user->id, $this->project->Id]);
+            DB::delete('DELETE FROM user2repository WHERE userid=? AND projectid=?', [$user->id, $this->project->Id]);
 
             // Remove the claim sites for this project if they are only part of this project
-            $db->executePrepared('
+            DB::delete('
                 DELETE FROM site2user
                 WHERE
                     userid=?
@@ -150,20 +151,20 @@ final class SubscribeProjectController extends AbstractProjectController
 
                 if ($Role == 0) {
                     // Remove the claim sites for this project if they are only part of this project
-                    $db->executePrepared('
-                    DELETE FROM site2user
-                    WHERE
-                        userid=?
-                        AND siteid NOT IN (
-                            SELECT build.siteid
-                            FROM build, user2project AS up
-                            WHERE
-                                up.projectid=build.projectid
-                                AND up.userid=?
-                                AND up.role>0
-                            GROUP BY build.siteid
-                        )
-                ', [$user->id, $user->id]);
+                    DB::delete('
+                        DELETE FROM site2user
+                        WHERE
+                            userid=?
+                            AND siteid NOT IN (
+                                SELECT build.siteid
+                                FROM build, user2project AS up
+                                WHERE
+                                    up.projectid=build.projectid
+                                    AND up.userid=?
+                                    AND up.role>0
+                                GROUP BY build.siteid
+                            )
+                    ', [$user->id, $user->id]);
                 }
             }
 
@@ -213,20 +214,20 @@ final class SubscribeProjectController extends AbstractProjectController
 
                 if ($Role == 0) {
                     // Remove the claim sites for this project if they are only part of this project
-                    $db->executePrepared('
-                    DELETE FROM site2user
-                    WHERE
-                        userid=?
-                        AND siteid NOT IN (
-                            SELECT build.siteid
-                            FROM build, user2project AS up
-                            WHERE
-                                up.projectid0=build.projectid
-                                AND up.userid=?
-                                AND up.role>0
-                            GROUP BY build.siteid
-                        )
-                ', [$user->id, $user->id]);
+                    DB::delete('
+                        DELETE FROM site2user
+                        WHERE
+                            userid=?
+                            AND siteid NOT IN (
+                                SELECT build.siteid
+                                FROM build, user2project AS up
+                                WHERE
+                                    up.projectid0=build.projectid
+                                    AND up.userid=?
+                                    AND up.role>0
+                                GROUP BY build.siteid
+                            )
+                    ', [$user->id, $user->id]);
                 }
             } else {
                 $db->executePrepared('

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -15,6 +15,7 @@
 =========================================================================*/
 namespace CDash\Model;
 
+use Illuminate\Support\Facades\DB;
 use PDO;
 use CDash\Database;
 
@@ -147,18 +148,13 @@ class BuildConfigure
         pdo_execute($stmt, [$this->Id]);
         $row = $stmt->fetch();
         if ($row['c'] < 2) {
-            $stmt = $this->PDO->prepare('DELETE FROM configure WHERE id = ?');
-            pdo_execute($stmt, [$this->Id]);
+            DB::delete('DELETE FROM configure WHERE id = ?', [$this->Id]);
             $retval = true;
         }
 
         if ($this->BuildId) {
             // Delete the build2configure row for this build.
-            $stmt = $this->PDO->prepare(
-                'DELETE FROM build2configure WHERE buildid = ?');
-            if (!pdo_execute($stmt, [$this->BuildId])) {
-                return false;
-            }
+            DB::delete('DELETE FROM build2configure WHERE buildid = ?', [$this->BuildId]);
         }
 
         return $retval;

--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -486,10 +486,10 @@ class BuildGroup
         }
 
         // We delete all the build2grouprule associated with the group
-        $this->PDO->executePrepared('DELETE FROM build2grouprule WHERE groupid=?', [$this->Id]);
+        DB::delete('DELETE FROM build2grouprule WHERE groupid=?', [$this->Id]);
 
         // We delete the buildgroup
-        $this->PDO->executePrepared('DELETE FROM buildgroup WHERE id=?', [$this->Id]);
+        DB::delete('DELETE FROM buildgroup WHERE id=?', [$this->Id]);
 
         // Restore the builds that were associated with this group
         $oldbuilds = $this->PDO->executePrepared('
@@ -532,7 +532,7 @@ class BuildGroup
 
         // Delete the buildgroupposition and update the position
         // of the other groups.
-        $this->PDO->executePrepared('DELETE FROM buildgroupposition WHERE buildgroupid=?', [$this->Id]);
+        DB::delete('DELETE FROM buildgroupposition WHERE buildgroupid=?', [$this->Id]);
         $buildgroupposition = $this->PDO->executePrepared('
                                   SELECT bg.buildgroupid
                                   FROM buildgroupposition AS bg, buildgroup AS g

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -16,6 +16,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 use PDO;
 
 /** This class shouldn't be used externally */
@@ -110,11 +111,13 @@ class CoverageFile
                 }
 
                 // Remove the file if the crc32 is NULL
-                $stmt = $this->PDO->prepare(
-                    'DELETE FROM coveragefile
-                        WHERE id=:prevfileid AND file IS NULL AND crc32 IS NULL');
-                $stmt->bindParam(':prevfileid', $prevfileid);
-                pdo_execute($stmt);
+                DB::delete('
+                    DELETE FROM coveragefile
+                    WHERE
+                        id = ?
+                        AND file IS NULL
+                        AND crc32 IS NULL
+                ', [$prevfileid]);
             }
         } else {
             // The file doesn't exist in the database

--- a/app/cdash/app/Model/CoverageFile2User.php
+++ b/app/cdash/app/Model/CoverageFile2User.php
@@ -17,6 +17,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 /** Coverage file to users */
 class CoverageFile2User
@@ -108,45 +109,32 @@ class CoverageFile2User
     } // function Insert
 
     /** Remove authors */
-    public function RemoveAuthors(): bool
+    public function RemoveAuthors(): void
     {
         if ($this->FullPath == '' || $this->ProjectId < 1) {
             abort(500, 'CoverageFile2User:RemoveAuthors: FullPath or ProjectId not set');
         }
-
-        $db = Database::getInstance();
-        $query_result = $db->executePrepared('DELETE FROM coveragefile2user WHERE fileid=?', [$this->GetId()]);
-        if (!$query_result) {
-            add_last_sql_error('CoverageFile2User:RemoveAuthors');
-            return false;
-        }
-        return true;
+        DB::delete('DELETE FROM coveragefile2user WHERE fileid = ?', [$this->GetId()]);
     }
 
     /** Remove the new user */
-    public function Remove(): bool
+    public function Remove(): void
     {
         if (!isset($this->UserId) || $this->UserId < 1) {
-            return false;
+            abort(500, 'Invalid UserId');
         }
         if (!isset($this->FileId) || $this->FileId < 1) {
-            return false;
+            abort(500, 'Invalid FileId');
         }
 
-        $db = Database::getInstance();
-        $query_result = $db->executePrepared('
-                            DELETE FROM coveragefile2user
-                            WHERE
-                                userid=?
-                                AND fileid=?
-                        ', [$this->UserId, $this->FileId]);
-        if ($query_result === false) {
-            add_last_sql_error('CoverageFile2User:Remove');
-            return false;
-        }
+        DB::delete('
+            DELETE FROM coveragefile2user
+            WHERE
+                userid=?
+                AND fileid=?
+        ', [$this->UserId, $this->FileId]);
 
         $this->FixPosition();
-        return true;
     }
 
     /** Fix the position given a file */

--- a/app/cdash/app/Model/DynamicAnalysisSummary.php
+++ b/app/cdash/app/Model/DynamicAnalysisSummary.php
@@ -16,6 +16,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 class DynamicAnalysisSummary
 {
@@ -57,18 +58,16 @@ class DynamicAnalysisSummary
     }
 
     /** Remove the dynamic analysis summary for this build. */
-    public function Remove()
+    public function Remove(): void
     {
         if ($this->BuildId < 1) {
-            return false;
+            abort(500, 'Invalid BuildId');
         }
         if (!$this->Exists()) {
-            return false;
+            abort(500, 'Dynamic Analysis does not exist.');
         }
 
-        $stmt = $this->PDO->prepare('
-            DELETE FROM dynamicanalysissummary WHERE buildid = ?');
-        return pdo_execute($stmt, [$this->BuildId]);
+        DB::delete('DELETE FROM dynamicanalysissummary WHERE buildid = ?', [$this->BuildId]);
     }
 
     // Insert the DynamicAnalysisSummary
@@ -84,7 +83,6 @@ class DynamicAnalysisSummary
                 INSERT INTO dynamicanalysissummary
                 (buildid, checker, numdefects)
                 VALUES (:buildid, :checker, :numdefects)');
-        $error_name = 'DynamicAnalysisSummary Insert';
 
         if ($this->Exists()) {
             if ($append) {

--- a/app/cdash/app/Model/SubProjectGroup.php
+++ b/app/cdash/app/Model/SubProjectGroup.php
@@ -16,6 +16,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 class SubProjectGroup
 {
@@ -200,7 +201,7 @@ class SubProjectGroup
         }
 
         if (!$keephistory) {
-            $db->executePrepared('DELETE FROM subprojectgroup WHERE id=?', [$this->Id]);
+            DB::delete('DELETE FROM subprojectgroup WHERE id=?', [$this->Id]);
         } else {
             $endtime = gmdate(FMT_DATETIME);
             $query = $db->executePrepared('

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -16,6 +16,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 class User
 {
@@ -169,8 +170,7 @@ class User
         if (!$this->Id) {
             return false;
         }
-        $stmt = $this->PDO->prepare("DELETE FROM $this->TableName WHERE id = ?");
-        pdo_execute($stmt, [$this->Id]);
+        DB::delete("DELETE FROM $this->TableName WHERE id = ?", [$this->Id]);
     }
 
     /** Get the email */
@@ -314,12 +314,7 @@ class User
                 $row = $stmt->fetch();
                 $cutoff = $row['date'];
                 // Then delete the ones that are too old
-                $stmt = $this->PDO->prepare(
-                    'DELETE FROM password
-                    WHERE userid= :userid AND date < :date');
-                $stmt->bindParam(':userid', $this->Id);
-                $stmt->bindParam(':date', $cutoff);
-                pdo_execute($stmt);
+                DB::delete('DELETE FROM password WHERE userid = ? AND date < ?', [$this->Id, $cutoff]);
             }
         }
     }

--- a/app/cdash/app/Model/UserProject.php
+++ b/app/cdash/app/Model/UserProject.php
@@ -17,6 +17,7 @@ namespace CDash\Model;
 
 use CDash\Database;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 class UserProject
 {
@@ -223,14 +224,13 @@ class UserProject
 
         // Remove the one that have been removed
         $prepared_array = $db->createPreparedArray(count($credentials));
-        $db->executePrepared("
+        DB::delete("
             DELETE FROM user2repository
             WHERE
                 userid=?
                 AND projectid=?
                 AND credential NOT IN $prepared_array
         ", array_merge([$this->UserId, $this->ProjectId], $credentials));
-        add_last_sql_error('UserProject UpdateCredentials');
         return true;
     }
 

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -890,17 +890,14 @@ function cleanBuildEmail(): void
 {
     $now = date(FMT_DATETIME, time() - 3600 * 48);
 
-    $db = Database::getInstance();
-    $db->executePrepared('DELETE FROM buildemail WHERE time<?', [$now]);
+    DB::delete('DELETE FROM buildemail WHERE time<?', [$now]);
 }
 
 /** Clean the usertemp table if more than 24hrs */
 function cleanUserTemp(): void
 {
     $now = date(FMT_DATETIME, time() - 3600 * 24);
-
-    $db = Database::getInstance();
-    $db->executePrepared('DELETE FROM usertemp WHERE registrationdate<?', [$now]);
+    DB::delete('DELETE FROM usertemp WHERE registrationdate < ?', [$now]);
 }
 
 /** Send an email to administrator of the project for users who are not registered */
@@ -1151,7 +1148,7 @@ function addDailyChanges(int $projectid): void
         }
 
         // Delete expired authentication tokens.
-        $db->executePrepared('DELETE FROM authtoken WHERE expires < NOW()');
+        DB::delete('DELETE FROM authtoken WHERE expires < NOW()');
 
         // Delete expired buildgroups and rules.
         $current_date = gmdate(FMT_DATETIME);

--- a/app/cdash/public/api/v1/build.php
+++ b/app/cdash/public/api/v1/build.php
@@ -20,6 +20,7 @@ require_once 'include/api_common.php';
 
 use CDash\Database;
 use CDash\Model\BuildGroupRule;
+use Illuminate\Support\Facades\DB;
 
 init_api_request();
 $build = get_request_build();
@@ -77,9 +78,7 @@ function rest_post($build)
         $newgroupid = $_POST['newgroupid'];
 
         // Remove the build from its previous group.
-        $delete_stmt = $pdo->prepare(
-            'DELETE FROM build2group WHERE buildid = :buildid');
-        $pdo->execute($delete_stmt, [':buildid' => $build->Id]);
+        DB::delete('DELETE FROM build2group WHERE buildid = ?', [$build->Id]);
 
         // Insert it into the new group.
         $insert_stmt = $pdo->prepare(

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -22,6 +22,7 @@ use App\Services\PageTimer;
 use CDash\Database;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 $pageTimer = new PageTimer();
 $response = begin_JSON_response();
@@ -65,8 +66,7 @@ if (isset($_POST['saveLayout'])) {
     $inputRows = json_decode($_POST['saveLayout'], true);
     if (!is_null($inputRows)) {
         // Remove any old overview layout from this project.
-        $db->executePrepared('DELETE FROM overview_components WHERE projectid=?', [intval($projectid)]);
-        add_last_sql_error('manageOverview::saveLayout::DELETE', $projectid);
+        DB::delete('DELETE FROM overview_components WHERE projectid=?', [intval($projectid)]);
 
         // Construct a query to insert the new layout.
         $query = 'INSERT INTO overview_components (projectid, buildgroupid, position, type) VALUES ';

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -7,6 +7,7 @@ use App\Models\AuthToken;
 use App\Services\AuthTokenService;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
+use Illuminate\Support\Facades\DB;
 
 class AuthTokenTestCase extends KWWebTestCase
 {
@@ -211,7 +212,7 @@ class AuthTokenTestCase extends KWWebTestCase
     public function testSubmissionFailsWithInvalidToken()
     {
         // Revoke user's access to this project.
-        $this->PDO->query("DELETE FROM user2project WHERE projectid = {$this->Project->Id}");
+        DB::delete("DELETE FROM user2project WHERE projectid = {$this->Project->Id}");
 
         // Make sure the various submission paths fail for our token now.
         $headers = ["Authorization: Bearer {$this->Token}"];

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -8,6 +8,7 @@ use App\Services\TestingDay;
 use CDash\Database;
 use CDash\Model\BuildGroup;
 use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
@@ -115,7 +116,7 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         $db->execute($stmt, $query_params);
 
         // Looks like it's a new day
-        $pdo->exec("DELETE FROM dailyupdate WHERE projectid='{$projectid}'");
+        DB::delete("DELETE FROM dailyupdate WHERE projectid='{$projectid}'");
 
         $testxml2 = "$rep/2_test.xml";
         if (!$this->submission('EmailProjectExample', $testxml2)) {

--- a/app/cdash/tests/test_buildgrouprule.php
+++ b/app/cdash/tests/test_buildgrouprule.php
@@ -12,6 +12,7 @@ use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
+use Illuminate\Support\Facades\DB;
 
 class BuildGroupRuleTestCase extends KWWebTestCase
 {
@@ -110,8 +111,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
         while ($row = $stmt->fetch()) {
             remove_build($row['id']);
         }
-        $this->PDO->exec(
-            "DELETE FROM build2grouprule WHERE buildname = 'no-project-leakage'");
+        DB::delete("DELETE FROM build2grouprule WHERE buildname = 'no-project-leakage'");
 
         // Create two similar builds that belong to different projects.
         $build1 = new Build();

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -10,6 +10,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 use CDash\Model\Build;
 use CDash\Model\BuildError;
+use Illuminate\Support\Facades\DB;
 
 class BuildModelTestCase extends KWWebTestCase
 {
@@ -28,7 +29,7 @@ class BuildModelTestCase extends KWWebTestCase
         $this->testDataFiles = ['build1.xml', 'build2.xml', 'build3.xml', 'build4.xml',
                                      'build5.xml', 'configure1.xml'];
 
-        pdo_query("INSERT INTO project (name) VALUES ('BuildModel')");
+        DB::insert("INSERT INTO project (name) VALUES ('BuildModel')");
 
         foreach ($this->testDataFiles as $testDataFile) {
             if (!$this->submission('BuildModel', $this->testDataDir . '/' . $testDataFile)) {

--- a/app/cdash/tests/test_createprojectpermissions.php
+++ b/app/cdash/tests/test_createprojectpermissions.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -75,8 +77,8 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
         $stmt->execute(['user1@kw']);
         $row = $stmt->fetch();
         $userid = $row['id'];
-        $pdo->query("DELETE FROM user2project WHERE userid=$userid");
-        $pdo->query("INSERT INTO user2project (userid, projectid, role, emailtype) VALUES ($userid, 5, 2, 2)");
+        DB::delete("DELETE FROM user2project WHERE userid=$userid");
+        DB::insert("INSERT INTO user2project (userid, projectid, role, emailtype) VALUES ($userid, 5, 2, 2)");
 
         // Cannot create project.
         $response = $this->get($this->url . '/api/v1/createProject.php');
@@ -114,6 +116,6 @@ class CreateProjectPermissionsTestCase extends KWWebTestCase
         $this->assertFalse(property_exists($response->project, 'UploadQuota'));
 
         // Cleanup.
-        $pdo->query("DELETE FROM user2project WHERE userid=$userid");
+        DB::delete("DELETE FROM user2project WHERE userid=$userid");
     }
 }

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -13,6 +13,9 @@
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
+
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -68,8 +71,7 @@ class DynamicAnalysisSummaryTestCase extends KWWebTestCase
         $ids[] = $this->ParentId;
         $ids[] = $this->StandaloneBuildId;
         $id_arg = implode(', ', $ids);
-        pdo_query(
-            "DELETE FROM dynamicanalysissummary WHERE buildid IN ($id_arg)");
+        DB::delete("DELETE FROM dynamicanalysissummary WHERE buildid IN ($id_arg)");
 
         // Run the upgrade function.
         require_once 'include/upgrade_functions.php';

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -69,10 +69,15 @@ class EmailTestCase extends KWWebTestCase
         if (!$user->id) {
             $this->fail('Failed to create user2');
         }
-        $db = \CDash\Database::getInstance();
 
-        $stmt = $db->prepare('INSERT INTO user2project (userid, projectid, role, emailtype) VALUES (?, ?, ?, ?)');
-        $db->execute($stmt, [$user->id, $this->project, 0, 0]);
+        DB::insert('
+            INSERT INTO user2project (
+                userid,
+                projectid,
+                role,
+                emailtype
+            ) VALUES (?, ?, ?, ?)
+        ', [$user->id, $this->project, 0, 0]);
     }
 
     public function testSubmissionFirstBuild()

--- a/app/cdash/tests/test_expectedandmissing.php
+++ b/app/cdash/tests/test_expectedandmissing.php
@@ -10,6 +10,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroupRule;
+use Illuminate\Support\Facades\DB;
 
 class ExpectedAndMissingTestCase extends KWWebTestCase
 {
@@ -112,7 +113,7 @@ class ExpectedAndMissingTestCase extends KWWebTestCase
 
         // Make it unexpected again by hard-deleting this buildgroup rule.
         $rule->Delete(false);
-        pdo_query("DELETE FROM build2grouprule WHERE buildname='$buildname'");
+        DB::delete("DELETE FROM build2grouprule WHERE buildname='$buildname'");
 
         if (!$found) {
             $this->fail("Expected missing build '$buildname' not included");

--- a/app/cdash/tests/test_limitedbuilds.php
+++ b/app/cdash/tests/test_limitedbuilds.php
@@ -11,6 +11,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
 
 class LimitedBuildsTestCase extends KWWebTestCase
 {
@@ -100,9 +101,8 @@ class LimitedBuildsTestCase extends KWWebTestCase
         foreach ($this->Projects as $project) {
             remove_project_builds($project->Id);
         }
-        $delete_stmt = $this->PDO->prepare('DELETE FROM project WHERE name = ?');
-        $delete_stmt->execute(['Limited']);
-        $delete_stmt->execute(['Unlimited']);
+        DB::delete("DELETE FROM project WHERE name = 'Limited'");
+        DB::delete("DELETE FROM project WHERE name = 'Unlimited'");
         $this->deleteLog($this->logfilename);
     }
 }

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -27,6 +27,7 @@ use CDash\Model\DynamicAnalysisSummary;
 use CDash\Model\Image;
 use CDash\Model\Label;
 use CDash\Model\UploadFile;
+use Illuminate\Support\Facades\DB;
 
 class RemoveBuildsTestCase extends KWWebTestCase
 {
@@ -168,7 +169,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $update->Command = 'git fetch';
         $update->Insert();
 
-        pdo_query("INSERT INTO build2update (buildid, updateid)
+        DB::insert("INSERT INTO build2update (buildid, updateid)
             VALUES ($existing_build->Id, $update->UpdateId)");
 
         // Coverage

--- a/app/cdash/tests/test_subprojectemail.php
+++ b/app/cdash/tests/test_subprojectemail.php
@@ -15,6 +15,7 @@ use CDash\Model\Project;
 use CDash\Model\SubProject;
 use CDash\Model\UserProject;
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 class SubProjectEmailTestCase extends KWWebTestCase
 {
@@ -55,9 +56,7 @@ class SubProjectEmailTestCase extends KWWebTestCase
         $this->Project->Id = $projectid;
 
         // Unsubscribe default admin from this project.
-        $stmt = $this->PDO->prepare(
-            'DELETE FROM user2project WHERE userid = ? AND projectid = ?');
-        pdo_execute($stmt, [1, $this->Project->Id]);
+        DB::delete('DELETE FROM user2project WHERE userid = 1 AND projectid = ?', [$this->Project->Id]);
 
         // Configure this project to send email for Experimental builds.
         $stmt = $this->PDO->prepare(

--- a/app/cdash/tests/test_subscribeprojectshowlabels.php
+++ b/app/cdash/tests/test_subscribeprojectshowlabels.php
@@ -6,6 +6,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 use CDash\Database;
 use CDash\Model\Label;
+use Illuminate\Support\Facades\DB;
 
 class SubscribeProjectShowLabelsTestCase extends KWWebTestCase
 {
@@ -31,19 +32,15 @@ class SubscribeProjectShowLabelsTestCase extends KWWebTestCase
         $label = new Label();
         $label->Id = 1;
         $label_text = $label->GetText();
-        $stmt = $this->PDO->prepare(
-            'INSERT INTO label2build (labelid, buildid) VALUES (:labelid, :buildid)');
-        $this->PDO->execute($stmt, [':labelid' => 1, ':buildid' => $buildid]);
+        DB::insert('INSERT INTO label2build (labelid, buildid) VALUES (?, ?)', [1, $buildid]);
 
         // Make sure this label shows up on the subscribeProject page.
         $this->login();
         $this->get($this->url . "/subscribeProject.php?projectid=$projectid");
         $content = $this->getBrowser()->getContent();
-        $this->assertTrue(strpos($content, $label_text) !== false);
+        $this->assertTrue(str_contains($content, $label_text));
 
         // Cleanup.
-        $stmt = $this->PDO->prepare(
-            'DELETE FROM label2build WHERE labelid = :labelid AND buildid = :buildid');
-        $this->PDO->execute($stmt, [':labelid' => 1, ':buildid' => $buildid]);
+        DB::delete('DELETE FROM label2build WHERE labelid = ? AND buildid = ?', [1, $buildid]);
     }
 }

--- a/app/cdash/tests/test_uniquediffs.php
+++ b/app/cdash/tests/test_uniquediffs.php
@@ -76,13 +76,9 @@ class UniqueDiffsTestCase extends KWWebTestCase
         $this->checkRowCount($pdo, 'testdiff', 1);
 
         // Cleanup
-        $stmt = $pdo->prepare('DELETE FROM builderrordiff WHERE buildid=?');
-        $stmt->execute([$this->BuildId]);
-        $stmt = $pdo->prepare('DELETE FROM configureerrordiff WHERE buildid=?');
-        $stmt->execute([$this->BuildId]);
-        $stmt = $pdo->prepare('DELETE FROM testdiff WHERE buildid=?');
-        $stmt->execute([$this->BuildId]);
-
+        DB::delete('DELETE FROM builderrordiff WHERE buildid=?', [$this->BuildId]);
+        DB::delete('DELETE FROM configureerrordiff WHERE buildid=?', [$this->BuildId]);
+        DB::delete('DELETE FROM testdiff WHERE buildid=?', [$this->BuildId]);
         DB::delete('DELETE FROM build WHERE id = ?', [$build->Id]);
     }
 

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -10,6 +10,7 @@ use CDash\Config;
 use CDash\Database;
 use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
+use Illuminate\Support\Facades\DB;
 
 class UpgradeTestCase extends KWWebTestCase
 {
@@ -573,10 +574,10 @@ class UpgradeTestCase extends KWWebTestCase
         // Remove any testing data that we inserted in the existing tables.
         foreach ($tables_to_update as $table_to_update) {
             foreach ($keepers as $keeper) {
-                pdo_query("DELETE FROM $table_to_update WHERE siteid=$keeper");
+                DB::delete("DELETE FROM $table_to_update WHERE siteid=$keeper");
             }
             foreach ($dupes as $dupe) {
-                pdo_query("DELETE FROM $table_to_update WHERE siteid=$dupe");
+                DB::delete("DELETE FROM $table_to_update WHERE siteid=$dupe");
             }
         }
 

--- a/app/cdash/tests/test_usernotes.php
+++ b/app/cdash/tests/test_usernotes.php
@@ -8,6 +8,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
 use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
 
 class UserNotesAPICase extends KWWebTestCase
 {
@@ -47,11 +48,7 @@ class UserNotesAPICase extends KWWebTestCase
         $project->Public = 1;
         $project->Save();
 
-        $query = "DELETE FROM buildnote WHERE note='{$expected}'";
-        $result = pdo_query($query);
-        if (false === $result) {
-            $this->fail("Test successful but delete of data failed [sql: {$query}");
-        }
+        DB::delete("DELETE FROM buildnote WHERE note='{$expected}'");
     }
 
     public function testAddNoteRequiresBuildId(): void

--- a/app/cdash/xml_handlers/JSCoverTar_handler.php
+++ b/app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -22,6 +22,7 @@ use CDash\Model\Coverage;
 use CDash\Model\CoverageFile;
 use CDash\Model\CoverageFileLog;
 use CDash\Model\CoverageSummary;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class JSCoverTarHandler extends NonSaxHandler
@@ -153,7 +154,7 @@ class JSCoverTarHandler extends NonSaxHandler
                                           WHERE fullpath=? AND file IS NULL
                                       ', [$path]);
                 if (count($coveragefile_array) == 0) {
-                    $db->executePrepared('INSERT INTO coveragefile (fullpath) VALUES (?)', [$path]);
+                    DB::insert('INSERT INTO coveragefile (fullpath) VALUES (?)', [$path]);
                     $coveragefile_array = $db->executePrepared('
                                               SELECT id
                                               FROM coveragefile

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,7 +361,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 45
+			count: 43
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -1385,7 +1385,7 @@ parameters:
 				#^Call to deprecated function pdo_error\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1401,7 +1401,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 6
+			count: 4
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -2011,14 +2011,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function add_last_sql_error\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_error\\(\\)\\:
 				04/01/2023$#
 			"""
@@ -2038,7 +2030,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 11
+			count: 8
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2475,7 +2467,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 10
+			count: 5
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -6248,7 +6240,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 9
+			count: 7
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
@@ -7289,28 +7281,7 @@ parameters:
 			path: app/cdash/app/Model/BuildGroupRule.php
 
 		-
-			message: """
-				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
-			message: """
-				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:ChangeGroup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
 
@@ -7330,11 +7301,6 @@ parameters:
 			path: app/cdash/app/Model/BuildGroupRule.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:DeleteExpiredRulesForProject\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:DeleteExpiredRulesForProject\\(\\) has parameter \\$cutoff_date with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
@@ -7346,11 +7312,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:Exists\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:FillFromRow\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
 
@@ -7390,17 +7351,7 @@ parameters:
 			path: app/cdash/app/Model/BuildGroupRule.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:SoftDeleteExpiredRules\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildGroupRule\\:\\:SoftDeleteExpiredRules\\(\\) has parameter \\$now with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildGroupRule.php
-
-		-
-			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildGroupRule.php
 
@@ -8057,7 +8008,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 14
+			count: 13
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-
@@ -8201,7 +8152,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 12
+			count: 10
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -8217,7 +8168,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 10
+			count: 8
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -8250,11 +8201,6 @@ parameters:
 
 		-
 			message: "#^Offset 'c' might not exist on array\\|null\\.$#"
-			count: 1
-			path: app/cdash/app/Model/CoverageFile2User.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
 
@@ -8469,15 +8415,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 6
-			path: app/cdash/app/Model/CoverageSummary.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 2
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
@@ -8485,7 +8423,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 9
+			count: 3
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
@@ -8657,7 +8595,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 4
+			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -8689,7 +8627,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -8907,7 +8845,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/app/Model/DynamicAnalysisSummary.php
 
 		-
@@ -8940,11 +8878,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\DynamicAnalysisSummary\\:\\:Insert\\(\\) has parameter \\$append with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/DynamicAnalysisSummary.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\DynamicAnalysisSummary\\:\\:Remove\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/DynamicAnalysisSummary.php
 
@@ -10121,7 +10054,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 4
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
@@ -10315,7 +10248,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 14
+			count: 12
 			path: app/cdash/app/Model/User.php
 
 		-
@@ -10496,7 +10429,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 7
+			count: 6
 			path: app/cdash/app/Model/UserProject.php
 
 		-
@@ -10520,7 +10453,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 4
 			path: app/cdash/app/Model/UserProject.php
 
 		-
@@ -14493,7 +14426,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 13
+			count: 10
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -17139,7 +17072,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 70
+			count: 62
 			path: app/cdash/include/upgrade_functions.php
 
 		-
@@ -17696,7 +17629,7 @@ parameters:
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/public/api/v1/build.php
 
 		-
@@ -17712,7 +17645,7 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/public/api/v1/build.php
 
 		-
@@ -17762,7 +17695,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/public/api/v1/build.php
 
 		-
@@ -18345,7 +18278,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/public/api/v1/manageOverview.php
 
 		-
@@ -18361,7 +18294,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/public/api/v1/manageOverview.php
 
 		-
@@ -24565,7 +24498,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_buildmodel.php
 
 		-
@@ -25084,14 +25017,6 @@ parameters:
 			path: app/cdash/tests/test_createprojectpermissions.php
 
 		-
-			message: """
-				#^Call to deprecated method query\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 3
-			path: app/cdash/tests/test_createprojectpermissions.php
-
-		-
 			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_createprojectpermissions.php
@@ -25601,7 +25526,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
@@ -25717,7 +25642,7 @@ parameters:
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -25738,7 +25663,7 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -25803,7 +25728,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -25865,14 +25790,6 @@ parameters:
 			message: "#^Variable \\$build might not be defined\\.$#"
 			count: 48
 			path: app/cdash/tests/test_excludesubprojects.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_expectedandmissing.php
 
 		-
 			message: """
@@ -27503,7 +27420,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 11
+			count: 10
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
@@ -28011,7 +27928,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_subprojectemail.php
 
 		-
@@ -28741,12 +28658,12 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 6
+			count: 3
 			path: app/cdash/tests/test_uniquediffs.php
 
 		-
 			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
-			count: 9
+			count: 6
 			path: app/cdash/tests/test_uniquediffs.php
 
 		-
@@ -28911,7 +28828,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 30
+			count: 28
 			path: app/cdash/tests/test_upgrade.php
 
 		-
@@ -29145,14 +29062,6 @@ parameters:
 			message: "#^Method UserTestCase\\:\\:testUser\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_user.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_usernotes.php
 
 		-
 			message: """
@@ -29922,7 +29831,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-


### PR DESCRIPTION
We currently have several pre-laravel methods which can execute DELETE queries, but it is preferable to use Laravel's database functions instead.  One advantage is that all queries executed by laravel are visible in Laravel's query log, which helps debug performance issues.  DELETE statements are an easy starting place because the return value is rarely used.