### PR TITLE
Expose site information via GraphQL

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -159,4 +159,12 @@ class Build extends Model
     {
         return $this->hasOneThrough(Configure::class, BuildConfigure::class, 'buildid', 'id', 'id', 'configureid');
     }
+
+    /**
+     * @return BelongsTo<Site, self>
+     */
+    public function site(): BelongsTo
+    {
+        return $this->belongsTo(Site::class, 'siteid', 'id');
+    }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -231,4 +231,15 @@ class Project extends Model
     {
         return $this->hasMany(Test::class, 'projectid', 'id');
     }
+
+    /**
+     * Queries the sites which have submitted builds to this project.  A convenience method to
+     * get sites from all builds in aggregate form.
+     *
+     * @return BelongsToMany<Site>
+     */
+    public function sites(): BelongsToMany
+    {
+        return $this->belongsToMany(Site::class, Build::class, 'projectid', 'siteid')->distinct();
+    }
 }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ add_unit_test(/CDash/XmlHandler/TestingHandler)
 add_unit_test(/CDash/XmlHandler/UpdateHandler)
 
 add_laravel_test(/Feature/GraphQL/ProjectTest)
+add_laravel_test(/Feature/GraphQL/SiteTest)
 
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
 add_laravel_test(/Feature/TestSchemaMigration)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -72,6 +72,9 @@ type Project {
   homeurl: String!
 
   builds: [Build!]! @hasMany @orderBy(column: "id")
+
+  "The sites which have submitted a build to this project."
+  sites: [Site!]! @belongsToMany @orderBy(column: "id")
 }
 
 
@@ -89,5 +92,24 @@ type Build {
   "End time."
   endtime: DateTime!
 
+  "The site associated with this build."
+  site: Site! @belongsTo
+
   # TODO: Figure out project relation.  project{build{project}} currently throws an error.
+}
+
+
+"Site."
+type Site {
+  "Unique primary key."
+  id: ID!
+
+  name: String!
+
+  "IP address."
+  ip: String!
+
+  latitude: Float!
+
+  longitude: Float!
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3007,6 +3007,11 @@ parameters:
 			path: app/Models/BuildTest.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\Site\\>\\:\\:distinct\\(\\)\\.$#"
+			count: 1
+			path: app/Models/Project.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:orWhere\\(\\)\\.$#"
 			count: 1
 			path: app/Models/Project.php

--- a/tests/Feature/GraphQL/SiteTest.php
+++ b/tests/Feature/GraphQL/SiteTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+use Tests\Traits\CreatesUsers;
+
+class SiteTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+    use CreatesSites;
+
+    /**
+     * @var array<Project> $projects
+     */
+    private array $projects;
+
+    /**
+     * @var array<User> $users
+     */
+    private array $users;
+
+    /**
+     * @var array<Site> $sites
+     */
+    private array $sites = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projects = [
+            'public1' => Project::findOrFail((int) $this->makePublicProject()->Id),
+            'private1' => Project::findOrFail((int) $this->makePrivateProject()->Id),
+        ];
+
+        $this->users = [
+            'normal' => $this->makeNormalUser(),
+            'admin' => $this->makeAdminUser(),
+        ];
+
+        $user2project_data = [
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => true,
+            'emailmissingsites' => true,
+        ];
+
+        $this->projects['public1']
+            ->users()
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+
+        $this->projects['private1']
+            ->users()
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->projects as $project) {
+            $project->delete();
+        }
+        $this->projects = [];
+
+        foreach ($this->users as $user) {
+            $user->delete();
+        }
+        $this->users = [];
+
+        foreach ($this->sites as $site) {
+            $site->delete();
+        }
+        $this->users = [];
+
+        parent::tearDown();
+    }
+
+    public function testSiteBuildRelationship(): void
+    {
+        $this->sites['site1'] = $this->makeSite();
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    builds {
+                        site {
+                            name
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    [
+                        'builds' => [
+                            [
+                                'site' => [
+                                    'name' => $this->sites['site1']->name,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    /**
+     * Users can see sites which have submitted a build to any project they can see.
+     */
+    public function testSiteVisibility(): void
+    {
+        // No usages
+        $this->sites['unused'] = $this->makeSite([
+            'name' => 'unused',
+        ]);
+
+        // Only submits to public projects
+        $this->sites['public_submission'] = $this->makeSite([
+            'name' => 'public_submission',
+        ]);
+
+        // Only submits to private projects
+        $this->sites['private_submission'] = $this->makeSite([
+            'name' => 'private_submission',
+        ]);
+
+        // Submits to both public and private projects
+        $this->sites['public_private_submission'] = $this->makeSite([
+            'name' => 'public_private_submission',
+        ]);
+
+        // Add a few builds
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['public_submission']->id,
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'build2',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['public_private_submission']->id,
+        ]);
+        $this->projects['private1']->builds()->create([
+            'name' => 'build3',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['public_private_submission']->id,
+        ]);
+        $this->projects['private1']->builds()->create([
+            'name' => 'build4',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['private_submission']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    name
+                    sites {
+                        name
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    [
+                        'name' => $this->projects['public1']->name,
+                        'sites' => [
+                            [
+                                'name' => $this->sites['public_submission']->name,
+                            ],
+                            [
+                                'name' => $this->sites['public_private_submission']->name,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+
+        $this->actingAs($this->users['normal'])->graphQL('
+            query {
+                projects {
+                    name
+                    sites {
+                        name
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    [
+                        'name' => $this->projects['public1']->name,
+                        'sites' => [
+                            [
+                                'name' => $this->sites['public_submission']->name,
+                            ],
+                            [
+                                'name' => $this->sites['public_private_submission']->name,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            query {
+                projects {
+                    name
+                    sites {
+                        name
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    [
+                        'name' => $this->projects['public1']->name,
+                        'sites' => [
+                            [
+                                'name' => $this->sites['public_submission']->name,
+                            ],
+                            [
+                                'name' => $this->sites['public_private_submission']->name,
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => $this->projects['private1']->name,
+                        'sites' => [
+                            [
+                                'name' => $this->sites['private_submission']->name,
+                            ],
+                            [
+                                'name' => $this->sites['public_private_submission']->name,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+}

--- a/tests/Traits/CreatesSites.php
+++ b/tests/Traits/CreatesSites.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Traits;
+
+use App\Models\Site;
+use Illuminate\Support\Str;
+
+trait CreatesSites
+{
+    /**
+     * @param array<string,mixed> $attributes
+     */
+    public function makeSite(array $attributes = []): Site
+    {
+        $attributes['name'] = ($attributes['name'] ?? 'Site') . '_' . Str::uuid()->toString();
+        return Site::create($attributes);
+    }
+}


### PR DESCRIPTION
This PR adds GraphQL fields which expose site data for individual builds, as well as aggregate site data for entire projects.  In the future, I will expand upon this by adding "site information", as well as a top-level site field.