### PR TITLE
Redirect old OAuth routes to Socialite

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -27,9 +27,9 @@ Auth::routes($routeList);
 Route::match(['get', 'post'], '/install', 'AdminController@install');
 Route::permanentRedirect('/install.php', '/install');
 
-Route::get('/oauth/{service}', 'OAuthController@authenticate');
-Route::get('/oauth/callback/{service}', 'OAuthController@login')
-    ->name('oauth.callback');
+Route::get('/oauth/{service}', 'OAuthController@socialite');
+Route::get('/oauth/callback/{service}', 'OAuthController@callback');
+
 Route::post('/saml2/login', 'Auth\LoginController@saml2Login');
 
 Route::get('/auth/{service}/redirect', 'OAuthController@socialite');


### PR DESCRIPTION
Change the controller for the old OAuth routes to be the new Socialite functions.  This should prevent already existing Apps from needing to change the redirect URL to match the current framework.