### PR TITLE
Set up Project<->Build Eloquent relationship

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -80,7 +80,7 @@ final class UserController extends AbstractController
             $project_response['role'] = $project_row['role']; // 0 is normal user, 1 is maintainer, 2 is administrator
             $project_response['name'] = $Project->Name;
             $project_response['name_encoded'] = urlencode($Project->Name);
-            $project_response['nbuilds'] = $Project->GetTotalNumberOfBuilds();
+            $project_response['nbuilds'] = $Project->GetNumberOfBuilds();
             $project_response['average_builds'] = round($Project->GetBuildsDailyAverage(gmdate(FMT_DATETIME, time() - (3600 * 24 * 7)), gmdate(FMT_DATETIME)), 2);
             $project_response['success'] = $Project->GetNumberOfPassingBuilds($start, gmdate(FMT_DATETIME));
             $project_response['error'] = $Project->GetNumberOfErrorBuilds($start, gmdate(FMT_DATETIME));

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
@@ -37,6 +38,8 @@ use Illuminate\Support\Carbon;
  * @property bool $done
  * @property string $uuid
  * @property string $changeid
+ *
+ * @method static Builder betweenDates(?Carbon $starttime, ?Carbon $endtime)
  *
  * @mixin Builder<Build>
  */
@@ -113,5 +116,29 @@ class Build extends Model
     {
         return $this->belongsToMany(Note::class, 'build2note', 'buildid', 'noteid')
             ->withPivot('time');
+    }
+
+    /**
+     * @return BelongsTo<Project, self>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'id', 'projectid');
+    }
+
+    /**
+     * Adds a betweenDates() query builder filter method...
+     *
+     * @param Builder<self> $query
+     */
+    public function scopeBetweenDates(Builder $query, ?Carbon $starttime, ?Carbon $endtime): void
+    {
+        if ($starttime !== null) {
+            $query->where('starttime', '>', $starttime);
+        }
+
+        if ($endtime !== null) {
+            $query->where('endtime', '<=', $endtime);
+        }
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -128,4 +128,16 @@ class Project extends Model
     {
         return $this->hasMany(BuildGroup::class, 'projectid', 'id');
     }
+
+    /**
+     * @return HasMany<Build>
+     */
+    public function builds(): HasMany
+    {
+        return $this->hasMany(Build::class, 'projectid', 'id')
+            ->where(function ($query) {
+                $query->where('parentid', 0)
+                    ->orWhere('parentid', -1);
+            });
+    }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3263,6 +3263,16 @@ parameters:
 			path: app/Models/BuildTest.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:orWhere\\(\\)\\.$#"
+			count: 1
+			path: app/Models/Project.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:where\\(\\)\\.$#"
+			count: 2
+			path: app/Models/Project.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SubProject\\>\\:\\:orWhere\\(\\)\\.$#"
 			count: 1
 			path: app/Models/Project.php
@@ -9370,6 +9380,21 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Project\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:betweenDates\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:max\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 


### PR DESCRIPTION
This PR introduces Eloquent relationships between the `Project` model and the `Build` model.

I used the new relationships to replace a few existing SQL queries in the legacy project model as examples, but by no means did I attempt to locate and refactor every possible place where the relationships can be used.  I expect to gradually use them more through my work in other PRs.