### PR TITLE
Refactor legacy `User` model

### DIFF
--- a/app/Console/Commands/SaveUser.php
+++ b/app/Console/Commands/SaveUser.php
@@ -46,7 +46,7 @@ class SaveUser extends Command
 
         // Are we creating a new user or updating an existing one?
         $user = \App\Models\User::where('email', $email)->first();
-        if (!$user) {
+        if ($user === null) {
             $user = new User();
             $user->email = $email;
             $create_new_user = true;
@@ -72,7 +72,7 @@ class SaveUser extends Command
 
         // Handle admin flag.
         if ($this->option('admin')) {
-            $user->admin = $this->option('admin');
+            $user->admin = (bool) $this->option('admin');
         }
 
         $user->save();

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -919,18 +919,13 @@ final class AdminController extends AbstractController
                             }
                         }
 
-                        $passwordHash = User::PasswordHash($admin_password);
-                        if ($passwordHash === false) {
-                            $xml .= '<alert>Failed to hash password</alert>';
-                        } else {
-                            $user = new \CDash\Model\User();
-                            $user->Email = $admin_email;
-                            $user->Password = $passwordHash;
-                            $user->FirstName = 'administrator';
-                            $user->Institution = 'Kitware Inc.';
-                            $user->Admin = 1;
-                            $user->Save();
-                        }
+                        $user = new \CDash\Model\User();
+                        $user->Email = $admin_email;
+                        $user->Password = password_hash($admin_password, PASSWORD_DEFAULT);
+                        $user->FirstName = 'administrator';
+                        $user->Institution = 'Kitware Inc.';
+                        $user->Admin = 1;
+                        $user->Save();
                         $xml .= '<db_created>1</db_created>';
 
                         // Set the database version

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -88,7 +88,7 @@ final class CoverageController extends AbstractBuildController
 
         $sql = 'SELECT id,name FROM project';
         $params = [];
-        if ($User->IsAdmin() == false) {
+        if ($User->admin) {
             $sql .= ' WHERE id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)';
             $params[] = intval($userid);
         }

--- a/app/Http/Controllers/ManageBannerController.php
+++ b/app/Http/Controllers/ManageBannerController.php
@@ -26,7 +26,7 @@ final class ManageBannerController extends AbstractController
         if (isset($_GET['projectid']) && (int) $_GET['projectid'] > 0) {
             $project->Id = (int) $_GET['projectid'];
             Gate::authorize('edit-project', $project);
-        } elseif ($user->IsAdmin()) {
+        } elseif ($user->admin) {
             // We are able to set the global banner
             $project->Id = (int) ($_GET['projectid'] ?? 0);
         } else {
@@ -37,7 +37,7 @@ final class ManageBannerController extends AbstractController
         $available_projects = [];
 
         // If user is admin then we can add a banner for all projects
-        if ($user->IsAdmin()) {
+        if ($user->admin) {
             $root_project = new Project();
             $root_project->Id = 0;
             $root_project->Name = 'All';
@@ -46,7 +46,7 @@ final class ManageBannerController extends AbstractController
 
         $sql = 'SELECT id, name FROM project';
         $params = [];
-        if (!$user->IsAdmin()) {
+        if (!$user->admin) {
             $sql .= " WHERE id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)";
             $params[] = intval(Auth::id());
         }

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -95,9 +95,7 @@ final class ManageProjectRolesController extends AbstractProjectController
                     if (strlen($email) > 0) {
                         $email .= ', ';
                     }
-                    $maintainer = new User();
-                    $maintainer->Id = $maintainerid;
-                    $email .= $maintainer->GetEmail();
+                    $email .= User::findOrFail((int) $maintainerid)->email;
                 }
 
                 $projectname = get_project_name($projectid);

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -24,7 +24,7 @@ final class ManageProjectRolesController extends AbstractProjectController
      */
     public function viewPage(): View|RedirectResponse
     {
-        $usersessionid = Auth::id();
+        /** @var User $current_user */
         $current_user = Auth::user();
 
         @$projectid = $_GET['projectid'];
@@ -41,12 +41,12 @@ final class ManageProjectRolesController extends AbstractProjectController
         if ($projectid > 0) {
             $current_user_project = new UserProject();
             $current_user_project->ProjectId = $projectid;
-            $current_user_project->UserId = $usersessionid;
+            $current_user_project->UserId = Auth::id();
             $current_user_project->FillFromUserId();
             $role = $current_user_project->Role;
         }
 
-        if (!$current_user->IsAdmin() && $role <= 1) {
+        if (!$current_user->admin && $role <= 1) {
             return view('cdash', [
                 'xsl' => true,
                 'xsl_content' => "You don't have the permissions to access this page!",
@@ -260,9 +260,9 @@ final class ManageProjectRolesController extends AbstractProjectController
 
         $sql = 'SELECT id, name FROM project';
         $params = [];
-        if (!$current_user->IsAdmin()) {
+        if (!$current_user->admin) {
             $sql .= ' WHERE id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)';
-            $params[] = intval($usersessionid);
+            $params[] = intval(Auth::id());
         }
         $sql .= ' ORDER BY name';
         $projects = $db->executePrepared($sql, $params);

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -105,7 +105,7 @@ final class ProjectController extends AbstractProjectController
             $project_response['TestTimeMaxStatus'] = 3;
             $project_response['TestTimeStd'] = 4.0;
             $project_response['TestTimeStdThreshold'] = 1.0;
-            if (!boolval(config('cdash.user_create_projects')) || $User->IsAdmin()) {
+            if (!boolval(config('cdash.user_create_projects')) || $User->admin) {
                 $project_response['UploadQuota'] = 1;
             }
             $project_response['WarningsFilter'] = "";

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -47,7 +47,7 @@ final class SubProjectController extends AbstractProjectController
 
         $sql = 'SELECT id, name FROM project';
         $params = [];
-        if (!$user->IsAdmin()) {
+        if (!$user->admin) {
             $sql .= " WHERE id IN (SELECT projectid AS id FROM user2project WHERE userid = ? AND role > 0)";
             $params[] = intval(Auth::id());
         }

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -313,7 +313,7 @@ final class SubscribeProjectController extends AbstractProjectController
 
         $sql = 'SELECT id, name FROM project';
         $params = [];
-        if ($user->IsAdmin() === false) {
+        if (!$user->admin) {
             $sql .= " WHERE public=1 OR id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)";
             $params[] = $user->id;
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -506,8 +506,8 @@ final class UserController extends AbstractController
         if (isset($_POST['recover'])) {
             $email = $_POST['email'];
             $user = new \CDash\Model\User();
-            $userid = $user->GetIdFromEmail($email);
-            if (!$userid) {
+            $userid = User::firstWhere('email', $email)?->id;
+            if ($userid === null) {
                 // Don't reveal whether or not this is a valid account.
                 $message = 'A confirmation message has been sent to your inbox.';
             } else {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -388,12 +388,6 @@ final class UserController extends AbstractController
                 $error_msg = "Password must be at least $minimum_length characters.";
             }
 
-            $password_hash = User::PasswordHash($passwd);
-            if ($password_hash === false) {
-                $password_is_good = false;
-                $error_msg = 'Failed to hash password.  Contact an admin.';
-            }
-
             if ($password_is_good && config('cdash.password.expires') > 0) {
                 $query = 'SELECT password FROM password WHERE userid=?';
                 $unique_count = (int) config('cdash.password.unique');
@@ -429,7 +423,7 @@ final class UserController extends AbstractController
             if (!$password_is_good) {
                 $xml .= "<error>$error_msg</error>";
             } else {
-                $user->Password = $password_hash;
+                $user->Password = password_hash($passwd, PASSWORD_DEFAULT);
                 if ($user->Save()) {
                     $xml .= '<error>Your password has been updated.</error>';
                     if (isset($_SESSION['cdash']['redirect'])) {
@@ -531,10 +525,9 @@ final class UserController extends AbstractController
 
                 if (cdashmail("$email", 'CDash password recovery', $text)) {
                     // If we can send the email we update the database
-                    $passwordHash = User::PasswordHash($password);
                     $user->Id = $userid;
                     $user->Fill();
-                    $user->Password = $passwordHash;
+                    $user->Password = password_hash($password, PASSWORD_DEFAULT);
                     $user->Save();
                     $message = 'A confirmation message has been sent to your inbox.';
                 } else {

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -15,7 +15,7 @@ class Admin
     {
         // We can assume that the user is logged in at this point.  We deliberately want to fail with an
         // exception if this is not the case.
-        if (!Auth::user()->IsAdmin()) {
+        if (!Auth::user()->admin) {
             abort(403, 'You must be an administrator to access this page.');
         }
 

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -15,7 +15,8 @@ class Admin
     {
         // We can assume that the user is logged in at this point.  We deliberately want to fail with an
         // exception if this is not the case.
-        if (!Auth::user()->admin) {
+        $user = Auth::user();
+        if ($user === null || !$user->admin) {
             abort(403, 'You must be an administrator to access this page.');
         }
 

--- a/app/Models/Password.php
+++ b/app/Models/Password.php
@@ -2,14 +2,37 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property int $userid
+ * @property string $password
+ * @property Carbon $date
+ *
+ * TODO: Determine if created_at and updated_at columns are necessary
+ *
+ * @mixin Builder<Password>
+ */
 class Password extends Model
 {
-    public $incrementing = false;
-
     protected $table = 'password';
-    protected $fillable = ['password', 'date'];
-    protected $hidden = ['password'];
-    protected $primaryKey = null;
+
+    protected $fillable = [
+        'userid',
+        'password',
+        'date',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'userid' => 'integer',
+        'date' => 'datetime',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -161,7 +161,7 @@ class Project extends Model
 
         if ($user === null) {
             $query->where('public', self::ACCESS_PUBLIC);
-        } elseif (!$user->IsAdmin()) {
+        } elseif (!$user->admin) {
             $query->whereHas('users', function ($query2) use ($user) {
                 $query2->where('user.id', $user->id);
                 $query2->orWhere('public', self::ACCESS_PUBLIC);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -21,6 +23,8 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
  * @property string $email
  * @property string $password
  * @property string $institution
+ *
+ * @property Password $currentPassword
  *
  * @mixin Builder<User>
  */
@@ -61,9 +65,20 @@ class User extends Authenticatable implements MustVerifyEmail
         'admin' => 'boolean',
     ];
 
-    public function passwords()
+    /**
+     * @return HasMany<Password>
+     */
+    public function passwords(): HasMany
     {
-        return $this->hasMany('App\Models\Password', 'userid')->orderBy('date');
+        return $this->hasMany(Password::class, 'userid')->orderBy('date', 'desc');
+    }
+
+    /**
+     * @return HasOne<Password>
+     */
+    public function currentPassword(): HasOne
+    {
+        return $this->hasOne(Password::class, 'userid')->ofMany('date', 'max');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,11 +11,11 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
  * All of these methods are accessed through reflection.  Only the ones currently necessary are
  * listed to encourage future developers to move User logic to this class.
  *
- * @method bool IsAdmin()
  * @method GetEmail()
  * @method int|false GetIdFromName($name)
  *
  * @property int $id
+ * @property bool $admin
  * @property string $firstname
  * @property string $lastname
  * @property string $email
@@ -55,6 +55,10 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $hidden = [
         'password', 'remember_token',
+    ];
+
+    protected $casts = [
+        'admin' => 'boolean',
     ];
 
     public function passwords()

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -60,7 +60,7 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         Gate::define('create-project', function (User $user) {
-            if (!$user->IsAdmin() && !boolval(config('cdash.user_create_projects'))) {
+            if (!$user->admin && !boolval(config('cdash.user_create_projects'))) {
                 return Response::denyWithStatus(403, 'You do not have permission to create new projects.');
             }
             return Response::allow();

--- a/app/Services/AuthTokenService.php
+++ b/app/Services/AuthTokenService.php
@@ -175,7 +175,7 @@ class AuthTokenService
                     if (
                         $expected_user_id !== $auth_token['userid']
                         && $user2project->Role !== UserProject::PROJECT_ADMIN
-                        && !$user->IsAdmin()
+                        && !$user->admin
                     ) {
                         return false;
                     }
@@ -188,7 +188,7 @@ class AuthTokenService
                 // Full-access tokens can be deleted by:
                 // 1. The user who created them
                 // 2. A system administrator
-                if ($expected_user_id !== $auth_token['userid'] && !$user->IsAdmin()) {
+                if ($expected_user_id !== $auth_token['userid'] && !$user->admin) {
                     return false;
                 }
                 break;

--- a/app/Services/ProjectPermissions.php
+++ b/app/Services/ProjectPermissions.php
@@ -31,7 +31,7 @@ class ProjectPermissions
     public static function canEditProject(Project $project, User $user): bool
     {
         // Check if this user is a global admin.
-        if ($user->IsAdmin()) {
+        if ($user->admin) {
             return true;
         }
 
@@ -65,7 +65,7 @@ class ProjectPermissions
         }
 
         // Global admins have access to all projects.
-        if ($user->IsAdmin()) {
+        if ($user->admin) {
             return true;
         }
 

--- a/app/cdash/app/Controller/Api/ViewProjects.php
+++ b/app/cdash/app/Controller/Api/ViewProjects.php
@@ -141,11 +141,11 @@ class ViewProjects extends \CDash\Controller\Api
      **/
     public function getVisibleProjects()
     {
-        if (is_null($this->user)) {
+        if ($this->user === null) {
             $this->projectids = DB::table('project')
                 ->where('public', Project::ACCESS_PUBLIC)
                 ->pluck('id');
-        } elseif ($this->user->IsAdmin()) {
+        } elseif ($this->user->admin) {
             $this->projectids = DB::table('project')
                 ->pluck('id');
         } else {

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -1480,9 +1480,8 @@ class Build
         $testdiff
     ): void {
         // Find user by email address.
-        $user = new User();
-        $userid = $user->GetIdFromEmail($email);
-        if (!$userid) {
+        $user = \App\Models\User::firstWhere('email', $email);
+        if ($user === null) {
             // Find user by author name.
             $stmt = $this->PDO->prepare(
                 'SELECT up.userid FROM user2project AS up
@@ -1500,6 +1499,8 @@ class Build
                 return;
             }
             $userid = $row['userid'];
+        } else {
+            $userid = $user->id;
         }
 
         $totalbuilds = 0;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1189,7 +1189,8 @@ class Project
         }
         $response['name_encoded'] = urlencode($this->Name ?? '');
 
-        $includeQuota = !boolval(config('cdash.user_create_projects')) || (Auth::check() && Auth::user()->admin);
+        $user = Auth::user();
+        $includeQuota = !boolval(config('cdash.user_create_projects')) || ($user !== null && $user->admin);
 
         if ($includeQuota) {
             $uploadQuotaGB = 0;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -34,6 +34,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Models\Project as EloquentProject;
+use App\Models\User;
 use RuntimeException;
 
 /** Main project class */
@@ -1046,10 +1047,9 @@ class Project
 
         $userids = $UserProject->GetUsers(2); // administrators
         $recipients = [];
+        // TODO: Simplify this loop
         foreach ($userids as $userid) {
-            $User = new User;
-            $User->Id = $userid;
-            $recipients[] = $User->GetEmail();
+            $recipients[] = User::findOrFail($userid)->email;
         }
 
         if (!empty($recipients)) {

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -1189,7 +1189,7 @@ class Project
         }
         $response['name_encoded'] = urlencode($this->Name ?? '');
 
-        $includeQuota = !boolval(config('cdash.user_create_projects')) || (Auth::check() && Auth::user()->IsAdmin());
+        $includeQuota = !boolval(config('cdash.user_create_projects')) || (Auth::check() && Auth::user()->admin);
 
         if ($includeQuota) {
             $uploadQuotaGB = 0;

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -270,35 +270,6 @@ class User
         }
     }
 
-    public function hasExpiredPassword()
-    {
-        $expires = config('cdash.password.expires');
-
-        if ($expires < 1) {
-            return false;
-        }
-
-        $stmt = $this->PDO->prepare(
-            'SELECT date FROM password WHERE userid = ?
-        ORDER BY date DESC LIMIT 1');
-        $this->PDO->execute($stmt, [$this->Id]);
-        $row = $stmt->fetch();
-
-        if (!$row) {
-            // If no result, then password rotation must have been enabled
-            // after this user set their password.  Force them to change it now.
-            return true;
-        }
-
-        $password_created_time = strtotime($row['date']);
-        $password_expiration_time =
-            strtotime("+{$expires} days", $password_created_time);
-        if (time() > $password_expiration_time) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Returns the current User's repository credentials. (There may be multiple credentials
      * for multiple repositories).

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -167,21 +167,6 @@ class User
         DB::delete("DELETE FROM $this->TableName WHERE id = ?", [$this->Id]);
     }
 
-    /** Get the email */
-    public function GetEmail()
-    {
-        // If no id specified return false.
-        if (!$this->Id) {
-            return false;
-        }
-
-        $stmt = $this->PDO->prepare(
-            "SELECT email FROM $this->TableName WHERE id = ?");
-        pdo_execute($stmt, [$this->Id]);
-        $row = $stmt->fetch();
-        return $row['email'];
-    }
-
     /** Get the password */
     public function GetPassword()
     {

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -27,9 +27,8 @@ class User
     public $LastName;
     public $Institution;
     public $Admin;
-    public $Filled;
+    private $Filled;
     public $TableName;
-    public $TempTableName;
     private $PDO;
     private $Credentials;
     private $LabelCollection;
@@ -45,7 +44,6 @@ class User
         $this->Admin = 0;
         $this->Filled = false;
         $this->TableName = qid('user');
-        $this->TempTableName = qid('usertemp');
         $this->PDO = Database::getInstance();
         $this->Credentials = null;
         $this->LabelCollection = collect();

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -168,7 +168,7 @@ class User
     }
 
     /** Get the password */
-    public function GetPassword()
+    private function GetPassword()
     {
         if (!$this->Id) {
             return false;

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -50,7 +50,7 @@ class User
     }
 
     /** Return if a user exists */
-    public function Exists()
+    public function Exists(): bool
     {
         if (!$this->Id) {
             // If no id is set check if a user with this email address exists.
@@ -147,7 +147,7 @@ class User
     }
 
     /** Get the password */
-    private function GetPassword()
+    private function GetPassword(): string|false
     {
         if (!$this->Id) {
             return false;
@@ -179,7 +179,7 @@ class User
     }
 
     /** Load this user's details from the datbase. */
-    public function Fill()
+    public function Fill(): bool
     {
         if (!$this->Id) {
             return false;
@@ -314,10 +314,8 @@ class User
 
     /**
      * Given a $label, the $label is added to the LabelCollection.
-     *
-     * @param Label $label
      */
-    public function AddLabel(Label $label)
+    public function AddLabel(Label $label): void
     {
         $this->LabelCollection->put($label->Text, $label);
     }

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -51,16 +51,6 @@ class User
         $this->LabelCollection = collect();
     }
 
-    /** Return if the user is admin */
-    public function IsAdmin(): bool
-    {
-        if (!$this->Id || !is_numeric($this->Id)) {
-            return false;
-        }
-        $this->Fill();
-        return (bool) $this->Admin;
-    }
-
     /** Return if a user exists */
     public function Exists()
     {

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -256,10 +256,10 @@ class User
     /** Record this user's password for the purposes of password rotation.
       * Does nothing if this feature is disabled.
       */
-    public function RecordPassword()
+    private function RecordPassword(): void
     {
         if (config('cdash.password.expires') < 1 || !$this->Id || !$this->Password) {
-            return false;
+            return;
         }
 
         $now = gmdate(FMT_DATETIME);

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -146,15 +146,6 @@ class User
         return true;
     }
 
-    // Remove this user from the database.
-    public function Delete()
-    {
-        if (!$this->Id) {
-            return false;
-        }
-        DB::delete("DELETE FROM $this->TableName WHERE id = ?", [$this->Id]);
-    }
-
     /** Get the password */
     private function GetPassword()
     {

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -327,18 +327,6 @@ class User
         return false;
     }
 
-    /** Wrapper around PHP's builtin password_hash function.
-      * Logs an error if it returns FALSE.
-      */
-    public static function PasswordHash($password)
-    {
-        $passwordHash = password_hash($password, PASSWORD_DEFAULT);
-        if ($passwordHash === false) {
-            add_log('password_hash returned false', 'PasswordHash', LOG_ERR);
-        }
-        return $passwordHash;
-    }
-
     /**
      * Returns the current User's repository credentials. (There may be multiple credentials
      * for multiple repositories).

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -57,14 +57,8 @@ class User
         if (!$this->Id || !is_numeric($this->Id)) {
             return false;
         }
-        $stmt = $this->PDO->prepare(
-            "SELECT admin FROM $this->TableName WHERE id = ?");
-        pdo_execute($stmt, [$this->Id]);
-        $row = $stmt->fetch();
-        if ($row && array_key_exists('admin', $row) && $row['admin'] == 1) {
-            return true;
-        }
-        return false;
+        $this->Fill();
+        return (bool) $this->Admin;
     }
 
     /** Return if a user exists */

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -61,9 +61,9 @@ class User
             }
 
             // Check if the email is already there
-            $userid = $this->GetIdFromEmail($this->Email);
-            if ($userid) {
-                $this->Id = $userid;
+            $user = \App\Models\User::firstWhere('email', $this->Email);
+            if ($user !== null) {
+                $this->Id = $user->id;
                 return true;
             }
             return false;
@@ -187,24 +187,6 @@ class User
             return false;
         }
         return intval($row['id']);
-    }
-
-    /** Get the user id from the email */
-    public function GetIdFromEmail($email)
-    {
-        $email = trim($email);
-        $stmt = $this->PDO->prepare(
-            "SELECT id FROM $this->TableName WHERE email = :email");
-        $stmt->bindParam(':email', $email);
-        if (!pdo_execute($stmt)) {
-            return false;
-        }
-
-        $row = $stmt->fetch();
-        if (!$row) {
-            return false;
-        }
-        return $row['id'];
     }
 
     /** Load this user's details from the datbase. */

--- a/app/cdash/app/Model/UserProject.php
+++ b/app/cdash/app/Model/UserProject.php
@@ -55,8 +55,7 @@ class UserProject
         /** @var \PDO $pdo */
         $pdo = Database::getInstance()->getPdo();
         $sql = 'SELECT id, name FROM project';
-        $admin = $user->IsAdmin();
-        if (!$admin) {
+        if (!$user->admin) {
             $sql .= "
                 WHERE id IN (
                     SELECT projectid AS id
@@ -70,7 +69,7 @@ class UserProject
 
         /** @var \PDOStatement $stmt */
         $stmt = $pdo->prepare($sql);
-        if (!$admin) {
+        if (!$user->admin) {
             $stmt->bindParam(':userid', $id);
         }
         $stmt->execute();

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -16,6 +16,7 @@
 
 namespace CDash\Api\v1\ManageBuildGroup;
 
+use App\Models\User;
 use App\Services\PageTimer;
 use CDash\Database;
 use CDash\Model\BuildGroup;
@@ -33,6 +34,7 @@ if (!Auth::check()) {
     echo json_encode($response);
     return;
 }
+/** @var User $user */
 $user = Auth::user();
 $userid = $user->id;
 
@@ -65,7 +67,7 @@ if ($projectid && is_numeric($projectid)) {
     $user2project->FillFromUserId();
 }
 
-if (!$user->IsAdmin() && $user2project->Role <= 1) {
+if (!$user->admin && $user2project->Role <= 1) {
     $response['error'] = "You don't have the permissions to access this page";
     echo json_encode($response);
     return;
@@ -74,7 +76,7 @@ if (!$user->IsAdmin() && $user2project->Role <= 1) {
 // List the available projects that this user has admin rights to.
 $sql = 'SELECT id,name FROM project';
 $params = [];
-if (!$user->IsAdmin()) {
+if (!$user->admin) {
     $sql .= " WHERE id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)";
     $params[] = intval($userid);
 }

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -64,7 +64,7 @@ class EmailTestCase extends KWWebTestCase
         $user->firstname = 'user2';
         $user->lastname = 'kw';
         $user->institution = 'Kitware';
-        $user->admin = 0;
+        $user->admin = false;
         $user->save();
         if (!$user->id) {
             $this->fail('Failed to create user2');

--- a/app/cdash/tests/test_recoverpassword.php
+++ b/app/cdash/tests/test_recoverpassword.php
@@ -35,7 +35,7 @@ class RecoverPasswordTestCase extends KWWebTestCase
 
         // fix the password so others can still login...
         $user = new User();
-        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')->id;
+        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')?->id;
         $user->Fill();
         $user->Password = password_hash('simpletest', PASSWORD_DEFAULT);
         if (!$user->Save()) {

--- a/app/cdash/tests/test_recoverpassword.php
+++ b/app/cdash/tests/test_recoverpassword.php
@@ -37,7 +37,7 @@ class RecoverPasswordTestCase extends KWWebTestCase
         $user = new User();
         $user->Id = $user->GetIdFromEmail('simpletest@localhost');
         $user->Fill();
-        $user->Password = User::PasswordHash('simpletest');
+        $user->Password = password_hash('simpletest', PASSWORD_DEFAULT);
         if (!$user->Save()) {
             $this->fail('user->Save() returned false');
         }

--- a/app/cdash/tests/test_recoverpassword.php
+++ b/app/cdash/tests/test_recoverpassword.php
@@ -35,7 +35,7 @@ class RecoverPasswordTestCase extends KWWebTestCase
 
         // fix the password so others can still login...
         $user = new User();
-        $user->Id = $user->GetIdFromEmail('simpletest@localhost');
+        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')->id;
         $user->Fill();
         $user->Password = password_hash('simpletest', PASSWORD_DEFAULT);
         if (!$user->Save()) {

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -75,7 +75,7 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
             $user->lastname = $user_details['lastname'];
             $user->password = password_hash('12345', PASSWORD_DEFAULT);
             $user->institution = 'Kitware';
-            $user->admin = 0;
+            $user->admin = false;
             $user->Save();
             $userproject->UserId = $user->id;
             $userproject->Save();

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -29,14 +29,7 @@ class UserTestCase extends KWWebTestCase
             return 1;
         }
 
-        $id = $user->GetIdFromEmail('simpletest@localhost');
-
-        if ($id === false) {
-            $this->fail('User::GetIdFromEmail returned false for a valid user');
-            return 1;
-        }
-
-        $user->Id = $id;
+        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')->id;
         $user->Admin = '1';
         $user->FirstName = 'administrator';
         $user->Institution = 'Kitware Inc.';

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -20,21 +20,8 @@ class UserTestCase extends KWWebTestCase
     public function testUser()
     {
         $user = new User();
-        $user->Id = 'non_numeric';
-
-        if (!($user->IsAdmin() === false)) {
-            $this->fail("User::IsAdmin didn't return false for non-numeric user id");
-            return 1;
-        }
 
         $user->Id = '';
-        $user->Email = '';
-
-        if (!($user->IsAdmin() === false)) {
-            $this->fail("User::Exists didn't return false for no user id and no email");
-            return 1;
-        }
-
         $user->Email = 'simpletest@localhost';
 
         if ($user->Exists() === false) {

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -59,7 +59,7 @@ class UserTestCase extends KWWebTestCase
             return 1;
         }
 
-        $user->Password = User::PasswordHash('simpletest');
+        $user->Password = password_hash('simpletest', PASSWORD_DEFAULT);
 
         // Coverage for update save
         $user->Save();

--- a/app/cdash/tests/test_user.php
+++ b/app/cdash/tests/test_user.php
@@ -29,7 +29,7 @@ class UserTestCase extends KWWebTestCase
             return 1;
         }
 
-        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')->id;
+        $user->Id = App\Models\User::firstWhere('email', 'simpletest@localhost')?->id;
         $user->Admin = '1';
         $user->FirstName = 'administrator';
         $user->Institution = 'Kitware Inc.';

--- a/app/cdash/xml_handlers/project_handler.php
+++ b/app/cdash/xml_handlers/project_handler.php
@@ -216,7 +216,7 @@ class ProjectHandler extends AbstractHandler
                 }
                 $user->email = $email;
                 $user->password = password_hash($email, PASSWORD_DEFAULT);
-                $user->admin = 0;
+                $user->admin = false;
                 $existing_user = User::where('email', $email)->first();
                 if ($existing_user) {
                     $userid = $existing_user->id;

--- a/database/migrations/2023_11_16_131418_password_primary_key.php
+++ b/database/migrations/2023_11_16_131418_password_primary_key.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('password', function (Blueprint $table) {
+            $table->integer('id', true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('password', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10294,11 +10294,6 @@ parameters:
 			path: app/cdash/app/Model/User.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\User\\:\\:\\$TempTableName has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -342,11 +342,6 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
-			message: "#^Call to an undefined static method App\\\\Models\\\\User\\:\\:PasswordHash\\(\\)\\.$#"
-			count: 1
-			path: app/Http/Controllers/AdminController.php
-
-		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -1413,11 +1408,6 @@ parameters:
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
-
-		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$Id\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
@@ -2654,11 +2644,6 @@ parameters:
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
-			path: app/Http/Controllers/UserController.php
-
-		-
-			message: "#^Call to an undefined static method App\\\\Models\\\\User\\:\\:PasswordHash\\(\\)\\.$#"
-			count: 2
 			path: app/Http/Controllers/UserController.php
 
 		-
@@ -10209,18 +10194,10 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function add_log\\(\\)\\:
-				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 12
+			count: 10
 			path: app/cdash/app/Model/User.php
 
 		-
@@ -10243,7 +10220,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/User.php
 
 		-
@@ -10263,11 +10240,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:Fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetEmail\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
@@ -10298,21 +10270,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetRepositoryCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:PasswordHash\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:PasswordHash\\(\\) has parameter \\$password with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:RecordPassword\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
@@ -10393,11 +10350,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\User\\:\\:\\$TempTableName has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2893,11 +2893,6 @@ parameters:
 			path: app/Http/Middleware/EncryptCookies.php
 
 		-
-			message: "#^PHPDoc tag @var with type CDash\\\\Model\\\\User is not subtype of type App\\\\Models\\\\User\\|null\\.$#"
-			count: 1
-			path: app/Http/Middleware/PasswordExpired.php
-
-		-
 			message: "#^PHPDoc type array of property App\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except is not the same as PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Foundation\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except\\.$#"
 			count: 1
 			path: app/Http/Middleware/TrimStrings.php
@@ -3322,11 +3317,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Models\\\\User\\:\\:__call\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: "#^Method App\\\\Models\\\\User\\:\\:passwords\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/User.php
 
@@ -10240,16 +10230,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:Save\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:hasExpiredPassword\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Parameter \\#2 \\$baseTimestamp of function strtotime expects int\\|null, \\(int\\|false\\) given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -212,11 +212,6 @@ parameters:
 			path: app/Console/Commands/SaveUser.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, App\\\\Models\\\\User\\|null given\\.$#"
-			count: 1
-			path: app/Console/Commands/SaveUser.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, array\\|bool\\|string\\|null given\\.$#"
 			count: 1
 			path: app/Console/Commands/SaveUser.php
@@ -234,11 +229,6 @@ parameters:
 		-
 			message: "#^Part \\$email \\(array\\|bool\\|string\\) of encapsed string cannot be cast to string\\.$#"
 			count: 2
-			path: app/Console/Commands/SaveUser.php
-
-		-
-			message: "#^Property App\\\\Models\\\\User\\:\\:\\$admin \\(int\\) does not accept array\\|string\\|true\\.$#"
-			count: 1
 			path: app/Console/Commands/SaveUser.php
 
 		-
@@ -1051,7 +1041,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 61
+			count: 60
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -1468,11 +1458,6 @@ parameters:
 				09/04/2023  Use url\\(\\) instead\\.$#
 			"""
 			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
-			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -2841,11 +2826,6 @@ parameters:
 			message: "#^Property App\\\\Http\\\\Kernel\\:\\:\\$routeMiddleware type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Http/Kernel.php
-
-		-
-			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
-			count: 1
-			path: app/Http/Middleware/Admin.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Middleware\\\\Admin\\:\\:handle\\(\\) has no return type specified\\.$#"
@@ -9324,11 +9304,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -10197,7 +10172,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 10
+			count: 9
 			path: app/cdash/app/Model/User.php
 
 		-
@@ -10240,16 +10215,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:Fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetIdFromEmail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetIdFromEmail\\(\\) has parameter \\$email with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
@@ -18135,18 +18100,8 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
-			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
-			count: 1
-			path: app/cdash/public/api/v1/manageBuildGroup.php
-
-		-
 			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\|null\\.$#"
 			count: 1
-			path: app/cdash/public/api/v1/manageBuildGroup.php
-
-		-
-			message: "#^Cannot call method IsAdmin\\(\\) on App\\\\Models\\\\User\\|null\\.$#"
-			count: 2
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10189,37 +10189,12 @@ parameters:
 			path: app/cdash/app/Model/User.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:AddLabel\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:Delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:Exists\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:Fill\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetIdFromName\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetLabelCollection\\(\\) has invalid return type CDash\\\\Model\\\\Collection\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetPassword\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 

--- a/tests/Traits/CreatesUsers.php
+++ b/tests/Traits/CreatesUsers.php
@@ -15,7 +15,7 @@ trait CreatesUsers
         $admin->email = 'admin@user';
         $admin->password = '45678';
         $admin->institution = 'me';
-        $admin->admin = 1;
+        $admin->admin = true;
         $admin->save();
         return $admin;
     }
@@ -29,7 +29,7 @@ trait CreatesUsers
         $user->email = 'jane@smith';
         $user->password = '12345';
         $user->institution = 'me';
-        $user->admin = 0;
+        $user->admin = false;
         $user->save();
         return $user;
     }


### PR DESCRIPTION
We currently have two user models: a legacy model, and an Eloquent model.  The reflection approach used to access legacy model members through the Eloquent model is not conducive to static analysis, and is a pain to work with.  This PR moves a significant portion of the legacy model logic to the Eloquent model.  Additionally, I have improved the User<->Password model relationship.