### PR TITLE
More gracefully handle misassigned configure records

### DIFF
--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -721,6 +721,7 @@ class Build
      */
     public function GetConfigures()
     {
+        $stmt = null;
         if ($this->IsParentBuild()) {
             // Count how many separate configure rows are associated with
             // this parent build.
@@ -742,7 +743,7 @@ class Build
                     JOIN subproject sp ON sp.id = sp2b.subprojectid
                     JOIN build b ON b.id = b2c.buildid
                     WHERE b.parentid = ?');
-            } else {
+            } elseif (count($configure_rows) === 1) {
                 // One configure row is shared by all the SubProjects.
                 $stmt = $this->PDO->prepare('
                     SELECT c.*, b.configureerrors, b.configurewarnings
@@ -753,7 +754,8 @@ class Build
                 pdo_execute($stmt, [$configure_rows[0]['id']]);
                 return $stmt;
             }
-        } else {
+        }
+        if (is_null($stmt)) {
             $stmt = $this->PDO->prepare('
                 SELECT c.*, b.configureerrors, b.configurewarnings
                 FROM configure c

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -245,6 +245,7 @@ add_php_test(redundanttests)
 add_php_test(configureappend)
 add_php_test(notesparsererrormessages)
 add_php_test(viewsubprojectslinkoption)
+add_php_test(misassignedconfigure)
 
 add_subdirectory(ctest)
 

--- a/app/cdash/tests/data/MultipleSubprojects/Configure_bad.xml
+++ b/app/cdash/tests/data/MultipleSubprojects/Configure_bad.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="CTestTest-Linux-c++-Subprojects"
+        BuildStamp="20160728-1932-Experimental"
+        Name="livonia-linux"
+        Generator="ctest-3.6.20160726-g3e55f-dirty"
+        CompilerName=""
+        CompilerVersion=""
+        OSName="Linux"
+        Hostname="livonia-linux"
+        OSRelease="3.13.0-35-generic"
+        OSVersion="#62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014"
+        OSPlatform="x86_64"
+        Is64Bits="1"
+        VendorString="GenuineIntel"
+        VendorID="Intel Corporation"
+        FamilyID="6"
+        ModelID="69"
+        ProcessorCacheSize="4096"
+        NumberOfLogicalCPU="4"
+        NumberOfPhysicalCPU="1"
+        TotalVirtualMemory="7627"
+        TotalPhysicalMemory="7890"
+        LogicalProcessorsPerPhysical="4"
+        ProcessorClockFrequency="756"
+        >
+        <Labels>
+                <Label>MyProductionCode</Label>
+        </Labels>
+        <Configure>
+                <StartDateTime>Jul 28 15:32 EDT</StartDateTime>
+                <StartConfigureTime>1469734334</StartConfigureTime>
+                <ConfigureCommand>"/home/betsy/cmake_build/bin/cmake" "-DCTEST_USE_LAUNCHERS=1" "-GUnix Makefiles" "/home/betsy/cmake/Tests/CTestTestSubprojects"</ConfigureCommand>
+                <Log>-- The C compiler identification is GNU 4.8.4
+-- The CXX compiler identification is GNU 4.8.4
+-- Check for working C compiler: /usr/bin/cc
+-- Check for working C compiler: /usr/bin/cc -- works
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Detecting C compile features
+-- Detecting C compile features - done
+-- Check for working CXX compiler: /usr/bin/c++
+-- Check for working CXX compiler: /usr/bin/c++ -- works
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+-- Detecting CXX compile features
+-- Detecting CXX compile features - done
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /home/betsy/cmake_build/Tests/CTestTestSubprojects
+CMake Warning: CMake is forcing CMAKE_CXX_COMPILER to "/usr/bin/c++" to match that imported from VTK.  This is required because C++ projects must use the same compiler.  If this message appears for more than one imported project, you have conflicting C++ compilers and will have to re-build one of those projects. Was set to /usr/bin/g++-4.0
+Fltk resources not found, GUI application will not respond to mouse events
+Error: example error #1
+</Log>
+                <ConfigureStatus>1</ConfigureStatus>
+                <EndDateTime>Jul 28 15:32 EDT</EndDateTime>
+                <EndConfigureTime>1469734335</EndConfigureTime>
+                <ElapsedMinutes>0</ElapsedMinutes>
+        </Configure>
+</Site>

--- a/app/cdash/tests/test_misassignedconfigure.php
+++ b/app/cdash/tests/test_misassignedconfigure.php
@@ -1,0 +1,58 @@
+<?php
+require_once dirname(__FILE__) . '/cdash_test_case.php';
+
+use CDash\Model\Project;
+use Illuminate\Support\Facades\DB;
+
+class MisassignedConfigureTestCase extends KWWebTestCase
+{
+    private Project $project;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function __destruct()
+    {
+        // Delete project & build created by this test.
+        remove_project_builds($this->project->Id);
+        $this->project->Delete();
+    }
+
+    public function testMisassignedConfigure() : void
+    {
+        // Create test project.
+        $this->login();
+        $this->project = new Project();
+        $this->project->Id = $this->createProject([
+            'Name' => 'MisassignedConfigureProject',
+        ]);
+        $this->project->Fill();
+        $this->deleteLog($this->logfilename);
+
+        $data_dir = dirname(__FILE__) . '/data/MultipleSubprojects/';
+
+        // Submit some testing data.
+        $this->submission($this->project->Name, "{$data_dir}/Configure_bad.xml");
+        $this->submission($this->project->Name, "{$data_dir}/Build.xml");
+
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+
+        $parent_builds = DB::select('
+            SELECT id FROM build
+            WHERE projectid = :projectid
+            AND parentid = -1', ['projectid' => $this->project->Id]);
+        $this->assertTrue(1 === count($parent_builds));
+        $parentid = $parent_builds[0]->id;
+
+        // Verify expected configure output.
+        $this->get("{$this->url}/api/v1/viewConfigure.php?buildid={$parentid}");
+        $content = $this->getBrowser()->getContent();
+        $jsonobj = json_decode($content, true);
+        if (count($jsonobj['configures']) !== 1) {
+            $this->fail('Did not find one configure record when expected');
+        }
+        $this->deleteLog($this->logfilename);
+    }
+}


### PR DESCRIPTION
We encountered a situation where a parent build had a configure record associated directly to it (and not to one of its children builds). In this case, CDash would throw a 500 error when attempting to view the configure output for this build.

While the cause was ultimately determined to be a non-standard XML format, we should also prevent CDash from throwing an error in this case, especially since the XML file in question was parsed "successfully".