### PR TITLE
Remove broken "Compress Test Output" button

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -143,26 +143,6 @@ final class AdminController extends AbstractController
 
         $configFile = $config->get('CDASH_ROOT_DIR') . "/AuditReport.log";
 
-        // Compress the test output
-        if (isset($_POST['CompressTestOutput'])) {
-            // Do it slowly so we don't take all the memory
-            $query = pdo_query('SELECT count(*) FROM testoutput');
-            $query_array = pdo_fetch_array($query);
-            $ntests = $query_array[0];
-            $ngroup = 1024;
-            for ($i = 0; $i < $ntests; $i += $ngroup) {
-                $query = pdo_query('SELECT id,output FROM testoutput ORDER BY id ASC LIMIT ' . $ngroup . ' OFFSET ' . $i);
-                while ($query_array = pdo_fetch_array($query)) {
-                    // Try uncompressing to see if it's already compressed
-                    if (@gzuncompress($query_array['output']) === false) {
-                        $compressed = pdo_real_escape_string(gzcompress($query_array['output']));
-                        pdo_query("UPDATE testoutput SET output='" . $compressed . "' WHERE id=" . $query_array['id']);
-                        echo pdo_error();
-                    }
-                }
-            }
-        }
-
         // Compute the testtime
         if ($ComputeTestTiming) {
             $TestTimingDays = (int) ($_POST['TestTimingDays'] ?? 0);

--- a/app/cdash/public/upgrade.xsl
+++ b/app/cdash/public/upgrade.xsl
@@ -31,10 +31,6 @@
     <td><div align="left">for the last <input type="text" name="UpdateStatisticsDays" size="2" value="4"/> days <input type="submit" name="ComputeUpdateStatistics" value="Compute update statistics"/></div></td>
   </tr>
   <tr>
-    <td><div align="right">Compress test output (can take a long time):</div></td>
-    <td><input type="submit" name="CompressTestOutput" value="Compress test output"/></td>
-  </tr>
-  <tr>
     <td><div align="right">Cleanup CDash (can take a long time):</div></td>
     <td><input type="submit" name="Cleanup" value="Cleanup database"/></td>
   </tr>

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -78,18 +78,6 @@ class UpgradeTestCase extends KWWebTestCase
        }
      */
 
-    public function testCompressTestOutput()
-    {
-        if (!$this->getMaintenancePage()) {
-            return 1;
-        }
-        set_time_limit(0);
-        if (!$this->clickSubmitByName('CompressTestOutput')) {
-            $this->fail('clicking CompressTestOutput returned false');
-        }
-        $this->pass('Passed');
-    }
-
     public function testCleanup()
     {
         if (!$this->getMaintenancePage()) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -251,7 +251,7 @@ parameters:
 				#^Call to deprecated function pdo_error\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 4
+			count: 3
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -259,7 +259,7 @@ parameters:
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 10
+			count: 8
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -275,15 +275,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 15
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 12
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -331,7 +323,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on array\\|false\\|null\\.$#"
-			count: 2
+			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -26110,7 +26102,7 @@ parameters:
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_upgrade.php
 
 		-
@@ -26135,11 +26127,6 @@ parameters:
 
 		-
 			message: "#^Method UpgradeTestCase\\:\\:testCleanup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_upgrade.php
-
-		-
-			message: "#^Method UpgradeTestCase\\:\\:testCompressTestOutput\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_upgrade.php
 


### PR DESCRIPTION
The "Compress Test Output" button on the CDash maintenance page is currently broken.  The functionality is no longer necessary because all test output is compressed upon upload by default.  This PR simply removes the button and associated logic.

Fixes #1970.