### PR TITLE
Delete `CURL_REQUEST_LOCALHOST` configuration option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,6 @@ DB_PASSWORD=secret
 # When set to 0 projects are not limited by number of builds.
 #BUILDS_PER_PROJECT=0
 
-# Should CDash use localhost or its full server name when attempting
-# to connect to itself?
-#CURL_REQUEST_LOCALHOST=true
-
 # Whether or not CDash submissions should trigger daily updates.
 # Disable this if you want more fine grained control over when/how
 # daily updates are triggered (e.g. cron).

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -52,7 +52,6 @@ return [
     'builds_per_project' => env('BUILDS_PER_PROJECT', 0),
     'coverage_dir' => env('CDASH_COVERAGE_DIR', '/cdash/_build/xdebugCoverage'),
     'curl_localhost_prefix' => env('CURL_LOCALHOST_PREFIX', ''),
-    'curl_request_localhost' => env('CURL_REQUEST_LOCALHOST', true),
     'daily_updates' => env('DAILY_UPDATES', true),
     'default_git_dir' => env('DEFAULT_GIT_DIRECTORY', '/cdash/_build'),
     'default_google_analytics' => env('DEFAULT_GOOGLE_ANALYTICS', ''),


### PR DESCRIPTION
The last reference to `CURL_REQUEST_LOCALHOST` was removed in #1341, but the configuration setting itself was missed.  This PR removes the last remnants of this configuration setting.