### PR TITLE
Delete invalid rows prior to creating FK constraint

### DIFF
--- a/database/migrations/2023_07_20_185727_project_foreign_keys.php
+++ b/database/migrations/2023_07_20_185727_project_foreign_keys.php
@@ -2,9 +2,28 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
+    private const tables_to_modify = [
+        'blockbuild',
+        'build',
+        'build_filters',
+        'buildgroup',
+        'coveragefilepriority',
+        'labelemail',
+        'measurement',
+        'overview_components',
+        'project2repositories',
+        'subproject',
+        'subprojectgroup',
+        'test',
+        'user2project',
+        'user2repository',
+        'userstatistics',
+    ];
+
     /**
      * Run the migrations.
      *
@@ -12,101 +31,24 @@ return new class extends Migration {
      */
     public function up()
     {
-        echo 'Adding projectid foreign key to authtoken table...' . PHP_EOL;
+        // The authtoken table is special because the projectid column can be nullable
+        echo "Adding projectid foreign key to authtoken table...";
+        $num_deleted = DB::delete("DELETE FROM authtoken WHERE projectid IS NOT NULL AND projectid NOT IN (SELECT id FROM project)");
+        echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
         Schema::table('authtoken', function (Blueprint $table) {
-            $table->integer('projectid')->change();
+            $table->integer('projectid')->nullable()->change();
             $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
         });
 
-        echo 'Adding projectid foreign key to blockbuild table...' . PHP_EOL;
-        Schema::table('blockbuild', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to build table...' . PHP_EOL;
-        Schema::table('build', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to build_filters table...' . PHP_EOL;
-        Schema::table('build_filters', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to buildgroup table...' . PHP_EOL;
-        Schema::table('buildgroup', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to coveragefilepriority table...' . PHP_EOL;
-        Schema::table('coveragefilepriority', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to labelemail table...' . PHP_EOL;
-        Schema::table('labelemail', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to measurement table...' . PHP_EOL;
-        Schema::table('measurement', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to overview_components table...' . PHP_EOL;
-        Schema::table('overview_components', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to project2repositories table...' . PHP_EOL;
-        Schema::table('project2repositories', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to subproject table...' . PHP_EOL;
-        Schema::table('subproject', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to subprojectgroup table...' . PHP_EOL;
-        Schema::table('subprojectgroup', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to test table...' . PHP_EOL;
-        Schema::table('test', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to user2project table...' . PHP_EOL;
-        Schema::table('user2project', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to user2repository table...' . PHP_EOL;
-        Schema::table('user2repository', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
-
-        echo 'Adding projectid foreign key to userstatistics table...' . PHP_EOL;
-        Schema::table('userstatistics', function (Blueprint $table) {
-            $table->integer('projectid')->nullable(false)->change();
-            $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
-        });
+        foreach (self::tables_to_modify as $table) {
+            echo "Adding projectid foreign key to $table table...";
+            $num_deleted = DB::delete("DELETE FROM $table WHERE projectid NOT IN (SELECT id FROM project)");
+            echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('projectid')->nullable(false)->change();
+                $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
+            });
+        }
     }
 
     /**
@@ -116,84 +58,11 @@ return new class extends Migration {
      */
     public function down()
     {
-        Schema::table('authtoken', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('blockbuild', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('build', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('build_filters', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('buildgroup', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('coveragefilepriority', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('labelemail', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('measurement', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('overview_components', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('project2repositories', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('subproject', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('subprojectgroup', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('test', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('user2project', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('user2repository', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
-
-        Schema::table('userstatistics', function (Blueprint $table) {
-            $table->integer('projectid')->change();
-            $table->dropForeign(['projectid']);
-        });
+        foreach (self::tables_to_modify + ['authtoken'] as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('projectid')->change();
+                $table->dropForeign(['projectid']);
+            });
+        }
     }
 };

--- a/database/migrations/2023_08_14_200318_user_foreign_keys.php
+++ b/database/migrations/2023_08_14_200318_user_foreign_keys.php
@@ -2,9 +2,26 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
+require_once 'include/common.php';
+
 return new class extends Migration {
+    private const tables_to_modify = [
+        'authtoken',
+        'buildemail',
+        'buildnote',
+        'coveragefile2user',
+        'labelemail',
+        'lockout',
+        'password',
+        'site2user',
+        'user2project',
+        'user2repository',
+        'userstatistics',
+    ];
+
     /**
      * Run the migrations.
      *
@@ -12,71 +29,16 @@ return new class extends Migration {
      */
     public function up()
     {
-        echo 'Adding userid foreign key to authtoken table...' . PHP_EOL;
-        Schema::table('authtoken', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to buildemail table...' . PHP_EOL;
-        Schema::table('buildemail', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to buildnote table...' . PHP_EOL;
-        Schema::table('buildnote', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to coveragefile2user table...' . PHP_EOL;
-        Schema::table('coveragefile2user', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to labelemail table...' . PHP_EOL;
-        Schema::table('labelemail', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to lockout table...' . PHP_EOL;
-        Schema::table('lockout', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to password table...' . PHP_EOL;
-        Schema::table('password', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to site2user table...' . PHP_EOL;
-        Schema::table('site2user', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to user2project table...' . PHP_EOL;
-        Schema::table('user2project', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to user2repository table...' . PHP_EOL;
-        Schema::table('user2repository', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
-
-        echo 'Adding userid foreign key to userstatistics table...' . PHP_EOL;
-        Schema::table('userstatistics', function (Blueprint $table) {
-            $table->integer('userid')->nullable(false)->change();
-            $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
-        });
+        foreach (self::tables_to_modify as $table) {
+            echo "Adding userid foreign key to $table table...";
+            $user_table = qid('user');
+            $num_deleted = DB::delete("DELETE FROM $table WHERE userid NOT IN (SELECT id FROM $user_table)");
+            echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('userid')->nullable(false)->change();
+                $table->foreign('userid')->references('id')->on('user')->cascadeOnDelete();
+            });
+        }
     }
 
     /**
@@ -86,59 +48,11 @@ return new class extends Migration {
      */
     public function down()
     {
-        Schema::table('authtoken', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('buildemail', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('buildnote', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('coveragefile2user', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('labelemail', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('lockout', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('password', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('site2user', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('user2project', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('user2repository', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
-
-        Schema::table('userstatistics', function (Blueprint $table) {
-            $table->integer('userid')->change();
-            $table->dropForeign(['userid']);
-        });
+        foreach (self::tables_to_modify as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('userid')->change();
+                $table->dropForeign(['userid']);
+            });
+        }
     }
 };

--- a/database/migrations/2023_08_14_205552_build_foreign_keys.php
+++ b/database/migrations/2023_08_14_205552_build_foreign_keys.php
@@ -2,9 +2,43 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
+    private const tables_to_modify = [
+        'build2configure',
+        'build2group',
+        'build2note',
+        'build2test',
+        'build2update',
+        'build2uploadfile',
+        'buildemail',
+        'builderror',
+        'builderrordiff',
+        'buildfailure',
+        'buildfile',
+        'buildinformation',
+        'buildnote',
+        'buildproperties',
+        'buildtesttime',
+        'configureerrordiff',
+        'coverage',
+        'coveragefilelog',
+        'coveragesummary',
+        'coveragesummarydiff',
+        'dynamicanalysis',
+        'dynamicanalysissummary',
+        'label2build',
+        'label2coveragefile',
+        'label2test',
+        'pending_submissions',
+        'related_builds',
+        'subproject2build',
+        'summaryemail',
+        'testdiff',
+    ];
+
     /**
      * Run the migrations.
      *
@@ -12,186 +46,15 @@ return new class extends Migration {
      */
     public function up()
     {
-        echo 'Adding buildid foreign key to build2configure table...' . PHP_EOL;
-        Schema::table('build2configure', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-
-        echo 'Adding buildid foreign key to build2group table...' . PHP_EOL;
-        Schema::table('build2group', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to build2note table...' . PHP_EOL;
-        Schema::table('build2note', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to build2test table...' . PHP_EOL;
-        Schema::table('build2test', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to build2update table...' . PHP_EOL;
-        Schema::table('build2update', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to build2uploadfile table...' . PHP_EOL;
-        Schema::table('build2uploadfile', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildemail table...' . PHP_EOL;
-        Schema::table('buildemail', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to builderror table...' . PHP_EOL;
-        Schema::table('builderror', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to builderrordiff table...' . PHP_EOL;
-        Schema::table('builderrordiff', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildfailure table...' . PHP_EOL;
-        Schema::table('buildfailure', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildfile table...' . PHP_EOL;
-        Schema::table('buildfile', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildinformation table...' . PHP_EOL;
-        Schema::table('buildinformation', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildnote table...' . PHP_EOL;
-        Schema::table('buildnote', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildproperties table...' . PHP_EOL;
-        Schema::table('buildproperties', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to buildtesttime table...' . PHP_EOL;
-        Schema::table('buildtesttime', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to configureerrordiff table...' . PHP_EOL;
-        Schema::table('configureerrordiff', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to coverage table...' . PHP_EOL;
-        Schema::table('coverage', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to coveragefilelog table...' . PHP_EOL;
-        Schema::table('coveragefilelog', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to coveragesummary table...' . PHP_EOL;
-        Schema::table('coveragesummary', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to coveragesummarydiff table...' . PHP_EOL;
-        Schema::table('coveragesummarydiff', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to dynamicanalysis table...' . PHP_EOL;
-        Schema::table('dynamicanalysis', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to dynamicanalysissummary table...' . PHP_EOL;
-        Schema::table('dynamicanalysissummary', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to label2build table...' . PHP_EOL;
-        Schema::table('label2build', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to label2coveragefile table...' . PHP_EOL;
-        Schema::table('label2coveragefile', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to label2test table...' . PHP_EOL;
-        Schema::table('label2test', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to pending_submissions table...' . PHP_EOL;
-        Schema::table('pending_submissions', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to related_builds table...' . PHP_EOL;
-        Schema::table('related_builds', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to subproject2build table...' . PHP_EOL;
-        Schema::table('subproject2build', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to summaryemail table...' . PHP_EOL;
-        Schema::table('summaryemail', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
-
-        echo 'Adding buildid foreign key to testdiff table...' . PHP_EOL;
-        Schema::table('testdiff', function (Blueprint $table) {
-            $table->integer('buildid')->nullable(false)->change();
-            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
-        });
+        foreach (self::tables_to_modify as $table) {
+            echo "Adding buildid foreign key to $table table...";
+            $num_deleted = DB::delete("DELETE FROM $table WHERE buildid NOT IN (SELECT id FROM build)");
+            echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('buildid')->nullable(false)->change();
+                $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
+            });
+        }
     }
 
     /**
@@ -201,154 +64,11 @@ return new class extends Migration {
      */
     public function down()
     {
-        Schema::table('build2configure', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('build2group', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('build2note', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('build2test', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('build2update', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('build2uploadfile', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildemail', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('builderror', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('builderrordiff', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildfailure', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildfile', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildinformation', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildnote', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildproperties', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('buildtesttime', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('configureerrordiff', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('coverage', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('coveragefilelog', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('coveragesummary', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('coveragesummarydiff', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('dynamicanalysis', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('dynamicanalysissummary', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('label2build', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('label2coveragefile', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('label2test', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('pending_submissions', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('related_builds', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('subproject2build', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('summaryemail', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
-
-        Schema::table('testdiff', function (Blueprint $table) {
-            $table->integer('buildid')->change();
-            $table->dropForeign(['buildid']);
-        });
+        foreach (self::tables_to_modify as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->integer('buildid')->change();
+                $table->dropForeign(['buildid']);
+            });
+        }
     }
 };

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2627,11 +2627,6 @@ parameters:
 			path: app/Http/Controllers/TestController.php
 
 		-
-			message: "#^Parameter \\#1 \\$projectid of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectById\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: app/Http/Controllers/TestController.php
-
-		-
 			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php


### PR DESCRIPTION
The CDash 3.3 release will include foreign-key constraints for the first time.  CDash does a poor job of cleaning up after itself when deleting rows, so the new constraints will fail during the migration for many existing CDash systems.  The only way to add these constraints is delete any data which violates them.  This should not be problematic, because there should be no way to access invalid data in the first place.

I also simplified the existing migrations due to an egregious violation of the DRY principle...