### PR TITLE
Suggest including logging information in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,9 +24,12 @@ assignees: ''
 ### Additional Information
 
 <!--
+
 Add additional information here if necessary.  Helpful information includes:
 - How to reproduce the problem
+- The contents of your logs (see ./storage/logs)
 - Screenshots of a UI issue
 - Browser/OS information (if applicable)
 - Any other information which might help us track down the bug
+
 -->


### PR DESCRIPTION
Logging information is often the most useful way to debug issues, and I frequently have to request the logs when responding to issues.  This PR adds a reminder to the issue template in the hope that we will have to post comments requesting the logs less frequently.