### PR TITLE
Fix permanent redirect when running from subdirectory

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ if(config('auth.user_registration_form_enabled') === false) {
 Auth::routes($routeList);
 
 Route::match(['get', 'post'], '/install', 'AdminController@install');
-Route::permanentRedirect('/install.php', '/install');
+Route::permanentRedirect('/install.php', url('/install'));
 
 Route::get('/oauth/{service}', 'OAuthController@socialite');
 Route::get('/oauth/callback/{service}', 'OAuthController@callback');
@@ -67,14 +67,14 @@ Route::get('/displayImage.php', function (Request $request) {
 });
 
 Route::get('/builds/{id}', 'BuildController@summary');
-Route::permanentRedirect('/build/{id}', '/builds/{id}');
+Route::permanentRedirect('/build/{id}', url('/builds/{id}'));
 Route::get('/buildSummary.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}", 301);
 });
 
 Route::get('/builds/{id}/configure', 'BuildController@configure');
-Route::permanentRedirect('/build/{id}/configure', '/builds/{id}/configure');
+Route::permanentRedirect('/build/{id}/configure', url('/builds/{id}/configure'));
 Route::get('/viewConfigure.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/configure", 301);
@@ -82,14 +82,14 @@ Route::get('/viewConfigure.php', function (Request $request) {
 
 
 Route::get('/builds/{id}/update', 'BuildController@update');
-Route::permanentRedirect('/build/{id}/update', '/builds/{id}/update');
+Route::permanentRedirect('/build/{id}/update', url('/builds/{id}/update'));
 Route::get('/viewUpdate.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/update", 301);
 });
 
 Route::get('/builds/{id}/notes', 'BuildController@notes');
-Route::permanentRedirect('/build/{id}/notes', '/builds/{id}/notes');
+Route::permanentRedirect('/build/{id}/notes', url('/builds/{id}/notes'));
 Route::get('/viewNotes.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/notes", 301);
@@ -97,7 +97,7 @@ Route::get('/viewNotes.php', function (Request $request) {
 
 Route::get('/builds/{id}/dynamic_analysis', 'DynamicAnalysisController@viewDynamicAnalysis')
     ->whereNumber('id');
-Route::permanentRedirect('/build/{id}/dynamic_analysis', '/builds/{id}/dynamic_analysis');
+Route::permanentRedirect('/build/{id}/dynamic_analysis', url('/builds/{id}/dynamic_analysis'));
 Route::get('/viewDynamicAnalysis.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/dynamic_analysis", 301);
@@ -112,17 +112,17 @@ Route::get('/viewFiles.php', function (Request $request) {
 Route::get('/build/{build_id}/file/{file_id}', 'BuildController@build_file')->whereNumber('build_id')->whereNumber('file_id');
 
 Route::get('/projects/{id}/edit', 'EditProjectController@edit');
-Route::permanentRedirect('/project/{id}/edit', '/projects/{id}/edit');
+Route::permanentRedirect('/project/{id}/edit', url('/projects/{id}/edit'));
 
 Route::get('/projects/new', 'EditProjectController@create');
-Route::permanentRedirect('/project/new', '/projects/new');
+Route::permanentRedirect('/project/new', url('/projects/new'));
 
 Route::get('/projects/{id}/testmeasurements', 'ManageMeasurementsController@show');
-Route::permanentRedirect('/project/{id}/testmeasurements', '/projects/{id}/testmeasurements');
+Route::permanentRedirect('/project/{id}/testmeasurements', url('/projects/{id}/testmeasurements'));
 
 Route::get('/projects/{id}/ctest_configuration', 'CTestConfigurationController@get')
     ->whereNumber('id');
-Route::permanentRedirect('/project/{id}/ctest_configuration', '/projects/{id}/ctest_configuration');
+Route::permanentRedirect('/project/{id}/ctest_configuration', url('/projects/{id}/ctest_configuration'));
 Route::get('/generateCTestConfig.php', function (Request $request) {
     $projectid = $request->query('projectid');
     if (!is_numeric($projectid)) {
@@ -132,7 +132,7 @@ Route::get('/generateCTestConfig.php', function (Request $request) {
 });
 
 Route::get('/tests/{id}', 'TestController@details');
-Route::permanentRedirect('/test/{id}', '/tests/{id}');
+Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
     $testid = $request->query('test');
@@ -208,11 +208,11 @@ Route::get('/manageBuildGroup.php', 'BuildController@manageBuildGroup');
 // Requests from users who are not logged in will be redirected to /login.
 Route::middleware(['auth'])->group(function () {
     Route::get('/user', 'UserController@userPage');
-    Route::permanentRedirect('/user.php', '/user');
+    Route::permanentRedirect('/user.php', url('/user'));
 
     // TODO: (williamjallen) send the POST route to a different function
     Route::match(['get', 'post'], '/profile', 'UserController@edit');
-    Route::permanentRedirect('/editUser.php', '/profile');
+    Route::permanentRedirect('/editUser.php', url('/profile'));
 
     // TODO: (williamjallen) send the POST route to a different function
     Route::get('/subscribeProject.php', 'SubscribeProjectController@subscribeProject');
@@ -252,7 +252,7 @@ Route::middleware(['auth'])->group(function () {
         // TODO: (williamjallen) Move this out of the admin-only section, and instead query only
         //       the sites a given user is able to see.
         Route::get('/sites', 'SiteController@siteStatistics');
-        Route::permanentRedirect('/siteStatistics.php', '/sites');
+        Route::permanentRedirect('/siteStatistics.php', url('/sites'));
 
         Route::get('/manageUsers.php', 'ManageUsersController@showPage');
         Route::post('/manageUsers.php', 'ManageUsersController@showPage');


### PR DESCRIPTION
Laravel's `permanentRedirect()` function does not automatically apply the `APP_URL` to the destination URL.  This causes the redirects to malfunction for instances where CDash is not running at the root path.