### PR TITLE
Remove default `.env` from Docker image

### DIFF
--- a/docker/cdash.docker
+++ b/docker/cdash.docker
@@ -96,8 +96,6 @@ COPY --chown=www-data:www-data . ./cdash
 
 WORKDIR /cdash
 
-COPY --chown=www-data:www-data ./.env.example ./.env
-
 COPY ./php.ini /usr/local/etc/php/conf.d/cdash.ini
 
 # Install PHP dependencies with composer


### PR DESCRIPTION
Our Docker image currently ships with a .env file which contains values which differ from our default configuration values. This can be incredibly confusing for CDash administrators who are trying to set configuration values via environment variables.

There is no good reason for us to ship an Image with values which essentially override our default values. Thus, I have removed it.