### PR TITLE
Simplify copied code in coverage file pivot model

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -158,12 +158,12 @@ final class CoverageController extends AbstractBuildController
 
         // Assign last author
         if (isset($_POST['assignLastAuthor'])) {
-            $CoverageFile2User->AssignLastAuthor(intval($buildid));
+            $CoverageFile2User->AssignAuthors($buildid, onlylast: true);
         }
 
         // Assign all authors
         if (isset($_POST['assignAllAuthors'])) {
-            $CoverageFile2User->AssignAllAuthors(intval($buildid));
+            $CoverageFile2User->AssignAuthors($buildid);
         }
 
         // Upload file

--- a/app/cdash/app/Model/CoverageFile2User.php
+++ b/app/cdash/app/Model/CoverageFile2User.php
@@ -275,8 +275,7 @@ class CoverageFile2User
         return intval($query_result['id']);
     }
 
-    /** Assign the last author */
-    public function AssignLastAuthor(int $buildid): bool
+    public function AssignAuthors(int $buildid, bool $onlylast = false): bool
     {
         if (!isset($this->ProjectId) || $this->ProjectId < 1) {
             abort(500, 'CoverageFile2User:AssignLastAuthor: ProjectId not set');
@@ -297,40 +296,7 @@ class CoverageFile2User
 
             $DailyUpdate = new DailyUpdate();
             $DailyUpdate->ProjectId = $this->ProjectId;
-            $userids = $DailyUpdate->GetAuthors($fullpath, true); // only last
-
-            foreach ($userids as $userid) {
-                $this->FullPath = $fullpath;
-                $this->UserId = $userid;
-                $this->Insert();
-            }
-        }
-        return true;
-    }
-
-    /** Assign all author author */
-    public function AssignAllAuthors(int $buildid): bool
-    {
-        if (!isset($this->ProjectId) || $this->ProjectId < 1) {
-            abort(500, 'CoverageFile2User:AssignLastAuthor: ProjectId not set');
-        }
-
-        if ($buildid === 0) {
-            abort(500, 'CoverageFile2User:AssignLastAuthor: buildid not valid');
-        }
-
-        // Find the files associated with the build
-        $Coverage = new Coverage();
-        $Coverage->BuildId = $buildid;
-        $fileIds = $Coverage->GetFiles();
-        foreach ($fileIds as $fileid) {
-            $CoverageFile = new CoverageFile();
-            $CoverageFile->Id = $fileid;
-            $fullpath = $CoverageFile->GetPath();
-
-            $DailyUpdate = new DailyUpdate();
-            $DailyUpdate->ProjectId = $this->ProjectId;
-            $userids = $DailyUpdate->GetAuthors($fullpath);
+            $userids = $DailyUpdate->GetAuthors($fullpath, $onlylast);
 
             foreach ($userids as $userid) {
                 $this->FullPath = $fullpath;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8139,12 +8139,12 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-


### PR DESCRIPTION
The `CoverageFile2User` model contained two functions which differed by only a single parameter on one function call.  This rather trivial PR simply eliminates one of the functions, and adds an extra argument to the other.