### PR TITLE
Add Vue component for standard tables

### DIFF
--- a/app/cdash/public/css/common.css
+++ b/app/cdash/public/css/common.css
@@ -448,28 +448,24 @@ div#calendar{
 }
 
 .activity-level-none {
-    float: right;
     background: url("../../img/activity-level.png") no-repeat scroll -16px -16px transparent;
     height: 16px;
     width: 16px;
 }
 
 .activity-level-low {
-    float: right;
     background: url("../../img/activity-level.png") no-repeat scroll 0 -16px transparent;
     height: 16px;
     width: 16px;
 }
 
 .activity-level-medium {
-    float: right;
     background: url("../../img/activity-level.png") no-repeat scroll -16px 0 transparent;
     height: 16px;
     width: 16px;
 }
 
 .activity-level-high {
-    float: right;
     background: url("../../img/activity-level.png") no-repeat scroll 0 0 transparent;
     height: 16px;
     width: 16px;
@@ -1113,7 +1109,8 @@ background-color: #adcae6
  border-bottom: solid 1px #244fb1;
 }
 
-.table-heading1 td:nth-child(even) {
+.table-heading1 td:nth-child(even),
+.table-heading1 th:nth-child(even) {
   background-color:#607dc1;
 }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -25,12 +25,13 @@ import AllProjects from './components/AllProjects.vue';
 import SubProjectDependencies from './components/SubProjectDependencies.vue';
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { library } from '@fortawesome/fontawesome-svg-core';
+import * as FA from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 import { far } from '@fortawesome/free-regular-svg-icons';
 import { fab } from '@fortawesome/free-brands-svg-icons';
 
-library.add(fas, far, fab);
+FA.library.add(fas, far, fab);
+FA.config.styleDefault = 'solid';
 
 const cdash_components = {
   FontAwesomeIcon,

--- a/resources/js/components/AllProjects.vue
+++ b/resources/js/components/AllProjects.vue
@@ -7,88 +7,40 @@
       No Projects Found
     </h1>
 
-    <!-- Main table -->
-    <table
-      v-if="cdash.projects.length > 0"
-      id="indexTable"
-      border="0"
-      cellpadding="4"
-      cellspacing="0"
-      width="100%"
-      class="tabb striped"
+    <DataTable
+      :columns="[
+        {
+          name: 'project',
+          displayName: 'Project',
+        },
+        {
+          name: 'description',
+          displayName: 'Description',
+          expand: true,
+        },
+        {
+          name: 'activity',
+          displayName: 'Last Activity',
+        }
+      ]"
+      :rows="tableRows"
+      class="projects-table"
     >
-      <thead>
-        <tr class="table-heading1">
-          <td
-            colspan="6"
-            align="left"
-            class="nob"
-          >
-            <h3>Dashboards</h3>
-          </td>
-        </tr>
-
-        <tr class="table-heading">
-          <th
-            id="sort_0"
-            align="center"
-            width="10%"
-          >
-            <b>Project</b>
-          </th>
-          <td
-            align="center"
-            width="65%"
-          >
-            <b>Description</b>
-          </td>
-          <th
-            id="sort_2"
-            align="center"
-            class="nob"
-            width="13%"
-          >
-            <b>Last activity</b>
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr
-          v-for="project in cdash.projects"
+      <template #activity="activity" >
+        <a
+          class="builddateelapsed"
+          :href="activity.props.link + '&date=' + activity.props.lastbuilddate"
         >
-          <td align="center">
-            <a :href="project.link">
-              {{ project.name }}
-            </a>
-          </td>
-          <td align="left">
-            {{ project.description }}
-          </td>
-          <td
-            align="center"
-            class="nob"
-          >
-            <span
-              class="sorttime"
-              style="display: none;"
-            >
-              {{ project.lastbuilddatefull }}
-            </span>
-            <a
-              class="builddateelapsed"
-              :href="project.link + '&date=' + project.lastbuilddate"
-            >
-              {{ project.lastbuild_elapsed }}
-            </a>
-            <img
-              :src="$baseURL + '/img/cleardot.gif'"
-              :class="'activity-level-' + project.activity"
-            >
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          {{ activity.props.lastbuild_elapsed }}
+        </a>
+        <img
+          alt="Activity level"
+          style="margin-left: 0.5em;"
+          :src="$baseURL + '/img/cleardot.gif'"
+          :class="'activity-level-' + activity.props.activity"
+        >
+      </template>
+    </DataTable>
 
     <table
       v-if="cdash.projects.length > 0"
@@ -136,9 +88,10 @@
 <script>
 import ApiLoader from './shared/ApiLoader';
 import LoadingIndicator from "./shared/LoadingIndicator.vue";
+import DataTable from "./shared/DataTable.vue";
 export default {
   name: 'AllProjects',
-  components: {LoadingIndicator},
+  components: {DataTable, LoadingIndicator},
 
   data () {
     return {
@@ -146,6 +99,7 @@ export default {
       cdash: {},
       loading: true,
       errored: false,
+      tableRows: [],
     }
   },
 
@@ -157,5 +111,28 @@ export default {
     }
     ApiLoader.loadPageData(this, '/api/v1/viewProjects.php' + queryParams);
   },
+
+  methods: {
+    postSetup: function () {
+      this.tableRows = this.cdash.projects.map((project) => {
+        return {
+          project: {
+            value: project.name,
+            href: project.link
+          },
+          description: project.description,
+          activity: project,
+        };
+      });
+    }
+  }
 }
 </script>
+
+<style scoped>
+
+.projects-table {
+  width: 100%;
+}
+
+</style>

--- a/resources/js/components/AllProjects.vue
+++ b/resources/js/components/AllProjects.vue
@@ -26,18 +26,18 @@
       :rows="tableRows"
       class="projects-table"
     >
-      <template #activity="activity" >
+      <template #activity="{ props }" >
         <a
           class="builddateelapsed"
-          :href="activity.props.link + '&date=' + activity.props.lastbuilddate"
+          :href="props.activity.link + '&date=' + props.activity.lastbuilddate"
         >
-          {{ activity.props.lastbuild_elapsed }}
+          {{ props.activity.lastbuild_elapsed }}
         </a>
         <img
           alt="Activity level"
           style="margin-left: 0.5em;"
           :src="$baseURL + '/img/cleardot.gif'"
-          :class="'activity-level-' + activity.props.activity"
+          :class="'activity-level-' + props.activity.activity"
         >
       </template>
     </DataTable>
@@ -121,7 +121,10 @@ export default {
             href: project.link
           },
           description: project.description,
-          activity: project,
+          activity: {
+            value: project.lastbuild_elapsed,
+            activity: project,
+          },
         };
       });
     }

--- a/resources/js/components/UserHomepage.vue
+++ b/resources/js/components/UserHomepage.vue
@@ -99,49 +99,49 @@
                 title="Edit subscription"
                 :href="$baseURL + '/subscribeProject.php?projectid=' + project.id + '&edit=1'"
               >
-                <font-awesome-icon icon="fa-solid fa-bell"/>
+                <font-awesome-icon icon="fa-bell"/>
               </a>
               <a
                 v-if="project.role > 0"
                 title="Claim sites"
                 :href="$baseURL + '/editSite.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-solid fa-computer"/>
+                <font-awesome-icon icon="fa-computer"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Edit project"
                 :href="$baseURL + '/project/' + project.id + '/edit'"
               >
-                <font-awesome-icon icon="fa-solid fa-pencil"/>
+                <font-awesome-icon icon="fa-pencil"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage subprojects"
                 :href="$baseURL + '/manageSubProject.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-solid fa-folder-tree"/>
+                <font-awesome-icon icon="fa-folder-tree"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project groups"
                 :href="$baseURL + '/manageBuildGroup.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-solid fa-layer-group"/>
+                <font-awesome-icon icon="fa-layer-group"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project users"
                 :href="$baseURL + '/manageProjectRoles.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-solid fa-user-pen"/>
+                <font-awesome-icon icon="fa-user-pen"/>
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project coverage"
                 :href="$baseURL + '/manageCoverage.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-solid fa-chart-line"/>
+                <font-awesome-icon icon="fa-chart-line"/>
               </a>
             </td>
             <td

--- a/resources/js/components/shared/DataTable.vue
+++ b/resources/js/components/shared/DataTable.vue
@@ -42,6 +42,7 @@
         <td
           v-for="column in columns"
           :class="{ shrink: !column.expand }"
+          class="table-cell"
           data-cy="data-table-cell"
         >
           <!--
@@ -239,6 +240,10 @@ export default {
 
 .full-width {
   width: 100%;
+}
+
+.table-cell {
+  overflow-wrap: anywhere;
 }
 
 </style>

--- a/resources/js/components/shared/DataTable.vue
+++ b/resources/js/components/shared/DataTable.vue
@@ -1,0 +1,244 @@
+<template>
+  <table
+    class="tabb striped"
+    :class="{ 'full-width': fullWidth }"
+    data-cy="data-table"
+  >
+    <thead>
+      <tr
+        v-if="columnGroups.length > 0"
+        class="table-heading1"
+      >
+        <th
+          v-for="group in columnGroups"
+          :colspan="group.width"
+        >
+          {{ group.displayName }}
+        </th>
+      </tr>
+      <tr
+        v-if="columns.length > 0"
+        :class="{ 'table-heading': columnGroups.length > 0, 'table-heading1': columnGroups.length === 0}"
+      >
+        <th
+          v-for="column in columns"
+          :class="{ shrink: !column.expand }"
+          data-cy="column-header"
+          @click="toggleSort(column.name)"
+        >
+          <font-awesome-icon
+            v-if="sortable"
+            :icon="sortColumn === column.name ? (sortAsc ? 'fa-caret-up' : 'fa-caret-down') : 'fa-sort'"
+          />
+          {{ column.displayName }}
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        v-for="row in (sortable ? sortedRows : rows)"
+        data-cy="data-table-row"
+      >
+        <td
+          v-for="column in columns"
+          :class="{ shrink: !column.expand }"
+          data-cy="data-table-cell"
+        >
+          <!--
+            Display a custom template for each table cell, or a default template
+            if a custom template is not provided.
+          -->
+          <slot
+            :name="column.name"
+            :props="row[column.name]"
+          >
+            <!-- Rows with the href attribute are links. -->
+            <a
+              v-if="Object.hasOwn(row[column.name], 'href')"
+              :href="row[column.name].href"
+            >
+              {{ row[column.name].value }}
+            </a>
+            <!-- If this is a text value, just display it. -->
+            <template v-else>
+              {{ row[column.name] }}
+            </template>
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default {
+  components: {
+    FontAwesomeIcon,
+  },
+
+  props: {
+    /**
+     * An array of columns.  displayName is the string to be displayed, while name is the identifier for the column.
+     *
+     * The expected input is of the form:
+     *   columns: [
+     *   |   {
+     *   |   |   displayName: <String>
+     *   |   |   name: <String>
+     *   |   |   ?expand: <Boolean> = false
+     *   |   },
+     *   |   ...
+     *   | ],
+     *   },
+     */
+    columns: {
+      type: Array,
+      default: () => [],
+    },
+
+    /**
+     * An array of column "groups", with a string name and the number of columns to group.
+     *
+     * The expected input is of the form:
+     *   columnGroups: [
+     *   |   {
+     *   |   |   displayName: <String>
+     *   |   |   width: <Integer>
+     *   |   },
+     *   |   ...
+     *   | ],
+     *   },
+     */
+    columnGroups: {
+      type: Array,
+      default: () => [],
+    },
+
+    /**
+     * A boolean indicating whether this table should maximize its width
+     */
+    fullWidth: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
+     * An array of objects of the form:
+     *   rows: [
+     *   |   {
+     *   |   |   <column name>: String | { metadata object },
+     *   |   |   ...
+     *   |   }
+     *   ]
+     *
+     * Use metadata objects of the following form to specify links:
+     *   {
+     *       value: String
+     *       href: String
+     *   }
+     *
+     * Custom metadata objects can be use to provide props to custom templates passed via slots.
+     *
+     * A "value" key is required in the metadata object.  The associated value will be used for sorting.
+     * In the case of a pure text item, the object will be sorted by text value.
+     */
+    rows: {
+      type: Array,
+      default: () => [],
+    },
+
+    /**
+     * A boolean indicating whether columns should be sortable, and whether the component should emit sorting events.
+     */
+    sortable: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
+     * If this table is sortable, specifies the initial sort direction.
+     */
+    initialSortAsc: {
+      type: Boolean,
+      default: true,
+    },
+
+    /**
+     * If this table is sortable, specifies the column to sort by initially.  Defaults to the first column.
+     */
+    initialSortColumn: {
+      type: String,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      sortAsc: this.initialSortAsc,
+      sortColumn: this.initialSortColumn ?? this.columns[0]['name'],
+    };
+  },
+
+  computed: {
+    sortedRows() {
+      return [...this.rows].sort((row1, row2) => {
+        // The "value" attribute is required.  Fail if it is not provided.
+        // If this is a text-only column, use the text instead.
+        const row1_sort = row1[this.sortColumn].value ?? row1[this.sortColumn];
+        const row2_sort = row2[this.sortColumn].value ?? row2[this.sortColumn];
+
+        const return_modifier = this.sortAsc ? 1 : -1;
+        if (row1_sort > row2_sort) {
+          return 1 * return_modifier;
+        }
+        else if (row1_sort < row2_sort) {
+          return -1 * return_modifier;
+        }
+        return 0;
+      });
+    },
+  },
+
+  methods: {
+    toggleSort(column_name) {
+      if (this.sortColumn === column_name) {
+        this.sortAsc = !this.sortAsc;
+      }
+      else {
+        this.sortAsc = true;
+        this.sortColumn = column_name;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+/* TODO: Move the relevant CSS from common.css to this file */
+
+.shrink {
+  width: 1px;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.table-heading1 > th:not(.shrink) {
+  text-align: left;
+}
+
+.table-heading1 > th {
+  padding: 6px;
+  font-size: 16px;
+}
+
+.table-heading th {
+  text-align: center;
+}
+
+.full-width {
+  width: 100%;
+}
+
+</style>

--- a/tests/cypress/component/data-table.cy.js
+++ b/tests/cypress/component/data-table.cy.js
@@ -1,236 +1,238 @@
 import DataTable from '../../../resources/js/components/shared/DataTable.vue';
 
-it('Handles unsorted text data', () => {
-  cy.mount(DataTable, {
-    props: {
-      columns: [
-        {
-          displayName: 'Test',
-          name: 'test',
-        },
-        {
-          displayName: 'Test 2',
-          name: 'test2',
-        },
-      ],
-      rows: [
-        {
-          test: 'Data value 1',
-          test2: 'Data value 2',
-        },
-        {
-          test: 'Data value 5',
-          test2: 'Data value 6',
-        },
-        {
-          test: 'Data value 3',
-          test2: 'Data value 4',
-        },
-      ],
-      sortable: false,
-    },
-  });
-
-  cy.get('[data-cy="sort-icon"]').should('not.exist');
-
-  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
-  cy.get('@table-rows').should('have.length', 3);
-
-  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
-  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
-  cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
-
-  cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
-  cy.get('@table-row-0').eq(1).should('contain', 'Data value 2');
-
-  cy.get('@table-row-1').eq(0).should('contain', 'Data value 5');
-  cy.get('@table-row-1').eq(1).should('contain', 'Data value 6');
-
-  cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
-  cy.get('@table-row-2').eq(1).should('contain', 'Data value 4');
-});
-
-it('Sorts text data', () => {
-  cy.mount(DataTable, {
-    props: {
-      columns: [
-        {
-          displayName: 'Test',
-          name: 'test',
-        },
-        {
-          displayName: 'Test 2',
-          name: 'test2',
-        },
-      ],
-      rows: [
-        {
-          test: 'Data value 1',
-          test2: 'Data value 5',
-        },
-        {
-          test: 'Data value 3',
-          test2: 'Data value 5',
-        },
-        {
-          test: 'Data value 2',
-          test2: 'Data value 4',
-        },
-      ],
-      sortable: true,
-      initialSortColumn: 'test2',
-    },
-  });
-
-  cy.get('[data-cy="column-header"]').should('be.visible');
-
-  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
-  cy.get('@table-rows').should('have.length', 3);
-
-  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
-  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
-  cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
-
-  // Initially sorted by the second column
-  cy.get('@table-row-0').eq(0).should('contain', 'Data value 2');
-  cy.get('@table-row-0').eq(1).should('contain', 'Data value 4');
-
-  // Can't test the first column values, because they aren't deterministic
-  cy.get('@table-row-1').eq(1).should('contain', 'Data value 5');
-  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
-
-  // Sort the first column
-  cy.get('[data-cy="column-header"]').eq(0).click();
-
-  cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
-  cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
-
-  cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
-  cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
-
-  cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
-  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
-
-  // Switch the sort direction of the first column and check again
-  cy.get('[data-cy="column-header"]').eq(0).click();
-
-  cy.get('@table-row-0').eq(0).should('contain', 'Data value 3');
-  cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
-
-  cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
-  cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
-
-  cy.get('@table-row-2').eq(0).should('contain', 'Data value 1');
-  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
-});
-
-it('Handles links', () => {
-  cy.mount(DataTable, {
-    props: {
-      columns: [
-        {
-          displayName: 'Test',
-          name: 'test',
-        },
-        {
-          displayName: 'Test 2',
-          name: 'test2',
-        },
-      ],
-      rows: [
-        {
-          test: 'Data value 1',
-          test2: {
-            value: 'Link 1',
-            href: 'http://localhost:8080/test',
+describe('Data table component tests', () => {
+  it('Handles unsorted text data', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
           },
-        },
-      ],
-    },
+          {
+            displayName: 'Test 2',
+            name: 'test2',
+          },
+        ],
+        rows: [
+          {
+            test: 'Data value 1',
+            test2: 'Data value 2',
+          },
+          {
+            test: 'Data value 5',
+            test2: 'Data value 6',
+          },
+          {
+            test: 'Data value 3',
+            test2: 'Data value 4',
+          },
+        ],
+        sortable: false,
+      },
+    });
+
+    cy.get('[data-cy="sort-icon"]').should('not.exist');
+
+    cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+    cy.get('@table-rows').should('have.length', 3);
+
+    cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
+    cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
+    cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
+
+    cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
+    cy.get('@table-row-0').eq(1).should('contain', 'Data value 2');
+
+    cy.get('@table-row-1').eq(0).should('contain', 'Data value 5');
+    cy.get('@table-row-1').eq(1).should('contain', 'Data value 6');
+
+    cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
+    cy.get('@table-row-2').eq(1).should('contain', 'Data value 4');
   });
 
-  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
-    .find('[data-cy="data-table-cell"]').as('table-cells');
-
-  cy.get('@table-cells').eq(0).should('have.text', 'Data value 1');
-  cy.get('@table-cells').eq(1).should('have.text', 'Link 1').get('a')
-    .invoke('attr', 'href').should('equal', 'http://localhost:8080/test');
-});
-
-it('Handles custom components', () => {
-  cy.mount(DataTable, {
-    props: {
-      columns: [
-        {
-          displayName: 'Test',
-          name: 'test',
-        },
-      ],
-      rows: [
-        {
-          test: {
-            value: 'test1',
-            myprop: 'Test 1 Prop',
+  it('Sorts text data', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
           },
-        },
-      ],
-    },
-    slots: {
-      test: '<p>{{ props.myprop }} static text</p>',
-    },
+          {
+            displayName: 'Test 2',
+            name: 'test2',
+          },
+        ],
+        rows: [
+          {
+            test: 'Data value 1',
+            test2: 'Data value 5',
+          },
+          {
+            test: 'Data value 3',
+            test2: 'Data value 5',
+          },
+          {
+            test: 'Data value 2',
+            test2: 'Data value 4',
+          },
+        ],
+        sortable: true,
+        initialSortColumn: 'test2',
+      },
+    });
+
+    cy.get('[data-cy="column-header"]').should('be.visible');
+
+    cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+    cy.get('@table-rows').should('have.length', 3);
+
+    cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
+    cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
+    cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
+
+    // Initially sorted by the second column
+    cy.get('@table-row-0').eq(0).should('contain', 'Data value 2');
+    cy.get('@table-row-0').eq(1).should('contain', 'Data value 4');
+
+    // Can't test the first column values, because they aren't deterministic
+    cy.get('@table-row-1').eq(1).should('contain', 'Data value 5');
+    cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
+
+    // Sort the first column
+    cy.get('[data-cy="column-header"]').eq(0).click();
+
+    cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
+    cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
+
+    cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
+    cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
+
+    cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
+    cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
+
+    // Switch the sort direction of the first column and check again
+    cy.get('[data-cy="column-header"]').eq(0).click();
+
+    cy.get('@table-row-0').eq(0).should('contain', 'Data value 3');
+    cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
+
+    cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
+    cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
+
+    cy.get('@table-row-2').eq(0).should('contain', 'Data value 1');
+    cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
   });
 
-  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
-    .find('[data-cy="data-table-cell"]').first().as('table-cell');
-
-  cy.get('@table-cell').should('contain.html', '<p>Test 1 Prop static text</p>');
-});
-
-it('Sorts custom components', () => {
-  cy.mount(DataTable, {
-    props: {
-      columns: [
-        {
-          displayName: 'Test',
-          name: 'test',
-        },
-      ],
-      rows: [
-        {
-          test: {
-            value: 'item1',
-            myprop: 'Test 1 Prop',
+  it('Handles links', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
           },
-        },
-        {
-          test: {
-            value: 'item0',
-            myprop: 'Test 2 Prop',
+          {
+            displayName: 'Test 2',
+            name: 'test2',
           },
-        },
-      ],
-      sortable: true,
-      sortColumn: 'test',
-      initialSortAsc: false,
-    },
-    slots: {
-      test: '<p>{{ props.myprop }} static text</p>',
-    },
+        ],
+        rows: [
+          {
+            test: 'Data value 1',
+            test2: {
+              value: 'Link 1',
+              href: 'http://localhost:8080/test',
+            },
+          },
+        ],
+      },
+    });
+
+    cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
+      .find('[data-cy="data-table-cell"]').as('table-cells');
+
+    cy.get('@table-cells').eq(0).should('have.text', 'Data value 1');
+    cy.get('@table-cells').eq(1).should('have.text', 'Link 1').get('a')
+      .invoke('attr', 'href').should('equal', 'http://localhost:8080/test');
   });
 
-  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
-  cy.get('@table-rows').should('have.length', 2);
+  it('Handles custom components', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
+          },
+        ],
+        rows: [
+          {
+            test: {
+              value: 'test1',
+              myprop: 'Test 1 Prop',
+            },
+          },
+        ],
+      },
+      slots: {
+        test: '<p>{{ props.myprop }} static text</p>',
+      },
+    });
 
-  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').first().as('table-cell-0');
-  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').first().as('table-cell-1');
+    cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
+      .find('[data-cy="data-table-cell"]').first().as('table-cell');
 
-  // Make sure we can sort by the value attribute
-  cy.get('@table-cell-0').should('contain.html', '<p>Test 1 Prop static text</p>');
-  cy.get('@table-cell-1').should('contain.html', '<p>Test 2 Prop static text</p>');
+    cy.get('@table-cell').should('contain.html', '<p>Test 1 Prop static text</p>');
+  });
 
-  // Change the sort direction
-  cy.get('[data-cy="column-header"]').eq(0).click();
+  it('Sorts custom components', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
+          },
+        ],
+        rows: [
+          {
+            test: {
+              value: 'item1',
+              myprop: 'Test 1 Prop',
+            },
+          },
+          {
+            test: {
+              value: 'item0',
+              myprop: 'Test 2 Prop',
+            },
+          },
+        ],
+        sortable: true,
+        sortColumn: 'test',
+        initialSortAsc: false,
+      },
+      slots: {
+        test: '<p>{{ props.myprop }} static text</p>',
+      },
+    });
 
-  cy.get('@table-cell-0').should('contain.html', '<p>Test 2 Prop static text</p>');
-  cy.get('@table-cell-1').should('contain.html', '<p>Test 1 Prop static text</p>');
+    cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+    cy.get('@table-rows').should('have.length', 2);
+
+    cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').first().as('table-cell-0');
+    cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').first().as('table-cell-1');
+
+    // Make sure we can sort by the value attribute
+    cy.get('@table-cell-0').should('contain.html', '<p>Test 1 Prop static text</p>');
+    cy.get('@table-cell-1').should('contain.html', '<p>Test 2 Prop static text</p>');
+
+    // Change the sort direction
+    cy.get('[data-cy="column-header"]').eq(0).click();
+
+    cy.get('@table-cell-0').should('contain.html', '<p>Test 2 Prop static text</p>');
+    cy.get('@table-cell-1').should('contain.html', '<p>Test 1 Prop static text</p>');
+  });
 });

--- a/tests/cypress/component/data-table.cy.js
+++ b/tests/cypress/component/data-table.cy.js
@@ -1,0 +1,236 @@
+import DataTable from '../../../resources/js/components/shared/DataTable.vue';
+
+it('Handles unsorted text data', () => {
+  cy.mount(DataTable, {
+    props: {
+      columns: [
+        {
+          displayName: 'Test',
+          name: 'test',
+        },
+        {
+          displayName: 'Test 2',
+          name: 'test2',
+        },
+      ],
+      rows: [
+        {
+          test: 'Data value 1',
+          test2: 'Data value 2',
+        },
+        {
+          test: 'Data value 5',
+          test2: 'Data value 6',
+        },
+        {
+          test: 'Data value 3',
+          test2: 'Data value 4',
+        },
+      ],
+      sortable: false,
+    },
+  });
+
+  cy.get('[data-cy="sort-icon"]').should('not.exist');
+
+  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+  cy.get('@table-rows').should('have.length', 3);
+
+  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
+  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
+  cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
+
+  cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
+  cy.get('@table-row-0').eq(1).should('contain', 'Data value 2');
+
+  cy.get('@table-row-1').eq(0).should('contain', 'Data value 5');
+  cy.get('@table-row-1').eq(1).should('contain', 'Data value 6');
+
+  cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
+  cy.get('@table-row-2').eq(1).should('contain', 'Data value 4');
+});
+
+it('Sorts text data', () => {
+  cy.mount(DataTable, {
+    props: {
+      columns: [
+        {
+          displayName: 'Test',
+          name: 'test',
+        },
+        {
+          displayName: 'Test 2',
+          name: 'test2',
+        },
+      ],
+      rows: [
+        {
+          test: 'Data value 1',
+          test2: 'Data value 5',
+        },
+        {
+          test: 'Data value 3',
+          test2: 'Data value 5',
+        },
+        {
+          test: 'Data value 2',
+          test2: 'Data value 4',
+        },
+      ],
+      sortable: true,
+      initialSortColumn: 'test2',
+    },
+  });
+
+  cy.get('[data-cy="column-header"]').should('be.visible');
+
+  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+  cy.get('@table-rows').should('have.length', 3);
+
+  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').as('table-row-0');
+  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').as('table-row-1');
+  cy.get('@table-rows').eq(2).find('[data-cy="data-table-cell"]').as('table-row-2');
+
+  // Initially sorted by the second column
+  cy.get('@table-row-0').eq(0).should('contain', 'Data value 2');
+  cy.get('@table-row-0').eq(1).should('contain', 'Data value 4');
+
+  // Can't test the first column values, because they aren't deterministic
+  cy.get('@table-row-1').eq(1).should('contain', 'Data value 5');
+  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
+
+  // Sort the first column
+  cy.get('[data-cy="column-header"]').eq(0).click();
+
+  cy.get('@table-row-0').eq(0).should('contain', 'Data value 1');
+  cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
+
+  cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
+  cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
+
+  cy.get('@table-row-2').eq(0).should('contain', 'Data value 3');
+  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
+
+  // Switch the sort direction of the first column and check again
+  cy.get('[data-cy="column-header"]').eq(0).click();
+
+  cy.get('@table-row-0').eq(0).should('contain', 'Data value 3');
+  cy.get('@table-row-0').eq(1).should('contain', 'Data value 5');
+
+  cy.get('@table-row-1').eq(0).should('contain', 'Data value 2');
+  cy.get('@table-row-1').eq(1).should('contain', 'Data value 4');
+
+  cy.get('@table-row-2').eq(0).should('contain', 'Data value 1');
+  cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
+});
+
+it('Handles links', () => {
+  cy.mount(DataTable, {
+    props: {
+      columns: [
+        {
+          displayName: 'Test',
+          name: 'test',
+        },
+        {
+          displayName: 'Test 2',
+          name: 'test2',
+        },
+      ],
+      rows: [
+        {
+          test: 'Data value 1',
+          test2: {
+            value: 'Link 1',
+            href: 'http://localhost:8080/test',
+          },
+        },
+      ],
+    },
+  });
+
+  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
+    .find('[data-cy="data-table-cell"]').as('table-cells');
+
+  cy.get('@table-cells').eq(0).should('have.text', 'Data value 1');
+  cy.get('@table-cells').eq(1).should('have.text', 'Link 1').get('a')
+    .invoke('attr', 'href').should('equal', 'http://localhost:8080/test');
+});
+
+it('Handles custom components', () => {
+  cy.mount(DataTable, {
+    props: {
+      columns: [
+        {
+          displayName: 'Test',
+          name: 'test',
+        },
+      ],
+      rows: [
+        {
+          test: {
+            value: 'test1',
+            myprop: 'Test 1 Prop',
+          },
+        },
+      ],
+    },
+    slots: {
+      test: '<p>{{ props.myprop }} static text</p>',
+    },
+  });
+
+  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').first()
+    .find('[data-cy="data-table-cell"]').first().as('table-cell');
+
+  cy.get('@table-cell').should('contain.html', '<p>Test 1 Prop static text</p>');
+});
+
+it('Sorts custom components', () => {
+  cy.mount(DataTable, {
+    props: {
+      columns: [
+        {
+          displayName: 'Test',
+          name: 'test',
+        },
+      ],
+      rows: [
+        {
+          test: {
+            value: 'item1',
+            myprop: 'Test 1 Prop',
+          },
+        },
+        {
+          test: {
+            value: 'item0',
+            myprop: 'Test 2 Prop',
+          },
+        },
+      ],
+      sortable: true,
+      sortColumn: 'test',
+      initialSortAsc: false,
+    },
+    slots: {
+      test: '<p>{{ props.myprop }} static text</p>',
+    },
+  });
+
+  cy.get('[data-cy="data-table"]').find('[data-cy="data-table-row"]').as('table-rows');
+  cy.get('@table-rows').should('have.length', 2);
+
+  cy.get('@table-rows').eq(0).find('[data-cy="data-table-cell"]').first().as('table-cell-0');
+  cy.get('@table-rows').eq(1).find('[data-cy="data-table-cell"]').first().as('table-cell-1');
+
+  // Make sure we can sort by the value attribute
+  cy.get('@table-cell-0').should('contain.html', '<p>Test 1 Prop static text</p>');
+  cy.get('@table-cell-1').should('contain.html', '<p>Test 2 Prop static text</p>');
+
+  // Change the sort direction
+  cy.get('[data-cy="column-header"]').eq(0).click();
+
+  cy.get('@table-cell-0').should('contain.html', '<p>Test 2 Prop static text</p>');
+  cy.get('@table-cell-1').should('contain.html', '<p>Test 1 Prop static text</p>');
+});


### PR DESCRIPTION
This PR introduces a single standardized Vue component which can be used for all tables across the site.  This sortable table supports table cells with text, links, and custom components.  Column headers can be grouped.

As an example for developers to copy in the future, I have converted the main table on the projects page to the new template.