### PR TITLE
Add GITHUB_ALWAYS_PASS configuration option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ DB_PASSWORD=secret
 # Optional secret used to secure the GitHub webhook.
 #GITHUB_WEBHOOK_SECRET=
 
+# If set to true, CDash will always report a status of 'success' for its GitHub check.
+# This option is useful if you don't want the CDash's GitHub check to block merging.
+#GITHUB_ALWAYS_PASS=false
+
 # API key for maps.google.com.
 # Set to a valid value to display maps of sites.
 #GOOGLE_MAP_API_KEY=null

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -384,6 +384,13 @@ class GitHub implements RepositoryInterface
         }
         $output['summary'] = "[$summary]($summary_url)";
         $params['output'] = $output;
+
+        if ((bool) config('cdash.github_always_pass')) {
+            $params['completed_at'] = $now;
+            $params['status'] = 'completed';
+            $params['conclusion'] = 'success';
+        }
+
         return $params;
     }
 

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -19,9 +19,11 @@ namespace CDash\Lib\Repository;
 use Github\Client as GitHubClient;
 use Github\HttpClient\Builder as GitHubBuilder;
 
+use Illuminate\Support\Facades\Log;
+
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Encoding\ChainedFormatter;
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 
 use CDash\Database;
@@ -39,28 +41,19 @@ class GitHub implements RepositoryInterface
 {
     public const BASE_URI = 'https://api.github.com';
 
-    /** @var string $installationId */
-    private $installationId;
-
-    /** @var string $owner */
-    private $owner;
-
-    /** @var string $repo */
-    private $repo;
-
-    /** @var string $hash */
-    private $hash;
-
+    private string $installationId = '';
+    private string $owner = '';
+    private string $repo = '';
     private $apiClient;
-    private $baseUrl;
+    private string $baseUrl;
     private $db;
-    private $foundConfigureErrors;
-    private $foundBuildErrors;
-    private $foundTestFailures;
-    private $numPassed;
-    private $numFailed;
-    private $numPending;
-    private $project;
+    private bool $foundConfigureErrors = false;
+    private bool $foundBuildErrors = false;
+    private bool $foundTestFailures = false;
+    private int $numPassed = 0;
+    private int $numFailed = 0;
+    private int $numPending = 0;
+    private Project $project;
 
     private $check;
 
@@ -77,7 +70,6 @@ class GitHub implements RepositoryInterface
 
         $this->getRepositoryInformation();
 
-        $installationId = '';
         $repositories = $this->project->GetRepositories();
         foreach ($repositories as $repo) {
             if (strpos($repo['url'], 'github.com') !== false) {
@@ -89,19 +81,22 @@ class GitHub implements RepositoryInterface
         $this->check = null;
     }
 
-    public function setApiClient(GitHubClient $client)
+    public function setApiClient(GitHubClient $client) : void
     {
         $this->apiClient = $client;
     }
 
-    protected function initializeApiClient()
+    protected function initializeApiClient() : void
     {
         $builder = new GitHubBuilder();
         $apiClient = new GithubClient($builder, 'machine-man-preview');
         $this->setApiClient($apiClient);
     }
 
-    public function authenticate($required = true)
+    /**
+     * Attempt to log in to the GitHub API
+     */
+    public function authenticate(bool $required = true) : bool
     {
         if (!config('cdash.use_vcs_api')) {
             return false;
@@ -111,7 +106,7 @@ class GitHub implements RepositoryInterface
             $this->initializeApiClient();
         }
 
-        if (empty($this->installationId)) {
+        if ($this->installationId === '') {
             if ($required) {
                 throw new \Exception('Unable to find installation ID for repository');
             }
@@ -137,7 +132,7 @@ class GitHub implements RepositoryInterface
 
         $config = Configuration::forSymmetricSigner(
             new Sha256(),
-            LocalFileReference::file($pem)
+            InMemory::file($pem)
         );
 
         $now = new \DateTimeImmutable();
@@ -157,7 +152,7 @@ class GitHub implements RepositoryInterface
             return false;
         }
         if ($token) {
-            $this->apiClient->authenticate($token['token'], null, GitHubClient::AUTH_ACCESS_TOKEN);
+            $this->apiClient->authenticate($token['token'], null, \Github\AuthMethod::ACCESS_TOKEN);
         }
         return true;
     }
@@ -175,9 +170,9 @@ class GitHub implements RepositoryInterface
      *
      * @see https://developer.github.com/v3/repos/statuses/ for property descriptions
      *
-     * @param array $options
+     * @param array<string, string> $options
      */
-    public function setStatus(array $options)
+    public function setStatus($options) : void
     {
         if (!$this->authenticate()) {
             return;
@@ -185,7 +180,7 @@ class GitHub implements RepositoryInterface
 
         $commitHash = $options['commit_hash'];
         $params = array_filter($options, function ($key) {
-            return in_array($key, ['state', 'context', 'description', 'target_url']);
+            return in_array($key, ['state', 'context', 'description', 'target_url'], true);
         }, ARRAY_FILTER_USE_KEY);
 
         $statuses = $this->apiClient
@@ -199,7 +194,7 @@ class GitHub implements RepositoryInterface
      *
      * @see https://developer.github.com/v3/checks/runs/#create-a-check-run
      */
-    public function createCheck($head_sha)
+    public function createCheck(string $head_sha): void
     {
         if (!$this->authenticate()) {
             return;
@@ -214,20 +209,16 @@ class GitHub implements RepositoryInterface
         try {
             $this->check->create($this->owner, $this->repo, $payload);
         } catch (\Github\Exception\RuntimeException $e) {
-            add_log("RunTimeException while trying to create the check.\n" . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n", 'createCheck', LOG_WARNING);
+            Log::warning("RunTimeException while trying to create the check.\n" . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n");
         }
-    }
-
-    public function setCheck(Check $check)
-    {
-        $this->check = $check;
     }
 
     /**
      * Query the database for information needed to generate a check
      * for a commit.
+     * @return array<int, array<string, int|string>>
      */
-    public function getBuildRowsForCheck($head_sha)
+    public function getBuildRowsForCheck(string $head_sha): array
     {
         $stmt = $this->db->prepare('
             SELECT b.id, b.name, b.builderrors, b.configureerrors, b.testfailed,
@@ -239,13 +230,14 @@ class GitHub implements RepositoryInterface
             WHERE bu.revision = :sha');
         $this->db->execute($stmt, [':sha' => $head_sha]);
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-        $rows = $this->dedupeAndSortBuildRows($rows);
-        return $rows;
+        return $this->dedupeAndSortBuildRows($rows);
     }
 
     /**
      * Include only one row per build name: the one with the most recent start time.
      * Also sort the rows by the build name (in alphabetical order).
+     * @param array<int, array<string, int|string>> $rows
+     * @return array<int, array<string, int|string>>
      */
     public function dedupeAndSortBuildRows($rows)
     {
@@ -271,7 +263,7 @@ class GitHub implements RepositoryInterface
             $newest_starttime = -1;
             $buildid_to_keep = -1;
             foreach ($builds as $build) {
-                $starttime = strtotime($build['starttime']);
+                $starttime = strtotime((string) $build['starttime']);
                 if ($starttime > $newest_starttime) {
                     $newest_starttime = $starttime;
                     $buildid_to_keep = $build['id'];
@@ -289,14 +281,14 @@ class GitHub implements RepositoryInterface
         // included in our report.
         $output_rows = [];
         foreach ($rows as $row) {
-            if (!in_array($row['id'], $buildids_to_remove)) {
+            if (!in_array($row['id'], $buildids_to_remove, true)) {
                 $output_rows[] = $row;
             }
         }
 
         // Alphabetize this array by build name.
         usort($output_rows, function ($a, $b) {
-            return strcmp($a['name'], $b['name']);
+            return strcmp((string) $a['name'], (string) $b['name']);
         });
 
         return $output_rows;
@@ -304,8 +296,10 @@ class GitHub implements RepositoryInterface
 
     /**
      * Create a payload to make a check from an array of build data.
+     * @param array<int, array<string, int|string>> $build_rows
+     * @return array<string, array<string, string>|string>
      */
-    public function generateCheckPayloadFromBuildRows($build_rows, $head_sha)
+    public function generateCheckPayloadFromBuildRows($build_rows, string $head_sha): array
     {
         // Get information about each build performed for this commit.
         $this->numPassed = 0;
@@ -396,12 +390,13 @@ class GitHub implements RepositoryInterface
 
     /**
      * Generate a check summary for a given row of build data.
+     * @param array<string, int|string> $row
      */
-    public function getCheckSummaryForBuildRow($row)
+    public function getCheckSummaryForBuildRow(array $row) : string|null
     {
         // Check properties to see if this build should be excluded
         // from the check.
-        $properties = json_decode($row['properties'], true);
+        $properties = json_decode((string) $row['properties'], true);
         if (is_array($properties) && array_key_exists('skip checks', $properties)) {
             return null;
         }
@@ -443,7 +438,7 @@ class GitHub implements RepositoryInterface
             $this->numFailed++;
             $this->foundTestFailures = true;
         } else {
-            if ($row['done'] == 1) {
+            if ((int) $row['done'] === 1) {
                 // Build completed without problems.
                 $icon = ':white_check_mark:';
                 $msg = 'success';
@@ -465,11 +460,11 @@ class GitHub implements RepositoryInterface
     /**
      * Record what changed between two commits.
      **/
-    public function compareCommits(BuildUpdate $update)
+    public function compareCommits(BuildUpdate $update) : bool
     {
         // Get current revision (head).
-        if (empty($update->Revision)) {
-            return;
+        if ($update->Revision === '') {
+            return false;
         }
         $head = $update->Revision;
 
@@ -478,13 +473,13 @@ class GitHub implements RepositoryInterface
         $build->Id = $update->BuildId;
         $previous_buildid = $build->GetPreviousBuildId();
         if ($previous_buildid < 1) {
-            return;
+            return false;
         }
         $previous_update = new BuildUpdate();
         $previous_update->BuildId = $previous_buildid;
         $previous_update->FillFromBuildId();
         if (!$previous_update->Revision) {
-            return;
+            return false;
         }
         $base = $previous_update->Revision;
 
@@ -495,7 +490,7 @@ class GitHub implements RepositoryInterface
 
         // Return early if we are configured to not use the GitHub API.
         if (!config('cdash.use_vcs_api')) {
-            return;
+            return false;
         }
 
         // Attempt to authenticate with the GitHub API.
@@ -517,7 +512,7 @@ class GitHub implements RepositoryInterface
         if (!is_array($commits) ||
                 !array_key_exists('commits', $commits) ||
                 !array_key_exists('files', $commits)) {
-            return;
+            return false;
         }
 
         // Discard merge commits.  We want to assign credit to the author who did
@@ -531,17 +526,18 @@ class GitHub implements RepositoryInterface
         // If we still have more than one commit, we'll need to perform follow-up
         // API calls to figure out which commit was likely responsible for each
         // changed file.
+        $list_of_commits = [];
         $multiple_commits = false;
         if (count($commits['commits']) > 1) {
             $multiple_commits = true;
             // Generate list of commits contained by this changeset in reverse order
             // (most recent first).
             $list_of_commits = array_reverse($commits['commits']);
-
-            // Also maintain a local cache of what files were changed by each commit.
-            // This prevents us from hitting the GitHub API more than necessary.
-            $cached_commits = [];
         }
+
+        // Maintain a local cache of what files were changed by each commit.
+        // This prevents us from hitting the GitHub API more than necessary.
+        $cached_commits = [];
 
         // Find the commit that changed each file.
         foreach ($commits['files'] as $modified_file) {
@@ -551,8 +547,8 @@ class GitHub implements RepositoryInterface
 
                 // First check our local cache.
                 foreach ($cached_commits as $sha => $files) {
-                    if (in_array($modified_file['filename'], $files)) {
-                        $idx = array_search($sha, array_column($list_of_commits, 'sha'));
+                    if (in_array($modified_file['filename'], $files, true)) {
+                        $idx = array_search($sha, array_column($list_of_commits, 'sha'), true);
                         $commit = $list_of_commits[$idx];
                         break;
                     }
@@ -566,7 +562,7 @@ class GitHub implements RepositoryInterface
                     $this->db->execute($stmt, [$modified_file['filename']]);
                     while ($row = $stmt->fetch()) {
                         foreach ($list_of_commits as $c) {
-                            if ($row['revision'] == $c['sha']) {
+                            if ($row['revision'] === $c['sha']) {
                                 $commit = $c;
                                 break;
                             }
@@ -648,31 +644,22 @@ class GitHub implements RepositoryInterface
         return true;
     }
 
-    /**
-     * @return string
-     */
-    public function getInstallationId()
+    public function getInstallationId() : string
     {
         return $this->installationId;
     }
 
-    /**
-     * @return string
-     */
-    public function getOwner()
+    public function getOwner() : string
     {
         return $this->owner;
     }
 
-    /**
-     * @return string
-     */
-    public function getRepository()
+    public function getRepository() : string
     {
         return $this->repo;
     }
 
-    protected function getRepositoryInformation()
+    protected function getRepositoryInformation() : void
     {
         $url = str_replace('//', '', $this->project->CvsUrl);
         $parts = explode('/', $url);

--- a/app/cdash/app/Lib/Repository/RepositoryInterface.php
+++ b/app/cdash/app/Lib/Repository/RepositoryInterface.php
@@ -18,5 +18,8 @@ namespace CDash\Lib\Repository;
 
 interface RepositoryInterface
 {
-    public function setStatus(array $options);
+    /**
+     * @param array<string, string> $options
+     */
+    public function setStatus(array $options) : void;
 }

--- a/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -16,12 +16,14 @@
 
 use CDash\Lib\Repository\GitHub;
 use CDash\Model\Project;
+use PHPUnit\Framework\MockObject\MockObject;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 
 class GitHubTest extends TestCase
 {
-    private $baseUrl;
+    private string $baseUrl;
+    /** @var Project|MockObject $project */
     private $project;
     public function setUp() : void
     {
@@ -32,7 +34,7 @@ class GitHubTest extends TestCase
         $this->baseUrl = config('app.url');
     }
 
-    public function testSetStatus()
+    public function testSetStatus() : void
     {
         $sut = $this->setupAuthentication();
         $options = [
@@ -45,9 +47,9 @@ class GitHubTest extends TestCase
         $sut->setStatus($options);
     }
 
-    public function testAuthenticateThrowsExceptionGivenNoInstallationId()
+    public function testAuthenticateThrowsExceptionGivenNoInstallationId() : void
     {
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn([]);
         $sut = new GitHub($this->project);
@@ -56,20 +58,20 @@ class GitHubTest extends TestCase
         $sut->authenticate();
     }
 
-    public function testSkipCheckPropertyIsHonored()
+    public function testSkipCheckPropertyIsHonored() : void
     {
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn([]);
         $sut = new GitHub($this->project);
 
         $build_row = ['properties' => '{ "skip checks": 1}'];
-        $this->assertNull($sut->getCheckSummaryForBuildRow($build_row));
+        $this::assertNull($sut->getCheckSummaryForBuildRow($build_row));
     }
 
-    public function testCheckSummaryForBuildRow()
+    public function testCheckSummaryForBuildRow() : void
     {
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn([]);
         $sut = new GitHub($this->project);
@@ -87,13 +89,13 @@ class GitHubTest extends TestCase
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $link = "$this->baseUrl/build/99999/configure";
         $expected = $common . ":x: | [1 configure error]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
 
         // Plural configure errors.
         $build_row['configureerrors'] = 2;
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":x: | [2 configure errors]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
         $build_row['configureerrors'] = 0;
 
         // Single build error.
@@ -101,13 +103,13 @@ class GitHubTest extends TestCase
         $link = "$this->baseUrl/viewBuildError.php?buildid=99999";
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":x: | [1 build error]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
 
         // Plural build errors.
         $build_row['builderrors'] = 2;
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":x: | [2 build errors]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
         $build_row['builderrors'] = 0;
 
         // Single test failure.
@@ -115,26 +117,26 @@ class GitHubTest extends TestCase
         $link = "$this->baseUrl/viewTest.php?buildid=99999";
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":x: | [1 failed test]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
 
         // Plural test failures.
         $build_row['testfailed'] = 2;
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":x: | [2 failed tests]($link)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
         $build_row['testfailed'] = 0;
 
         // Pending.
         $build_row['done'] = 0;
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":hourglass_flowing_sand: | [pending]($summary_url)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
 
         // Success.
         $build_row['done'] = 1;
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":white_check_mark: | [success]($summary_url)";
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
     }
 
     /**
@@ -149,12 +151,12 @@ class GitHubTest extends TestCase
         }
         unset($actual['started_at']);
         unset($actual['completed_at']);
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
     }
 
     private function validateCheckPayloadFromBuildRows() : void
     {
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn([]);
         $this->project->Name = 'TestChecksProject';
@@ -259,9 +261,9 @@ class GitHubTest extends TestCase
         $this->validateCheckPayloadFromBuildRows();
     }
 
-    public function testDedupeAndSortBuildRows()
+    public function testDedupeAndSortBuildRows() : void
     {
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn([]);
         $sut = new GitHub($this->project);
@@ -280,10 +282,10 @@ class GitHubTest extends TestCase
             ['id' => 6, 'name' => 'b', 'starttime' => '2019-05-01 18:08:40'],
             ['id' => 1, 'name' => 'c', 'starttime' => '2019-05-01 18:08:35'],
         ];
-        $this->assertEquals($expected, $actual);
+        $this::assertEquals($expected, $actual);
     }
 
-    private function setupAuthentication()
+    private function setupAuthentication() : GitHub
     {
         $github_url = 'https://github.com/Foo/Bar';
         $repositories = [];
@@ -292,27 +294,32 @@ class GitHubTest extends TestCase
             'username' => 12345,
         ];
         $this->project->CvsUrl = $github_url;
-        $this->project->expects($this->once())
+        $this->project->expects($this::once())
             ->method('GetRepositories')
             ->willReturn($repositories);
 
         $sut = new GitHub($this->project);
 
-        $statuses = $this->getMockBuilder(\Github\Api\Apps::class)
+        $statuses = $this->getMockBuilder(\Github\Api\Repository\Statuses::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
-        $statuses->expects($this->any())
+        $statuses->expects($this::any())
             ->method('create')
             ->willReturn(true);
 
-        $api = $this->getMockBuilder(\Github\Api\Apps::class)
+        $apps = $this->getMockBuilder(\Github\Api\Apps::class)
             ->disableOriginalConstructor()
-            ->setMethods(['createInstallationToken', 'statuses'])
+            ->onlyMethods(['createInstallationToken'])
             ->getMock();
-        $api->expects($this->any())
+        $apps->expects($this::any())
             ->method('createInstallationToken');
-        $api->expects($this->any())
+
+        $repo = $this->getMockBuilder(\Github\Api\Repo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['statuses'])
+            ->getMock();
+        $repo->expects($this::any())
             ->method('statuses')
             ->willReturn($statuses);
 
@@ -320,11 +327,14 @@ class GitHubTest extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['api', 'authenticate', 'getHttpClient'])
             ->getMock();
-        $client->expects($this->any())
+        $client->expects($this::any())
             ->method('authenticate');
-        $client->expects($this->any())
+        $client->expects($this::any())
             ->method('api')
-            ->willReturn($api);
+            ->willReturnMap([
+               ['apps', $apps],
+               ['repo', $repo],
+        ]);
 
         $sut->setApiClient($client);
         $pem =  base_path() . "/app/cdash/tests/data/key_for_testing_only";
@@ -334,14 +344,9 @@ class GitHubTest extends TestCase
         return $sut;
     }
 
-    public function testCreateCheck()
+    public function testCreateCheck() : void
     {
         $sut = $this->setupAuthentication();
-        $check = $this->getMockBuilder(\CDash\Lib\Repository\Check::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
-        $sut->setCheck($check);
         $sut->createCheck(str_replace('-', '', Uuid::uuid4()->toString()));
     }
 }

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -57,6 +57,7 @@ return [
     'default_project' => env('DEFAULT_PROJECT', null),
     'delete_old_subprojects' => env('DELETE_OLD_SUBPROJECTS', true),
     'google_map_api_key' => env('GOOGLE_MAP_API_KEY', null),
+    'github_always_pass' => env('GITHUB_ALWAYS_PASS', false),
     'github_app_id' => env('GITHUB_APP_ID', null),
     'github_private_key' => env('GITHUB_PRIVATE_KEY', null),
     'github_webhook_secret' => env('GITHUB_WEBHOOK_SECRET', null),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16557,7 +16557,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 13
+			count: 10
 			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
 
 		-
@@ -16597,11 +16597,6 @@ parameters:
 
 		-
 			message: "#^Method GitHubTest\\:\\:testDedupeAndSortBuildRows\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testGenerateCheckPayloadFromBuildRows\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6188,72 +6188,13 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
-			message: """
-				#^Call to deprecated function add_log\\(\\)\\:
-				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 3
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: """
-				#^Call to method file\\(\\) of deprecated class Lcobucci\\\\JWT\\\\Signer\\\\Key\\\\LocalFileReference\\:
-				please use \\{@see InMemory\\} instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: "#^Comparison operation \"\\>\" between 0 and 0 is always false\\.$#"
 			count: 2
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant AUTH_ACCESS_TOKEN of class Github\\\\Client\\:
-				Use the AuthMethod const$#
-			"""
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 3
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Implicit array creation is not allowed \\- variable \\$cached_commits might not exist\\.$#"
-			count: 2
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 2
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:authenticate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:authenticate\\(\\) has parameter \\$required with no type specified\\.$#"
-			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
@@ -6282,96 +6223,6 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:compareCommits\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:createCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:createCheck\\(\\) has parameter \\$head_sha with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:dedupeAndSortBuildRows\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:dedupeAndSortBuildRows\\(\\) has parameter \\$rows with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:generateCheckPayloadFromBuildRows\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:generateCheckPayloadFromBuildRows\\(\\) has parameter \\$build_rows with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:generateCheckPayloadFromBuildRows\\(\\) has parameter \\$head_sha with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:getBuildRowsForCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:getBuildRowsForCheck\\(\\) has parameter \\$head_sha with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:getCheckSummaryForBuildRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:getCheckSummaryForBuildRow\\(\\) has parameter \\$row with no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:getRepositoryInformation\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:initializeApiClient\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:setApiClient\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:setCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:setStatus\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:setStatus\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 2
 			path: app/cdash/app/Lib/Repository/GitHub.php
@@ -6382,17 +6233,7 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			message: "#^Parameter \\$check of method CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:setCheck\\(\\) has invalid type CDash\\\\Lib\\\\Repository\\\\Check\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$apiClient has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$baseUrl has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
@@ -6407,69 +6248,9 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$foundBuildErrors has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$foundConfigureErrors has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$foundTestFailures has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$hash is unused\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$numFailed has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$numPassed has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$numPending has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$project has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between 0 and 0 will always evaluate to true\\.$#"
 			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Variable \\$cached_commits might not be defined\\.$#"
-			count: 2
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Variable \\$list_of_commits might not be defined\\.$#"
-			count: 4
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\RepositoryInterface\\:\\:setStatus\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/RepositoryInterface.php
-
-		-
-			message: "#^Method CDash\\\\Lib\\\\Repository\\\\RepositoryInterface\\:\\:setStatus\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Lib/Repository/RepositoryInterface.php
 
 		-
 			message: "#^Property CDash\\\\Model\\\\ActionableTypes\\:\\:\\$categories has no type specified\\.$#"
@@ -16541,94 +16322,6 @@ parameters:
 			message: "#^Method DynamicAnalysisUseCaseTest\\:\\:testUseCaseBuildsDynamicAnalysisUseCase\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 3
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Class CDash\\\\Lib\\\\Repository\\\\Check not found\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 10
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\)\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:any\\(\\)\\.$#"
-			count: 5
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
-			count: 6
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:setupAuthentication\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testAuthenticateThrowsExceptionGivenNoInstallationId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testCheckSummaryForBuildRow\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testCreateCheck\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testDedupeAndSortBuildRows\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testSetStatus\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Method GitHubTest\\:\\:testSkipCheckPropertyIsHonored\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Property GitHubTest\\:\\:\\$baseUrl has no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Property GitHubTest\\:\\:\\$project has no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Trying to mock an undefined method create\\(\\) on class Github\\\\Api\\\\Apps\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
-
-		-
-			message: "#^Trying to mock an undefined method statuses\\(\\) on class Github\\\\Api\\\\Apps\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"


### PR DESCRIPTION
When this environment variable is set to true, CDash will always report a status of 'success' to any GitHub repositories that have installed this CDash server as a GitHub App.

This is useful in cases where you do not want the CDash GitHub check to prevent a PR from being merged.