### PR TITLE
Enable GraphiQL execution of protected queries

### DIFF
--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,5 +1,5 @@
-vendor
-node_modules
-storage
-bootstrap/cache
+/vendor
+/node_modules
+/storage
+/bootstrap/cache
 *.swp

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\Timer::class,
+        \Illuminate\Session\Middleware\StartSession::class,
     ];
 
     /**
@@ -31,7 +32,6 @@ class Kernel extends HttpKernel
         'web' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
@@ -41,7 +41,6 @@ class Kernel extends HttpKernel
         'api' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\JsonOnly::class,
             // 'throttle:60,1',
@@ -51,7 +50,6 @@ class Kernel extends HttpKernel
         'saml' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \Illuminate\Session\Middleware\StartSession::class,
         ],
     ];
 

--- a/config/graphiql.php
+++ b/config/graphiql.php
@@ -16,7 +16,7 @@ return [
     'routes' => [
         '/graphql/explorer' => [
             'name' => 'graphiql',
-             'middleware' => ['web'],
+            'middleware' => ['web'],
             // 'prefix' => '',
             // 'domain' => 'graphql.' . env('APP_DOMAIN', 'localhost'),
 

--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -29,7 +29,7 @@ return [
          */
         'middleware' => [
             // Ensures the request is not vulnerable to cross-site request forgery.
-            // Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
+             Nuwave\Lighthouse\Http\Middleware\EnsureXHR::class,
 
             // Always set the `Accept: application/json` header.
             Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,

--- a/resources/views/vendor/graphiql/index.blade.php
+++ b/resources/views/vendor/graphiql/index.blade.php
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+@php use MLL\GraphiQL\DownloadAssetsCommand; @endphp
+<head>
+    <meta charset=utf-8/>
+    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>GraphiQL</title>
+    <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+
+        #graphiql {
+            height: 100vh;
+        }
+
+        /* Make the explorer feel more integrated */
+        .docExplorerWrap {
+            overflow: auto !important;
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        .doc-explorer-title-bar {
+            font-weight: var(--font-weight-medium);
+            font-size: var(--font-size-h2);
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .doc-explorer-rhs {
+            display: none;
+        }
+
+        .doc-explorer-contents {
+            margin: var(--px-16) 0 0;
+        }
+
+        .graphiql-explorer-actions select {
+            margin-left: var(--px-12);
+        }
+    </style>
+    <script src="{{ DownloadAssetsCommand::reactPath() }}"></script>
+    <script src="{{ DownloadAssetsCommand::reactDOMPath() }}"></script>
+    <link rel="stylesheet" href="{{ DownloadAssetsCommand::cssPath() }}"/>
+    <link rel="shortcut icon" href="{{ DownloadAssetsCommand::faviconPath() }}"/>
+</head>
+
+<body>
+
+<div id="graphiql">Loading...</div>
+<script src="{{ DownloadAssetsCommand::jsPath() }}"></script>
+<script src="{{ DownloadAssetsCommand::pluginExplorerPath() }}"></script>
+<script>
+    const fetcher = GraphiQL.createFetcher({
+        url: '{{ $url }}',
+        subscriptionUrl: '{{ $subscriptionUrl }}',
+    });
+
+    function GraphiQLWithExplorer() {
+        const [query, setQuery] = React.useState('');
+
+        return React.createElement(GraphiQL, {
+            fetcher,
+            query,
+            onEditQuery: setQuery,
+            defaultEditorToolsVisibility: true,
+            plugins: [
+                GraphiQLPluginExplorer.useExplorerPlugin({
+                    query,
+                    onEdit: setQuery,
+                }),
+            ],
+        });
+    }
+
+    ReactDOM.render(
+        React.createElement(GraphiQLWithExplorer),
+        document.getElementById('graphiql'),
+    );
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2079 introduced the first GraphQL mutation to our schema, but GraphiQL is currently unable to execute it because the session-handling middleware is out of order.  This PR adds support for authenticated queries via GraphiQL by rearranging the middleware order.  I also added CSRV validation.