### PR TITLE
Fix base URL for authtoken delete route in subpath

### DIFF
--- a/resources/js/components/ManageAuthTokens.vue
+++ b/resources/js/components/ManageAuthTokens.vue
@@ -119,7 +119,7 @@ export default {
   methods: {
     revokeToken(token) {
       this.$axios
-        .delete('/api/authtokens/delete/' + token.hash)
+        .delete(this.$baseURL + '/api/authtokens/delete/' + token.hash)
         .then(() => {
           this.$delete(this.cdash.tokens, token.hash);
         })


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/1973 missed the delete route on the manage auth tokens page.  This will be released as part of CDash 3.2.3.

Fixes #1980 