### PR TITLE
Handle missing search parameter more gracefully

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -918,8 +918,8 @@ final class CoverageController extends AbstractBuildController
         $SQLsearchTerm = '';
         $SQLsearchTermParams = [];
         if (isset($_GET['sSearch']) && $_GET['sSearch'] != '') {
-            $SQLsearchTerm = " AND cf.fullpath LIKE CONCAT('%', ?, '%')";
-            $SQLsearchTermParams[] = htmlspecialchars($_GET['sSearch']);
+            $SQLsearchTerm = " AND cf.fullpath LIKE ?";
+            $SQLsearchTermParams[] = '%' . htmlspecialchars($_GET['sSearch']) . '%';
         }
 
         $SQLDisplayAuthors = '';

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -512,10 +512,10 @@ final class ManageProjectRolesController extends AbstractProjectController
             $sql = 'email=?';
             $params[] = $search;
         } else {
-            $sql = "(email LIKE CONCAT('%', ?, '%') OR firstname LIKE CONCAT('%', ?, '%') OR lastname LIKE CONCAT('%', ?, '%'))";
-            $params[] = $search;
-            $params[] = $search;
-            $params[] = $search;
+            $sql = "(email LIKE ? OR firstname LIKE ? OR lastname LIKE ?)";
+            $params[] = '%' . $search . '%';
+            $params[] = '%' . $search . '%';
+            $params[] = '%' . $search . '%';
         }
 
         $params[] = $this->project->Id;

--- a/app/Http/Controllers/ManageUsersController.php
+++ b/app/Http/Controllers/ManageUsersController.php
@@ -83,15 +83,20 @@ final class ManageUsersController extends AbstractController
     {
         $config = Config::getInstance();
 
-        $search = $_GET['search'];
-        if ($config->get('CDASH_FULL_EMAIL_WHEN_ADDING_USER') == 1) {
-            $sql = "email=?";
-            $params = [$search];
+        $search = trim($_GET['search'] ?? '');
+        if ($search !== '') {
+            if ($config->get('CDASH_FULL_EMAIL_WHEN_ADDING_USER') == 1) {
+                $sql = "email=?";
+                $params = [$search];
+            } else {
+                $search = '%' . $search . '%';
+                $sql = "email LIKE ? OR firstname LIKE ? OR lastname LIKE ?";
+                $params = [$search, $search, $search];
+            }
+            $users = DB::select('SELECT * FROM ' . qid('user') . ' WHERE ' . $sql, $params);
         } else {
-            $sql = "email LIKE CONCAT('%', ?, '%') OR firstname LIKE CONCAT('%', ?, '%') OR lastname LIKE CONCAT('%', ?, '%')";
-            $params = [$search, $search, $search];
+            $users = [];
         }
-        $users = DB::select('SELECT * FROM ' . qid('user') . ' WHERE ' . $sql, $params);
 
         return view('admin.find-users')
             ->with('users', $users)


### PR DESCRIPTION
The user search feature currently leaves errors in the logs if the search only contains whitespace on postgres, or if the search parameter is not specified.  The UI experience is not affected.  This PR eliminates the errors previously generated by a somewhat reasonable search.