### PR TITLE
Rename "Services" to "Utilities"

### DIFF
--- a/app/Console/Commands/QueueSubmissions.php
+++ b/app/Console/Commands/QueueSubmissions.php
@@ -3,7 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Jobs\ProcessSubmission;
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use CDash\Model\Project;
 
 use Illuminate\Console\Command;
@@ -88,7 +88,7 @@ class QueueSubmissions extends Command
                 return;
             }
             $len = $end - $begin;
-            if (!AuthTokenService::checkToken(substr($filename, $begin, $len), $project->Id)) {
+            if (!AuthTokenUtil::checkToken(substr($filename, $begin, $len), $project->Id)) {
                 \Storage::move("inbox/{$filename}", "failed/{$filename}");
                 echo "Invalid authentication token for $filename\n";
                 return;

--- a/app/Console/Commands/QueueSubmissions.php
+++ b/app/Console/Commands/QueueSubmissions.php
@@ -3,7 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Jobs\ProcessSubmission;
-use App\Services\AuthTokenService;
+use App\Utils\AuthTokenService;
 use CDash\Model\Project;
 
 use Illuminate\Console\Command;

--- a/app/Http/Controllers/AbstractBuildController.php
+++ b/app/Http/Controllers/AbstractBuildController.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Model\Build;
 use Illuminate\View\View;
 

--- a/app/Http/Controllers/AbstractProjectController.php
+++ b/app/Http/Controllers/AbstractProjectController.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;

--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\AuthToken;
-use App\Services\AuthTokenService;
+use App\Utils\AuthTokenService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;

--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\AuthToken;
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -25,7 +25,7 @@ final class AuthTokenController extends AbstractController
      */
     public function fetchAll(): JsonResponse
     {
-        $token_array = AuthTokenService::getAllTokens();
+        $token_array = AuthTokenUtil::getAllTokens();
         $token_map = [];
         foreach ($token_array as $token) {
             $token_map[$token['hash']] = $token;
@@ -55,7 +55,7 @@ final class AuthTokenController extends AbstractController
         }
 
         try {
-            $gen_auth_token = AuthTokenService::generateToken(
+            $gen_auth_token = AuthTokenUtil::generateToken(
                 Auth::id(),
                 $projectid,
                 $request->input('scope'),
@@ -70,7 +70,7 @@ final class AuthTokenController extends AbstractController
 
     public function deleteToken(string $token_hash): JsonResponse
     {
-        if (!AuthTokenService::deleteToken($token_hash, Auth::id())) {
+        if (!AuthTokenUtil::deleteToken($token_hash, Auth::id())) {
             return response()->json(['error' => 'Permissions error'], status: Response::HTTP_FORBIDDEN);
         }
         return response()->json('Token deleted');

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -3,8 +3,8 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Models\Build as EloquentBuild;
-use App\Services\PageTimer;
-use App\Services\TestingDay;
+use App\Utils\PageTimer;
+use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildConfigure;

--- a/app/Http/Controllers/BuildNoteController.php
+++ b/app/Http/Controllers/BuildNoteController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Build as EloquentBuild;
 use App\Models\Note;
-use App\Services\PageTimer;
-use App\Services\TestingDay;
+use App\Utils\PageTimer;
+use App\Utils\TestingDay;
 use CDash\Model\Build;
 use Illuminate\Http\JsonResponse;
 

--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Database;
 use DateInterval;
 use DateTime;

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -2,8 +2,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Services\PageTimer;
-use App\Services\TestingDay;
+use App\Utils\PageTimer;
+use App\Utils\TestingDay;
 use CDash\Config;
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/Http/Controllers/DynamicAnalysisController.php
+++ b/app/Http/Controllers/DynamicAnalysisController.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Services\PageTimer;
-use App\Services\TestingDay;
+use App\Utils\PageTimer;
+use App\Utils\TestingDay;
 use CDash\Model\DynamicAnalysis;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Measurement;
 use App\Models\Project as EloquentProject;
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Gate;
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Config;
 use CDash\Model\Project;
 use CDash\Model\Repository;

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Site;
 use App\Models\User;
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Banner;
 use App\Models\User;
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Model\SubProject;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;

--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Jobs\ProcessSubmission;
 use App\Models\Site;
-use App\Services\AuthTokenService;
-use App\Services\UnparsedSubmissionProcessor;
+use App\Utils\AuthTokenService;
+use App\Utils\UnparsedSubmissionProcessor;
 use CDash\Model\Build;
 use CDash\Model\PendingSubmissions;
 use CDash\Model\Project;

--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Jobs\ProcessSubmission;
 use App\Models\Site;
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use App\Utils\UnparsedSubmissionProcessor;
 use CDash\Model\Build;
 use CDash\Model\PendingSubmissions;
@@ -75,8 +75,8 @@ final class SubmissionController extends AbstractProjectController
         }
 
         // Get auth token (if any).
-        $authtoken = AuthTokenService::getBearerToken();
-        $authtoken_hash = $authtoken === null || $authtoken === '' ? '' : AuthTokenService::hashToken($authtoken);
+        $authtoken = AuthTokenUtil::getBearerToken();
+        $authtoken_hash = $authtoken === null || $authtoken === '' ? '' : AuthTokenUtil::hashToken($authtoken);
 
         // Save the incoming file in the inbox directory.
         $filename = "{$projectname}_-_{$authtoken_hash}_-_" . Str::uuid()->toString() . "_-_{$expected_md5}.xml";
@@ -115,7 +115,7 @@ final class SubmissionController extends AbstractProjectController
         $this->project->CheckForTooManyBuilds();
 
         // Check for valid authentication token if this project requires one.
-        if ($this->project->AuthenticateSubmissions && !AuthTokenService::checkToken($authtoken_hash, $this->project->Id)) {
+        if ($this->project->AuthenticateSubmissions && !AuthTokenUtil::checkToken($authtoken_hash, $this->project->Id)) {
             Storage::delete("inbox/{$filename}");
             abort(Response::HTTP_FORBIDDEN, 'Invalid Token');
         } elseif (intval($this->project->Id) < 1) {

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -2,7 +2,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\BuildTest;
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Database;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,8 +2,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Services\AuthTokenService;
-use App\Services\PageTimer;
+use App\Utils\AuthTokenService;
+use App\Utils\PageTimer;
 use App\Validators\Password;
 use CDash\Config;
 use CDash\Database;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,7 +2,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use App\Utils\PageTimer;
 use App\Validators\Password;
 use CDash\Config;
@@ -89,7 +89,7 @@ final class UserController extends AbstractController
         }
         $response['projects'] = $projects_response;
 
-        $response['authtokens'] = AuthTokenService::getTokensForUser($userid);
+        $response['authtokens'] = AuthTokenUtil::getTokensForUser($userid);
         $response['allow_full_access_tokens'] = config('cdash.allow_full_access_tokens') === true;
         $response['allow_submit_only_tokens'] = config('cdash.allow_submit_only_tokens') === true;
 

--- a/app/Http/Controllers/UserStatisticsController.php
+++ b/app/Http/Controllers/UserStatisticsController.php
@@ -2,7 +2,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use Illuminate\Http\JsonResponse;
 
 final class UserStatisticsController extends AbstractProjectController

--- a/app/Http/Middleware/AuthenticateToken.php
+++ b/app/Http/Middleware/AuthenticateToken.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use App\Services\AuthTokenService;
+use App\Utils\AuthTokenService;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Middleware/AuthenticateToken.php
+++ b/app/Http/Middleware/AuthenticateToken.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -19,7 +19,7 @@ class AuthenticateToken
      */
     public function handle(Request $request, Closure $next)
     {
-        $user_id = AuthTokenService::getUserIdFromRequest();
+        $user_id = AuthTokenUtil::getUserIdFromRequest();
         if ($user_id !== null) {
             Auth::loginUsingId($user_id);
         }

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Services\UnparsedSubmissionProcessor;
+use App\Utils\UnparsedSubmissionProcessor;
 use App\Models\SuccessfulJob;
 
 use BuildPropertiesJSONHandler;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,7 +7,7 @@ namespace App\Providers;
 use App\Models\Test;
 use App\Models\TestImage;
 use App\Models\User;
-use App\Services\ProjectPermissions;
+use App\Utils\ProjectPermissions;
 use CDash\Model\Image;
 use CDash\Model\Project;
 use Illuminate\Auth\Access\Response;

--- a/app/Utils/AuthTokenService.php
+++ b/app/Utils/AuthTokenService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Utils;
 
 use App\Models\AuthToken;
 use App\Models\User;

--- a/app/Utils/AuthTokenUtil.php
+++ b/app/Utils/AuthTokenUtil.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use RuntimeException;
 
-class AuthTokenService
+class AuthTokenUtil
 {
     /**
      * Contract: we assume that $user_id has already been validated and blindly create a token

--- a/app/Utils/NoteCreator.php
+++ b/app/Utils/NoteCreator.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Services;
+namespace App\Utils;
 
 use App\Models\Note;
 

--- a/app/Utils/PageTimer.php
+++ b/app/Utils/PageTimer.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Services;
+namespace App\Utils;
 
 /**
  * This class handles page load time calculations, reporting, and logging.

--- a/app/Utils/ProjectPermissions.php
+++ b/app/Utils/ProjectPermissions.php
@@ -16,7 +16,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Utils;
 
 use CDash\Model\Project;
 use CDash\Model\UserProject;

--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Services;
+namespace App\Utils;
 
 use App\Models\BuildTest;
 use App\Models\TestImage;

--- a/app/Utils/TestDiffService.php
+++ b/app/Utils/TestDiffService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services;
+namespace App\Utils;
 
 use App\Enums\TestDiffType;
 use App\Models\TestDiff;

--- a/app/Utils/TestDiffUtil.php
+++ b/app/Utils/TestDiffUtil.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Log;
  * It also sets `build2test::newstatus` = 1 as appropriate.
  **/
 
-class TestDiffService
+class TestDiffUtil
 {
     public static function computeDifferences(Build $build) : bool
     {

--- a/app/Utils/TestingDay.php
+++ b/app/Utils/TestingDay.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Services;
+namespace App\Utils;
 
 use CDash\Model\Project;
 

--- a/app/Utils/UnparsedSubmissionProcessor.php
+++ b/app/Utils/UnparsedSubmissionProcessor.php
@@ -154,7 +154,7 @@ class UnparsedSubmissionProcessor
         $projectid = $project_row->id;
 
         // Check if this submission requires a valid authentication token.
-        if (($this->token || $project_row->authenticatesubmissions) && !AuthTokenService::checkToken($this->token, $projectid)) {
+        if (($this->token || $project_row->authenticatesubmissions) && !AuthTokenUtil::checkToken($this->token, $projectid)) {
             abort(Response::HTTP_FORBIDDEN, 'Forbidden');
         }
 
@@ -311,9 +311,9 @@ class UnparsedSubmissionProcessor
 
         // Check if this submission requires a valid authentication token.
         if ($this->project->AuthenticateSubmissions) {
-            $token = AuthTokenService::getBearerToken();
-            $authtoken_hash = AuthTokenService::hashToken($token);
-            if (!AuthTokenService::checkToken($authtoken_hash, $this->project->Id)) {
+            $token = AuthTokenUtil::getBearerToken();
+            $authtoken_hash = AuthTokenUtil::hashToken($token);
+            if (!AuthTokenUtil::checkToken($authtoken_hash, $this->project->Id)) {
                 Storage::delete($this->inboxdatafilename);
                 abort(Response::HTTP_FORBIDDEN, 'Forbidden');
             }
@@ -444,9 +444,9 @@ class UnparsedSubmissionProcessor
         if ($this->token) {
             return;
         }
-        $token = AuthTokenService::getBearerToken();
+        $token = AuthTokenUtil::getBearerToken();
         if ($token) {
-            $this->token = AuthTokenService::hashToken($token);
+            $this->token = AuthTokenUtil::hashToken($token);
         } else {
             $this->token = '';
         }

--- a/app/Utils/UnparsedSubmissionProcessor.php
+++ b/app/Utils/UnparsedSubmissionProcessor.php
@@ -14,7 +14,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Services;
+namespace App\Utils;
 
 use App\Jobs\ProcessSubmission;
 use CDash\Model\Build;

--- a/app/cdash/app/Controller/Api.php
+++ b/app/cdash/app/Controller/Api.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 namespace CDash\Controller;
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Database;
 
 /**

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 namespace CDash\Controller\Api;
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;

--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 namespace CDash\Controller\Api;
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -18,7 +18,7 @@ namespace CDash\Controller\Api;
 
 use App\Enums\ClassicPalette;
 use App\Enums\HighContrastPalette;
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -23,7 +23,7 @@ use App\Models\BuildTest;
 use App\Models\Site;
 use App\Models\Test;
 use App\Utils\TestingDay;
-use App\Utils\TestDiffService;
+use App\Utils\TestDiffUtil;
 use App\Models\BuildInformation;
 
 use CDash\Collection\BuildEmailCollection;
@@ -1235,7 +1235,7 @@ class Build
 
         // Record test differences from the previous build.
         // (+/- number of tests that failed, etc.)
-        TestDiffService::computeDifferences($this);
+        TestDiffUtil::computeDifferences($this);
 
         $project_stmt = $this->PDO->prepare(
             'SELECT testtimestd, testtimestdthreshold, testtimemaxstatus

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -22,8 +22,8 @@ require_once 'include/repository.php';
 use App\Models\BuildTest;
 use App\Models\Site;
 use App\Models\Test;
-use App\Services\TestingDay;
-use App\Services\TestDiffService;
+use App\Utils\TestingDay;
+use App\Utils\TestDiffService;
 use App\Models\BuildInformation;
 
 use CDash\Collection\BuildEmailCollection;

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -16,7 +16,7 @@
 
 use Illuminate\Support\Facades\Auth;
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 
 use CDash\Config;
 use CDash\Database;

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -17,7 +17,7 @@
 namespace CDash\Api\v1\ManageBuildGroup;
 
 use App\Models\User;
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Database;
 use CDash\Model\BuildGroup;
 use CDash\Model\Project;

--- a/app/cdash/public/api/v1/manageOverview.php
+++ b/app/cdash/public/api/v1/manageOverview.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\ManageOverview;
 
 include_once 'include/api_common.php';
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 use CDash\Database;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\Auth;

--- a/app/cdash/public/api/v1/relateBuilds.php
+++ b/app/cdash/public/api/v1/relateBuilds.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\RelateBuilds;
 
 require_once 'include/api_common.php';
 
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use CDash\Model\Build;
 use CDash\Model\BuildRelationship;
 use CDash\Model\Project;
@@ -78,8 +78,8 @@ if ($request_method == 'POST') {
     // Check for valid authentication token if this project requires one.
     $project->Fill();
 
-    $token_hash = AuthTokenService::hashToken(AuthTokenService::getBearerToken());
-    if ($project->AuthenticateSubmissions && !AuthTokenService::checkToken($token_hash, $project->Id)) {
+    $token_hash = AuthTokenUtil::hashToken(AuthTokenUtil::getBearerToken());
+    if ($project->AuthenticateSubmissions && !AuthTokenUtil::checkToken($token_hash, $project->Id)) {
         return;
     }
 

--- a/app/cdash/public/api/v1/relateBuilds.php
+++ b/app/cdash/public/api/v1/relateBuilds.php
@@ -18,7 +18,7 @@ namespace CDash\Api\v1\RelateBuilds;
 
 require_once 'include/api_common.php';
 
-use App\Services\AuthTokenService;
+use App\Utils\AuthTokenService;
 use CDash\Model\Build;
 use CDash\Model\BuildRelationship;
 use CDash\Model\Project;

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Api\v1\SubProject;
 
-use App\Services\PageTimer;
+use App\Utils\PageTimer;
 
 use CDash\Database;
 use CDash\Model\Project;

--- a/app/cdash/tests/case/CDash/NightlyTimeTest.php
+++ b/app/cdash/tests/case/CDash/NightlyTimeTest.php
@@ -14,7 +14,7 @@
  * =========================================================================
  */
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 
 use CDash\Model\Project;
 use Tests\TestCase;

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -4,7 +4,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
 use App\Models\AuthToken;
-use App\Services\AuthTokenService;
+use App\Utils\AuthTokenService;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Support\Facades\DB;

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -4,7 +4,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
 use App\Models\AuthToken;
-use App\Utils\AuthTokenService;
+use App\Utils\AuthTokenUtil;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Support\Facades\DB;
@@ -258,7 +258,7 @@ class AuthTokenTestCase extends KWWebTestCase
     public function testRemoveExpiredToken()
     {
         // Put an expired token in the database.
-        $result = AuthTokenService::generateToken(1, -1, AuthToken::SCOPE_FULL_ACCESS, "Test Token 1");
+        $result = AuthTokenUtil::generateToken(1, -1, AuthToken::SCOPE_FULL_ACCESS, "Test Token 1");
         $token = $result['raw_token'];
         $authtoken = $result['token'];
         $authtoken['expires'] = gmdate(FMT_DATETIME, 1);

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -3,7 +3,7 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 
 use CDash\Database;
 use CDash\Model\BuildGroup;

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -3,7 +3,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
 
-use App\Services\TestCreator;
+use App\Utils\TestCreator;
 
 use CDash\Database;
 use CDash\Model\Build;

--- a/app/cdash/tests/test_consistenttestingday.php
+++ b/app/cdash/tests/test_consistenttestingday.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-use App\Services\TestingDay;
+use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Project;

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -6,8 +6,8 @@
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 use App\Models\TestMeasurement;
-use App\Services\TestCreator;
-use App\Services\NoteCreator;
+use App\Utils\TestCreator;
+use App\Utils\NoteCreator;
 
 use CDash\Model\Build;
 use CDash\Model\BuildConfigure;

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -15,7 +15,7 @@
 =========================================================================*/
 require_once 'xml_handlers/NonSaxHandler.php';
 
-use App\Services\TestCreator;
+use App\Utils\TestCreator;
 
 use CDash\Model\Build;
 use CDash\Model\BuildConfigure;

--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -16,7 +16,7 @@
 
 require_once 'xml_handlers/abstract_handler.php';
 
-use App\Services\NoteCreator;
+use App\Utils\NoteCreator;
 
 use CDash\Model\Build;
 use App\Models\BuildInformation;

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -4,7 +4,7 @@ require_once 'xml_handlers/abstract_handler.php';
 require_once 'xml_handlers/actionable_build_interface.php';
 
 use App\Models\TestMeasurement;
-use App\Services\TestCreator;
+use App\Utils\TestCreator;
 
 use CDash\Collection\BuildCollection;
 use CDash\Collection\Collection;

--- a/app/cdash/xml_handlers/testing_junit_handler.php
+++ b/app/cdash/xml_handlers/testing_junit_handler.php
@@ -16,7 +16,7 @@
 
 require_once 'xml_handlers/abstract_handler.php';
 
-use App\Services\TestCreator;
+use App\Utils\TestCreator;
 
 use CDash\Model\Build;
 use App\Models\BuildInformation;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -501,12 +501,12 @@ parameters:
 			path: app/Http/Controllers/AuthTokenController.php
 
 		-
-			message: "#^Parameter \\#1 \\$user_id of static method App\\\\Services\\\\AuthTokenService\\:\\:generateToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$user_id of static method App\\\\Utils\\\\AuthTokenUtil\\:\\:generateToken\\(\\) expects int, int\\|string\\|null given\\.$#"
 			count: 1
 			path: app/Http/Controllers/AuthTokenController.php
 
 		-
-			message: "#^Parameter \\#2 \\$expected_user_id of static method App\\\\Services\\\\AuthTokenService\\:\\:deleteToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$expected_user_id of static method App\\\\Utils\\\\AuthTokenUtil\\:\\:deleteToken\\(\\) expects int, int\\|string\\|null given\\.$#"
 			count: 1
 			path: app/Http/Controllers/AuthTokenController.php
 
@@ -2843,7 +2843,7 @@ parameters:
 			path: app/Http/Middleware/VerifyCsrfToken.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$backupFileName\\.$#"
+			message: "#^Access to an undefined property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$backupFileName\\.$#"
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
@@ -3383,32 +3383,32 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\AuthToken\\>\\:\\:leftJoin\\(\\)\\.$#"
 			count: 3
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$params does not exist\\.$#"
 			count: 1
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 1
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, \\(int\\|string\\) given\\.$#"
 			count: 1
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int given\\.$#"
 			count: 1
-			path: app/Services/AuthTokenService.php
+			path: app/Utils/AuthTokenUtil.php
 
 		-
 			message: """
@@ -3416,362 +3416,362 @@ parameters:
 				04/01/2023$#
 			"""
 			count: 2
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Method App\\\\Services\\\\NoteCreator\\:\\:computeCrc32\\(\\) has no return type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\NoteCreator\\:\\:computeCrc32\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Method App\\\\Services\\\\NoteCreator\\:\\:create\\(\\) has no return type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\NoteCreator\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\NoteCreator\\:\\:\\$buildid has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\NoteCreator\\:\\:\\$buildid has no type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\NoteCreator\\:\\:\\$crc32 has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\NoteCreator\\:\\:\\$crc32 has no type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\NoteCreator\\:\\:\\$name has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\NoteCreator\\:\\:\\$name has no type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\NoteCreator\\:\\:\\$text has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\NoteCreator\\:\\:\\$text has no type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\NoteCreator\\:\\:\\$time has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\NoteCreator\\:\\:\\$time has no type specified\\.$#"
 			count: 1
-			path: app/Services/NoteCreator.php
+			path: app/Utils/NoteCreator.php
 
 		-
-			message: "#^Class App\\\\Services\\\\PageTimer has an uninitialized property \\$duration\\. Give it default value or assign it in the constructor\\.$#"
+			message: "#^Class App\\\\Utils\\\\PageTimer has an uninitialized property \\$duration\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
-			path: app/Services/PageTimer.php
+			path: app/Utils/PageTimer.php
 
 		-
-			message: "#^Method App\\\\Services\\\\PageTimer\\:\\:end\\(\\) has no return type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\PageTimer\\:\\:end\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/Services/PageTimer.php
+			path: app/Utils/PageTimer.php
 
 		-
-			message: "#^Method App\\\\Services\\\\PageTimer\\:\\:end\\(\\) has parameter \\$response with no type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\PageTimer\\:\\:end\\(\\) has parameter \\$response with no type specified\\.$#"
 			count: 1
-			path: app/Services/PageTimer.php
+			path: app/Utils/PageTimer.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 3
-			path: app/Services/ProjectPermissions.php
+			path: app/Utils/ProjectPermissions.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\:\\:\\$measurements\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
 			count: 2
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Method App\\\\Services\\\\TestCreator\\:\\:saveImage\\(\\) has parameter \\$outputid with no type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\TestCreator\\:\\:saveImage\\(\\) has parameter \\$outputid with no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, array given\\.$#"
 			count: 2
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Parameter \\#1 \\$image of function imagegif expects GdImage, GdImage\\|false given\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Parameter \\#1 \\$image of function imagejpeg expects GdImage, GdImage\\|false given\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Parameter \\#1 \\$image of function imagepng expects GdImage, GdImage\\|false given\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function crc32 expects string, string\\|false given\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$time \\(float\\) does not accept string\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$alreadyCompressed has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$alreadyCompressed has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$buildTestTime has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$buildTestTime has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$images has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$images has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$labels has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$labels has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$measurements has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$measurements has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$projectid has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$projectid has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testCommand has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testCommand has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testDetails has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testDetails has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testName has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testName has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testOutput has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testOutput has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testPath has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testPath has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Services\\\\TestCreator\\:\\:\\$testStatus has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\TestCreator\\:\\:\\$testStatus has no type specified\\.$#"
 			count: 1
-			path: app/Services/TestCreator.php
+			path: app/Utils/TestCreator.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$difference_negative\\.$#"
 			count: 1
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$difference_positive\\.$#"
 			count: 1
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 2
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
 			count: 2
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
 			message: "#^Parameter \\#1 \\$array of function array_column expects array, array\\|false given\\.$#"
 			count: 2
-			path: app/Services/TestDiffService.php
+			path: app/Utils/TestDiffUtil.php
 
 		-
-			message: "#^Method App\\\\Services\\\\TestingDay\\:\\:get\\(\\) has no return type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\TestingDay\\:\\:get\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/Services/TestingDay.php
+			path: app/Utils/TestingDay.php
 
 		-
-			message: "#^Method App\\\\Services\\\\TestingDay\\:\\:get\\(\\) has parameter \\$date with no type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\TestingDay\\:\\:get\\(\\) has parameter \\$date with no type specified\\.$#"
 			count: 1
-			path: app/Services/TestingDay.php
+			path: app/Utils/TestingDay.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$authenticatesubmissions\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Method App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:deserializeBuildMetadata\\(\\) has parameter \\$fp with no type specified\\.$#"
+			message: "#^Method App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:deserializeBuildMetadata\\(\\) has parameter \\$fp with no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, \\(array\\<int, string\\>\\|string\\) given\\.$#"
 			count: 2
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|null given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, \\(array\\<int, string\\>\\|string\\) given\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Parameter \\#2 \\$contents of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:put\\(\\) expects resource\\|string, string\\|false given\\.$#"
 			count: 2
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$backupfilename has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$backupfilename has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$build has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$build has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$buildid has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$buildid has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$buildname has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$buildname has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$buildstamp has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$buildstamp has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$endtime has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$endtime has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$generator has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$generator has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$inboxdatafilename has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$inboxdatafilename has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$md5 has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$md5 has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$project has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$project has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$projectname has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$projectname has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$sitename has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$sitename has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$starttime has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$starttime has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$subprojectname has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$subprojectname has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$token has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$token has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
-			message: "#^Property App\\\\Services\\\\UnparsedSubmissionProcessor\\:\\:\\$type has no type specified\\.$#"
+			message: "#^Property App\\\\Utils\\\\UnparsedSubmissionProcessor\\:\\:\\$type has no type specified\\.$#"
 			count: 1
-			path: app/Services/UnparsedSubmissionProcessor.php
+			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"


### PR DESCRIPTION
In Laravel, a "service" is a specific term used to describe [service providers](https://laravel.com/docs/10.x/providers).  CDash stores those at the default `app/Providers` path.  Having an additional `app/Services` directory is confusing, because the contents therein are not services.  The current contents of `app/Services` are simply helper classes, mostly classes with static member functions for performing various utility features.  As such, I have renamed the directory to `app/Utils`.

I eventually plan to move some of our legacy global functions into container classes in this directory.  Some of the global functions pollute our global namespace, and interfere with static analysis 