### PR TITLE
Add project visibility field to GraphQL schema

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -77,6 +77,9 @@ type Project {
   "Homepage for this project."
   homeurl: String!
 
+  "Visibility."
+  visibility: ProjectVisibility! @rename(attribute: "public")
+
   builds: [Build!]! @hasMany @orderBy(column: "id")
 
   "The sites which have submitted a build to this project."
@@ -84,6 +87,17 @@ type Project {
 
   "Users with the administrator role for this project."
   administrators: [User!]! @belongsToMany @orderBy(column: "id")
+}
+
+enum ProjectVisibility {
+  "Available to all users and guests."
+  PUBLIC @enum(value: 1)
+
+  "Available to all registered users."
+  PROTECTED @enum(value: 2)
+
+  "Only available to users added to the project."
+  PRIVATE @enum(value: 0)
 }
 
 input CreateProjectInput {
@@ -95,6 +109,9 @@ input CreateProjectInput {
 
   "Project homepage"
   homeurl: String!
+
+  "Visibility."
+  visibility: ProjectVisibility! @rename(attribute: "public")
 }
 
 

--- a/tests/Feature/GraphQL/ProjectTest.php
+++ b/tests/Feature/GraphQL/ProjectTest.php
@@ -315,6 +315,7 @@ class ProjectTest extends TestCase
                 'name' => $name,
                 'description' => 'test',
                 'homeurl' => 'https://cdash.org',
+                'visibility' => 'PUBLIC',
             ],
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
 
@@ -339,6 +340,7 @@ class ProjectTest extends TestCase
                 'name' => $name,
                 'description' => 'test',
                 'homeurl' => 'https://cdash.org',
+                'visibility' => 'PUBLIC',
             ],
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
 
@@ -365,6 +367,7 @@ class ProjectTest extends TestCase
                 'name' => $name,
                 'description' => 'test',
                 'homeurl' => 'https://cdash.org',
+                'visibility' => 'PUBLIC',
             ],
         ])->assertGraphQLErrorMessage('This action is unauthorized.');
 
@@ -391,6 +394,7 @@ class ProjectTest extends TestCase
                 'name' => $name,
                 'description' => 'test',
                 'homeurl' => 'https://cdash.org',
+                'visibility' => 'PUBLIC',
             ],
         ]);
 
@@ -423,6 +427,7 @@ class ProjectTest extends TestCase
                 'name' => $name,
                 'description' => 'test',
                 'homeurl' => 'https://cdash.org',
+                'visibility' => 'PUBLIC',
             ],
         ]);
 
@@ -580,6 +585,51 @@ class ProjectTest extends TestCase
                     [
                         'name' => $this->projects['private3']->name,
                         'administrators' => [],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testProjectVisibilityValue(): void
+    {
+        $this->actingAs($this->users['admin'])->graphQL('
+            query {
+                projects {
+                    name
+                    visibility
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    [
+                        'name' => $this->projects['public1']->name,
+                        'visibility' => 'PUBLIC',
+                    ],
+                    [
+                        'name' => $this->projects['public2']->name,
+                        'visibility' => 'PUBLIC',
+                    ],
+                    [
+                        'name' => $this->projects['protected1']->name,
+                        'visibility' => 'PROTECTED',
+                    ],
+                    [
+                        'name' => $this->projects['protected2']->name,
+                        'visibility' => 'PROTECTED',
+                    ],
+                    [
+                        'name' => $this->projects['private1']->name,
+                        'visibility' => 'PRIVATE',
+                    ],
+                    [
+                        'name' => $this->projects['private2']->name,
+                        'visibility' => 'PRIVATE',
+                    ],
+                    [
+                        'name' => $this->projects['private3']->name,
+                        'visibility' => 'PRIVATE',
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR exposes a visibility field in the project type in the new GraphQL API.

I intend to gradually phase in each of the columns in the project table after carefully considering the name, necessary constraints, and purpose of each one.  This is the first of several planned PRs on this topic.