### PR TITLE
Add unique constraint to email column of users table

### DIFF
--- a/database/migrations/2023_12_19_211314_user_unique_email.php
+++ b/database/migrations/2023_12_19_211314_user_unique_email.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user', function (Blueprint $table) {
+            $table->dropUnique('email');
+        });
+    }
+};


### PR DESCRIPTION
The email address column of the user table is considered to be unique for login purposes, but the database allows multiple users to have the same email address.  This could potentially allow some users to be locked out of their account.  This PR adds a unique constraint to the email column, so it is impossible to have multiple users with the same email.