### PR TITLE
Fix links to and from site page

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -448,10 +448,7 @@ final class SiteController extends AbstractController
 
         $xml = begin_XML_for_XSLT();
 
-        $projectid = 0;
-        if(isset($_GET['project'])) {
-            $projectid = (int) $_GET['project'];
-        }
+        $projectid =  (int) ($_GET['project'] ?? 0);
 
         if ($projectid > 0) {
             $project = new Project();

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -448,7 +448,11 @@ final class SiteController extends AbstractController
 
         $xml = begin_XML_for_XSLT();
 
-        $projectid = (int) $_GET['project'];
+        $projectid = 0;
+        if(isset($_GET['project'])) {
+            $projectid = (int) $_GET['project'];
+        }
+
         if ($projectid > 0) {
             $project = new Project();
             $project->Id = $projectid;

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -470,6 +470,7 @@ final class SiteController extends AbstractController
         $xml .= '<dashboard>';
         $xml .= '<title>CDash</title>';
 
+        $xml .= add_XML_value('baseURL', config('app.url'));
         $apikey = config('cdash.google_map_api_key');
 
         $MB = 1048576;

--- a/app/cdash/public/viewSite.xsl
+++ b/app/cdash/public/viewSite.xsl
@@ -113,7 +113,7 @@
   <b>This site belongs to the following projects:</b><br/>
   <xsl:for-each select="cdash/project">
   <a>
-  <xsl:attribute name="href">index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
+  <xsl:attribute name="href">/index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
   <xsl:value-of select="name"/>
   </a>
   (<xsl:value-of select="submittime"/>)<br/>

--- a/app/cdash/public/viewSite.xsl
+++ b/app/cdash/public/viewSite.xsl
@@ -7,7 +7,7 @@
     <xsl:template match="/">
 
   <xsl:if test="cdash/user/sitemanager=1">
-  <a><xsl:attribute name="href">editSite.php?siteid=<xsl:value-of select="cdash/site/id"/></xsl:attribute>
+  <a><xsl:attribute name="href"><xsl:value-of select="cdash/dashboard/baseURL"/>/editSite.php?siteid=<xsl:value-of select="cdash/site/id"/></xsl:attribute>
   <xsl:if test="cdash/user/siteclaimed=0">Are you maintaining this site? [claim this site]</xsl:if><xsl:if test="cdash/user/siteclaimed=1">[edit site description]</xsl:if></a>
   <br/>
   </xsl:if>
@@ -113,7 +113,7 @@
   <b>This site belongs to the following projects:</b><br/>
   <xsl:for-each select="cdash/project">
   <a>
-  <xsl:attribute name="href">/index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
+  <xsl:attribute name="href"><xsl:value-of select="../dashboard/baseURL"/>/index.php?project=<xsl:value-of select="name_encoded"/></xsl:attribute>
   <xsl:value-of select="name"/>
   </a>
   (<xsl:value-of select="submittime"/>)<br/>


### PR DESCRIPTION
Fix the controller to accept that the site page can be accessed without specifying a project.

Ensure that the links back to the projects of a site have the leading `/` to not be relative to the `sites/` of the page.