### PR TITLE
Bump CDash to v3.3

### DIFF
--- a/config/cdash.php
+++ b/config/cdash.php
@@ -21,7 +21,7 @@ return [
         'expires' => env('PASSWORD_EXPIRATION', 0),
         'unique' => env('UNIQUE_PASSWORD_COUNT', 0),
     ],
-    'version' => '3.2.0',
+    'version' => '3.3.0',
     'registration' => [
         'email' => [
             'verify' => env('REGISTRATION_EMAIL_VERIFY', true),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdash",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdash",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdash",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Continuous integration dashboard.",
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This PR should be the last thing merged before the CDash 3.3 branch is created, so that it is the most recent commit on the 3.3 branch.

By merging this into master before creating a release branch for 3.3, there will be less confusion about what the current version of master is derived from.  During the previous release cycle, master showed a version of 3.1, while in reality it was dozens commits ahead of 3.2, which confused the authors of multiple bug reports.