### PR TITLE
Re-index array after removing duplicates

### DIFF
--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -303,7 +303,7 @@ final class TestController extends AbstractProjectController
         foreach ($result as $row) {
             $buildids[] = (int) $row->buildid;
         }
-        $buildids = array_unique($buildids);
+        $buildids = array_values(array_unique($buildids));
 
         $prepared_array = Database::getInstance()->createPreparedArray(count($buildids));
         $query = DB::select("


### PR DESCRIPTION
PHP's `array_unique()` function does not re-index the array when duplicates are removed.  PDO expects an array with sequential numeric keys, and fails if any duplicates were removed from the array.  I fixed the issue by re-indexing the array with `array_values()`.

This problem does not exist on master because the offending code was refactored since the 3.2 release branch was cut.