### PR TITLE
Delete unnecessary robots.txt files

### DIFF
--- a/app/cdash/public/robots.txt
+++ b/app/cdash/public/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Disallow: /local
-Disallow: /backup
-Disallow: /tests
-Disallow: /sql

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:


### PR DESCRIPTION
We currently have two `robots.txt` files.  One is unused, so I have deleted it.  The other disallows nothing, and is thus effectively useless, so it has been deleted as well.