### PR TITLE
Standardize usages of PHPUnit's `assertEquals()`

### DIFF
--- a/app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
+++ b/app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
@@ -17,6 +17,6 @@ class LinkifyCompilerOutputTest extends CDashTestCase
 
         $expected_output = "<a href='https://github.com/Kitware/CDash/blob/master/file.cxx#L1'>file.cxx:1</a>:22: error: &lt;fakefile.h&gt;: No such file";
 
-        $this->assertEquals($linkified_output, $expected_output);
+        $this->assertEquals($expected_output, $linkified_output);
     }
 }

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -103,26 +103,26 @@ class TestUseCaseTest extends CDashUseCaseTestCase
         $build = $builds->current();
         $information = $build->GetSite()->mostRecentInformation;
 
-        $this->assertEquals($information->description, $siteInformation['Description']);
-        $this->assertEquals($information->processoris64bits, $siteInformation['Is64Bits']);
-        $this->assertEquals($information->processorvendor, $siteInformation['VendorString']);
-        $this->assertEquals($information->processorvendorid, $siteInformation['VendorID']);
-        $this->assertEquals($information->processorfamilyid, $siteInformation['FamilyID']);
-        $this->assertEquals($information->processormodelid, $siteInformation['ModelID']);
-        $this->assertEquals($information->processorcachesize, $siteInformation['ProcessorCacheSize']);
-        $this->assertEquals($information->numberlogicalcpus, $siteInformation['NumberOfLogicalCPU']);
-        $this->assertEquals($information->numberphysicalcpus, $siteInformation['NumberOfPhysicalCPU']);
-        $this->assertEquals($information->totalvirtualmemory, $siteInformation['TotalVirtualMemory']);
-        $this->assertEquals($information->totalphysicalmemory, $siteInformation['TotalPhysicalMemory']);
-        $this->assertEquals($information->logicalprocessorsperphysical, $siteInformation['LogicalProcessorsPerPhysical']);
-        $this->assertEquals($information->processorclockfrequency, $siteInformation['ProcessorClockFrequency']);
+        $this->assertEquals($siteInformation['Description'], $information->description);
+        $this->assertEquals($siteInformation['Is64Bits'], $information->processoris64bits);
+        $this->assertEquals($siteInformation['VendorString'], $information->processorvendor);
+        $this->assertEquals($siteInformation['VendorID'], $information->processorvendorid);
+        $this->assertEquals($siteInformation['FamilyID'], $information->processorfamilyid);
+        $this->assertEquals($siteInformation['ModelID'], $information->processormodelid);
+        $this->assertEquals($siteInformation['ProcessorCacheSize'], $information->processorcachesize);
+        $this->assertEquals($siteInformation['NumberOfLogicalCPU'], $information->numberlogicalcpus);
+        $this->assertEquals($siteInformation['NumberOfPhysicalCPU'], $information->numberphysicalcpus);
+        $this->assertEquals($siteInformation['TotalVirtualMemory'], $information->totalvirtualmemory);
+        $this->assertEquals($siteInformation['TotalPhysicalMemory'], $information->totalphysicalmemory);
+        $this->assertEquals($siteInformation['LogicalProcessorsPerPhysical'], $information->logicalprocessorsperphysical);
+        $this->assertEquals($siteInformation['ProcessorClockFrequency'], $information->processorclockfrequency);
 
-        $this->assertEquals($build->Information->osname, $siteInformation['OSName']);
-        $this->assertEquals($build->Information->osrelease, $siteInformation['OSRelease']);
-        $this->assertEquals($build->Information->osversion, $siteInformation['OSVersion']);
-        $this->assertEquals($build->Information->osplatform, $siteInformation['OSPlatform']);
-        $this->assertEquals($build->Information->compilername, $siteInformation['CompilerName']);
-        $this->assertEquals($build->Information->compilerversion, $siteInformation['CompilerVersion']);
+        $this->assertEquals($siteInformation['OSName'], $build->Information->osname);
+        $this->assertEquals($siteInformation['OSRelease'], $build->Information->osrelease);
+        $this->assertEquals($siteInformation['OSVersion'], $build->Information->osversion);
+        $this->assertEquals($siteInformation['OSPlatform'], $build->Information->osplatform);
+        $this->assertEquals($siteInformation['CompilerName'], $build->Information->compilername);
+        $this->assertEquals($siteInformation['CompilerVersion'], $build->Information->compilerversion);
     }
 
     public function testTestUseCaseSetsSiteProperty()

--- a/tests/Feature/MeasurementPositionMigration.php
+++ b/tests/Feature/MeasurementPositionMigration.php
@@ -70,7 +70,7 @@ class MeasurementPositionMigration extends TestCase
             '--force' => true]);
 
         // Verify results.
-        $this::assertEquals(DB::table('measurement')->count(), 6);
+        $this::assertEquals(6, DB::table('measurement')->count());
         $expected_measurements = [
             [
                 'projectid' => $project1->Id,

--- a/tests/Feature/TestSchemaMigration.php
+++ b/tests/Feature/TestSchemaMigration.php
@@ -174,7 +174,7 @@ class TestSchemaMigration extends TestCase
             '--force' => true]);
 
         // Verify results.
-        $this::assertEquals(DB::table('test')->count(), 3);
+        $this::assertEquals(3, DB::table('test')->count());
         $expected_tests = [
             [
                 'name' => 'a test',
@@ -193,7 +193,7 @@ class TestSchemaMigration extends TestCase
             $this->assertDatabaseHas('test', $expected_test);
         }
 
-        $this::assertEquals(DB::table('testoutput')->count(), 4);
+        $this::assertEquals(4, DB::table('testoutput')->count());
         $expected_testoutputs = [
             [
                 'crc32' => 123,
@@ -219,7 +219,7 @@ class TestSchemaMigration extends TestCase
         }
 
         foreach (['build2test', 'label2test', 'test2image', 'testmeasurement'] as $table) {
-            $this::assertEquals(DB::table($table)->count(), 4);
+            $this::assertEquals(4, DB::table($table)->count());
             $this->assertDatabaseHas($table, ['outputid' => 1]);
             $this->assertDatabaseHas($table, ['outputid' => 2]);
             $this->assertDatabaseHas($table, ['outputid' => 3]);


### PR DESCRIPTION
According to [the PHPUnit docs for `assertEquals()`](https://docs.phpunit.de/en/9.6/assertions.html#assertequals), the first argument to the function should be the expected output, and the second argument should be the actual value as produced by the test. Currently,  we have multiple places in the codebase where this ordering of the arguments is not respected. Calling this function with the arguments swapped can lead to confusion when debugging failed tests, as PHPUnit's error messages present failed comparisons in terms of an "expected" and an "actual" value.

The changes in this PR correct the instances where we use the wrong ordering (except for the file `tests/Feature/Monitor.php` which is being improved in PR https://github.com/Kitware/CDash/pull/1826). 

There are many other PHPUnit assertion functions that follow this argument format and are used in our test suites. Future PRs will correct the cases for those functions where the argument ordering is not respected as well.

It would also be nice if we could add tools to automatically enforce this, in order to prevent this from happening in the future and improve our development experience.