### PR TITLE
Use single log file by default in testing environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -6,6 +6,8 @@ APP_URL=http://localhost:8080
 MIX_APP_URL="${APP_URL}"
 APP_TIMEZONE=America/New_York
 
+LOG_CHANNEL=single
+
 DB_DATABASE=cdash4simpletest
 DB_PASSWORD=cdash4simpletest
 


### PR DESCRIPTION
Fixes https://github.com/Kitware/CDash/issues/1451 by using a single log file for all logging.