### PR TITLE
Backport Project Administration disabling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,9 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # Whether or not "normal" username+password registration form submission is enabled
 # USER_REGISTRATION_FORM_ENABLED=true
 
+# Whether or not a Project administrator can register a user
+# PROJECT_ADMIN_REGISTRATION_FORM_ENABLED=true
+
 
 # ldap.php
 #LDAP_HOSTS=

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -399,6 +399,9 @@ final class ManageProjectRolesController extends AbstractProjectController
         if ($config->get('CDASH_FULL_EMAIL_WHEN_ADDING_USER') == 1) {
             $xml .= add_XML_value('fullemail', '1');
         }
+        if ((config('auth.project_admin_registration_form_enabled') === true) || $current_user->admin) {
+            $xml .= add_XML_value('canRegister', '1');
+        }
         $xml .= '</cdash>';
 
         return view('cdash', [
@@ -412,6 +415,10 @@ final class ManageProjectRolesController extends AbstractProjectController
     private function register_user($projectid, $email, $firstName, $lastName, $repositoryCredential)
     {
         $config = Config::getInstance();
+
+        if(config('auth.project_admin_registration_form_enabled') === false) {
+            return '<error>Users cannot be registered via this form at the current time.</error>';
+        }
 
         $UserProject = new UserProject();
         $UserProject->ProjectId = $projectid;

--- a/app/cdash/public/manageProjectRoles.xsl
+++ b/app/cdash/public/manageProjectRoles.xsl
@@ -103,8 +103,10 @@
             <a href="#fragment-1"><span>Current users</span></a></li>
           <li>
             <a href="#fragment-2"><span>Search for already registered users</span></a></li>
-          <li>
-            <a href="#fragment-3"><span>Register a new user</span></a></li>
+          <xsl:if test="/cdash/canRegister">
+            <li>
+              <a href="#fragment-3"><span>Register a new user</span></a></li>
+          </xsl:if>
           <li>
             <a href="#fragment-4"><span>Import users from CVS file </span></a></li>
       </ul>
@@ -230,44 +232,46 @@
             </tr>
           </table>
     </div>
-    <div id="fragment-3" class="tab_content" >
-        <div class="tab_help"></div>
-        <form  method="post">
-          <table width="800"  border="0">
-            <tr>
-                <td><div align="right">User Email:</div></td>
-            <td>
-            <input name="registeruseremail" type="text" id="registeruseremail" size="40"/>
-            </td>
-            </tr>
-            <tr>
-             <td><div align="right">First name:</div></td>
-            <td>
-            <input name="registeruserfirstname" type="text" id="registeruserfirstname" size="40"/>
-            </td>
-            </tr>
-            <tr>
-             <td><div align="right">Last name:</div></td>
-            <td>
-            <input name="registeruserlastname" type="text" id="registeruserlastname" size="40"/>
-            </td>
-            </tr>
-            <tr>
-             <td><div align="right">Repository credential:</div></td>
-            <td>
-            <input name="registeruserrepositorycredential" type="text" id="registeruserrepositorycredential" size="40"/>
-            * email address is automatically added as a credential
-            </td>
-            </tr>
-            <tr>
-            <td></td>
-            <td>
-            <input type="submit" name="registerUser" value="Register User"/>
-            </td>
-            </tr>
-          </table>
-          </form>
-    </div>
+    <xsl:if test="/cdash/canRegister">
+      <div id="fragment-3" class="tab_content" >
+          <div class="tab_help"></div>
+          <form  method="post">
+            <table width="800"  border="0">
+              <tr>
+                  <td><div align="right">User Email:</div></td>
+              <td>
+              <input name="registeruseremail" type="text" id="registeruseremail" size="40"/>
+              </td>
+              </tr>
+              <tr>
+              <td><div align="right">First name:</div></td>
+              <td>
+              <input name="registeruserfirstname" type="text" id="registeruserfirstname" size="40"/>
+              </td>
+              </tr>
+              <tr>
+              <td><div align="right">Last name:</div></td>
+              <td>
+              <input name="registeruserlastname" type="text" id="registeruserlastname" size="40"/>
+              </td>
+              </tr>
+              <tr>
+              <td><div align="right">Repository credential:</div></td>
+              <td>
+              <input name="registeruserrepositorycredential" type="text" id="registeruserrepositorycredential" size="40"/>
+              * email address is automatically added as a credential
+              </td>
+              </tr>
+              <tr>
+              <td></td>
+              <td>
+              <input type="submit" name="registerUser" value="Register User"/>
+              </td>
+              </tr>
+            </table>
+            </form>
+      </div>
+    </xsl:if>
     <div id="fragment-4" class="tab_content" >
         <div class="tab_help"></div>
           <table width="800"  border="0">

--- a/config/auth.php
+++ b/config/auth.php
@@ -5,6 +5,8 @@ return [
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),
     // Whether or not "normal" username+password authentication is enabled
     'user_registration_form_enabled' => env('USER_REGISTRATION_FORM_ENABLED', true),
+    # Whether or not a Project administrator can register a user
+    'project_admin_registration_form_enabled' => env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Originally was: 3003562cb032b7517d6a97e56fbaad32382b2f06

Add config to disable Project Administrator user registration (#2019)

Add a new environment variable that will disable the registration form that is found on the manageProjectRoles page. If the current user is a site administrator, the form will always be shown.

Issue: #2007