### PR TITLE
Fix upload_handler for remote workers

### DIFF
--- a/app/Console/Commands/MakeStorageDirectories.php
+++ b/app/Console/Commands/MakeStorageDirectories.php
@@ -34,6 +34,7 @@ class MakeStorageDirectories extends Command
             "{$storage_path}/app/inprogress",
             "{$storage_path}/app/parsed",
             "{$storage_path}/app/public",
+            "{$storage_path}/app/tmp",
             "{$storage_path}/app/upload",
             "{$storage_path}/framework/cache/data",
             "{$storage_path}/framework/sessions",

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -121,10 +121,8 @@ class UploadHandler extends AbstractHandler
             }
 
             // Create tmp file
-            $this->TmpFilename = tempnam(sys_get_temp_dir(), 'cdash_upload'); // TODO Handle error
-            chmod($this->TmpFilename, 0o644);
-
-            if (empty($this->TmpFilename)) {
+            $this->TmpFilename = tempnam(storage_path('app/tmp'), 'cdash_upload');
+            if ($this->TmpFilename === false) {
                 Log::error('Failed to create temporary filename');
                 $this->UploadError = true;
                 return;
@@ -167,16 +165,6 @@ class UploadHandler extends AbstractHandler
             // Note: Using stream_filter_append/stream_copy_to_stream is more efficient but
             // return an "invalid byte sequence" on windows
             $rhandle = fopen($this->Base64TmpFilename, 'r');
-
-            // Create tmp file
-            $this->TmpFilename = tempnam(sys_get_temp_dir(), 'cdash_upload');
-            if ($this->TmpFilename === false) {
-                Log::error('Failed to create temporary filename');
-                $this->UploadError = true;
-                return;
-            }
-            chmod($this->TmpFilename, 0o644);
-
             $whandle = fopen($this->TmpFilename, 'w+');
             $chunksize = 4096;
             while (!feof($rhandle)) {

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -27,8 +27,10 @@ use CDash\Model\UploadFile;
 
 use Illuminate\Http\File;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 /**
  * For each uploaded file the following steps occur:
@@ -141,8 +143,8 @@ class UploadHandler extends AbstractHandler
         }
     }
 
-    /** Function endElement
-     * @throws \Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException
+    /**
+     * Function endElement
      */
     public function endElement($parser, $name)
     {
@@ -165,6 +167,16 @@ class UploadHandler extends AbstractHandler
             // Note: Using stream_filter_append/stream_copy_to_stream is more efficient but
             // return an "invalid byte sequence" on windows
             $rhandle = fopen($this->Base64TmpFilename, 'r');
+
+            // Create tmp file
+            $this->TmpFilename = tempnam(sys_get_temp_dir(), 'cdash_upload');
+            if ($this->TmpFilename === false) {
+                Log::error('Failed to create temporary filename');
+                $this->UploadError = true;
+                return;
+            }
+            chmod($this->TmpFilename, 0o644);
+
             $whandle = fopen($this->TmpFilename, 'w+');
             $chunksize = 4096;
             while (!feof($rhandle)) {
@@ -212,15 +224,46 @@ class UploadHandler extends AbstractHandler
             } else {
                 $this->UploadFile->IsUrl = false;
 
-                // Store the file if we don't already have it.
-                $upload_filepath = "upload/{$this->UploadFile->Sha1Sum}";
-                if (!Storage::exists($upload_filepath)) {
-                    $result = Storage::putFileAs('upload', new File($this->TmpFilename), $this->UploadFile->Sha1Sum);
-                    if ($result === false) {
-                        Log::error("Failed to store {$this->TmpFilename} as {$upload_filepath}");
-                        $this->UploadError = true;
+                if ((bool) config('cdash.remote_workers')) {
+                    // Make an API request to store this file.
+                    $encrypted_sha1sum = encrypt($this->UploadFile->Sha1Sum);
+                    $fp_to_upload = fopen($this->TmpFilename, 'r');
+                    if ($fp_to_upload === false) {
+                        Log::error("Failed to open temporary file {$this->TmpFilename} for upload");
                         cdash_unlink($this->TmpFilename);
+                        $this->UploadError = true;
                         return;
+                    }
+                    $response = Http::attach(
+                        'attachment', $fp_to_upload, (string) $this->UploadFile->Sha1Sum
+                    )->post(url('/api/v1/store_upload'), [
+                        'sha1sum' => $encrypted_sha1sum,
+                    ]);
+                    fclose($fp_to_upload);
+                    if (!$response->successful()) {
+                        Log::error('Error uploading file via API: ' .  $response->status() . ' ' . $response->body());
+                        cdash_unlink($this->TmpFilename);
+                        $this->UploadError = true;
+                        return;
+                    }
+                } else {
+                    // Store the file if we don't already have it.
+                    $uploadFilepath = "upload/{$this->UploadFile->Sha1Sum}";
+                    if (!Storage::exists($uploadFilepath)) {
+                        try {
+                            $fileToUpload = new File($this->TmpFilename);
+                        } catch (FileNotFoundException $e) {
+                            Log::error("Could not find file {$this->TmpFilename} to upload");
+                            cdash_unlink($this->TmpFilename);
+                            $this->UploadError = true;
+                            return;
+                        }
+                        if (Storage::putFileAs('upload', $fileToUpload, (string) $this->UploadFile->Sha1Sum) === false) {
+                            Log::error("Failed to store {$this->TmpFilename} as {$uploadFilepath}");
+                            cdash_unlink($this->TmpFilename);
+                            $this->UploadError = true;
+                            return;
+                        }
                     }
                 }
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29263,11 +29263,6 @@ parameters:
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
-			message: "#^Parameter \\#3 \\$name of static method Illuminate\\\\Filesystem\\\\FilesystemAdapter\\:\\:putFileAs\\(\\) expects array\\|string\\|null, string\\|false given\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
 			message: "#^Property UploadHandler\\:\\:\\$Base64TmpFileWriteHandle has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29139,7 +29139,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
@@ -29214,11 +29214,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, resource\\|false given\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: "#^Parameter \\#1 \\$filename of function chmod expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,8 @@ Route::get('/v1/timeline.php', 'TimelineController@apiTimeline');
 
 Route::get('/v1/testOverview.php', 'TestController@apiTestOverview');
 
+Route::post('/v1/store_upload', 'SubmissionController@storeUploadedFile');
+
 Route::match(['get', 'post', 'delete'], '/v1/expectedbuild.php', 'ExpectedBuildController@apiResponse');
 
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
Use an internal, secured API endpoint to store files parsed from Upload.xml when CDash is configured to use remote workers.

Follow-up to #2143