### PR TITLE
Bump default PHP to 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG DEVELOPMENT_BUILD
 ###############################################################################
 # The base image for regular Debian-based images
 ###############################################################################
-FROM php:8.1-apache-bookworm AS cdash-debian-intermediate
+FROM php:8.2-apache-bookworm AS cdash-debian-intermediate
 
 ARG BASE_IMAGE
 ARG DEVELOPMENT_BUILD

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -32,6 +32,7 @@ class BuildConfigure
     public $BuildId;
     public $NumberOfWarnings;
     public $NumberOfErrors;
+    public $LabelCollection;
     private $Crc32;
 
     private $PDO;

--- a/app/cdash/app/Model/BuildErrorFilter.php
+++ b/app/cdash/app/Model/BuildErrorFilter.php
@@ -21,8 +21,8 @@ class BuildErrorFilter
 {
     private $ErrorsFilter;
     private $WarningsFilter;
-
     public $Project;
+    private $PDO;
 
     public function __construct(Project $project)
     {

--- a/app/cdash/tests/test_buildgetdate.php
+++ b/app/cdash/tests/test_buildgetdate.php
@@ -46,7 +46,6 @@ class BuildGetDateTestCase extends KWWebTestCase
         $build->StartTime = $evening_after;
 
         $expected_date = '2009-02-24';
-        $build->NightlyStartTime = false;
         $date = $build->GetDate();
         if ($date !== $expected_date) {
             $this->fail("Evening case: expected $expected_date, found $date");
@@ -56,7 +55,6 @@ class BuildGetDateTestCase extends KWWebTestCase
         $build->GetProject()->SetNightlyTime('09:00:00 America/New_York');
         $build->StartTime = $morning_before;
         $expected_date = '2009-02-22';
-        $build->NightlyStartTime = false;
         $date = $build->GetDate();
         if ($date !== $expected_date) {
             $this->fail("Morning case: expected $expected_date, found $date");
@@ -64,7 +62,6 @@ class BuildGetDateTestCase extends KWWebTestCase
 
         $build->StartTime = $morning_after;
         $expected_date = '2009-02-23';
-        $build->NightlyStartTime= false;
         $date = $build->GetDate();
         if ($date !== $expected_date) {
             $this->fail("Morning case: expected $expected_date, found $date");

--- a/app/cdash/xml_handlers/done_handler.php
+++ b/app/cdash/xml_handlers/done_handler.php
@@ -26,6 +26,7 @@ class DoneHandler extends AbstractHandler
     private $FinalAttempt;
     private $PendingSubmissions;
     private $Requeue;
+    public $backupFileName;
 
     public function __construct($projectID)
     {

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -37,6 +37,9 @@ class TestingHandler extends AbstractHandler implements ActionableBuildInterface
     private $TestMeasurement;
     private $Label;
 
+    // TODO: Evaluate whether this is needed
+    private $Labels;
+
     private $TestCreator;
 
     /** @var Build[] Builds */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6775,11 +6775,6 @@ parameters:
 			path: app/cdash/app/Model/Build.php
 
 		-
-			message: "#^Access to an undefined property CDash\\\\Model\\\\BuildConfigure\\:\\:\\$LabelCollection\\.$#"
-			count: 5
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -6878,6 +6873,11 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\BuildConfigure\\:\\:\\$Id has no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
+			message: "#^Property CDash\\\\Model\\\\BuildConfigure\\:\\:\\$LabelCollection has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
@@ -7154,11 +7154,6 @@ parameters:
 			path: app/cdash/app/Model/BuildError.php
 
 		-
-			message: "#^Access to an undefined property CDash\\\\Model\\\\BuildErrorFilter\\:\\:\\$PDO\\.$#"
-			count: 8
-			path: app/cdash/app/Model/BuildErrorFilter.php
-
-		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildErrorFilter.php
@@ -7255,6 +7250,11 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\BuildErrorFilter\\:\\:\\$ErrorsFilter has no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildErrorFilter.php
+
+		-
+			message: "#^Property CDash\\\\Model\\\\BuildErrorFilter\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildErrorFilter.php
 
@@ -21140,11 +21140,6 @@ parameters:
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
-			message: "#^Access to an undefined property CDash\\\\Model\\\\Build\\:\\:\\$NightlyStartTime\\.$#"
-			count: 1
-			path: app/cdash/tests/test_buildgetdate.php
-
-		-
 			message: "#^Method BuildGetDateTestCase\\:\\:testBuildGetDate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildgetdate.php
@@ -27878,6 +27873,11 @@ parameters:
 			path: app/cdash/xml_handlers/done_handler.php
 
 		-
+			message: "#^Property DoneHandler\\:\\:\\$backupFileName has no type specified\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/done_handler.php
+
+		-
 			message: "#^Access to an undefined property DynamicAnalysisHandler\\:\\:\\$BuildName\\.$#"
 			count: 5
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -28594,11 +28594,6 @@ parameters:
 			path: app/cdash/xml_handlers/stack.php
 
 		-
-			message: "#^Access to an undefined property TestingHandler\\:\\:\\$Labels\\.$#"
-			count: 3
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
 			message: "#^Call to an undefined method CDash\\\\Messaging\\\\Preferences\\\\NotificationPreferencesInterface\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
@@ -28730,6 +28725,11 @@ parameters:
 
 		-
 			message: "#^Property TestingHandler\\:\\:\\$Label has no type specified\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Property TestingHandler\\:\\:\\$Labels has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
 


### PR DESCRIPTION
As per the [support schedule](https://www.php.net/supported-versions.php), PHP 8.1 is only receiving security fixes and will become EOL as of December 8, 2024.  Given that many CDash systems go long periods of time between updates, it makes sense to proactively increase the default PHP version in our base images to PHP 8.2.  Unfortunately, RedHat has not released a PHP 8.2 UBI image yet, so only the Debian image has been updated.  The UBI image will be updated to PHP 8.2 once an image becomes available.

Closes https://github.com/Kitware/CDash/issues/2094.