### PR TITLE
Fix date generation in test-summary cypress test

### DIFF
--- a/tests/cypress/e2e/test-summary.cy.js
+++ b/tests/cypress/e2e/test-summary.cy.js
@@ -98,7 +98,7 @@ describe('testSummary', () => {
 
     // navigate to current day
     cy.get('li.btncurr').find('a').click();
-    const today_str = new Date().toLocaleDateString('en-CA');
+    const today_str = new Date().toISOString().slice(0, 10);
     cy.url().should('include', `${base_url}&date=${today_str}`);
     cy.get('li.btnnext').find('a').should('not.exist');
 


### PR DESCRIPTION
Fixes a minor issue with a Date object timezone introduced in https://github.com/Kitware/CDash/pull/1933.