### PR TITLE
Expose project administrators via GraphQL API

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -162,9 +162,9 @@ class Project extends Model
         } elseif (!$user->admin) {
             $query->whereHas('users', function ($query2) use ($user) {
                 $query2->where('user.id', $user->id);
-                $query2->orWhere('public', self::ACCESS_PUBLIC);
-                $query2->orWhere('public', self::ACCESS_PROTECTED);
-            });
+            })
+            ->orWhere('public', self::ACCESS_PUBLIC)
+            ->orWhere('public', self::ACCESS_PROTECTED);
         }
         // Else, this is an admin user, so we shouldn't apply any filters...
     }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -81,6 +81,9 @@ type Project {
 
   "The sites which have submitted a build to this project."
   sites: [Site!]! @belongsToMany @orderBy(column: "id")
+
+  "Users with the administrator role for this project."
+  administrators: [User!]! @belongsToMany @orderBy(column: "id")
 }
 
 input CreateProjectInput {


### PR DESCRIPTION
This PR exposes a new "administrators" field in the Project type.  A subsequent PR will add similar fields for project maintainers.

This PR also fixes an issue which prevented aggregate queries from selecting public and protected projects the user could otherwise query individually.  