### PR TITLE
Add loading indicator Vue template

### DIFF
--- a/resources/js/components/AllProjects.vue
+++ b/resources/js/components/AllProjects.vue
@@ -1,8 +1,5 @@
 <template>
-  <section v-if="errored">
-    <p>{{ cdash.error }}</p>
-  </section>
-  <section v-else-if="!loading">
+  <loading-indicator :is-loading="loading">
     <h1
       v-if="cdash.projects.length === 0"
       class="text-info text-center"
@@ -133,13 +130,15 @@
         </td>
       </tr>
     </table>
-  </section>
+  </loading-indicator>
 </template>
 
 <script>
 import ApiLoader from './shared/ApiLoader';
+import LoadingIndicator from "./shared/LoadingIndicator.vue";
 export default {
   name: 'AllProjects',
+  components: {LoadingIndicator},
 
   data () {
     return {

--- a/resources/js/components/UserHomepage.vue
+++ b/resources/js/components/UserHomepage.vue
@@ -1,8 +1,5 @@
 <template>
-  <section v-if="errored">
-    <p>{{ cdash.error }}</p>
-  </section>
-  <section v-else-if="!loading">
+  <loading-indicator :is-loading="loading">
     <!-- Message -->
     <table v-if="cdash.message">
       <tr>
@@ -700,13 +697,15 @@
         </tr>
       </tbody>
     </table>
-  </section>
+  </loading-indicator>
 </template>
 
 <script>
 import ApiLoader from './shared/ApiLoader';
+import LoadingIndicator from "./shared/LoadingIndicator.vue";
 export default {
   name: "UserHomepage",
+  components: {LoadingIndicator},
 
   data () {
     return {

--- a/resources/js/components/shared/LoadingIndicator.vue
+++ b/resources/js/components/shared/LoadingIndicator.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <div v-if="isLoading">
+      <img
+        v-if="initialDelayComplete"
+        :src="$baseURL + '/img/loading.gif'"
+        class="loading-indicator"
+        alt="The page is loading."
+      >
+    </div>
+    <slot v-else />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    isLoading: {
+      type: Boolean,
+      default: true,
+    },
+  },
+
+  data() {
+    return {
+      initialDelayComplete: false,
+    };
+  },
+
+  mounted() {
+    // Prevent a flicker if the page loads quickly
+    setTimeout(() => {
+      this.initialDelayComplete = true;
+    }, 500);
+  },
+};
+</script>
+
+<style scoped>
+.loading-indicator {
+  margin: 0 auto;
+  display: block;
+}
+</style>


### PR DESCRIPTION
We currently provide no information about the state of the page for pages with API endpoints which take a long time to return.  This PR adds a Vue template which accepts a slot for content to be rendered when the page is loaded, and a boolean prop which indicates whether the loading indicator should be shown.  I have initially used this template to add loading indicators to two pages as an example for future use.  I plan to switch the loading indicator icon to a Font Awesome icon instead of a grainy GIF once #1895 is merged.