### PR TITLE
Drop `user2project.cvslogin` column

### DIFF
--- a/database/migrations/2023_10_05_213910_drop_cvslogin_column.php
+++ b/database/migrations/2023_10_05_213910_drop_cvslogin_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('user2project')) {
+            Schema::dropColumns('user2project', 'cvslogin');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // This migration is irreversible
+    }
+};

--- a/tests/Feature/ProjectPermissions.php
+++ b/tests/Feature/ProjectPermissions.php
@@ -155,7 +155,6 @@ class ProjectPermissions extends TestCase
             'userid' => $this->normal_user->id,
             'projectid' => $this->private_project1->Id,
             'role' => 0,
-            'cvslogin' => '',
             'emailtype' => 0,
             'emailcategory' => 0,
             'emailsuccess' => 0,


### PR DESCRIPTION
The `cvslogin` column was superseded by the `user2repository` table and is currently unused.  All of the references in the code ultimately lead to the `user2repository` table, so I have eliminated the original `cvslogin` column.