### PR TITLE
Add additional files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,11 @@ ansible/site.retry
 /app/cdash/public/build/
 /app/cdash/public/js/nv.d3.js.map
 /app/cdash/public/upload/
+/app/cdash/AuditReport.log
 _build/
 CDash_*.min.js*
 composer.phar
+.composer
 .DS_Store
 .env
 .env.bak
@@ -34,7 +36,8 @@ public/main.js
 /public/storage
 /public/COMMITHASH
 /public/VERSION
-/storage/*.key
+/public/LASTCOMMITDATETIME
+/storage/
 .vagrant
 /vendor/
 yarn-error.log


### PR DESCRIPTION
A few auto-generated files are not being ignored by Git.  This is particularly annoying on Docker systems where these files are generated during the image build process.  I also ignored all of the cache directories entirely.