### PR TITLE
Disable slow page warnings by default in dev/testing environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -14,3 +14,6 @@ DB_PASSWORD=cdash4simpletest
 REGISTRATION_EMAIL_VERIFY=false
 
 QUEUE_CONNECTION=sync
+
+# Disable the slow page warning messages when testing
+SLOW_PAGE_TIME=1000000


### PR DESCRIPTION
The slow page warning log messages sometimes interfere with CDash tests which run slowly in our CI pipeline, or on slow computers.  This PR disables the warning in the dev/testing environment by setting the configuration value to a large number.  This PR should resolve some of the flaky tests which have been observed in the last few weeks, and eliminate the need for manual configuration settings on some developer machines.