### PR TITLE
Delete outdated testing info from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,3 @@ Your efforts to improve CDash are welcome and appreciated!
 but you're not sure where to start.
 
 For bigger changes, please begin by [introducing yourself on our mailing list](http://public.kitware.com/mailman/listinfo/cdash).
-
-## Testing
-
-[See here for information about our testing infrastructure](http://public.kitware.com/Wiki/CDash:Testing).


### PR DESCRIPTION
The testing information in our `README.md` is no longer relevant and directs users to a page which was last updated in 2017.