### PR TITLE
Add new `REQUIRE_AUTHENTICATED_SUBMISSIONS` config option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,11 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # Whether or not a Project administrator can register a user
 # PROJECT_ADMIN_REGISTRATION_FORM_ENABLED=true
 
+# Require all new projects to use authenticated submissions.
+# Instance administrators can override this, and this setting has no effect on
+# existing projects.
+# REQUIRE_AUTHENTICATED_SUBMISSIONS=false
+
 
 # ldap.php
 #LDAP_HOSTS=

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -92,7 +92,7 @@ final class ProjectController extends AbstractProjectController
             }
         } else {
             // Initialize some variables for project creation.
-            $project_response['AuthenticateSubmissions'] = 0;
+            $project_response['AuthenticateSubmissions'] = (bool) config('cdash.require_authenticated_submissions') ? 1 : 0;
             $project_response['Public'] = Project::ACCESS_PRIVATE;
             $project_response['AutoremoveMaxBuilds'] = 500;
             $project_response['AutoremoveTimeframe'] = 60;

--- a/app/Rules/ProjectAuthenticateSubmissions.php
+++ b/app/Rules/ProjectAuthenticateSubmissions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class ProjectAuthenticateSubmissions implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param Closure(string): PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $value = (bool) $value;
+
+        $user = Auth::user();
+        if ($user !== null && $user->admin) {
+            // Instance admins can set any value they wish
+            return;
+        }
+
+        if ((bool) config('cdash.require_authenticated_submissions') && !$value) {
+            $fail('This CDash instance is configured to require authenticated submissions.');
+        }
+    }
+}

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -19,6 +19,7 @@ namespace CDash\Api\v1\Project;
 require_once 'include/api_common.php';
 
 
+use App\Rules\ProjectAuthenticateSubmissions;
 use App\Rules\ProjectVisibilityAllowed;
 use App\Utils\RepositoryUtils;
 use CDash\Model\Project;
@@ -258,12 +259,15 @@ function populate_project($Project)
         $project_settings['CvsUrl'] = str_replace('&amp;', '&', $cvsurl);
     }
 
-    if (Validator::make([
+    $validator = Validator::make([
         'visibility' => $project_settings['Public'],
+        'authenticatesubmissions' => (bool) ($project_settings['AuthenticateSubmissions'] ?? false),
     ], [
         'visibility' => new ProjectVisibilityAllowed(),
-    ])->fails()) {
-        abort(403, "Project visibility {$project_settings['Public']} prohibited for this instance.");
+        'authenticatesubmissions' => new ProjectAuthenticateSubmissions(),
+    ]);
+    if ($validator->fails()) {
+        abort(403, $validator->messages());
     }
 
     foreach ($project_settings as $k => $v) {

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -83,5 +83,6 @@ return [
     'user_create_projects' => env('USER_CREATE_PROJECTS', false),
     // Defaults to public.  Only meaningful if USER_CREATE_PROJECT=true.
     'max_project_visibility' => env('MAX_PROJECT_VISIBILITY', 'PUBLIC'),
+    'require_authenticated_submissions' => env('REQUIRE_AUTHENTICATED_SUBMISSIONS', false),
     'use_vcs_api' => env('USE_VCS_API', true),
 ];

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -65,6 +65,9 @@ type Project {
   "Visibility."
   visibility: ProjectVisibility! @rename(attribute: "public")
 
+  "A boolean indicating whether authenticated submissions are required."
+  authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions")
+
   builds: [Build!]! @hasMany @orderBy(column: "id")
 
   "The sites which have submitted a build to this project."
@@ -97,6 +100,9 @@ input CreateProjectInput {
 
   "Visibility."
   visibility: ProjectVisibility! @rename(attribute: "public") @rules(attribute: "public", apply: ["App\\Rules\\ProjectVisibilityAllowed"])
+
+  "A boolean indicating whether authenticated submissions are required."
+  authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions") @rules(attribute: "authenticatesubmissions", apply: ["App\\Rules\\ProjectAuthenticateSubmissions"])
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29726,7 +29726,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
-			count: 4
+			count: 5
 			path: tests/Feature/GraphQL/ProjectTest.php
 
 		-


### PR DESCRIPTION
This builds on top of the work done in #2115, and adds a new `REQUIRE_AUTHENTICATED_SUBMISSIONS` configuration option which requires regular users to enable authenticated submissions when creating or editing projects.  Instance administrators are able to override this setting.

This should be merged after #2115.