### PR TITLE
Remove top-level User GraphQL field

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,21 +4,6 @@ scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date
 
 "Indicates what fields are available at the top level of a query operation."
 type Query {
-  "Find a single user."
-  user(
-    "Search by primary key."
-    id: ID @eq @rules(apply: ["prohibits:email", "required_without:email"])
-
-    "Search by email address."
-    email: String @eq @rules(apply: ["prohibits:id", "required_without:id"])
-  ): User @find
-
-  "List multiple users."
-  users(
-    "Filters by email. Accepts SQL LIKE wildcards `%` and `_`."
-    email: String @where(operator: "like")
-  ): [User!]! @all @orderBy(column: "id")
-
   "Find a single project."
   project(
     "Search by primary key."


### PR DESCRIPTION
There is currently no need for a top-level user field in our GraphQL API.  It may be desirable to limit user visibility in the future, so I have removed the top-level user field.  Instead, I plan to offer more limited access to users on a per-project basis in an upcoming PR.  The decision to offer a top-level user field can be reconsidered in the future once the API is more mature.