### PR TITLE
Remove duplicate `.gitattributes` file

### DIFF
--- a/app/cdash/.gitattributes
+++ b/app/cdash/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
We currently have two `.gitattributes` files.  The lower-level file duplicates information from the top level file, and is thus unnecessary.