### PR TITLE
Replace most usages of deprecated PHPUnit `setMethods()` function 

### DIFF
--- a/app/cdash/include/Test/BuildDiffForTesting.php
+++ b/app/cdash/include/Test/BuildDiffForTesting.php
@@ -81,7 +81,7 @@ trait BuildDiffForTesting
     {
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
+            ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
             ->getMock();
 
         $build->expects($this->any())

--- a/app/cdash/include/Test/CDashUseCaseTestCase.php
+++ b/app/cdash/include/Test/CDashUseCaseTestCase.php
@@ -28,7 +28,7 @@ class CDashUseCaseTestCase extends CDashTestCase
 
         $mockServiceContainer = $this->getMockBuilder(ServiceContainer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $mockServiceContainer

--- a/app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
+++ b/app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
@@ -28,7 +28,7 @@ class GitHubWebhookTest extends CDash\Test\CDashTestCase
 
         $this->mock_system = $this->getMockBuilder(System::class)
             ->disableOriginalConstructor()
-            ->setMethods(['system_exit'])
+            ->onlyMethods(['system_exit'])
             ->getMock();
         $container->set(System::class, $this->mock_system);
 

--- a/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -297,7 +297,7 @@ class GitHubTest extends TestCase
 
         $client = $this->getMockBuilder(\Github\Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(['api', 'authenticate', 'getHttpClient'])
+            ->onlyMethods(['api', 'authenticate', 'getHttpClient'])
             ->getMock();
         $client->expects($this->any())
             ->method('authenticate');

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
@@ -113,7 +113,7 @@ class CommitAuthorSubscriptionBuilderTest extends TestCase
         /** @var BuildGroup|PHPUnit_Framework_MockObject_MockObject $mock_group */
         $mock_group = $this->getMockBuilder(BuildGroup::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isNotifyingCommitters'])
+            ->onlyMethods(['isNotifyingCommitters'])
             ->getMock();
 
         $mock_group->expects($this->any())
@@ -123,7 +123,7 @@ class CommitAuthorSubscriptionBuilderTest extends TestCase
         /** @var ActionableBuildInterface|PHPUnit_Framework_MockObject_MockObject $mock_handler */
         $mock_handler = $this->getMockBuilder($handler_class)
             ->disableOriginalConstructor()
-            ->setMethods(['GetProject', 'GetSite', 'GetBuildCollection', 'GetCommitAuthors', 'GetBuildGroup', 'GetTopicCollectionForSubscriber'])
+            ->onlyMethods(['GetProject', 'GetSite', 'GetBuildCollection', 'GetCommitAuthors', 'GetBuildGroup', 'GetTopicCollectionForSubscriber'])
             ->getMock();
 
         $mock_handler->expects($this->any())

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -69,7 +69,7 @@ class UserSubscriptionBuilderTest extends TestCase
             ->getMockForAbstractClass();
 
         $mock_project = $this->getMockBuilder(Project::class)
-            ->setMethods(['GetSubscriberCollection'])
+            ->onlyMethods(['GetSubscriberCollection'])
             ->getMock();
 
         $mock_project->expects($this->any())

--- a/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
@@ -39,7 +39,7 @@ class AuthoredTopicTest extends \CDash\Test\CDashTestCase
 
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetCommitAuthors'])
+            ->onlyMethods(['GetCommitAuthors'])
             ->getMock();
 
         $build->expects($this->exactly(2))

--- a/app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
@@ -173,7 +173,7 @@ class BuildErrorTopicTest extends \CDash\Test\CDashTestCase
 
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetErrorDifferences'])
+            ->onlyMethods(['GetErrorDifferences'])
             ->getMock();
 
         $build->expects($this->never())
@@ -185,7 +185,7 @@ class BuildErrorTopicTest extends \CDash\Test\CDashTestCase
         $this->assertFalse($sut->hasFixes());
 
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
+            ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
             ->getMock();
 
         $build->expects($this->once())

--- a/app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
@@ -27,7 +27,7 @@ class MissingTestTopicTest extends TestCase
 
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build1 */
         $build1 = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetMissingTests'])
+            ->onlyMethods(['GetMissingTests'])
             ->getMock();
 
         $build1->expects($this->once())
@@ -39,7 +39,7 @@ class MissingTestTopicTest extends TestCase
 
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build2 */
         $build2 = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetMissingTests'])
+            ->onlyMethods(['GetMissingTests'])
             ->getMock();
 
         $build2->expects($this->once())
@@ -86,7 +86,7 @@ class MissingTestTopicTest extends TestCase
 
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $build2 */
         $build2 = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetMissingTests'])
+            ->onlyMethods(['GetMissingTests'])
             ->getMock();
 
         $build2->expects($this->any())

--- a/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
@@ -320,7 +320,7 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $diff = $this->createNew('testfailedpositive');
         $diff['testfailedpositive'] = 0;
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetErrorDifferences', 'GetPreviousBuildId', 'GetNumberOfFailedTests'])
+            ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId', 'GetNumberOfFailedTests'])
             ->getMock();
         $build->expects($this->any())
             ->method('GetErrorDifferences')

--- a/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
@@ -24,7 +24,7 @@ class BuildFailureTest extends CDashTestCase
         $container = ServiceContainer::container();
         $this->mock_buildfailure = $this->getMockBuilder(BuildFailure::class)
             ->disableOriginalConstructor()
-            ->setMethods(['GetBuildFailureArguments'])
+            ->onlyMethods(['GetBuildFailureArguments'])
             ->getMock();
         $this->mock_project = $this->getMockBuilder(Project::class)
             ->disableOriginalConstructor()

--- a/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
@@ -29,7 +29,7 @@ class BuildRelationshipTest extends CDashTestCase
 
         $this->mock_build1 = $this->getMockBuilder(Build::class)
             ->disableOriginalConstructor()
-            ->setMethods(['Exists', 'FillFromId'])
+            ->onlyMethods(['Exists', 'FillFromId'])
             ->getMock();
         $this->mock_build1->Id = 1;
         $this->mock_build1->ProjectId = 1;
@@ -37,7 +37,7 @@ class BuildRelationshipTest extends CDashTestCase
 
         $this->mock_build2 = $this->getMockBuilder(Build::class)
             ->disableOriginalConstructor()
-            ->setMethods(['Exists', 'FillFromId'])
+            ->onlyMethods(['Exists', 'FillFromId'])
             ->getMock();
         $this->mock_build2->Id = 2;
         $this->mock_build2->ProjectId = 1;

--- a/app/cdash/tests/case/CDash/Model/BuildTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildTest.php
@@ -41,7 +41,7 @@ class BuildTest extends CDashTestCase
         // TODO: refactor asap
         /** @var Build|PHPUnit_Framework_MockObject_MockObject $sut */
         $sut = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
+            ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
             ->getMock();
         $sut->Id = 1;
         $sut->expects($this->once())

--- a/app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
+++ b/app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
@@ -29,7 +29,7 @@ class PendingSubmissionsTest extends CDashTestCase
 
         $this->mock_build = $this->getMockBuilder(Build::class)
             ->disableOriginalConstructor()
-            ->setMethods(['Exists', 'FillFromId'])
+            ->onlyMethods(['Exists', 'FillFromId'])
             ->getMock();
         $this->mock_build->Id = 1;
         $this->mock_build->ProjectId = 1;

--- a/app/cdash/tests/case/CDash/Model/RepositoryTest.php
+++ b/app/cdash/tests/case/CDash/Model/RepositoryTest.php
@@ -30,7 +30,7 @@ class RepositoryTest extends TestCase
 
         $this->project = $this->getMockBuilder(Project::class)
             ->disableOriginalConstructor()
-            ->setMethods(['GetRepositories'])
+            ->onlyMethods(['GetRepositories'])
             ->getMock();
 
         $this->project->CvsViewerType = Repository::VIEWER_GITHUB;

--- a/app/cdash/tests/case/CDash/ServiceContainerTest.php
+++ b/app/cdash/tests/case/CDash/ServiceContainerTest.php
@@ -44,7 +44,7 @@ class ServiceContainerTest extends CDashTestCase
     {
         $mock_di = $this->getMockBuilder(DI\Container::class)
             ->disableOriginalConstructor()
-            ->setMethods(['make'])
+            ->onlyMethods(['make'])
             ->getMock();
 
         $mock_di
@@ -61,7 +61,7 @@ class ServiceContainerTest extends CDashTestCase
     {
         $mock_di = $this->getMockBuilder(DI\Container::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->getMock();
 
         $mock_di

--- a/app/cdash/tests/case/CDash/Submission/CommitAuthorHandlerTraitTest.php
+++ b/app/cdash/tests/case/CDash/Submission/CommitAuthorHandlerTraitTest.php
@@ -10,12 +10,12 @@ class CommitAuthorHandlerTraitTest extends TestCase
     {
         $has_errors = $this->getMockBuilder(Build::class)
             ->disableOriginalConstructor()
-            ->setMethods(['GetCommitAuthors'])
+            ->onlyMethods(['GetCommitAuthors'])
             ->getMock();
 
         $has_warnings = $this->getMockBuilder(Build::class)
             ->disableOriginalConstructor()
-            ->setMethods(['GetCommitAuthors'])
+            ->onlyMethods(['GetCommitAuthors'])
             ->getMock();
 
         $has_errors->expects($this->once())

--- a/app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
@@ -37,7 +37,7 @@ class UpdateHandlerTest extends CDashTestCase
     public function testGetCommitAuthors()
     {
         $build = $this->getMockBuilder(Build::class)
-            ->setMethods(['GetCommitAuthors'])
+            ->onlyMethods(['GetCommitAuthors'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12511,7 +12511,7 @@ parameters:
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
 
 		-
@@ -16189,14 +16189,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 3
 			path: app/cdash/tests/case/CDash/Api/GitHubWebhookTest.php
@@ -16560,7 +16552,7 @@ parameters:
 				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
 				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
 			"""
-			count: 4
+			count: 3
 			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
 
 		-
@@ -16694,14 +16686,6 @@ parameters:
 		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
@@ -16925,14 +16909,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -17048,14 +17024,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
-
-		-
 			message: "#^Call to method expects\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
@@ -17098,14 +17066,6 @@ parameters:
 		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 4
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
 		-
@@ -17479,14 +17439,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
@@ -17607,14 +17559,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 3
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
 			message: "#^Call to method expects\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
@@ -17701,14 +17645,6 @@ parameters:
 
 		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
@@ -17968,14 +17904,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
@@ -18224,14 +18152,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildFailureTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/BuildFailureTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildFailureTest.php
@@ -18277,14 +18197,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 11
 			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
@@ -18327,14 +18239,6 @@ parameters:
 		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 2
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 
 		-
@@ -18443,14 +18347,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 8
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
@@ -18459,14 +18355,6 @@ parameters:
 			message: "#^Method PendingSubmissionsTest\\:\\:testPendingSubmissionsModel\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
 
 		-
 			message: "#^Call to method getInstallationId\\(\\) on an unknown class CDash\\\\Model\\\\RepositoryInterface\\.$#"
@@ -18717,14 +18605,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/cdash/tests/case/CDash/ServiceContainerTest.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/ServiceContainerTest.php
@@ -18768,14 +18648,6 @@ parameters:
 			message: "#^Property ServiceContainerTest\\:\\:\\$di has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/ServiceContainerTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/cdash/tests/case/CDash/Submission/CommitAuthorHandlerTraitTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContains\\(\\)\\.$#"
@@ -19236,14 +19108,6 @@ parameters:
 			message: "#^Method TestingHandlerTest\\:\\:testTestingHandlerIsACommitAuthorHandler\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/XmlHandler/TestingHandlerTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'CDash\\\\\\\\Submission\\\\\\\\CommitAuthorHandlerInterface' and UpdateHandler will always evaluate to true\\.$#"
@@ -30016,14 +29880,6 @@ parameters:
 			message: "#^Property Tests\\\\Feature\\\\PasswordRotation\\:\\:\\$user has no type specified\\.$#"
 			count: 1
 			path: tests/Feature/PasswordRotation.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: tests/Feature/ProjectPermissions.php
 
 		-
 			message: "#^Property Tests\\\\Feature\\\\ProjectPermissions\\:\\:\\$mock_system has no type specified\\.$#"

--- a/tests/Feature/ProjectPermissions.php
+++ b/tests/Feature/ProjectPermissions.php
@@ -40,7 +40,7 @@ class ProjectPermissions extends TestCase
         $container = ServiceContainer::container();
         $this->mock_system = $this->getMockBuilder(System::class)
             ->disableOriginalConstructor()
-            ->setMethods(['system_exit'])
+            ->onlyMethods(['system_exit'])
             ->getMock();
         $container->set(System::class, $this->mock_system);
     }


### PR DESCRIPTION
This PR is the second in the series for addressing changes that will need to be made before https://github.com/Kitware/CDash/pull/1866 can be merged. The PHPUnit function `setMethods()` is [deprecated](https://github.com/sebastianbergmann/phpunit/blob/9.6/DEPRECATIONS.md#test-double-api), so our usages of it were switched to `onlyMethods()` instead. The only locations that weren't updated and still being suppressed in `phpstan-baseline.neon` are:
* `app/cdash/include/Test/CDashTestCase.php`
* `app/cdash/include/Test/CDashUseCaseTestCase.php`
* `app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php`
* `app/cdash/tests/case/CDash/Model/BuildErrorTest.php`
* `tests/Unit/app/Validators/PasswordTest.php`

since a simple replacement of `setMethods()` by `onlyMethods()` does not work for these cases.


