### PR TITLE
Bugfix reroute for the build configure page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -74,7 +74,7 @@ Route::get('/buildSummary.php', function (Request $request) {
 });
 
 Route::get('/builds/{id}/configure', 'BuildController@configure');
-Route::permanentRedirect('/builds/{id}/configure', '/builds/{id}/configure');
+Route::permanentRedirect('/build/{id}/configure', '/builds/{id}/configure');
 Route::get('/viewConfigure.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/configure", 301);


### PR DESCRIPTION
This change fixes to a typo in the pluralization rerouting logic (introduced in https://github.com/Kitware/CDash/pull/1900) that broke all existing references to the url: `build/<buildid>/configure`.