### PR TITLE
Create new CDash installation script

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -79,8 +79,11 @@ RUN chown -R www-data:www-data /etc/apache2
 # Disable git repo ownership check system wide
 RUN git config --system --add safe.directory '*'
 
-RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                               \
+RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                                \
   echo "alias cdash_copy_source='rsync -r -l --exclude-from /cdash_src/.rsyncignore /cdash_src/ /cdash'" >> /etc/bash.bashrc; \
+  echo "alias cdash_install='cdash_copy_source && bash /cdash/install.sh'" >> /etc/bash.bashrc; \
+else                                                                       \
+  echo "alias cdash_install='bash /cdash/install.sh'" >> /etc/bash.bashrc; \
 fi
 
 # Run the rest of the commands as www-data

--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -80,7 +80,7 @@ RUN chown -R www-data:www-data /etc/apache2
 RUN git config --system --add safe.directory '*'
 
 RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then                               \
-  echo "alias cdash_install='rsync -r -l --exclude-from /cdash_src/.rsyncignore /cdash_src/ /cdash'" >> /etc/bash.bashrc; \
+  echo "alias cdash_copy_source='rsync -r -l --exclude-from /cdash_src/.rsyncignore /cdash_src/ /cdash'" >> /etc/bash.bashrc; \
 fi
 
 # Run the rest of the commands as www-data

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+echo "=================================================================================";
+echo "Beginning CDash installation...";
+
+INSTALLATION_ERROR_MESSAGE="
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+*                             INSTALLATION FAILURE!                             *
+*                                                                               *
+* An error occurred while upgrading your CDash installation and CDash was not   *
+* able to recover automatically.  If you believe that this is a problem with    *
+* CDash, please report the error here:                                          *
+*                                                                               *
+* -> https://github.com/Kitware/CDash/issues/new                                *
+*                                                                               *
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+";
+
+# Temporarily change to /cdash
+{
+  pushd "/cdash" > /dev/null &&
+
+  echo "Enabling maintenance mode..." &&
+  php artisan down --render="maintenance" --refresh=5 &&
+
+  echo "Updating vendor dependencies..." &&
+  npm install &&
+  composer install &&
+
+  echo "Running migrations..." &&
+  php artisan migrate &&
+  php artisan version:set &&
+
+  echo "Clearing caches..." &&
+  php artisan route:cache &&
+  php artisan view:cache &&
+
+  echo "Building the website..." &&
+  npm run prod --stats-children &&
+
+  echo "Bringing CDash back online..." &&
+  php artisan up &&
+
+  popd > /dev/null
+} || { echo "${INSTALLATION_ERROR_MESSAGE}"; exit $?; }
+
+echo "done."

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CDash</title>
+</head>
+<body>
+    CDash is being updated.  Please try again in 2 minutes.
+</body>
+</html>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,11 +1,12 @@
 // Load required modules.
 const mix = require('laravel-mix');
 mix.disableNotifications();
+mix.options({
+  clearConsole: false,
+});
 
 const ESLintPlugin = require('eslint-webpack-plugin');
 const ReplaceInFileWebpackPlugin = require('replace-in-file-webpack-plugin');
-
-const { exec } = require('child_process');
 
 // Clean up from previous webpack runs.
 del = require('del'),
@@ -151,9 +152,9 @@ mix.sass('resources/sass/app.scss', 'public/laravel/css').version();
 // Added this line to get mocha testing working with versioning.
 mix.copy('resources/js/app.js', 'public/main.js');
 
-exec('php artisan route:cache');
-exec('php artisan view:cache');
-
 mix.webpackConfig({
-  plugins: webpack_plugins
+  plugins: webpack_plugins,
+  stats: {
+    children: true,
+  },
 });


### PR DESCRIPTION
CDash administrators must run several commands to update a CDash system.  For administrators who are unfamiliar with CDash, this creates an unnecessary burden.

This PR introduces a new global `cdash_install` script which runs all of the necessary installation steps.  It's worth noting that Laravel's "maintenance mode" will be activated for the duration of the installation.  That will prevent users from accessing the system, and will block submissions.  In the future, I plan to update this script to allow submissions to be accepted while the system is in maintenance mode, but that is a significant undertaking which is beyond the scope of this PR.

#1492 added a `cdash_install` script for developers to sync files between the host and Docker container.  That script has been renamed `cdash_copy_source`.  The new `cdash_install` script runs `cdash_copy_source` before the regular installation script is run by default when the container is build with development mode turned on.