### PR TITLE
Add new UBI-based CDash image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 project(CDash)
 include(CTest)
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file(
 # set some cache variables that can be used
 # to configure the testing install
 set(CDASH_SERVER localhost CACHE STRING "CDash testing server")
+set(CDASH_IMAGE "$ENV{BASE_IMAGE}" CACHE STRING "Docker image name")
 
 get_filename_component(CDASH_DIR_NAME_DEFAULT ${CDash_SOURCE_DIR} NAME)
 set(CDASH_DIR_NAME "${CDASH_DIR_NAME_DEFAULT}" CACHE STRING "URL suffix. Ie 'http://<CDASH_SERVER>/<CDASH_DIR_NAME>'")

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -100,7 +100,10 @@ add_unit_test(/CDash/Database)
 set_tests_properties(/CDash/Database PROPERTIES DEPENDS /CDash/ConfigUseCase)
 
 add_unit_test(/CDash/Lib/Repository/GitHub)
-set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES DEPENDS /CDash/Database)
+set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES
+    DEPENDS /CDash/Database
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
+)
 
 add_unit_test(/CDash/LinkifyCompilerOutput)
 set_tests_properties(/CDash/LinkifyCompilerOutput PROPERTIES DEPENDS /CDash/Lib/Repository/GitHub)

--- a/app/cdash/tests/ctest/coveragedriver.ctest.in
+++ b/app/cdash/tests/ctest/coveragedriver.ctest.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 
 # Settings:

--- a/app/cdash/tests/ctest/ctestdriver.ctest.in
+++ b/app/cdash/tests/ctest/ctestdriver.ctest.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 
 # Settings:

--- a/app/cdash/tests/ctest/sameImage/CMakeLists.txt
+++ b/app/cdash/tests/ctest/sameImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 project(SameImage)
 include(CTest)
 

--- a/app/cdash/tests/ctest/sameImage/test.cmake.in
+++ b/app/cdash/tests/ctest/sameImage/test.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 # Settings:
 set(CTEST_DASHBOARD_ROOT                "@CMake_BINARY_DIR@/Tests/CTestTest")

--- a/app/cdash/tests/ctest/simple/CMakeLists.txt
+++ b/app/cdash/tests/ctest/simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 project(Simple)
 include(CTest)
 

--- a/app/cdash/tests/ctest/simple/test.cmake.in
+++ b/app/cdash/tests/ctest/simple/test.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 # Settings:
 set(CTEST_DASHBOARD_ROOT                "@CMake_BINARY_DIR@/Tests/CTestTest")

--- a/app/cdash/tests/ctest/simple2/CMakeLists.txt
+++ b/app/cdash/tests/ctest/simple2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 project(Simple2)
 include(CTest)
 

--- a/app/cdash/tests/ctest/simple2/simple.ctest.in
+++ b/app/cdash/tests/ctest/simple2/simple.ctest.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 # Settings:
 set(CTEST_DASHBOARD_ROOT                "@CMake_BINARY_DIR@/Tests/CTestTest")

--- a/app/cdash/tests/ctest/simple2/test.cmake.in
+++ b/app/cdash/tests/ctest/simple2/test.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.20)
 
 # Settings:
 set(CTEST_DASHBOARD_ROOT                "@CMake_BINARY_DIR@/Tests/CTestTest")

--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -4,7 +4,7 @@ services:
       DB_CONNECTION: pgsql
       DB_LOGIN: postgres
       DB_PORT: 5432
-  # Uncomment this section for production postgres insallations.
+  # Uncomment this section for production postgres installations.
   #worker:
   #  environment:
   #    DB_CONNECTION: pgsql

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -13,6 +13,9 @@ services:
     build:
       context: ..
       target: cdash-worker
+      # Uncomment to use RedHat UBI as base image
+      # args:
+      #  BASE_IMAGE: ubi
     environment:
       DB_HOST: database
     deploy:

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -13,9 +13,9 @@ services:
     build:
       context: ..
       target: cdash-worker
-      # Uncomment to use RedHat UBI as base image
-      # args:
-      #  BASE_IMAGE: ubi
+      # Set the environment variable BASE_IMAGE=ubi to use RedHat UBI as base image
+      args:
+        BASE_IMAGE: ${BASE_IMAGE-debian}
     environment:
       DB_HOST: database
     deploy:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     build:
       context: ..
       target: cdash
-      # Uncomment to use RedHat UBI as base image
-      # args:
-      #  BASE_IMAGE: ubi
+      # Set the environment variable BASE_IMAGE=ubi to use RedHat UBI as base image
+      args:
+       BASE_IMAGE: ${BASE_IMAGE-debian}
     environment:
       DB_HOST: database
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: ..
       target: cdash
+      # Uncomment to use RedHat UBI as base image
+      # args:
+      #  BASE_IMAGE: ubi
     environment:
       DB_HOST: database
     healthcheck:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,11 @@ if [ "$1" = "start-website" ] ; then
 
   # Start Apache under the current user, in case the current user isn't www-data.  Kubernetes-based systems
   # typically run under a random user.
-  APACHE_RUN_USER=$(id -u -n) /usr/sbin/apache2ctl -D FOREGROUND
+  if [ "$BASE_IMAGE" = "debian" ] ; then
+    APACHE_RUN_USER=$(id -u -n) /usr/sbin/apache2ctl -D FOREGROUND
+  elif [ "$BASE_IMAGE" = "ubi" ]; then
+    /usr/libexec/s2i/run
+  fi
 
 # If the start-worker argument was provided, start a worker process instead
 elif [ "$1" = "start-worker" ] ; then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,10 +34,9 @@ function(add_cypress_e2e_test TestName)
       --config baseUrl=${APP_URL}
   )
   # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
-  set_tests_properties(
-    cypress/e2e/${TestName}
-    PROPERTIES
+  set_tests_properties(cypress/e2e/${TestName} PROPERTIES
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
   )
 endfunction()
 
@@ -53,10 +52,9 @@ function(add_cypress_component_test TestName)
       --config baseUrl=${APP_URL}
   )
   # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
-  set_tests_properties(
-    cypress/component/${TestName}
-    PROPERTIES
+  set_tests_properties(cypress/component/${TestName} PROPERTIES
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
   )
 endfunction()
 


### PR DESCRIPTION
We currently provide support for a Debian-based CDash image, but some clients require a RedHat UBI-based image.  RedHat does not support libsodium and the corresponding sodium PHP extension, which is required for our GitHub App integration to function.  That means that it is impractical for us to switch to UBI for our general-purpose CDash image.  To support the needs of clients who require a RedHat UBI-based image, this PR introduces a dual-image system in which users can choose their preferred base image, with the caveat that the UBI-based image does not support GitHub App integration.

To create a UBI-based image, simply set the `BASE_IMAGE` build argument to `ubi`.  The `BASE_IMAGE` build argument defaults to `debian`, which results in a build similar to the previous image build.

It is worth noting that the new UBI image uses php-fpm, while our standard Debian image continues to use mod_php.  I will create a follow-up PR to switch our default image to php-fpm at a future point.