### PR TITLE
Fix Angular routing behavior after login

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Request;
 use Illuminate\View\View;
 
 abstract class AbstractController extends BaseController
@@ -52,7 +53,7 @@ abstract class AbstractController extends BaseController
 
     protected function redirectToLogin(): RedirectResponse
     {
-        session(['url.intended' => url()->current()]);
+        session(['url.intended' => Request::getRequestUri()]);
         return redirect()->route('login');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
@@ -37,6 +38,9 @@ class AppServiceProvider extends ServiceProvider
 
         // This allows us to do response()->angular_view(<view_name>).
         Response::macro('angular_view', function (string $view_name) {
+            // A hack to ensure that redirects work properly after being redirected to the login page
+            session(['url.intended' => Request::getRequestUri()]);
+
             $controller_name = '';
             $path = request()->path() === '/' ? 'index.php' : request()->path();
             $file = pathinfo(substr($path, strrpos($path, '/')), PATHINFO_FILENAME);


### PR DESCRIPTION
Pages rendered by AngularJS which require authentication currently redirect to the index page after login.  This is inconsistent with the behavior elsewhere, where the user is redirected back to the page they attempted to access prior to being redirected to the login page.

This PR is a temporary patch to make the login redirect behavior more consistent.  The ultimate goal is to remove AngularJS entirely.