### PR TITLE
Create storage directories automatically

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,9 @@ else
   composer install --no-dev --optimize-autoloader
 fi
 
+echo "Creating storage directories..."
+php artisan storage:mkdirs
+
 echo "Running migrations..."
 php artisan migrate --force
 


### PR DESCRIPTION
Storage directories are not created by default when running `cdash_install` currently.  Requiring users to run the `storage:mkdirs` artisan command manually creates unnecessary busywork.  This PR changes the behavior to create the required directories automatically on install.