### PR TITLE
Add new `MAX_PROJECT_VISIBILITY` config option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -258,5 +258,11 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # Whether or not to automatically register new users upon first login
 #SAML2_AUTO_REGISTER_NEW_USERS=false
 
-# Should normal user allowed to create projects
+# Should normal users be allowed to create projects
 # USER_CREATE_PROJECTS = false
+
+# The maximum visibility level for user-created projects on this instance.
+# Instance admins are able to override this setting and set project visibility
+# to anything.  Thus, this setting is only meaningful if USER_CREATE_PROJECTS=true.
+# Options: PUBLIC, PROTECTED, PRIVATE
+# MAX_PROJECT_VISIBILITY=PUBLIC

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -142,6 +142,8 @@ final class ProjectController extends AbstractProjectController
 
         $response['vcsviewers'] = array_map($callback, array_keys($viewers));
 
+        $response['max_project_visibility'] = $User->admin ? 'PUBLIC' : config('cdash.max_project_visibility');
+
         $pageTimer->end($response);
         return response()->json(cast_data_for_JSON($response));
     }

--- a/app/Rules/ProjectVisibilityAllowed.php
+++ b/app/Rules/ProjectVisibilityAllowed.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\Project;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class ProjectVisibilityAllowed implements ValidationRule
+{
+    /**
+     * Verify that the current user is able to create/edit a project with the requested visibility.
+     *
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $value = (int) $value;
+
+        if ($value < 0 || $value > 2) {
+            $fail('Invalid project visibility setting');
+        }
+
+        $user = Auth::user();
+        // Admins can always set the project to whatever visibility they want
+        if ($user === null || !$user->admin) {
+            $max_visibility = match (Str::upper(config('cdash.max_project_visibility'))) {
+                'PUBLIC' => Project::ACCESS_PUBLIC,
+                'PROTECTED' => Project::ACCESS_PROTECTED,
+                'PRIVATE' => Project::ACCESS_PRIVATE,
+                default => $fail('This instance contains an improper MAX_PROJECT_VISIBILITY configuration.'),
+            };
+
+            // This horrible logic is an unfortunate byproduct of the decision to misorder the access numbering scheme,
+            // which prevents range-based logic...
+            if ($max_visibility === Project::ACCESS_PROTECTED && $value === Project::ACCESS_PUBLIC) {
+                $fail('This instance is only configured to contain protected or private projects.');
+            } elseif ($max_visibility === Project::ACCESS_PRIVATE && ($value === Project::ACCESS_PUBLIC || $value === Project::ACCESS_PROTECTED)) {
+                $fail('This instance is only configured to contain private projects.');
+            }
+        }
+    }
+}

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -81,5 +81,7 @@ return [
     'unlimited_projects' => $unlimited_projects,
     'use_compression' => env('USE_COMPRESSION', true),
     'user_create_projects' => env('USER_CREATE_PROJECTS', false),
+    // Defaults to public.  Only meaningful if USER_CREATE_PROJECT=true.
+    'max_project_visibility' => env('MAX_PROJECT_VISIBILITY', 'PUBLIC'),
     'use_vcs_api' => env('USE_VCS_API', true),
 ];

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -111,7 +111,7 @@ input CreateProjectInput {
   homeurl: String!
 
   "Visibility."
-  visibility: ProjectVisibility! @rename(attribute: "public")
+  visibility: ProjectVisibility! @rename(attribute: "public") @rules(attribute: "public", apply: ["App\\Rules\\ProjectVisibilityAllowed"])
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29471,7 +29471,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
-			count: 3
+			count: 4
 			path: tests/Feature/GraphQL/ProjectTest.php
 
 		-

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -371,13 +371,21 @@
                       @change="cdash.changesmade = true"
                       @focus="showHelp('public_help')"
                     >
-                      <option value="0">
+                      <option
+                        value="0"
+                      >
                         Private
                       </option>
-                      <option value="1">
+                      <option
+                        value="1"
+                        v-if="cdash.max_project_visibility === 'PUBLIC'"
+                      >
                         Public
                       </option>
-                      <option value="2">
+                      <option
+                        value="2"
+                        v-if="cdash.max_project_visibility === 'PUBLIC' || cdash.max_project_visibility === 'PROTECTED'"
+                      >
                         Protected
                       </option>
                     </select>


### PR DESCRIPTION
Some CDash administrators may want users to be able to create projects on their own, but not public or protected projects.  This PR adds a new `MAX_PROJECT_VISIBILITY` environment variable which specifies the most visible setting a project can be configured to use.  Instance administrators can override this setting, to allow some projects to be made public or protected with administrator approval.