### PR TITLE
Add new eslint rules for array and object formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,29 +4,101 @@ module.exports = {
     'plugin:vue/recommended',
   ],
   rules: {
-    'indent': ['error', 2],
+    'indent': [
+      'error',
+      2,
+    ],
     'vue/no-v-html': 'off',
     'vue/require-v-for-key': 'off',
-    'eqeqeq': ['error', 'always'],
-    'arrow-spacing': ['error'],
-    'block-spacing': ['error'],
-    'brace-style': ['error', 'stroustrup'],
-    'comma-dangle': ['error', 'always-multiline'],
-    'curly' : ['error'],
-    'default-param-last': ['error'],
-    'eol-last': ['error'],
-    'keyword-spacing': ['error', {'before': true, 'after': true}],
-    'space-before-blocks': ['error', 'always'],
-    'linebreak-style': ['error', 'unix'],
-    'no-trailing-spaces': ['error'],
-    'no-var': ['error'],
-    'prefer-arrow-callback': ['error'],
-    'prefer-const': ['error'],
-    'prefer-template': ['error'],
-    'quotes': ['error', 'single', {'avoidEscape': true}],
-    'semi': ['error', 'always'],
-    'semi-style': ['error', 'last'],
-    'template-curly-spacing': ['error', 'never'],
+    'eqeqeq': [
+      'error',
+      'always',
+    ],
+    'arrow-spacing': [
+      'error',
+    ],
+    'block-spacing': [
+      'error',
+    ],
+    'brace-style': [
+      'error',
+      'stroustrup',
+    ],
+    'comma-dangle': [
+      'error',
+      'always-multiline',
+    ],
+    'curly' : [
+      'error',
+    ],
+    'default-param-last': [
+      'error',
+    ],
+    'eol-last': [
+      'error',
+    ],
+    'keyword-spacing': [
+      'error',
+      {
+        'before': true,
+        'after': true,
+      },
+    ],
+    'space-before-blocks': [
+      'error',
+      'always',
+    ],
+    'linebreak-style': [
+      'error',
+      'unix',
+    ],
+    'no-trailing-spaces': [
+      'error',
+    ],
+    'no-var': [
+      'error',
+    ],
+    'prefer-arrow-callback': [
+      'error',
+    ],
+    'prefer-const': [
+      'error',
+    ],
+    'prefer-template': [
+      'error',
+    ],
+    'quotes': [
+      'error',
+      'single',
+      {
+        'avoidEscape': true,
+      },
+    ],
+    'semi': [
+      'error',
+      'always',
+    ],
+    'semi-style': [
+      'error',
+      'last',
+    ],
+    'template-curly-spacing': [
+      'error',
+      'never',
+    ],
+    'object-property-newline': [
+      'error',
+    ],
+    'array-element-newline': [
+      'error',
+    ],
+    'array-bracket-newline': [
+      'error',
+      'always',
+    ],
+    'object-curly-spacing': [
+      'error',
+    ],
   },
   ignorePatterns: [
     '**/*.min.js',


### PR DESCRIPTION
These rule changes make object and array formatting more consistent throughout our javascript code.  The goal of these changes is to make diffs easier to read when developers add new entries to objects or arrays.

As with most of the eslint style rules, these rules are officially deprecated, because the style rules have been moved to another repository.  I plan to make a separate PR to address that in the future.