### PR TITLE
Enable horizontal scaling of queue workers from docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ MIX_APP_URL="${APP_URL}"
 # The following two variables are only used for docker compose production installations.
 SSL_CERTIFICATE_FILE=/etc/ssl/certs/ssl-cert-snakeoil.pem
 SSL_CERTIFICATE_KEY_FILE=/etc/ssl/private/ssl-cert-snakeoil.key
+NUM_WORKERS=1
 
 # database.php
 DB_DATABASE=cdash

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -8,15 +8,18 @@ services:
       - "${SSL_CERTIFICATE_FILE}:/var/www/my-cert.pem"
       - "${SSL_CERTIFICATE_KEY_FILE}:/var/www/my-cert.key"
   worker:
+    env_file:
+      - ../.env
     image: kitware/cdash-worker
-    container_name: cdash_worker
     build:
       context: ..
       target: cdash-worker
     environment:
       DB_HOST: database
     deploy:
-      replicas: 1
+      replicas: ${NUM_WORKERS:-1}
+      restart_policy:
+        condition: any
     depends_on:
       cdash:
         condition: service_healthy

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -69,6 +69,7 @@ To set up a CDash production instance using docker compose, follow these steps:
   - `APP_URL=https://<my-cdash-url>`
   - `SSL_CERTIFICATE_FILE=</path/to/certs/my-cert.pem>`
   - `SSL_CERTIFICATE_KEY_FILE=</path/to/certs/my-cert.key>`
+  - `NUM_WORKERS=<desired number of queue worker replicas, defaults to 1>`
 * For postgres only, edit `docker/docker-compose.postgres.yml` and uncomment the `worker` section.
 * Run this command to start your CDash containers:
 ```bash


### PR DESCRIPTION
Introduce a new environment variable `NUM_WORKERS` that allows us to specify how many queue workers should be created by docker compose.

Also reconfigure these queue workers to restart automatically upon failure.