### PR TITLE
Drop unused build log column

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -24,7 +24,6 @@ use Illuminate\Support\Carbon;
  * @property Carbon $endtime
  * @property Carbon $submittime
  * @property string $command
- * @property string $log
  * @property int $configureerrors
  * @property int $configurewarnings
  * @property int $configureduration
@@ -63,7 +62,6 @@ class Build extends Model
         'endtime',
         'submittime',
         'command',
-        'log',
         'configureerrors',
         'configurewarnings',
         'configureduration',

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -57,7 +57,6 @@ class Build
     public string $EndTime = '1980-01-01 00:00:00';
     public string $SubmitTime = '1980-01-01 00:00:00';
     public string $Command = '';
-    public string $Log = '';
     public BuildInformation $Information;
     public int $BuildErrorCount;
     public int $TestFailedCount;
@@ -1903,16 +1902,7 @@ class Build
             }
 
             if ($build->parentid !== -1) {
-                // If this is not a parent build, check if its log or command
-                // has changed.
-                if ($this->Log !== '' && $this->Log !== $build->log) {
-                    if (!empty($build->log)) {
-                        $log = $build->log . " " . $this->Log;
-                    } else {
-                        $log = $this->Log;
-                    }
-                    $fields_to_update['log'] = $log;
-                }
+                // If this is not a parent build, check if its command has changed.
                 if ($this->Command !== '' && $this->Command !== $build->command) {
                     if (!empty($build->command)) {
                         $command = $build->command . "; " . $this->Command;
@@ -2429,7 +2419,6 @@ class Build
                     'endtime'        => $this->EndTime,
                     'submittime'     => $this->SubmitTime,
                     'command'        => $this->Command,
-                    'log'            => $this->Log,
                     'builderrors'    => $nbuilderrors,
                     'buildwarnings'  => $nbuildwarnings,
                     'parentid'       => $this->ParentId,

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -52,7 +52,6 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
     private BuildInformation $BuildInformation;
     private $BuildCommand;
     private $BuildGroup;
-    private $BuildLog;
     private $Labels;
     // Map SubProjects to Labels
     private $SubProjects;
@@ -68,7 +67,6 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
         parent::__construct($projectid);
         $this->Builds = [];
         $this->BuildCommand = '';
-        $this->BuildLog = '';
         $this->Labels = [];
         $this->SubProjects = [];
         $project = new Project();
@@ -196,7 +194,6 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
                 }
                 $build->Append = $this->Append;
                 $build->Command = $this->BuildCommand;
-                $build->Log .= $this->BuildLog;
 
                 foreach ($this->Labels as $label) {
                     $build->AddLabel($label);
@@ -305,9 +302,6 @@ class BuildHandler extends AbstractHandler implements ActionableBuildInterface, 
                     break;
                 case 'BUILDCOMMAND':
                     $this->BuildCommand = htmlspecialchars_decode($data);
-                    break;
-                case 'LOG':
-                    $this->BuildLog .= htmlspecialchars_decode($data);
                     break;
             }
         } elseif ($parent == 'ACTION') {

--- a/database/migrations/2024_04_13_161402_drop_build_log_column.php
+++ b/database/migrations/2024_04_13_161402_drop_build_log_column.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('build')) {
+            Schema::dropColumns('build', ['log']);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // This migration is irreversible
+
+        if (Schema::hasTable('build')) {
+            Schema::table('build', function (Blueprint $table) {
+                $table->string('log')->nullable();
+            });
+        }
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6506,7 +6506,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 20
+			count: 19
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -27444,11 +27444,6 @@ parameters:
 
 		-
 			message: "#^Property BuildHandler\\:\\:\\$BuildGroup is unused\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: "#^Property BuildHandler\\:\\:\\$BuildLog has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
 


### PR DESCRIPTION
The log column in the build table appears to be unused.  Information can be written to the column, but there is no way to extract the contents.  Since this appears to be a legacy feature which is obsolete in CDash today, I have removed the log column and all remaining references to it.  Build.xml files containing the LOG element will be ignored.

While I've done a significant amount of digging to try to find additional references to the log column, it is theoretically possible that the column is still referenced in a SQL query or via reflection somewhere.