### PR TITLE
Backport graph timestamp formatting

### DIFF
--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -1024,7 +1024,11 @@ export default {
       var options = {
         lines: {show: true},
         points: {show: true},
-        xaxis: {mode: "time"},
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         grid: {
           backgroundColor: "#fffaff",
           clickable: true,

--- a/resources/js/components/BuildUpdate.vue
+++ b/resources/js/components/BuildUpdate.vue
@@ -200,7 +200,11 @@ export default {
       const options = {
         lines: {show: true},
         points: {show: true},
-        xaxis: {mode: "time"},
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         grid: {
           backgroundColor: "#fffaff",
           clickable: true,

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -398,7 +398,11 @@ export default {
         },
         pan: { interactive: true },
         zoom: { interactive: true, amount: 1.1 },
-        xaxis: { mode: "time" },
+        xaxis: {
+          mode: "time",
+          timeformat: "%Y/%m/%d %H:%M",
+          timeBase: "milliseconds",
+        },
         yaxis: {
           zoomRange: false,
           panRange: false

--- a/resources/views/test/ajax-test-failure-graph.blade.php
+++ b/resources/views/test/ajax-test-failure-graph.blade.php
@@ -23,6 +23,8 @@
                 mode: "time",
                 min: {{ $t - 604800 }},
                 max: {{ $t + 100000 }},
+                timeformat: "%Y/%m/%d %H:%M",
+                timeBase: "milliseconds",
             },
             grid: {backgroundColor: "#fffaff"},
             selection: {mode: "x"},


### PR DESCRIPTION
Cherry-picks #1816 to the 3.2 release branch.