### PR TITLE
Fix remote worker job processing

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -234,11 +234,11 @@ class ProcessSubmission implements ShouldQueue
         $tmpFilename = "{$_t}.{$ext}";
         rename($_t, $tmpFilename);
 
-        $client = new GuzzleHttp\Client();
+        $client = new \GuzzleHttp\Client();
         $response = $client->request('GET',
             config('app.url') . '/api/v1/getSubmissionFile.php',
             ['query' => ['filename' => $filename],
-                  'save_to' => $tmpFilename]);
+                  'sink' => $tmpFilename]);
 
         if ($response->getStatusCode() === 200) {
             // @todo I'm sure Guzzle can be used to return a file handle from the stream, but for now

--- a/app/cdash/public/api/v1/getSubmissionFile.php
+++ b/app/cdash/public/api/v1/getSubmissionFile.php
@@ -38,7 +38,7 @@ if (!config('cdash.remote_workers')) {
 }
 
 if (isset($_GET['filename'])) {
-    $filename = Storage::path('inbox') . '/' . basename($_REQUEST['filename']);
+    $filename = Storage::path('inprogress') . '/' . basename($_REQUEST['filename']);
     if (!is_readable($filename)) {
         return response('Not found', Response::HTTP_NOT_FOUND);
     } else {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2863,16 +2863,6 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			message: "#^Call to method request\\(\\) on an unknown class App\\\\Jobs\\\\GuzzleHttp\\\\Client\\.$#"
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			message: "#^Instantiated class App\\\\Jobs\\\\GuzzleHttp\\\\Client not found\\.$#"
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/Jobs/ProcessSubmission.php


### PR DESCRIPTION
When using remote workers, the GuzzleHttp client isn't found in the namespace, add a `\` to use the global namespace

Files waiting on remote workers are copied into the `inprogress` directory, but the remote api looks for them in the `inbox` directory