### PR TITLE
Handle null logline condition

### DIFF
--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -81,7 +81,7 @@ class BuildError
                  ', [
                      intval($this->BuildId),
                      $this->Type,
-                     $this->LogLine,
+                     $this->LogLine ?? 0,
                      $this->Text,
                      $this->SourceFile ?? '',
                      intval($this->SourceLine),


### PR DESCRIPTION
#1332 failed to handle null values, which resulted in errors when no logline was provided.  This code was refactored again after the 3.2 release branch was cut, and this problem does not exist on master.