### PR TITLE
Replace usage of deprecated PHPUnit `returnCallback()` function

### DIFF
--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -82,10 +82,9 @@ class CDashTestCase extends TestCase
         $mock_pdo
             ->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($arg) {
+            ->willReturnCallback(function ($arg) {
                 return "'" . $arg . "'";
-            })
-            );
+            });
 
         Database::setInstance(Database::class, $mock_pdo);
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12412,11 +12412,6 @@ parameters:
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
-			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:returnCallback\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/include/Test/CDashTestCase.php
-
-		-
 			message: "#^Method CDash\\\\Test\\\\CDashTestCase\\:\\:createMockFromBuilder\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Test/CDashTestCase.php


### PR DESCRIPTION
This PR is meant to serve as a first step for addressing changes that will need to be made before https://github.com/Kitware/CDash/pull/1866 can be merged. The PHPUnit function `returnCallback()` is [deprecated](https://github.com/sebastianbergmann/phpunit/issues/5423), so our usage of it was switched to its shorthand syntax, as recommended by the docs.