### PR TITLE
Fix subproject dependency graph rendering

### DIFF
--- a/app/cdash/public/css/d3.dependencyedgebundling.css
+++ b/app/cdash/public/css/d3.dependencyedgebundling.css
@@ -79,7 +79,7 @@ div.tooltipTail {
     top: 12px;
     width: 7px;
     height: 13px;
-    background: url("../images/tail_white.png") 50% 0%;
+    background: url("../img/tail_white.png") 50% 0%;
 }
 
 div.toolTipBody {

--- a/resources/views/project/subproject-dependencies.blade.php
+++ b/resources/views/project/subproject-dependencies.blade.php
@@ -3,7 +3,7 @@
 ])
 
 @section('main_content')
-    <div style="position:relative; top:10px; left:20px; overflow:hidden;">
+    <div style="top:10px; left:20px; overflow:hidden;">
         <label style="font-size:1.2em;"><b>SubProject Dependencies Graph</b></label>
         <label for="selectedsort" style="margin-left:80px; font-size:.95em;">Sorted by:</label>
         <select id="selectedsort">
@@ -12,10 +12,10 @@
         </select>
         <button onclick="download_svg()" style="float:right; width:200px; margin-right:30px">Export as svg file</button>
     </div>
-    <div class="hint" style="position:relative; top:20px; left:20px; font-size:0.9em; width:350px; color:#999;">
+    <div class="hint" style="top:20px; left:20px; font-size:0.9em; width:350px; color:#999;">
         This circle plot captures the interrelationships among subgroups. Mouse over any of the subgroup in this graph to see incoming links (dependents) in green and the outgoing links (dependencies) in red.
     </div>
-    <div id="chart_placeholder" style="position:relative; left:150px; top:-60px">
+    <div id="chart_placeholder" style="left:150px; top:-60px; text-align:center;">
     </div>
     <!-- Tooltip -->
     <div id="toolTip" class="tooltip" style="opacity:0;">


### PR DESCRIPTION
### Current behavior
Currently, when loading the SubProject Dependencies page for a given project, depending on the number of subprojects and the length of their names, the rendering of the graph may overlap the text on the page. 
<img width="959" alt="before_aligning" src="https://github.com/Kitware/CDash/assets/71195502/402ec889-913d-48e4-8ebd-74506b0e051f">

Additionally, when hovering on top of nodes in the graph, the following error is printed to the console:
<img width="467" alt="image" src="https://github.com/Kitware/CDash/assets/71195502/9a475b24-9fc0-496e-9b2c-7dda26b8575f">

### New behavior
The graph will never overlap the text on the page anymore, and it set to be rendered on the center of the page. The console error is fixed and the tooltip now displays properly (the tiny white triangle connected to the textbox that pops up on hover).

<img width="957" alt="after_aligning" src="https://github.com/Kitware/CDash/assets/71195502/36462d92-18b5-4026-b72a-9530bab89114">
