### PR TITLE
Improve flakiness of `sub-project-group-order` test

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
   downloadsFolder: 'tests/cypress/downloads',
   trashAssetsBeforeRuns: true,
   pageLoadTimeout: 300000,
+  retries: 2,
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/tests/cypress/e2e/sub-project-group-order.cy.js
+++ b/tests/cypress/e2e/sub-project-group-order.cy.js
@@ -2,11 +2,7 @@ describe('subProjectGroupOrder', () => {
 
   it('can change the group order', () => {
     cy.login();
-    cy.visit('index.php?project=CrossSubProjectExample');
-
-    // hover over 'Settings' and click 'SubProjects'
-    cy.get('#admin').contains('a', 'SubProjects').click({ force: true });
-    cy.url().should('contain', 'manageSubProject.php?projectid=16');
+    cy.visit('manageSubProject.php?projectid=16');
 
     // navigate to the 'SubProjects Groups' tab
     cy.get('a').contains('SubProject Groups').click();


### PR DESCRIPTION
This is an attempt to improve the flakey behavior seen by the `sub-project-group-order` Cypress test on our CI (see [here](https://open.cdash.org/testSummary.php?project=24&name=cypress%2Fe2e%2Fsub-project-group-order&date=2024-03-01)). We speculate that the flakes have to do with the UI design of the page and how Cypress can interact with it, namely actions like hover, and drag and drop.