### PR TITLE
Fix #2141 - No error message provided to user for failed login attempts

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -29,7 +29,7 @@
                     <input class="textbox" name="email" size="40" value="{{ old('email') }}">
                     @if ($errors->has('email'))
                         <div>
-                        <span class="invalid-feedback" role="alert">
+                        <span class="invalid-feedback d-block" role="alert">
                             <strong>{{ $errors->first('email') }}</strong>
                         </span>
                         </div>
@@ -45,7 +45,7 @@
 					<input class="textbox" type="checkbox" name="remember" id="remember" {{old('remember') ? 'checked' : ''}}> Remember Me
 					@if ($errors->has('password'))
 						<div>
-							<span class="invalid-feedback" role="alert">
+							<span class="invalid-feedback d-block" role="alert">
 								<strong>{{ $errors->first('password') }}</strong>
 							</span>
 						</div>


### PR DESCRIPTION
The issue occurs because the css class `invalid-feedback` contains `display: none`. 
I used this feedback to solve the issue: https://stackoverflow.com/a/50522718

The screenshot shows an example for a failed LDAP login:
![image](https://github.com/Kitware/CDash/assets/7921443/a9901c7b-447b-438c-99f1-6fb5a2aa1584)
