### PR TITLE
Bump master version to 3.4

### DIFF
--- a/config/cdash.php
+++ b/config/cdash.php
@@ -21,7 +21,7 @@ return [
         'expires' => env('PASSWORD_EXPIRATION', 0),
         'unique' => env('UNIQUE_PASSWORD_COUNT', 0),
     ],
-    'version' => '3.3.0',
+    'version' => '3.4.0',
     'registration' => [
         'email' => [
             'verify' => env('REGISTRATION_EMAIL_VERIFY', true),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdash",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdash",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdash",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Continuous integration dashboard.",
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Bumps the reported version of CDash to 3.4 on master in anticipation of the upcoming 3.4 release, and to prevent confusion when handling bug reports from users running master but claiming that they are running 3.3.