### PR TITLE
Explicitly set maximum number of Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
       interval: "monthly"
     labels:
       - dependencies
+    open-pull-requests-limit: 100
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     labels:
       - dependencies
+    open-pull-requests-limit: 100


### PR DESCRIPTION
Dependabot only opens 5 PRs by [default](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).  This potentially interferes with some of our monthly dependency upgrades.  After discussing the issue with GitHub support, I have bumped the allowable number of consecutive PRs to 100.  I will manually trigger Dependabot after this is merged to test the changes.