### PR TITLE
Label dependency PRs automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "monthly"
     labels:
       - dependencies
+      - "release notes: external dependencies"
     open-pull-requests-limit: 100
   - package-ecosystem: "npm"
     directory: "/"
@@ -13,4 +14,5 @@ updates:
       interval: "monthly"
     labels:
       - dependencies
+      - "release notes: external dependencies"
     open-pull-requests-limit: 100


### PR DESCRIPTION
The automatic release notes generation process uses the "release notes: external dependencies" label to automatically put dependency PRs in the right section of the release notes.  Manually adding the label to all of the dependency PRs is a time consuming process which this PR aims to automate.