### PR TITLE
Specify format string for graphs with timestamps

### DIFF
--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -1160,7 +1160,11 @@ export default {
       var options = {
         lines: {show: true},
         points: {show: true},
-        xaxis: {mode: "time"},
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         grid: {
           backgroundColor: "#fffaff",
           clickable: true,

--- a/resources/js/components/BuildUpdate.vue
+++ b/resources/js/components/BuildUpdate.vue
@@ -200,7 +200,11 @@ export default {
       const options = {
         lines: {show: true},
         points: {show: true},
-        xaxis: {mode: "time"},
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         grid: {
           backgroundColor: "#fffaff",
           clickable: true,

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -398,7 +398,11 @@ export default {
         },
         pan: { interactive: true },
         zoom: { interactive: true, amount: 1.1 },
-        xaxis: { mode: "time" },
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         yaxis: {
           zoomRange: false,
           panRange: false

--- a/resources/views/test/ajax-test-failure-graph.blade.php
+++ b/resources/views/test/ajax-test-failure-graph.blade.php
@@ -23,6 +23,8 @@
                 mode: "time",
                 min: {{ $t - 604800 }},
                 max: {{ $t + 100000 }},
+                timeformat: "%Y/%m/%d %H:%M",
+                timeBase: "milliseconds",
             },
             grid: {backgroundColor: "#fffaff"},
             selection: {mode: "x"},


### PR DESCRIPTION
Some graphs with timestamps on the x-axis do not render the timestamps properly.  This PR adds a format string to each of those plots to force a standardized date format.  This serves as a temporary patch until the upcoming graph library refactor is ready to merge.

| Before | After |
|---|---|
| ![image](https://github.com/Kitware/CDash/assets/16820599/87511c51-cbaa-4b2f-8fce-b1df984f9b35) | ![image](https://github.com/Kitware/CDash/assets/16820599/b97416f3-ae23-449a-8733-fd78f9bbe277) |
