### PR TITLE
Convert backend of `Configure` model to Eloquent

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1073,7 +1073,7 @@ final class BuildController extends AbstractBuildController
             if (isset($configure['subprojectid'])) {
                 $has_subprojects = 1;
             }
-            $configures_response[] = buildconfigure::marshal($configure);
+            $configures_response[] = BuildConfigure::marshal($configure);
         }
         $response['configures'] = $configures_response;
 

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Support\Carbon;
 
 /**
@@ -149,5 +150,13 @@ class Build extends Model
     public function buildtests(): HasMany
     {
         return $this->hasMany(BuildTest::class, 'buildid');
+    }
+
+    /**
+     * @return HasOneThrough<Configure, BuildConfigure>
+     */
+    public function configure(): HasOneThrough
+    {
+        return $this->hasOneThrough(Configure::class, BuildConfigure::class, 'buildid', 'id', 'id', 'configureid');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -153,7 +153,7 @@ class Build extends Model
     }
 
     /**
-     * @return HasOneThrough<Configure, BuildConfigure>
+     * @return HasOneThrough<Configure>
      */
     public function configure(): HasOneThrough
     {

--- a/app/Models/BuildConfigure.php
+++ b/app/Models/BuildConfigure.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+
+/**
+ * TODO: This class has a one-to-one relationship with the Build model.
+ *       In the future, the columns of this model could simply be moved to the Build model.
+ *
+ * @property int $buildid
+ * @property int $configureid
+ * @property Carbon $starttime
+ * @property Carbon $endtime
+ *
+ * @mixin Builder<BuildConfigure>
+ */
+class BuildConfigure extends Model
+{
+    protected $table = 'build2configure';
+
+    protected $primaryKey = 'buildid';
+
+    public $incrementing = false;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'configureid',
+        'starttime',
+        'endtime',
+    ];
+
+    protected $casts = [
+        'buildid' => 'integer',
+        'configureid' => 'integer',
+        'starttime' => 'datetime',
+        'endtime' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Build, self>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return HasOne<Configure>
+     */
+    public function configure(): HasOne
+    {
+        return $this->hasOne(Configure::class, 'id', 'buildid');
+    }
+}

--- a/app/Models/Configure.php
+++ b/app/Models/Configure.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * @property int $id
+ * @property string $command
+ * @property string $log
+ * @property int $status
+ * @property int $warnings
+ * @property int $crc32
+ *
+ * @mixin Builder<Configure>
+ */
+class Configure extends Model
+{
+    protected $table = 'configure';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'command',
+        'log',
+        'status',
+        'warnings',
+        'crc32',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'status' => 'integer',
+        'warnings' => 'integer',
+        'crc32' => 'integer',
+    ];
+
+    /**
+     * @return HasManyThrough<Build, BuildConfigure>
+     */
+    public function builds(): HasManyThrough
+    {
+        return $this->hasManyThrough(Build::class, BuildConfigure::class, 'configureid', 'id', 'id', 'buildid');
+    }
+}

--- a/app/Models/Configure.php
+++ b/app/Models/Configure.php
@@ -38,7 +38,7 @@ class Configure extends Model
     ];
 
     /**
-     * @return HasManyThrough<Build, BuildConfigure>
+     * @return HasManyThrough<Build>
      */
     public function builds(): HasManyThrough
     {

--- a/app/cdash/tests/test_buildconfigure.php
+++ b/app/cdash/tests/test_buildconfigure.php
@@ -62,7 +62,7 @@ class BuildConfigureTestCase extends KWWebTestCase
             $this->fail("configure->Insert returned true");
         }
 
-        if (!$configure->GetConfigureForBuild(PDO::FETCH_ASSOC)) {
+        if (!$configure->GetConfigureForBuild()) {
             $this->fail("configure->GetConfigureForBuild returned false");
         }
 

--- a/app/cdash/tests/test_longbuildname.php
+++ b/app/cdash/tests/test_longbuildname.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-use CDash\Model\BuildConfigure;
+use App\Models\Build;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;
 
@@ -54,9 +54,8 @@ class LongBuildNameTestCase extends KWWebTestCase
         $this->assertTrue(1 === count($results));
 
         // Its configure log was stored correctly.
-        $configure = new BuildConfigure();
-        $configure->BuildId = $results[0]->id;
-        $log = $configure->GetConfigureForBuild()['log'];
-        $this->assertTrue(str_contains($log, 'This is my config output'));
+        $configure = Build::findOrFail((int) $results[0]->id)->configure()->first();
+        $this->assertTrue($configure !== null);
+        $this->assertTrue(str_contains($configure->log, 'This is my config output'));
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6370,21 +6370,13 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 7
+			count: 3
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
 			message: """
 				#^Call to deprecated function pdo_insert_id\\(\\)\\:
 				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: """
-				#^Call to deprecated method getBaseUrl\\(\\) of class CDash\\\\Config\\:
-				09/04/2023  Use url\\(\\) instead\\.$#
 			"""
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
@@ -6403,57 +6395,17 @@ parameters:
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\BuildConfigure\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:AddLabel\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:AddLabel\\(\\) has parameter \\$label with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ComputeErrors\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ComputeWarnings\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:Delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:Exists\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ExistsByBuildId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ExistsByCrc32\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ExistsHelper\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:ExistsHelper\\(\\) has parameter \\$field with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
@@ -6473,32 +6425,12 @@ parameters:
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:InsertLabelAssociations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:IsConfigureWarning\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:IsConfigureWarning\\(\\) has parameter \\$line with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:marshal\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\BuildConfigure\\:\\:marshal\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
@@ -16626,16 +16558,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property UpdateHandler\\:\\:\\$BuildId\\.$#"
-			count: 1
-			path: app/cdash/include/sendemail.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$log\\.$#"
-			count: 1
-			path: app/cdash/include/sendemail.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$status\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
 


### PR DESCRIPTION
This PR continues our ongoing effort to use Eloquent for all database interactions.  I created two new Eloquent models, and refactored some portions of the legacy BuildConfigure model to use them.  The legacy model in this case is difficult to work with, and I intend to return to it at a future point for a more significant refactor.