### PR TITLE
Enforce `eslint` warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,9 @@ add_test(
   COMMAND npm run eslint
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
+set_tests_properties(eslint PROPERTIES
+  FAIL_REGULAR_EXPRESSION " \+[0-9]\+:[0-9]\+ \+warning"
+)
 
 add_vue_test(Spec/build-configure)
 add_vue_test(Spec/build-notes)


### PR DESCRIPTION
Currently, `eslint` warnings don't cause the `ctest` test to fail, which can easily be missed when testing locally or on the CI. This change forces the test to fail if any lines are flagged with a warning. Any `eslint` errors will make the test fail as before.