### PR TITLE
Improve test label query performance

### DIFF
--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -368,6 +368,7 @@ class QueryTests extends ResultsApi
                             WHERE
                                 label.id=label2test.labelid
                                 AND label2test.outputid=test.id
+                                AND label2test.buildid=b.id
                         ) AS labelstring
                         $output_select
                     FROM build AS b

--- a/database/migrations/2023_11_09_182206_test_labels_index.php
+++ b/database/migrations/2023_11_09_182206_test_labels_index.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('label2test', function (Blueprint $table) {
+            $table->unique(['outputid', 'buildid', 'labelid']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('label2test', function (Blueprint $table) {
+            $table->dropUnique(['outputid', 'buildid', 'labelid']);
+        });
+    }
+};


### PR DESCRIPTION
`queryTests.php` is currently slow on some large production systems due to the changes introduced in #1455.  Adding this index improved the query time by two orders of magnitude on a large production system.  This PR also fixes a small bug introduced by #1455, in which labels associated with the same test run, but not the same build could appear in the results for the wrong build.

I will backport this to the 3.2 release branch once it's merged into master.