### PR TITLE
Add GraphQL data loader Vue component

### DIFF
--- a/resources/js/components/shared/GraphqlLoader.vue
+++ b/resources/js/components/shared/GraphqlLoader.vue
@@ -1,0 +1,75 @@
+<template>
+  <loading-indicator :is-loading="isLoading">
+    <span
+      v-if="error"
+      data-cy="loading-error-message"
+    >
+      An error occurred while querying the API!
+    </span>
+    <slot
+      v-else
+      :data="data"
+    />
+  </loading-indicator>
+</template>
+
+<script>
+import LoadingIndicator from './LoadingIndicator.vue';
+
+export default {
+  name: 'GraphqlLoader',
+
+  components: {LoadingIndicator},
+
+  props: {
+    query: {
+      type: String,
+      default: '',
+    },
+    params: {
+      type: Object,
+      default: undefined,
+    },
+  },
+
+  data() {
+    return {
+      isLoading: true,
+      data: undefined,
+      error: false,
+    };
+  },
+
+  async mounted() {
+    this.isLoading = true;
+
+    await this.$axios.post(`${this.$baseURL}/graphql`, {
+      query: this.query,
+      variables: this.params,
+    })
+      .then((response) => {
+        if (!response || response.data.errors || !response.data.data) {
+          try {
+            // This was probably a GraphQL issue.  Log just the message for convenience.
+            // Network errors will fall into the axios catch() callback.
+            console.error(`GraphQL error: ${response.data.errors[0].message}`);
+          }
+          catch (e) {
+            // If it wasn't an obvious GraphQL issue we can parse, just log the entire response object.
+            console.error(response);
+          }
+          this.error = true;
+        }
+        else {
+          this.data = response.data.data;
+        }
+      })
+      .catch(() => {
+        this.error = true;
+      });
+
+    this.isLoading = false;
+  },
+};
+</script>
+

--- a/tests/cypress/component/graphql-loader.cy.js
+++ b/tests/cypress/component/graphql-loader.cy.js
@@ -1,0 +1,125 @@
+import GraphqlLoader from '../../../resources/js/components/shared/GraphqlLoader.vue';
+import axios from 'axios';
+import { config } from '@vue/test-utils';
+
+describe('GraphQL loader component tests', () => {
+  it('Displays loading indicator while loading', () => {
+    cy.intercept('**/graphql', {
+      delay: 1000,
+      statusCode: 200,
+      body: {
+        data: {
+          projects: {},
+        },
+      },
+    }).as('request');
+
+    cy.mount(GraphqlLoader, {
+      props: {
+        query: `
+          query {
+            projects {
+              name
+              builds {
+                name
+              }
+            }
+          }
+        `,
+      },
+      slots: {
+        default: '<div id="testcontent">test content</div>',
+      },
+      global: {
+        config: {
+          globalProperties: {
+            $axios: axios,
+            $baseURL: 'http://localhost:1234',
+          },
+        },
+      },
+    });
+
+    cy.get('#testcontent').should('not.exist');
+
+    cy.wait('@request');
+
+    cy.get('#testcontent').should('contain.text', 'test content');
+  });
+
+  it('Displays error message on invalid request', () => {
+    cy.intercept('**/graphql', {
+      statusCode: 200,
+      body: {
+        error: [
+          {
+            message: 'Invalid query',
+          },
+        ],
+      },
+    });
+
+    cy.mount(GraphqlLoader, {
+      props: {
+        query: `
+          this is not a valid query! }
+        `,
+      },
+      slots: {
+        default: '<div id="testcontent">test content</div>',
+      },
+      global: {
+        config: {
+          globalProperties: {
+            $axios: axios,
+            $baseURL: 'http://localhost:1234',
+          },
+        },
+      },
+    });
+
+    cy.get('#testcontent').should('not.exist');
+
+    cy.get('[data-cy="loading-error-message"]')
+      .should('be.visible')
+      .should('contain', 'An error occurred while querying the API!');
+  });
+
+  it('Displays error message on failed request', () => {
+    cy.intercept('**/graphql', {
+      forceNetworkError: true,
+    });
+
+    cy.mount(GraphqlLoader, {
+      props: {
+        query: `
+          query {
+            projects {
+              name
+              builds {
+                name
+              }
+            }
+          }
+        `,
+      },
+      slots: {
+        default: '<div id="testcontent">test content</div>',
+      },
+      global: {
+        config: {
+          globalProperties: {
+            $axios: axios,
+            $baseURL: 'http://localhost:1234',
+          },
+        },
+      },
+    });
+
+    cy.get('#testcontent').should('not.exist');
+
+    cy.get('[data-cy="loading-error-message"]')
+      .should('be.visible')
+      .should('contain', 'An error occurred while querying the API!');
+  });
+});


### PR DESCRIPTION
#1772 added a brand new GraphQL API.  Moving forward, we plan to gradually convert the entire CDash UI to use this new API.

This PR introduces a new Vue component which executes a GraphQL query, and provides the resulting data to a child component.  An example usage might look like this:
```vue
<graphql-loader
  query="
    query {
      projects {
        id
        name
        builds {
          id
          name
        }
      }
    }
  "
>
  <template v-slot="{ data }">
    Plain text or component here...  Use data like this: {{ data }}
  </template>
</graphql-loader>
```