### PR TITLE
Index `buildfailureid` column in `label2buildfailure` table

### DIFF
--- a/database/migrations/2024_03_22_234620_label2buildfailure_index.php
+++ b/database/migrations/2024_03_22_234620_label2buildfailure_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('label2buildfailure')) {
+            Schema::table('label2buildfailure', function (Blueprint $table) {
+                $table->index(['buildfailureid', 'labelid']);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('label2buildfailure')) {
+            Schema::table('label2buildfailure', function (Blueprint $table) {
+                $table->dropIndex(['buildfailureid', 'labelid']);
+            });
+        }
+    }
+};


### PR DESCRIPTION
Resolves half of https://github.com/Kitware/CDash/issues/2046 by indexing the `label2buildfailure` pivot table such that it is possible to look up the `labelid` by the `buildfailureid`.