### PR TITLE
Fix base-level redirect for CDash-in-a-subdir 

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -118,7 +118,7 @@ Route::get('/manageOverview.php', 'ProjectController@manageOverview');
 Route::get('/ajax/showtestfailuregraph.php', 'TestController@ajaxTestFailureGraph');
 
 Route::match(['get', 'post'], '/projects', 'ViewProjectsController@viewAllProjects');
-Route::permanentRedirect('/viewProjects.php', '/projects');
+Route::permanentRedirect('/viewProjects.php', url('/projects'));
 
 Route::get('/viewTest.php', 'ViewTestController@viewTest');
 


### PR DESCRIPTION
Prior to this commit, when CDash is deployed in a subdirectory like so:
http://mydomain.com/cdash

Navigating to this base-level URL would cause CDash to respond with "The requested page does not exist".