### PR TITLE
Fix navigation when clicking on test details graph

### DIFF
--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -442,7 +442,6 @@ export default {
       var vm = this;
       $("#graph_holder").bind("plotclick", function (e, pos, item) {
         if (item) {
-          plot.highlight(item.series, item.datapoint);
           var buildtestid = buildtestids[item.datapoint[0]];
           window.location = vm.$baseURL + "/test/" + buildtestid + "?graph=" + vm.graphSelection;
         }


### PR DESCRIPTION
This functionality was broken with the following error message in the console:
    Cannot read properties of undefined (reading 'highlight')

This was due to the fact that the 'plot' variable was undefined.

Highlighting this data point before we navigate to another page seems unnecessary, so this commit fixes the bug by removing the offending line of code.