### PR TITLE
Move `php.ini` to outer directory

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -95,7 +95,7 @@ WORKDIR /cdash
 
 COPY --chown=www-data:www-data ./.env.example ./.env
 
-COPY ./app/cdash/php.ini /usr/local/etc/php/conf.d/cdash.ini
+COPY ./php.ini /usr/local/etc/php/conf.d/cdash.ini
 
 # Install PHP dependencies with composer
 # Set up testing environment if this is a development build

--- a/php.ini
+++ b/php.ini
@@ -1,6 +1,3 @@
-google_app_engine.enable_curl_lite = "1"
-google_app_engine.enable_functions = "getmypid, parse_str, phpversion"
-
 display_errors = Off
 log_errors = On
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT


### PR DESCRIPTION
Our PHP configuration file is currently located inside the old part of the codebase.  This PR moves it to the top level directory where it is more noticeable.  I also eliminated outdated Google App Engine settings.