### PR TITLE
Show proper version for lightweight tags

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -64,7 +64,9 @@ const webpack_plugins = [
 
 if (git_clone) {
   const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
-  webpack_plugins.push(new GitRevisionPlugin());
+  webpack_plugins.push(new GitRevisionPlugin({
+    lightweightTags: true,
+  }));
 }
 
 // Copy angularjs files to build directory.


### PR DESCRIPTION
Our Git Webpack plugin supports lightweight tags, but we don't have the right configuration options set to enable it.  This PR enables support for lightweight tags.