### PR TITLE
Add production/development flag to `cdash_install`

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -6,7 +6,11 @@ php artisan key:check || exit 1
 
 # If the "start-website" argument was provided, start the web server
 if [ "$1" = "start-website" ] ; then
-  bash /cdash/install.sh
+  if [ "$DEVELOPMENT_BUILD" = "1" ]; then
+    bash /cdash/install.sh --dev
+  else
+    bash /cdash/install.sh
+  fi
 
   echo "Starting Apache..."
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
+if [[ "$1" == "--dev" ]]; then
+  DEVELOPMENT=true
+else
+  DEVELOPMENT=false
+fi
+
 echo "=================================================================================";
-echo "Beginning CDash installation...";
+if $DEVELOPMENT; then
+  echo "Beginning development CDash installation..."
+else
+  echo "Configuring production CDash installation..."
+fi
 
 error_handler() {
 echo "
@@ -29,11 +39,16 @@ echo "Enabling maintenance mode..."
 php artisan down --render="maintenance" --refresh=5
 
 echo "Updating vendor dependencies..."
-npm install
-composer install
+if $DEVELOPMENT; then
+  npm install
+  composer install
+else
+  npm install --omit=dev
+  composer install --no-dev --optimize-autoloader
+fi
 
 echo "Running migrations..."
-php artisan migrate
+php artisan migrate --force
 php artisan version:set
 
 echo "Clearing caches..."

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "vue": "^3.3.8",
     "vue-loader": "^17.4.2",
     "vuedraggable": "^4.1.0",
-    "webpack": "^5.89.0"
+    "webpack": "^5.89.0",
+    "resolve-url-loader": "^5.0.0"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.3",
@@ -62,7 +63,6 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.32",
-    "protractor": "^7.0.0",
-    "resolve-url-loader": "^5.0.0"
+    "protractor": "^7.0.0"
   }
 }


### PR DESCRIPTION
#1893 accidentally started installing dev dependencies in production containers via the `cdash_install` command.  This PR adds a `--dev` flag to `cdash_install` to control whether dev dependencies are installed or not.

Fixes #1951