### PR TITLE
Add additional error checking to label handling

### DIFF
--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -280,7 +280,7 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
         } elseif ($name == 'LABEL' && $parent == 'LABELS') {
             if (!empty($this->ErrorSubProjectName)) {
                 $this->SubProjectName = $this->ErrorSubProjectName;
-            } elseif (isset($this->Error)) {
+            } elseif (isset($this->Error) && $this->Error instanceof BuildFailure) {
                 $this->Error->AddLabel($this->Label);
             } else {
                 $this->Labels[] = $this->Label;


### PR DESCRIPTION
CDash currently fails during the submission process if a label is applied to something other than a build failure.  This PR adds additional checking, which allows the submission process to continue when labels are applied to invalid elements.