### PR TITLE
Create `BlockedBuild` Eloquent model

### DIFF
--- a/app/Models/BlockedBuild.php
+++ b/app/Models/BlockedBuild.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $projectid
+ * @property string $buildname
+ * @property string $sitename
+ * @property string $ipaddress
+ *
+ * @mixin Builder<BlockedBuild>
+ */
+class BlockedBuild extends Model
+{
+    protected $table = 'blockbuild';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'projectid',
+        'buildname',
+        'sitename',
+        'ipaddress',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'projectid' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Project, self>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'id', 'projectid');
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -140,4 +140,12 @@ class Project extends Model
                     ->orWhere('parentid', -1);
             });
     }
+
+    /**
+     * @return HasMany<BlockedBuild>
+     */
+    public function blockedbuilds(): HasMany
+    {
+        return $this->hasMany(BlockedBuild::class, 'projectid', 'id');
+    }
 }

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1264,17 +1264,21 @@ class Project
 
     public function AddBlockedBuild(string $buildname, string $sitename, string $ip): int
     {
-        return DB::table('blockbuild')->insertGetId([
-            'projectid' => $this->Id,
-            'buildname' => $buildname,
-            'sitename' => $sitename,
-            'ip' => $ip,
-        ]);
+        return EloquentProject::findOrFail((int) $this->Id)
+            ->blockedbuilds()
+            ->create([
+                'buildname' => $buildname,
+                'sitename' => $sitename,
+                'ipaddress' => $ip,
+            ])->id;
     }
 
     public function RemoveBlockedBuild(int $id): void
     {
-        DB::table('blockbuild')->delete($id);
+        EloquentProject::findOrFail((int) $this->Id)
+            ->blockedbuilds()
+            ->findOrFail($id)
+            ->delete();
     }
 
     /** Delete old builds if this project has too many. */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9384,6 +9384,11 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\BlockedBuild\\>\\:\\:findOrFail\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:betweenDates\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php


### PR DESCRIPTION
The "blocked build" functionality currently resides entirely within the project model.  This PR creates a new Eloquent model to represent the `blockbuild` table.  This PR is part of our ongoing effort to migrate our SQL queries to Laravel's Eloquent ORM.