### PR TITLE
Bump master version to 3.5

### DIFF
--- a/config/cdash.php
+++ b/config/cdash.php
@@ -21,7 +21,7 @@ return [
         'expires' => env('PASSWORD_EXPIRATION', 0),
         'unique' => env('UNIQUE_PASSWORD_COUNT', 0),
     ],
-    'version' => '3.4.0',
+    'version' => '3.5.0',
     'registration' => [
         'email' => [
             'verify' => env('REGISTRATION_EMAIL_VERIFY', true),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdash",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdash",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdash",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Continuous integration dashboard.",
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
In accordance with the release process [checklist](https://github.com/Kitware/CDash/blob/master/docs/release_process.md), the version of CDash reported on master should be increased to the next upcoming minor release when a release is made to prevent confusion when handling bug reports.