### PR TITLE
Don't fail date validation on PHP >= 8.2

### DIFF
--- a/app/cdash/app/Controller/Api/ResultsApi.php
+++ b/app/cdash/app/Controller/Api/ResultsApi.php
@@ -81,8 +81,11 @@ abstract class ResultsApi extends ProjectApi
     public function validateDateString($date)
     {
         $dt = \DateTime::createFromFormat("Y-m-d", $date);
-        if ($dt !== false && !array_sum($dt::getLastErrors())) {
-            return $date;
+        if ($dt !== false) {
+            $err = $dt::getLastErrors();
+            if ($err === false || array_sum($err) === 0) {
+                return $date;
+            }
         }
         return false;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5589,16 +5589,6 @@ parameters:
 			path: app/cdash/app/Controller/Api/ResultsApi.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, \\(float\\|int\\) given\\.$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/ResultsApi.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_sum expects array, array\\<string, array\\<int, string\\>\\|int\\>\\|false given\\.$#"
-			count: 1
-			path: app/cdash/app/Controller/Api/ResultsApi.php
-
-		-
 			message: "#^Property CDash\\\\Controller\\\\Api\\\\ResultsApi\\:\\:\\$beginDate has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ResultsApi.php


### PR DESCRIPTION
As specified [here](https://www.php.net/manual/en/datetimeimmutable.getlasterrors.php), before PHP 8.2.0, `DateTime::getLastErrors()` did not return `false` when there were no warnings or errors. Instead, it would always return the documented array structure. But on PHP 8.2.0 and newer, it actually may be `false`, and using `array_sum()` on it shall cause an error like:
```
[2024-02-13 19:47:40] production.ERROR: array_sum(): Argument #1 ($array) must be of type array, false given {"userId":1,"exception":"[object] (TypeError(code: 0): array_sum(): Argument #1 ($array) must be of type array, false given at /opt/CDash/app/cdash/app/Controller/Api/ResultsApi.php:84)
[stacktrace]
#0 /opt/CDash/app/cdash/app/Controller/Api/ResultsApi.php(84): array_sum()
#1 /opt/CDash/app/cdash/app/Controller/Api/ResultsApi.php(153): CDash\\Controller\\Api\\ResultsApi->validateDateString()
...
```
And this leads to complete unusable build results pages except the one for current date.

This PR fixes it.