### PR TITLE
Revert "Add new eslint rules for array and object formatting"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,101 +4,29 @@ module.exports = {
     'plugin:vue/recommended',
   ],
   rules: {
-    'indent': [
-      'error',
-      2,
-    ],
+    'indent': ['error', 2],
     'vue/no-v-html': 'off',
     'vue/require-v-for-key': 'off',
-    'eqeqeq': [
-      'error',
-      'always',
-    ],
-    'arrow-spacing': [
-      'error',
-    ],
-    'block-spacing': [
-      'error',
-    ],
-    'brace-style': [
-      'error',
-      'stroustrup',
-    ],
-    'comma-dangle': [
-      'error',
-      'always-multiline',
-    ],
-    'curly' : [
-      'error',
-    ],
-    'default-param-last': [
-      'error',
-    ],
-    'eol-last': [
-      'error',
-    ],
-    'keyword-spacing': [
-      'error',
-      {
-        'before': true,
-        'after': true,
-      },
-    ],
-    'space-before-blocks': [
-      'error',
-      'always',
-    ],
-    'linebreak-style': [
-      'error',
-      'unix',
-    ],
-    'no-trailing-spaces': [
-      'error',
-    ],
-    'no-var': [
-      'error',
-    ],
-    'prefer-arrow-callback': [
-      'error',
-    ],
-    'prefer-const': [
-      'error',
-    ],
-    'prefer-template': [
-      'error',
-    ],
-    'quotes': [
-      'error',
-      'single',
-      {
-        'avoidEscape': true,
-      },
-    ],
-    'semi': [
-      'error',
-      'always',
-    ],
-    'semi-style': [
-      'error',
-      'last',
-    ],
-    'template-curly-spacing': [
-      'error',
-      'never',
-    ],
-    'object-property-newline': [
-      'error',
-    ],
-    'array-element-newline': [
-      'error',
-    ],
-    'array-bracket-newline': [
-      'error',
-      'always',
-    ],
-    'object-curly-spacing': [
-      'error',
-    ],
+    'eqeqeq': ['error', 'always'],
+    'arrow-spacing': ['error'],
+    'block-spacing': ['error'],
+    'brace-style': ['error', 'stroustrup'],
+    'comma-dangle': ['error', 'always-multiline'],
+    'curly' : ['error'],
+    'default-param-last': ['error'],
+    'eol-last': ['error'],
+    'keyword-spacing': ['error', {'before': true, 'after': true}],
+    'space-before-blocks': ['error', 'always'],
+    'linebreak-style': ['error', 'unix'],
+    'no-trailing-spaces': ['error'],
+    'no-var': ['error'],
+    'prefer-arrow-callback': ['error'],
+    'prefer-const': ['error'],
+    'prefer-template': ['error'],
+    'quotes': ['error', 'single', {'avoidEscape': true}],
+    'semi': ['error', 'always'],
+    'semi-style': ['error', 'last'],
+    'template-curly-spacing': ['error', 'never'],
   },
   ignorePatterns: [
     '**/*.min.js',


### PR DESCRIPTION
Reverts Kitware/CDash#1869 due to unintended formatting side effects.  I will investigate further, and find a better set of eslint rules in the future.