### PR TITLE
Rename central menu item from "current" to "latest"

### DIFF
--- a/resources/js/components/page-header/HeaderNav.vue
+++ b/resources/js/components/page-header/HeaderNav.vue
@@ -29,7 +29,7 @@
       id="header-nav-current-btn"
       :class="currentClass"
     >
-      <a :href="current">CURRENT</a>
+      <a :href="current">LATEST</a>
     </li>
     <li
       id="header-nav-next-btn"

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -76,7 +76,7 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
                         <li class="btncurr">
                             <a ng-if="cdash.menu.current"
                                ng-href="{{::cdash.menu.current}}{{::cdash.filterurl}}">
-                                Current
+                                Latest
                             </a>
                         </li>
                         <li class="btnnext">


### PR DESCRIPTION
The navigation menu in the middle of the header menu is confusing, because the "current" option takes the user to the most recent change, while the "prev" and "next" options allow the user to navigate through items one at a time.  I changed the text from "current" to "latest" to better reflect the action being performed, but I decided not to update the underlying code to avoid breaking the API.  I would like to hear any feedback reviewers have regarding this decision.

After the change:
![image](https://github.com/Kitware/CDash/assets/16820599/1d46820d-029b-4f63-9270-2006b4a584a0)
