### PR TITLE
Drop `bugtrackerfileurl` column

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Facades\Auth;
  * @property string $homeurl
  * @property string $cvsurl
  * @property string $bugtrackerurl
- * @property string $bugtrackerfileurl
  * @property string $bugtrackernewissueurl
  * @property string $bugtrackertype
  * @property string $documentationurl
@@ -64,7 +63,6 @@ class Project extends Model
         'homeurl',
         'cvsurl',
         'bugtrackerurl',
-        'bugtrackerfileurl',
         'bugtrackernewissueurl',
         'bugtrackertype',
         'documentationurl',

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -55,7 +55,6 @@ class Project
     public $CvsUrl;
     public $DocumentationUrl;
     public $BugTrackerUrl;
-    public $BugTrackerFileUrl;
     public $BugTrackerNewIssueUrl;
     public $BugTrackerType;
     public $ImageId;
@@ -261,7 +260,6 @@ class Project
             'cvsurl' => $this->CvsUrl ?? '',
             'documentationurl' => $this->DocumentationUrl ?? '',
             'bugtrackerurl' => $this->BugTrackerUrl ?? '',
-            'bugtrackerfileurl' => $this->BugTrackerFileUrl ?? '',
             'bugtrackernewissueurl' => $this->BugTrackerNewIssueUrl ?? '',
             'bugtrackertype' => $this->BugTrackerType ?? '',
             'public' => (int) $this->Public,
@@ -353,7 +351,6 @@ class Project
             $this->CvsUrl = $project->cvsurl;
             $this->DocumentationUrl = $project->documentationurl;
             $this->BugTrackerUrl = $project->bugtrackerurl;
-            $this->BugTrackerFileUrl = $project->bugtrackerfileurl;
             $this->BugTrackerNewIssueUrl = $project->bugtrackernewissueurl;
             $this->BugTrackerType = $project->bugtrackertype;
             $this->ImageId = $project->imageid;

--- a/app/cdash/tests/test_compressedtest.php
+++ b/app/cdash/tests/test_compressedtest.php
@@ -22,7 +22,6 @@ class CompressedTestCase extends KWWebTestCase
             'Description' => 'Project compression example',
             'CvsUrl' => 'public.kitware.com/cgi-bin/viewcvs.cgi/?cvsroot=TestCompressionExample',
             'CvsViewerType' => 'github',
-            'BugTrackerFileUrl' =>  'http://public.kitware.com/Bug/view.php?id=',
         ];
         $this->createProject($settings);
 

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -42,7 +42,6 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
             'Description' => 'CDash',
             'CvsUrl' => 'github.com/Kitware/CDash',
             'CvsViewerType' => 'github',
-            'BugTrackerFileUrl' => 'http://public.kitware.com/Bug/view.php?id=',
             'repositories' => [[
                 'url' => 'https://github.com/Kitware/CDash',
                 'branch' => 'master',

--- a/database/migrations/2024_03_22_233702_drop_bugtrackerfileurl_column.php
+++ b/database/migrations/2024_03_22_233702_drop_bugtrackerfileurl_column.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('project')) {
+            Schema::dropColumns('project', 'bugtrackerfileurl');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // This migration is irreversible
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9858,11 +9858,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$BugTrackerFileUrl has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$BugTrackerNewIssueUrl has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php


### PR DESCRIPTION
The `bugtrackerfileurl` column in the project table is no longer used and no longer serves a purpose.  This PR introduces an irreversible migration to drop the column.