### PR TITLE
Add `merge_group` CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As per the [docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions), the `merge_group` trigger is necessary to trigger CI runs when using the merge queue.  This should fix the jobs which are currently stuck in the queue.