### PR TITLE
Remove `moment` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "expect": "^29.7.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "moment": "^2.29.4",
         "postcss": "^8.4.32",
         "protractor": "^7.0.0",
         "resolve-url-loader": "^5.0.0"
@@ -11670,15 +11669,6 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "expect": "^29.7.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "moment": "^2.29.4",
     "postcss": "^8.4.32",
     "protractor": "^7.0.0",
     "resolve-url-loader": "^5.0.0"

--- a/tests/Spec/page-header/header-menu.spec.js
+++ b/tests/Spec/page-header/header-menu.spec.js
@@ -3,10 +3,9 @@ config.global.mocks['$baseURL'] = 'http://localhost';
 import HeaderMenu from '../../../resources/js/components/page-header/HeaderMenu.vue';
 
 import expect from 'expect';
-import moment from 'moment';
 
 let component;
-const today = moment().format('YYYY-MM-DD');
+const today = new Date().toISOString().slice(0, 10);
 const bugUrl = 'https://github.com/project/project/issues';
 const docUrl = 'https://github.com/project/project/wiki';
 const homeUrl = 'https://www.project.tld/';


### PR DESCRIPTION
`moment` is only used once, for a basic task raw Javascript is more than capable of handling.  This PR removes our unnecessary dependency on the `moment` library.  This PR will render https://github.com/Kitware/CDash/pull/1916 unnecessary.