### PR TITLE
Add 'inprogress' to the list of directories to clean

### DIFF
--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -1135,7 +1135,7 @@ function addDailyChanges(int $projectid): void
 
         // Clean the backup directories.
         $timeframe = config('cdash.backup_timeframe');
-        $dirs_to_clean = ['parsed', 'failed'];
+        $dirs_to_clean = ['parsed', 'failed', 'inprogress'];
         foreach ($dirs_to_clean as $dir_to_clean) {
             $files = Storage::allFiles($dir_to_clean);
             foreach ($files as $filename) {


### PR DESCRIPTION
Automatically delete old files out of the `inprogress/` directory in case they get stuck here for some reason.