### PR TITLE
Add Font Awesome free icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "version": "3.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-brands-svg-icons": "^6.5.1",
+        "@fortawesome/free-regular-svg-icons": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/vue-fontawesome": "^3.0.5",
         "angular": "^1.8.0",
         "angular-animate": "^1.4.7",
         "angular-ui-bootstrap": "^2.0.0",
@@ -1949,6 +1954,72 @@
       "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-093l7DAkx0aEtBq66Sf19MgoZewv1zeY9/4C7vSKPO4qMwEsW/2VYTUTpBtLwfb9T2R73tXaRDPmE4UqLCYHfg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.5.tgz",
+      "integrity": "sha512-isZZ4+utQH9qg9cWxWYHQ9GwI3r5FeO7GnmzKYV+gbjxcptQhh+F99iZXi1Y9AvFUEgy8kRpAdvDlbb3drWFrw==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "eslint:fix": "eslint --fix \"**/*.js\" \"**/*.vue\""
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/vue-fontawesome": "^3.0.5",
     "angular": "^1.8.0",
     "angular-animate": "^1.4.7",
     "angular-ui-bootstrap": "^2.0.0",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,6 +6,7 @@
 
 import * as Vue from 'vue';
 import axios from 'axios';
+
 import BuildConfigure from './components/BuildConfigure';
 import BuildNotes from './components/BuildNotes';
 import BuildSummary from './components/BuildSummary';
@@ -23,7 +24,16 @@ import ViewDynamicAnalysis from './components/ViewDynamicAnalysis.vue';
 import AllProjects from './components/AllProjects.vue';
 import SubProjectDependencies from './components/SubProjectDependencies.vue';
 
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { far } from '@fortawesome/free-regular-svg-icons';
+import { fab } from '@fortawesome/free-brands-svg-icons';
+
+library.add(fas, far, fab);
+
 const cdash_components = {
+  FontAwesomeIcon,
   BuildConfigure,
   BuildNotes,
   BuildSummary,

--- a/resources/js/components/UserHomepage.vue
+++ b/resources/js/components/UserHomepage.vue
@@ -93,82 +93,55 @@
             <td
               align="center"
               bgcolor="#DDDDDD"
+              class="icon-row"
             >
               <a
                 title="Edit subscription"
                 :href="$baseURL + '/subscribeProject.php?projectid=' + project.id + '&edit=1'"
               >
-                <img
-                  :src="$baseURL + '/img/edit.png'"
-                  border="0"
-                  alt="subscribe"
-                >
+                <font-awesome-icon icon="fa-solid fa-bell"/>
               </a>
               <a
                 v-if="project.role > 0"
                 title="Claim sites"
                 :href="$baseURL + '/editSite.php?projectid=' + project.id"
               >
-                <img
-                  :src="$baseURL + '/img/systemtray.png'"
-                  border="0"
-                  alt="claimsite"
-                >
+                <font-awesome-icon icon="fa-solid fa-computer"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Edit project"
                 :href="$baseURL + '/project/' + project.id + '/edit'"
               >
-                <img
-                  :src="$baseURL + '/img/edit2.png'"
-                  border="0"
-                  alt="editproject"
-                >
+                <font-awesome-icon icon="fa-solid fa-pencil"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage subprojects"
                 :href="$baseURL + '/manageSubProject.php?projectid=' + project.id"
               >
-                <img
-                  :src="$baseURL + '/img/subproject.png'"
-                  border="0"
-                  alt="subproject"
-                >
+                <font-awesome-icon icon="fa-solid fa-folder-tree"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project groups"
                 :href="$baseURL + '/manageBuildGroup.php?projectid=' + project.id"
               >
-                <img
-                  :src="$baseURL + '/img/edit_group.png'"
-                  border="0"
-                  alt="managegroups"
-                >
+                <font-awesome-icon icon="fa-solid fa-layer-group"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project users"
                 :href="$baseURL + '/manageProjectRoles.php?projectid=' + project.id"
               >
-                <img
-                  :src="$baseURL + '/img/users.png'"
-                  border="0"
-                  alt="manageusers"
-                >
+                <font-awesome-icon icon="fa-solid fa-user-pen"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project coverage"
                 :href="$baseURL + '/manageCoverage.php?projectid=' + project.id"
               >
-                <img
-                  :src="$baseURL + '/img/filecoverage.png'"
-                  border="0"
-                  alt="managecoverage"
-                >
+                <font-awesome-icon icon="fa-solid fa-chart-line"/>
               </a>
             </td>
             <td
@@ -703,9 +676,10 @@
 <script>
 import ApiLoader from './shared/ApiLoader';
 import LoadingIndicator from "./shared/LoadingIndicator.vue";
+import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
 export default {
   name: "UserHomepage",
-  components: {LoadingIndicator},
+  components: { FontAwesomeIcon, LoadingIndicator },
 
   data () {
     return {
@@ -799,5 +773,9 @@ export default {
 
 #tokenDescriptionlabel {
   margin: 0 0.5em 0 0;
+}
+
+.icon-row > a {
+  padding: 0 0.3em;
 }
 </style>


### PR DESCRIPTION
Most of the icons throughout the CDash UI are low resolution PNGs.  User expectations have changed since those icons were introduced, and pixelated icons are no longer considered acceptable, given that most users have high-resolution screens.  Font Awesome is a well known icon provider which provides a vast number of free SVG icons.

I've opened this PR up to get some feedback.  As an initial demonstration, I have changed the action buttons on the user homepage to font awesome icons.  CDash is in dire need of a substantial UI overhaul, and I'm by no means a UI/UX designer, so I'm open to any feedback anyone might have about the specific icons I've chosen, as well as general feedback about this idea as a whole.

| Before | After |
|---|--- |
|![image](https://github.com/Kitware/CDash/assets/16820599/b3ad368f-93e9-49bd-bb89-52e36af147fa) | ![image](https://github.com/Kitware/CDash/assets/16820599/376a1ebd-9754-419f-ab3f-e0e47538912a) |
