### PR TITLE
Inject Vue APP_URL at page load time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -303,6 +303,8 @@ RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \
         cp /cdash/.env.dev /cdash/.env; \
     fi
 
+RUN npm run prod --stats-children
+
 # Make sure the build args are set in the ENV for reference in docker-entrypoint.sh
 ENV DEVELOPMENT_BUILD=$DEVELOPMENT_BUILD
 ENV BASE_IMAGE=$BASE_IMAGE

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,9 +7,9 @@ php artisan key:check || exit 1
 # If the "start-website" argument was provided, start the web server
 if [ "$1" = "start-website" ] ; then
   if [ "$DEVELOPMENT_BUILD" = "1" ]; then
-    bash /cdash/install.sh --dev
+    bash /cdash/install.sh --dev --initial-docker-install
   else
-    bash /cdash/install.sh
+    bash /cdash/install.sh --initial-docker-install
   fi
 
   echo "Starting Apache..."

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -63,9 +63,9 @@ const app = Vue.createApp({
   components:  cdash_components,
 });
 
-app.config.globalProperties.$baseURL = process.env.MIX_APP_URL;
+app.config.globalProperties.$baseURL = $('#app').attr('data-app-url');
 
-axios.defaults.baseURL = process.env.MIX_APP_URL;
+axios.defaults.baseURL = app.config.globalProperties.$baseURL;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 const token = document.head.querySelector('meta[name="csrf-token"]');
 if (token) {

--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -61,7 +61,10 @@
     <div ng-if="cdash.requirelogin == 1" ng-include="'login'"></div>
     <div ng-if="cdash.requirelogin != 1" id="app">
 @else
-    <div id="app">
+    <div
+        id="app"
+        data-app-url="{{ url('/') }}"
+    >
 @endif
         @section('header')
             @include('components.header')
@@ -82,8 +85,6 @@
         @section('footer')
             @include('components.footer')
         @show
-
-        @yield('post_content_script')
     </div>
 </body>
 </html>


### PR DESCRIPTION
The CDash UI currently needs the `APP_URL` environment variable at build time, which means that our Docker container startup time is limited by the time it takes to build the UI.  It also means that our container is not fully static.

This PR adds a data attribute to the Vue mount point, which means the `APP_URL` is no longer built into the UI.  To take advantage of this, I added commands to build the website during the Docker image build, and added a new `--initial-docker-install` flag to `cdash_install` which skips unnecessary steps if it's the first run of the script.  The CDash container is now able to begin serving requests less than 5 seconds after starting if no migrations are necessary.

Although I have not tested it yet, I believe this change also means that the web service can be scaled horizontally because each instance is derived from the same image with the same cache busting tokens.