### PR TITLE
Lint JS tests and JS helper files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -81,14 +81,6 @@ public/js/cdashCoverageGraph.js
 public/js/bulletchart.js
 public/js/OptionTransfer.js
 webpack.mix.js
-tests/Spec/test-details.spec.js
-tests/Spec/page-header/header-menu.spec.js
-tests/Spec/manage-measurements.spec.js
-tests/Spec/edit-project.spec.js
-tests/Spec/build-summary.spec.js
-tests/Spec/build-notes.spec.js
-tests/Spec/build-configure.spec.js
-jest.config.js
 app/cdash/tests/js/pages/login.page.js
 app/cdash/tests/js/pages/catchConsoleErrors.page.js
 app/cdash/tests/js/e2e_tests/viewTestPagination.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -76,7 +76,6 @@ public/js/cdashFilters.js
 public/js/cdashCoverageGraph.js
 public/js/bulletchart.js
 public/js/OptionTransfer.js
-webpack.mix.js
 app/cdash/tests/js/pages/login.page.js
 app/cdash/tests/js/pages/catchConsoleErrors.page.js
 app/cdash/tests/js/e2e_tests/viewTestPagination.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,9 +3,6 @@ public/laravel/*
 public/build/*
 _build/*
 cypress_cache/*
-resources/js/components/shared/TextMutator.js
-resources/js/components/shared/QueryParams.js
-resources/js/components/shared/ApiLoader.js
 resources/js/components/page-header/HeaderNav.vue
 resources/js/components/page-header/HeaderMenu.vue
 resources/js/components/ViewDynamicAnalysis.vue
@@ -20,7 +17,6 @@ resources/js/components/BuildSummary.vue
 resources/js/components/BuildNotes.vue
 resources/js/components/BuildConfigure.vue
 resources/js/components/AllProjects.vue
-resources/js/app.js
 app/cdash/public/*
 public/main.js
 public/js/ui.tabs.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,12 @@
 module.exports = {
   verbose: true,
   moduleFileExtensions: ['js', 'vue'],
-  testEnvironment: "jsdom",
+  testEnvironment: 'jsdom',
   testEnvironmentOptions: {
-    customExportConditions: ["node", "node-addons"],
+    customExportConditions: ['node', 'node-addons'],
   },
   transform: {
-    "^.+\\.js$": "babel-jest",
-    "^.+\\.vue$": "@vue/vue3-jest",
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.vue$': '@vue/vue3-jest',
   },
 };

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,23 +4,23 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-import * as Vue from 'vue'
+import * as Vue from 'vue';
 import axios from 'axios';
-import BuildConfigure from "./components/BuildConfigure";
-import BuildNotes from "./components/BuildNotes";
-import BuildSummary from "./components/BuildSummary";
-import BuildUpdate from "./components/BuildUpdate";
-import EditProject from "./components/EditProject";
-import UserHomepage from "./components/UserHomepage";
-import ManageAuthTokens from "./components/ManageAuthTokens.vue";
-import ManageMeasurements from "./components/ManageMeasurements";
-import Monitor from "./components/Monitor";
-import TestDetails from "./components/TestDetails";
-import HeaderNav from "./components/page-header/HeaderNav.vue";
-import HeaderMenu from "./components/page-header/HeaderMenu.vue";
-import HeaderLogo from "./components/page-header/HeaderLogo.vue";
-import ViewDynamicAnalysis from "./components/ViewDynamicAnalysis.vue";
-import AllProjects from "./components/AllProjects.vue";
+import BuildConfigure from './components/BuildConfigure';
+import BuildNotes from './components/BuildNotes';
+import BuildSummary from './components/BuildSummary';
+import BuildUpdate from './components/BuildUpdate';
+import EditProject from './components/EditProject';
+import UserHomepage from './components/UserHomepage';
+import ManageAuthTokens from './components/ManageAuthTokens.vue';
+import ManageMeasurements from './components/ManageMeasurements';
+import Monitor from './components/Monitor';
+import TestDetails from './components/TestDetails';
+import HeaderNav from './components/page-header/HeaderNav.vue';
+import HeaderMenu from './components/page-header/HeaderMenu.vue';
+import HeaderLogo from './components/page-header/HeaderLogo.vue';
+import ViewDynamicAnalysis from './components/ViewDynamicAnalysis.vue';
+import AllProjects from './components/AllProjects.vue';
 
 const cdash_components = {
   BuildConfigure,
@@ -47,17 +47,18 @@ const cdash_components = {
  */
 
 const app = Vue.createApp({
-  components:  cdash_components
+  components:  cdash_components,
 });
 
 app.config.globalProperties.$baseURL = process.env.MIX_APP_URL;
 
 axios.defaults.baseURL = process.env.MIX_APP_URL;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-let token = document.head.querySelector('meta[name="csrf-token"]');
+const token = document.head.querySelector('meta[name="csrf-token"]');
 if (token) {
   axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
-} else {
+}
+else {
   console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
 }
 

--- a/resources/js/components/shared/ApiLoader.js
+++ b/resources/js/components/shared/ApiLoader.js
@@ -1,4 +1,4 @@
-import emitter from 'tiny-emitter/instance'
+import emitter from 'tiny-emitter/instance';
 
 export default {
   // Replacement emitters for the Vue 2 -> 3 conversion.  TODO: Remove these eventually.
@@ -12,7 +12,7 @@ export default {
       .get(endpoint_path)
       .then(response => {
         // Pre-assigment hook for components.
-        if (typeof vm.preSetup === "function") {
+        if (typeof vm.preSetup === 'function') {
           vm.preSetup(response);
         }
 
@@ -20,39 +20,39 @@ export default {
         vm.cdash.endpoint = vm.$baseURL + endpoint_path;
 
         // Post-assigment hook for components.
-        if (typeof vm.postSetup === "function") {
+        if (typeof vm.postSetup === 'function') {
           vm.postSetup(response);
         }
 
         // Add vuejs render time to page load time in footer.
-        var renderTime = +((new Date().getTime() - vm.start) / 1000);
+        const renderTime = +((new Date().getTime() - vm.start) / 1000);
         if (vm.cdash.generationtime === undefined) {
           vm.cdash.generationtime = 0;
         }
-        var generationTimeStr = (renderTime + vm.cdash.generationtime).toFixed(2);
+        let generationTimeStr = (renderTime + vm.cdash.generationtime).toFixed(2);
         generationTimeStr += `s (${vm.cdash.generationtime}s)`;
         vm.cdash.generationtime = generationTimeStr;
 
 
         // A brutal hack to populate the footer with content
         // TODO: (williamjallen) Clean this up
-        if (document.getElementById("api-endpoint")) {
-          document.getElementById("api-endpoint")?.setAttribute('href', vm.cdash.endpoint);
+        if (document.getElementById('api-endpoint')) {
+          document.getElementById('api-endpoint')?.setAttribute('href', vm.cdash.endpoint);
         }
-        if (document.getElementById("generation-time")) {
-          document.getElementById("generation-time").textContent = vm.cdash.generationtime;
+        if (document.getElementById('generation-time')) {
+          document.getElementById('generation-time').textContent = vm.cdash.generationtime;
         }
-        if (document.getElementById("testing-day") && vm.cdash.nightlytime !== undefined) {
-          document.getElementById("testing-day").textContent = `Current Testing Day ${vm.cdash.currentdate} | Started at ${vm.cdash.nightlytime}`;
+        if (document.getElementById('testing-day') && vm.cdash.nightlytime !== undefined) {
+          document.getElementById('testing-day').textContent = `Current Testing Day ${vm.cdash.currentdate} | Started at ${vm.cdash.nightlytime}`;
         }
 
         // Let other components know that data has been loaded from the API.
         this.$emit('api-loaded', vm.cdash);
       })
       .catch(error => {
-        console.log(error)
-        vm.errored = true
+        console.log(error);
+        vm.errored = true;
       })
-      .finally(() => vm.loading = false)
+      .finally(() => vm.loading = false);
   },
-}
+};

--- a/resources/js/components/shared/QueryParams.js
+++ b/resources/js/components/shared/QueryParams.js
@@ -1,11 +1,11 @@
 export default {
-	get: function () {
-    var params = {};
-    var kv_pairs = window.location.search.substring(1).split("&");
-    for (var i = 0; i < kv_pairs.length; i++) {
-      var kv = kv_pairs[i].split("=");
+  get: function () {
+    const params = {};
+    const kv_pairs = window.location.search.substring(1).split('&');
+    for (let i = 0; i < kv_pairs.length; i++) {
+      const kv = kv_pairs[i].split('=');
       params[kv[0]] = kv[1];
     }
     return params;
-	},
-}
+  },
+};

--- a/resources/js/components/shared/TextMutator.js
+++ b/resources/js/components/shared/TextMutator.js
@@ -1,14 +1,14 @@
 export default {
-	ctestNonXmlCharEscape: function (input) {
-		var pattern = /\[NON-XML-CHAR-0x1B\]/g;
-		return input.replace(pattern, '\x1B');
-	},
+  ctestNonXmlCharEscape: function (input) {
+    const pattern = /\[NON-XML-CHAR-0x1B\]/g;
+    return input.replace(pattern, '\x1B');
+  },
 
-	terminalColors: function (input, htmlEscape) {
-		var ansiUp = new AnsiUp;
-		if (htmlEscape !== undefined) {
-			ansiUp.escape_for_html = htmlEscape;
-		}
-		return ansiUp.ansi_to_html(input);
-	},
-}
+  terminalColors: function (input, htmlEscape) {
+    const ansiUp = new AnsiUp;
+    if (htmlEscape !== undefined) {
+      ansiUp.escape_for_html = htmlEscape;
+    }
+    return ansiUp.ansi_to_html(input);
+  },
+};

--- a/tests/Spec/build-configure.spec.js
+++ b/tests/Spec/build-configure.spec.js
@@ -1,8 +1,8 @@
-import { mount, config } from "@vue/test-utils";
+import { mount, config } from '@vue/test-utils';
 import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import expect from 'expect';
-import BuildConfigure from "../../resources/js/components/BuildConfigure.vue";
+import BuildConfigure from '../../resources/js/components/BuildConfigure.vue';
 
 config.global.mocks['$baseURL'] = 'http://localhost';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
@@ -16,19 +16,19 @@ beforeEach(() => {
 
   apiResponse = {
     build: {
-      site: "mysite",
+      site: 'mysite',
       siteid: 1,
-      buildname: "my build",
+      buildname: 'my build',
       buildid: 2,
-      buildstarttime: "2023-08-21 12:30:48",
-      hassubprojects: 0
+      buildstarttime: '2023-08-21 12:30:48',
+      hassubprojects: 0,
     },
     configures: [{
       status: 0,
-      command: "cmake",
-      output: "-- Configuring done\n-- Generating done\n-- Build files have been written to: \/tmp\/bin\/\n",
+      command: 'cmake',
+      output: '-- Configuring done\n-- Generating done\n-- Build files have been written to: \/tmp\/bin\/\n',
       configureerrors: 0,
-      configurewarnings: 0
+      configurewarnings: 0,
     }],
   };
 
@@ -43,7 +43,7 @@ test('BuildConfigure handles API response', async () => {
   const component = mount(BuildConfigure);
   await new Promise(process.nextTick);
   expect(component.vm.loading).toBe(false);
-  var html = component.html();
+  const html = component.html();
   expect(html).toContain('mysite');
   expect(html).toContain('my build');
   expect(html).toContain('2023-08-21 12:30:48');

--- a/tests/Spec/build-notes.spec.js
+++ b/tests/Spec/build-notes.spec.js
@@ -1,20 +1,22 @@
-import { mount, config } from "@vue/test-utils";
-import axios from 'axios'
+import { mount, config } from '@vue/test-utils';
+import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import expect from 'expect';
-import BuildNotes from "../../resources/js/components/BuildNotes.vue";
+import BuildNotes from '../../resources/js/components/BuildNotes.vue';
 
 config.global.mocks['$baseURL'] = 'http://localhost';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
 
-import $ from 'jquery'
-$.plot = function() { return null; };
-global.$ = $
+import $ from 'jquery';
+$.plot = function() {
+  return null;
+};
+global.$ = $;
 
 let apiResponse;
 let axiosMockAdapter;
 
-beforeEach(function() {
+beforeEach(() => {
   axiosMockAdapter = new AxiosMockAdapter(axios);
   config.global.mocks['$axios'] = axios;
   apiResponse = {
@@ -38,7 +40,7 @@ beforeEach(function() {
   };
 });
 
-afterEach(function() {
+afterEach(() => {
   axiosMockAdapter.restore();
 });
 
@@ -50,7 +52,7 @@ test('BuildNote handles API response', async () => {
   expect(component.vm.cdash.notes.length).toBe(1);
 
   // Verify some expected content.
-  var html = component.html();
+  const html = component.html();
   expect(html).toContain('my build');
   expect(html).toContain('mysite');
   expect(html).toContain('5 minutes ago');
@@ -75,7 +77,7 @@ test('BuildNote can toggle notes', async () => {
   expect(component.find('#notetext1').isVisible()).toBe(false);
 
   // Toggle a note back on.
-  var note_button = component.find('#note0')
+  const note_button = component.find('#note0');
   note_button.trigger('click');
   await new Promise(process.nextTick);
   expect(component.find('#notetext0').isVisible()).toBe(true);

--- a/tests/Spec/build-summary.spec.js
+++ b/tests/Spec/build-summary.spec.js
@@ -1,20 +1,22 @@
-import { mount, config } from "@vue/test-utils";
-import axios from 'axios'
+import { mount, config } from '@vue/test-utils';
+import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import expect from 'expect';
-import BuildSummary from "../../resources/js/components/BuildSummary.vue";
+import BuildSummary from '../../resources/js/components/BuildSummary.vue';
 
 config.global.mocks['$baseURL'] = 'http://localhost';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
 
-import $ from 'jquery'
-$.plot = function() { return null; };
-global.$ = $
+import $ from 'jquery';
+$.plot = function() {
+  return null;
+};
+global.$ = $;
 
 let apiResponse;
 let axiosMockAdapter;
 
-beforeEach(function() {
+beforeEach(() => {
   axiosMockAdapter = new AxiosMockAdapter(axios);
   config.global.mocks['$axios'] = axios;
   apiResponse = {
@@ -98,7 +100,7 @@ beforeEach(function() {
   };
 });
 
-afterEach(function() {
+afterEach(() => {
   axiosMockAdapter.restore();
 });
 
@@ -109,7 +111,7 @@ test('BuildSummary handles API response', async () => {
 
   expect(component.vm.loading).toBe(false);
   expect(component.vm.cdash.coverage).toBe(98);
-  var html = component.html();
+  const html = component.html();
   expect(html).toContain('MyProject');
   expect(html).toContain('mysite');
   expect(html).toContain('Linux');
@@ -175,7 +177,7 @@ test('BuildSummary can toggle the graphs', async () => {
   expect(component.vm.showTestGraph).toBe(false);
   expect(component.find('#buildtestsfailedgrapholder').isVisible()).toBe(false);
 
-  let graph_data = {
+  const graph_data = {
     builds: [{
       id: 1,
       nfiles: 0,
@@ -187,10 +189,10 @@ test('BuildSummary can toggle the graphs', async () => {
       timestamp: 'today',
       testfailed: 0,
       time: 0,
-    }]
+    }],
   };
   axiosMockAdapter.onGet('/api/v1/getPreviousBuilds.php?buildid=').reply(200, graph_data);
-  const history_button = component.find('#toggle_history_graph')
+  const history_button = component.find('#toggle_history_graph');
   history_button.trigger('click');
   await new Promise(process.nextTick);
 
@@ -202,7 +204,7 @@ test('BuildSummary can toggle the graphs', async () => {
   expect(component.vm.showHistoryGraph).toBe(false);
   expect(component.find('#historyGraph').isVisible()).toBe(false);
 
-  const time_button = component.find('#toggle_time_graph')
+  const time_button = component.find('#toggle_time_graph');
   time_button.trigger('click');
   await component.vm.$nextTick();
   expect(component.vm.showTimeGraph).toBe(true);
@@ -212,7 +214,7 @@ test('BuildSummary can toggle the graphs', async () => {
   expect(component.vm.showTimeGraph).toBe(false);
   expect(component.find('#buildtimegrapholder').isVisible()).toBe(false);
 
-  const error_button = component.find('#toggle_error_graph')
+  const error_button = component.find('#toggle_error_graph');
   error_button.trigger('click');
   await component.vm.$nextTick();
   expect(component.vm.showErrorGraph).toBe(true);
@@ -222,7 +224,7 @@ test('BuildSummary can toggle the graphs', async () => {
   expect(component.vm.showErrorGraph).toBe(false);
   expect(component.find('#builderrorsgrapholder').isVisible()).toBe(false);
 
-  const warning_button = component.find('#toggle_warning_graph')
+  const warning_button = component.find('#toggle_warning_graph');
   warning_button.trigger('click');
   await component.vm.$nextTick();
   expect(component.vm.showWarningGraph).toBe(true);
@@ -256,13 +258,13 @@ test('BuildSummary can add a build note', async () => {
   await component.vm.$nextTick();
   expect(component.find('#new_note_div').isVisible()).toBe(true);
 
-  var api_response = {
+  const api_response = {
     note: {
       user: 'administrator',
       date: 'now',
       status: '[note]',
       text: 'This is a note',
-    }
+    },
   };
   axiosMockAdapter.onPost('/api/v1/addUserNote.php').reply(200, api_response);
 

--- a/tests/Spec/edit-project.spec.js
+++ b/tests/Spec/edit-project.spec.js
@@ -1,22 +1,22 @@
-import {mount, config, createLocalVue} from "@vue/test-utils";
-import axios from 'axios'
+import {mount, config, createLocalVue} from '@vue/test-utils';
+import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import expect from 'expect';
-import EditProject from "../../resources/js/components/EditProject.vue";
+import EditProject from '../../resources/js/components/EditProject.vue';
 
 // const localVue = createLocalVue();
 
 config.global.mocks['$baseURL'] = '';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
 
-import $ from 'jquery'
-global.$ = $
+import $ from 'jquery';
+global.$ = $;
 
 let axiosMockAdapter;
 let newResponse;
 let editResponse;
 
-beforeEach(function() {
+beforeEach(() => {
   axiosMockAdapter = new AxiosMockAdapter(axios);
   config.global.mocks['$axios'] = axios;
   newResponse = {
@@ -30,15 +30,15 @@ beforeEach(function() {
       EmailBrokenSubmission: 1,
       EmailMaxChars: 255,
       EmailMaxItems: 5,
-      ErrorsFilter: "",
-      NightlyTime: "01:00:00 UTC",
+      ErrorsFilter: '',
+      NightlyTime: '01:00:00 UTC',
       Public: 0,
       ShowCoverageCode: 1,
       TestTimeMaxStatus: 3,
       TestTimeStd: 4,
       TestTimeStdThreshold: 1,
       UploadQuota: 1,
-      WarningsFilter: "",
+      WarningsFilter: '',
       repositories: [],
     },
     user: {
@@ -55,19 +55,19 @@ beforeEach(function() {
       AutoremoveMaxBuilds: 500,
       AutoremoveTimeframe: 60,
       CoverageThreshold: 70,
-      CvsViewerType: "github",
-      Description: "my project desc",
+      CvsViewerType: 'github',
+      Description: 'my project desc',
       DisplayLabels: 0,
       EmailBrokenSubmission: 1,
       EmailMaxChars: 255,
       EmailMaxItems: 5,
-      ErrorsFilter: "",
+      ErrorsFilter: '',
       Filled: true,
       Id: 1,
       ImageId: 0,
       MaxUploadQuota: 10,
-      Name: "MyTestingProject",
-      NightlyTime: "01:00:00 UTC",
+      Name: 'MyTestingProject',
+      NightlyTime: '01:00:00 UTC',
       Public: 1,
       ShareLabelFilters: 0,
       ShowCoverageCode: 1,
@@ -78,9 +78,9 @@ beforeEach(function() {
       TestTimeStdThreshold: 1,
       UploadQuota: 1,
       ViewSubProjectsLink: 1,
-      WarningsFilter: "",
+      WarningsFilter: '',
       blockedbuilds: [],
-      name_encoded: "MyTestingProject",
+      name_encoded: 'MyTestingProject',
       repositories: [],
     },
     user: {
@@ -90,7 +90,7 @@ beforeEach(function() {
   };
 });
 
-afterEach(function() {
+afterEach(() => {
   axiosMockAdapter.restore();
 });
 

--- a/tests/Spec/manage-measurements.spec.js
+++ b/tests/Spec/manage-measurements.spec.js
@@ -1,20 +1,20 @@
 import {mount, config, createLocalVue} from '@vue/test-utils';
-import axios from 'axios'
+import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
-import bootstrap from 'bootstrap'
+import bootstrap from 'bootstrap';
 import expect from 'expect';
 import ManageMeasurements from '../../resources/js/components/ManageMeasurements.vue';
 
 config.global.mocks['$baseURL'] = '';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
 
-import $ from 'jquery'
-global.$ = $
+import $ from 'jquery';
+global.$ = $;
 
 let axiosMockAdapter;
 let apiResponse;
 
-beforeEach(function() {
+beforeEach(() => {
   axiosMockAdapter = new AxiosMockAdapter(axios);
   config.global.mocks['$axios'] = axios;
   apiResponse = {
@@ -33,7 +33,7 @@ beforeEach(function() {
   };
 });
 
-afterEach(function() {
+afterEach(() => {
   axiosMockAdapter.restore();
 });
 
@@ -50,7 +50,7 @@ test('ManageMeasurements can add a measurement', async () => {
   const component = mount(ManageMeasurements);
   await new Promise(process.nextTick);
 
-  var api_response = {
+  const api_response = {
     id: 2,
   };
   axiosMockAdapter.onPost('/api/v1/manageMeasurements.php').reply(200, api_response);
@@ -81,7 +81,7 @@ test('ManageMeasurements can delete a measurement', async () => {
   expect(component.vm.measurementToDelete).toBe(1);
 
   // Click confirmation button.
-  var api_response = {
+  const api_response = {
     id: 1,
   };
   axiosMockAdapter.onDelete('/api/v1/manageMeasurements.php').reply(200, api_response);

--- a/tests/Spec/page-header/header-menu.spec.js
+++ b/tests/Spec/page-header/header-menu.spec.js
@@ -1,16 +1,16 @@
-import {mount, config, createWrapper} from "@vue/test-utils";
+import {mount, config, createWrapper} from '@vue/test-utils';
 config.global.mocks['$baseURL'] = 'http://localhost';
-import HeaderMenu from "../../../resources/js/components/page-header/HeaderMenu.vue";
+import HeaderMenu from '../../../resources/js/components/page-header/HeaderMenu.vue';
 
 import expect from 'expect';
-import moment from "moment";
+import moment from 'moment';
 
 let component;
 const today = moment().format('YYYY-MM-DD');
-const bugUrl = "https://github.com/project/project/issues";
-const docUrl = "https://github.com/project/project/wiki";
-const homeUrl = "https://www.project.tld/";
-const vcsUrl = "https://github.com/project/project";
+const bugUrl = 'https://github.com/project/project/issues';
+const docUrl = 'https://github.com/project/project/wiki';
+const homeUrl = 'https://www.project.tld/';
+const vcsUrl = 'https://github.com/project/project';
 
 const verifyLink = (url, text) => {
   const selector = `a[href='${url}']`;
@@ -22,53 +22,53 @@ const verifyLink = (url, text) => {
 
 beforeEach(() => {
   component = mount(HeaderMenu);
-  var apiData = {
-    "bugtracker": bugUrl,
-    "date": today,
-    "documentation": docUrl,
-    "home": homeUrl,
-    "menu": {},
-    "projectid": 111,
-    "projectname_encoded": "TestProject",
-    "querytestfilters": "&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed",
-    "user": {"id": null},
-    "vcs": vcsUrl,
+  const apiData = {
+    'bugtracker': bugUrl,
+    'date': today,
+    'documentation': docUrl,
+    'home': homeUrl,
+    'menu': {},
+    'projectid': 111,
+    'projectname_encoded': 'TestProject',
+    'querytestfilters': '&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed',
+    'user': {'id': null},
+    'vcs': vcsUrl,
   };
   component.vm.handleApiResponse(apiData);
 });
 
 test('HeaderMenu has a "Dashboard" link', () => {
-  var expected = `http://localhost/index.php?project=TestProject&date=${today}`;
+  const expected = `http://localhost/index.php?project=TestProject&date=${today}`;
   expect(component.vm.indexUrl).toBe(expected);
   verifyLink(expected, 'Dashboard');
 });
 
 test('HeaderMenu has an "Overview" link', () => {
-  var expected = `http://localhost/overview.php?project=TestProject&date=${today}`;
+  const expected = `http://localhost/overview.php?project=TestProject&date=${today}`;
   expect(component.vm.overviewUrl).toBe(expected);
   verifyLink(expected, 'Overview');
 });
 
 test('HeaderMenu has a "Builds" link', () => {
-  var expected = `http://localhost/buildOverview.php?project=TestProject&date=${today}`;
+  const expected = `http://localhost/buildOverview.php?project=TestProject&date=${today}`;
   expect(component.vm.buildsUrl).toBe(expected);
   verifyLink(expected, 'Builds');
 });
 
 test('HeaderMenu has a "Tests Query" link', () => {
-  var expected = `http://localhost/queryTests.php?project=TestProject&date=${today}&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed`;
+  const expected = `http://localhost/queryTests.php?project=TestProject&date=${today}&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed`;
   expect(component.vm.testQueryUrl).toBe(expected);
   verifyLink(expected, 'Tests Query');
 });
 
 test('HeaderMenu has a "Statistics" link', () => {
-  var expected = `http://localhost/userStatistics.php?project=TestProject&date=${today}`;
+  const expected = `http://localhost/userStatistics.php?project=TestProject&date=${today}`;
   expect(component.vm.statisticsUrl).toBe(expected);
   verifyLink(expected, 'Statistics');
 });
 
 test('HeaderMenu has a "Sites" link', () => {
-  var expected = `http://localhost/viewMap.php?project=TestProject&date=${today}`;
+  const expected = `http://localhost/viewMap.php?project=TestProject&date=${today}`;
   expect(component.vm.sitesUrl).toBe(expected);
   verifyLink(expected, 'Sites');
 });
@@ -100,7 +100,7 @@ test('HeaderMenu has a "Bug Tracker" link', () => {
 });
 
 test('HeaderMenu has a "Subscribe" link', () => {
-  var expected = "http://localhost/subscribeProject.php?projectid=111";
+  const expected = 'http://localhost/subscribeProject.php?projectid=111';
   expect(component.vm.subscribeUrl).toBe(expected);
   verifyLink(component.vm.subscribeUrl, 'Subscribe');
 });

--- a/tests/Spec/test-details.spec.js
+++ b/tests/Spec/test-details.spec.js
@@ -1,15 +1,19 @@
-import {mount, config} from "@vue/test-utils";
-import axios from 'axios'
+import {mount, config} from '@vue/test-utils';
+import axios from 'axios';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import expect from 'expect';
-import TestDetails from "../../resources/js/components/TestDetails.vue";
+import TestDetails from '../../resources/js/components/TestDetails.vue';
 
-config.global.mocks['$baseURL'] = "http://localhost";
+config.global.mocks['$baseURL'] = 'http://localhost';
 axios.defaults.baseURL = config.global.mocks['$baseURL'];
 
-import $ from 'jquery'
-$.plot = function() { return null; };
-$.fn.je_compare = function() { return null; };
+import $ from 'jquery';
+$.plot = function() {
+  return null;
+};
+$.fn.je_compare = function() {
+  return null;
+};
 global.$ = $;
 
 import AnsiUp from 'ansi_up';
@@ -22,7 +26,7 @@ let axiosMockAdapter;
 let apiResponse;
 let graphData;
 
-beforeEach(function() {
+beforeEach(() => {
   axiosMockAdapter = new AxiosMockAdapter(axios);
   config.global.mocks['$axios'] = axios;
   apiResponse = {
@@ -47,7 +51,7 @@ beforeEach(function() {
       details: 'Completed (OTHER_FAULT)',
       environment: 'foo=bar',
       labels: 'label1, label2, label3',
-      output: "\u001b[32mHello world!\n\u001b[91m<script type=\"text\/javascript\">console.log(\"MALICIOUS JAVASCRIPT!!!\");<\/script>\n\u001b[0mGood bye world!\n",
+      output: '\u001b[32mHello world!\n\u001b[91m<script type="text\/javascript">console.log("MALICIOUS JAVASCRIPT!!!");<\/script>\n\u001b[0mGood bye world!\n',
       summaryLink: 'testSummary.php?project=1&name=my-test',
       status: 'Failed',
       statusColor: 'error-text',
@@ -103,7 +107,7 @@ lines`,
   ];
 });
 
-afterEach(function() {
+afterEach(() => {
   axiosMockAdapter.restore();
 });
 
@@ -114,7 +118,7 @@ it('handles API response', async () => {
   expect(component.vm.loading).toBe(false);
 
   // Verify some expected content.
-  var html = component.html();
+  const html = component.html();
   expect(html).toContain('my build');
   expect(html).toContain('my-test');
   expect(html).toContain('Completed (OTHER_FAULT)');
@@ -124,8 +128,8 @@ it('handles API response', async () => {
 lines</pre>`);
 
   // Verify colorized/escaped output.
-  const test_output = component.find("#test_output");
-  const spans = test_output.findAll("span");
+  const test_output = component.find('#test_output');
+  const spans = test_output.findAll('span');
   expect(spans.length).toBe(2);
   expect(spans.at(0).attributes('style')).toBe('color:rgb(0,187,0)');
   expect(spans.at(0).text()).toBe('Hello world!');
@@ -163,7 +167,7 @@ it('can toggle command line', async () => {
   expect(component.find('#commandline').isVisible()).toBe(false);
 
   // Toggle it on.
-  var commandlinelink = component.find('#commandlinelink')
+  const commandlinelink = component.find('#commandlinelink');
   commandlinelink.trigger('click');
   await new Promise(process.nextTick);
   expect(component.find('#commandline').isVisible()).toBe(true);
@@ -180,7 +184,7 @@ it('can toggle environment', async () => {
   expect(component.find('#environment').isVisible()).toBe(false);
 
   // Toggle it on.
-  var environmentlink = component.find('#environmentlink')
+  const environmentlink = component.find('#environmentlink');
   environmentlink.trigger('click');
   await new Promise(process.nextTick);
   expect(component.find('#environment').isVisible()).toBe(true);
@@ -230,7 +234,7 @@ it('can load the graphs by default', async () => {
   // This is an apparent side effect of the way that vue-test-utils and
   // jsdom-global work together.
   // TODO: revisit this when we upgrade to Vue 3.
-  expect(window.location.search).toBe("?graph=time");
+  expect(window.location.search).toBe('?graph=time');
   axiosMockAdapter.onGet('/api/v1/testDetails.php?buildtestid=&graph=time').reply(200, apiResponse);
   axiosMockAdapter.onGet('/api/v1/testGraph.php?testid=1&buildid=1&type=time').reply(200, graphData);
   const component = mount(TestDetails);

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -24,11 +24,12 @@ if (fs.existsSync('.git')) {
   // to report in the footer.
   // Use current UNIX timestamp for cache busting.
   version = new Date().getTime().toString();
-} else {
+}
+else {
   // Otherwise if this is a release download, use the version from package.json.
   const config = require('./package.json');
   version = config.version;
-  fs.writeFileSync('./public/VERSION', 'v' + version);
+  fs.writeFileSync('./public/VERSION', `v${version}`);
 }
 
 // Write out version file for angular.js
@@ -36,7 +37,7 @@ const dir = 'public/build/js';
 if (!fs.existsSync(dir)) {
   fs.mkdirSync(dir);
 }
-fs.writeFileSync(dir + '/version.js', "angular.module('CDash').constant('VERSION', '" + version + "');");
+fs.writeFileSync(`${dir}/version.js`, `angular.module('CDash').constant('VERSION', '${version}');`);
 
 // Webpack plugins.
 const webpack_plugins = [
@@ -47,22 +48,22 @@ const webpack_plugins = [
       test: /\.html$/,
       rules: [{
         search: /@@version/g,
-        replace: version
-      }]
+        replace: version,
+      }],
     },
     {
       dir: 'public/js',
       test: /\.js$/,
       rules: [{
         search: /@@cdash_version/g,
-        replace: version
-      }]
+        replace: version,
+      }],
     },
   ]),
 ];
 
 if (git_clone) {
-  const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
+  const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
   webpack_plugins.push(new GitRevisionPlugin());
 }
 
@@ -70,21 +71,21 @@ if (git_clone) {
 mix.copy('public/views/*.html', 'public/build/views/');
 
 // Cache busting for angularjs partials.
-const glob = require("glob");
-glob.sync('public/views/partials/*.html').forEach(function(src) {
-  let dest = src.replace('.html', '_' + version + '.html');
+const glob = require('glob');
+glob.sync('public/views/partials/*.html').forEach((src) => {
+  let dest = src.replace('.html', `_${version}.html`);
   dest = dest.replace('views', 'build/views');
   mix.copy(src, dest);
 });
 
 // Version CSS files.
-mix.copy('public/css/cdash.css', 'public/build/css/cdash_' + version + '.css');
-mix.copy('public/css/colorblind.css', 'public/build/css/colorblind_' + version + '.css');
+mix.copy('public/css/cdash.css', `public/build/css/cdash_${version}.css`);
+mix.copy('public/css/colorblind.css', `public/build/css/colorblind_${version}.css`);
 mix.copy('public/css/common.css', 'public/build/css/common.css');
 mix.styles([
   'node_modules/bootstrap/dist/css/bootstrap.css',
   'node_modules/jquery-ui-dist/jquery-ui.css',
-  'node_modules/nvd3/build/nv.d3.min.css'
+  'node_modules/nvd3/build/nv.d3.min.css',
 ], 'public/build/css/3rdparty.css').version();
 mix.copy('node_modules/nvd3/build/nv.d3.min.css.map', 'public/build/css/nv.d3.min.css.map');
 
@@ -109,7 +110,7 @@ mix.scripts([
   'node_modules/d3/d3.js',
   'node_modules/ng-file-upload/dist/ng-file-upload.js',
   'node_modules/nvd3/build/nv.d3.js',
-  'public/js/ui-bootstrap-tpls-0.14.2.min.js'
+  'public/js/ui-bootstrap-tpls-0.14.2.min.js',
 ], 'public/js/3rdparty.min.js');
 mix.copy('node_modules/nvd3/build/nv.d3.js.map', 'public/js/nv.d3.js.map');
 
@@ -124,14 +125,14 @@ mix.scripts([
   'public/js/directives/**.js',
   'public/js/filters/**.js',
   'public/js/services/**.js',
-  'public/js/controllers/**.js'
+  'public/js/controllers/**.js',
 ], 'public/js/1stparty.min.js');
 
 // Combine 1st and 3rd party into a single file.
 mix.scripts([
   'public/js/3rdparty.min.js',
   'public/js/1stparty.min.js',
-], 'public/js/CDash_' + version + '.min.js');
+], `public/js/CDash_${version}.min.js`);
 
 // Copy jquery-ui images to public/css/images/
 mix.copyDirectory('node_modules/jquery-ui-dist/images', 'public/build/css/images');


### PR DESCRIPTION
This PR is the first of several incremental PRs which will gradually enable eslint linting for all of our JavaScript files.  To prevent merge conflicts with current and upcoming PRs, I have initially listed just the Jest tests, and a handful of configuration files.