### PR TITLE
Fix broken navigation links on `Build Files Updated` page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -548,15 +548,19 @@ final class BuildController extends AbstractBuildController
         $next_buildid = $this->build->GetNextBuildId();
 
         if ($previous_buildid > 0) {
-            $menu_response['previous'] = url("/build/$previous_buildid/update");
+            $menu_response['previous'] = "/build/$previous_buildid/update";
         } else {
             $menu_response['previous'] = false;
         }
 
-        $menu_response['current'] = url("/build/$current_buildid/update");
+        if ($current_buildid > 0) {
+            $menu_response['current'] = "/build/$current_buildid/update";
+        } else {
+            $menu_response['current'] = false;
+        }
 
         if ($next_buildid > 0) {
-            $menu_response['next'] = url("/build/$next_buildid/update");
+            $menu_response['next'] = "/build/$next_buildid/update";
         } else {
             $menu_response['next'] = false;
         }


### PR DESCRIPTION
Fixes https://github.com/Kitware/CDash/issues/1748

This resolves a bug that was introduced in https://github.com/Kitware/CDash/pull/1561, and also adds a missing check for the `CURRENT` navigation button.
