### PR TITLE
Fix xdebug issue in production UBI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,7 +222,7 @@ COPY ./php.ini /etc/php.d/cdash.ini
 COPY ./docker/cdash-site.conf /etc/httpd/conf.d/cdash-site.conf
 
 # remove lcobucci/jwt due to libsodium rhel issue
-RUN composer remove "lcobucci/jwt"
+RUN composer remove "lcobucci/jwt" --ignore-platform-reqs && rm -rf vendor
 
 ###############################################################################
 # Do shared installation tasks as the root user


### PR DESCRIPTION
The final revision of #2088 only included xdebug in the development image, which led to a failure when attempting to use `composer remove`, as caught by #2095.  This PR addresses that failure, and ensures that both development and production images build properly for Debian and UBI.