### PR TITLE
Add parallelism to CTest CI tests

### DIFF
--- a/.circleci/commands.bash
+++ b/.circleci/commands.bash
@@ -34,7 +34,7 @@ cdash_run_and_submit_ctest() {
   echo "postgres=$postgres"
   echo "ctest_driver=$ctest_driver"
 
-  docker exec --user www-data cdash bash -c "/usr/bin/ctest -VV -DSITENAME=\"${site}\" -DBUILDNAME=\"${branch}_${database}\" -Dpostgres=${postgres} -S ${ctest_driver}"
+  docker exec --user www-data cdash bash -c "/usr/bin/ctest -VV -j 2 --schedule-random -DSITENAME=\"${site}\" -DBUILDNAME=\"${branch}_${database}\" -Dpostgres=${postgres} -S ${ctest_driver}"
 }
 
 cdash_run_and_submit_mysql_ctest() {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,18 @@ jobs:
           name: MySQL Build
           command: |
             set -x
-            source ~/project/docker/commands.bash
+            source ~/project/.circleci/commands.bash
             docker compose -f docker/docker-compose.yml \
                            -f docker/docker-compose.dev.yml \
                            -f docker/docker-compose.mysql.yml \
                            --env-file .env.dev up -d \
-                           --build
+                           --build \
+                           --wait
       - run:
           name: Test MySQL
           command: |
             set -x
-            source ~/project/docker/commands.bash
+            source ~/project/.circleci/commands.bash
             cdash_run_and_submit_mysql_ctest
       - run:
           name: Tear Down MySQL Build
@@ -34,17 +35,18 @@ jobs:
           name: Postgres Build
           command: |
             set -x
-            source ~/project/docker/commands.bash
+            source ~/project/.circleci/commands.bash
             docker compose -f docker/docker-compose.yml \
                            -f docker/docker-compose.dev.yml \
                            -f docker/docker-compose.postgres.yml \
                            --env-file .env.dev up -d \
-                           --build
+                           --build \
+                           --wait
       - run:
           name: Test Postgres
           command: |
             set -x
-            source ~/project/docker/commands.bash
+            source ~/project/.circleci/commands.bash
             cdash_run_and_submit_pgsql_ctest
       - run:
           name: Build Production Docker Images


### PR DESCRIPTION
This PR serves as a follow up to PR https://github.com/Kitware/CDash/pull/2077 to take advantage of the new ability to run some of the tests in parallel. Also, as per @williamjallen's request in https://github.com/Kitware/CDash/pull/2078#pullrequestreview-1913036531, the `docker/commands.bash` script was moved to the `.circleci/` directory. 