### PR TITLE
Base64 decode preformatted measurements.

### DIFF
--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -254,7 +254,7 @@ class TestDetails extends BuildTestApi
                 $test_response['environment'] = $row['value'];
                 continue;
             } elseif ($row['type'] == 'text/preformatted') {
-                $preformatted_measurement = ['name' => $row['name'], 'value' => $row['value']];
+                $preformatted_measurement = ['name' => $row['name'], 'value' => base64_decode($row['value'])];
                 $preformatted_measurements[] = $preformatted_measurement;
                 continue;
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4621,7 +4621,7 @@ parameters:
 
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
-			count: 2
+			count: 3
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
 		-


### PR DESCRIPTION
Make CDash base64-decode preformatted measurements encoded by CTest.
