### PR TITLE
Add missing slash for URL in Dynamic Analysis

### DIFF
--- a/resources/js/components/ViewDynamicAnalysis.vue
+++ b/resources/js/components/ViewDynamicAnalysis.vue
@@ -63,7 +63,7 @@
             align="center"
           >
             <td align="left">
-              <a :href="$baseURL + 'viewDynamicAnalysisFile.php?id=' + DA.id">
+              <a :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id">
                 {{ DA.name }}
               </a>
             </td>


### PR DESCRIPTION
Add in a `/` to properly form the URL for a link to a specific dynamic analysis file from the listing page.

Fixes: #1759