### PR TITLE
Index `label2dynamicanalysis` (`dynamicanalysisid`)

### DIFF
--- a/database/migrations/2024_03_23_001025_label2dynamicanalysis_index.php
+++ b/database/migrations/2024_03_23_001025_label2dynamicanalysis_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('label2dynamicanalysis')) {
+            Schema::table('label2dynamicanalysis', function (Blueprint $table) {
+                $table->index(['dynamicanalysisid', 'labelid']);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('label2dynamicanalysis')) {
+            Schema::table('label2dynamicanalysis', function (Blueprint $table) {
+                $table->dropIndex(['dynamicanalysisid', 'labelid']);
+            });
+        }
+    }
+};


### PR DESCRIPTION
Related to #2103.  Adds an index to the `dynamicanalysisid` column of the `label2dynamicanalysis` pivot table to allow efficient lookup of the `labelid` by the `dynamicanalysisid`.  See https://github.com/Kitware/CDash/issues/2046.