### PR TITLE
Use Project::ComputeTestingDayBounds in upload_handler

### DIFF
--- a/app/cdash/tests/data/TestingDay/Upload.xml
+++ b/app/cdash/tests/data/TestingDay/Upload.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
+<Site BuildName="testing_day_upload_file" BuildStamp="20231129-0400-Nightly" Name="hesperides" Generator="ctest-3.24.2">
+	<Upload>
+		<File filename="/tmp/tmp.txt">
+			<Content encoding="base64">VGhpcyBpcyBteSB1cGxvYWRlZCBmaWxlCg==</Content>
+		</File>
+	</Upload>
+</Site>

--- a/app/cdash/tests/test_consistenttestingday.php
+++ b/app/cdash/tests/test_consistenttestingday.php
@@ -110,5 +110,23 @@ class ConsistentTestingDayTestCase extends KWWebTestCase
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);
         $this->assertEqual(0, count($jsonobj['buildgroups']));
+
+        // Change nightly time & time zone for this project.
+        $this->createProject([
+            'Id' => $this->project->Id,
+            'Name' => 'ConsistentTestingDay',
+            'NightlyTime' => '22:00:00 America/Denver'
+        ], true);
+
+        // Submit Upload.xml file.
+        $this->submission('ConsistentTestingDay', "$dir/Upload.xml");
+
+        // Verify that it appears on the correct date.
+        $this->get("{$this->url}/api/v1/index.php?project=ConsistentTestingDay&date=2023-11-29");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        $buildgroup = array_pop($jsonobj['buildgroups']);
+        $this->assertEqual(1, count($buildgroup['builds']));
+        $this->assertEqual('testing_day_upload_file', $buildgroup['builds'][0]['buildname']);
     }
 }

--- a/app/cdash/xml_handlers/abstract_handler.php
+++ b/app/cdash/xml_handlers/abstract_handler.php
@@ -19,7 +19,6 @@ require_once 'xml_handlers/CDashSubmissionHandlerInterface.php';
 require_once 'xml_handlers/sax_handler.php';
 require_once 'xml_handlers/stack.php';
 
-use CDash\Config;
 use CDash\Model\Build;
 use CDash\Model\Project;
 use App\Models\Site;
@@ -35,15 +34,13 @@ abstract class AbstractHandler implements SaxHandler, CDashSubmissionHandlerInte
     protected $SubProjectName;
 
     protected $ModelFactory;
-    protected $Project;
-    protected $conifg;
+    protected Project $Project;
 
     public function __construct($projectid)
     {
         $this->projectid = $projectid;
         $this->Append = false;
-        $this->stack = new Stack();
-        $this->config = Config::getInstance();
+        $this->stack = new stack();
     }
 
     protected function getParent()
@@ -137,10 +134,10 @@ abstract class AbstractHandler implements SaxHandler, CDashSubmissionHandlerInte
 
     public function GetProject()
     {
-        if (!$this->Project) {
-            $factory = $this->getModelFactory();
-            $this->Project = $factory->create(Project::class);
+        if (!isset($this->Project)) {
+            $this->Project = $this->getModelFactory()->create(Project::class);
             $this->Project->Id = $this->projectid;
+            $this->Project->Fill();
         }
         return $this->Project;
     }

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -17,13 +17,12 @@
 require_once 'xml_handlers/abstract_handler.php';
 
 use CDash\Config;
-use \CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildInformation;
 use CDash\Model\Label;
+use CDash\Model\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
-use CDash\Model\Project;
 use CDash\Model\UploadFile;
 
 use Illuminate\Http\File;
@@ -50,6 +49,7 @@ class UploadHandler extends AbstractHandler
     private $Base64TmpFileWriteHandle;
     private $Base64TmpFilename;
     private $Label;
+    protected Project $Project;
 
     /** If True, means an error happened while processing the file */
     private $UploadError;
@@ -66,6 +66,7 @@ class UploadHandler extends AbstractHandler
         $this->Base64TmpFileWriteHandle = 0;
         $this->Base64TmpFilename = '';
         $this->UploadError = false;
+        $this->Project = $this->GetProject();
     }
 
     /** Start element */
@@ -110,51 +111,20 @@ class UploadHandler extends AbstractHandler
             // when we call UpdateBuild() below.
             //
             // For end time, we use the start of the testing day.
-            // For start time, we use either the submit time (now) or
-            // one second before the start time of the *next* testing day
-            // (whichever is earlier).
+            // For start time, we use the end of the testing day.
             // Yes, this means the build finished before it began.
             //
             // This associates the build with the correct day if it is only
             // an upload.  Otherwise we defer to the values set by the
             // other handlers.
-
-            $db = Database::getInstance();
-            $row = $db->executePreparedSingleRow('
-                       SELECT nightlytime FROM project where id=?
-                   ', [intval($this->projectid)]);
-            $nightly_time = $row['nightlytime'];
-            $build_date =
+            $buildDate =
                 extract_date_from_buildstamp($this->Build->GetStamp());
+            list($beginningOfDay, $endOfDay) =
+                $this->Project->ComputeTestingDayBounds($buildDate);
 
-            list($prev, $nightly_start_time, $next) =
-                get_dates($build_date, $nightly_time);
-
-            // If the nightly start time is after noon (server time)
-            // and this buildstamp is on or after the nightly start time
-            // then this build belongs to the next testing day.
-            if (date(FMT_TIME, $nightly_start_time) > '12:00:00') {
-                $build_timestamp = strtotime($build_date);
-                $next_timestamp = strtotime($next);
-                if (strtotime(date(FMT_TIME, $build_timestamp), $next_timestamp) >=
-                    strtotime(date(FMT_TIME, $nightly_start_time), $next_timestamp)) {
-                    $nightly_start_time += 3600 * 24;
-                }
-            }
-
-            $this->Build->EndTime = gmdate(FMT_DATETIME, $nightly_start_time);
-
-            $now = time();
-            $one_second_before_tomorrow =
-                strtotime('+1 day -1 second', $nightly_start_time);
-            if ($one_second_before_tomorrow < time()) {
-                $this->Build->StartTime =
-                    gmdate(FMT_DATETIME, $one_second_before_tomorrow);
-            } else {
-                $this->Build->StartTime = gmdate(FMT_DATETIME, $now);
-            }
-
-            $this->Build->SubmitTime = gmdate(FMT_DATETIME, $now);
+            $this->Build->EndTime = $beginningOfDay;
+            $this->Build->StartTime = $endOfDay;
+            $this->Build->SubmitTime = gmdate(FMT_DATETIME);
 
             $this->Build->ProjectId = $this->projectid;
             $this->Build->SetSubProject($this->SubProjectName);
@@ -260,11 +230,8 @@ class UploadHandler extends AbstractHandler
 
             // Check file size against the upload quota
             $upload_file_size = filesize($this->TmpFilename);
-            $Project = new Project;
-            $Project->Id = $this->projectid;
-            $Project->Fill();
-            if ($upload_file_size > $Project->UploadQuota) {
-                Log::error("Size of uploaded file {$this->TmpFilename} is {$upload_file_size} bytes, which is greater than the total upload quota for this project ({$Project->UploadQuota} bytes)");
+            if ($upload_file_size > $this->Project->UploadQuota) {
+                Log::error("Size of uploaded file {$this->TmpFilename} is {$upload_file_size} bytes, which is greater than the total upload quota for this project ({$this->Project->UploadQuota} bytes)");
                 $this->UploadError = true;
                 cdash_unlink($this->TmpFilename);
                 return;
@@ -316,7 +283,7 @@ class UploadHandler extends AbstractHandler
             if (!$success) {
                 Log::error("UploadFile model - Failed to insert row associated with file: '{$this->UploadFile->Filename}'");
             }
-            $Project->CullUploadedFiles();
+            $this->Project->CullUploadedFiles();
 
             // Reset UploadError so that the handler could attempt to process following files
             $this->UploadError = false;

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -119,8 +119,7 @@ class UploadHandler extends AbstractHandler
             // other handlers.
             $buildDate =
                 extract_date_from_buildstamp($this->Build->GetStamp());
-            list($beginningOfDay, $endOfDay) =
-                $this->Project->ComputeTestingDayBounds($buildDate);
+            [$beginningOfDay, $endOfDay] = $this->Project->ComputeTestingDayBounds($buildDate);
 
             $this->Build->EndTime = $beginningOfDay;
             $this->Build->StartTime = $endOfDay;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26951,16 +26951,6 @@ parameters:
 			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
 
 		-
-			message: "#^Access to an undefined property AbstractHandler\\:\\:\\$config\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/abstract_handler.php
-
-		-
-			message: "#^Class stack referenced with incorrect case\\: Stack\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/abstract_handler.php
-
-		-
 			message: "#^Method AbstractHandler\\:\\:GetProject\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_handler.php
@@ -27186,17 +27176,7 @@ parameters:
 			path: app/cdash/xml_handlers/abstract_handler.php
 
 		-
-			message: "#^Property AbstractHandler\\:\\:\\$Project has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/abstract_handler.php
-
-		-
 			message: "#^Property AbstractHandler\\:\\:\\$SubProjectName has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/abstract_handler.php
-
-		-
-			message: "#^Property AbstractHandler\\:\\:\\$conifg has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_handler.php
 
@@ -29060,14 +29040,6 @@ parameters:
 			message: "#^Property UpdateHandler\\:\\:\\$UpdateFile has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"


### PR DESCRIPTION
This removes duplicated logic and fixes a bug that sometimes caused builds to be assigned to the wrong testing day.

This commit also cleans up some code in abstract_handler.