### PR TITLE
Display merge queue CDash results in separate build group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           if [ "${{github.event_name}}" == "pull_request" ]; then
             BUILD_GROUP="Pull Requests";
+          elif [ "${{github.event_name}}" == "workflow_dispatch" ]; then
+            BUILD_GROUP="Merge Queue";
           elif [[ "${GITHUB_REF}" =~ "/master" ]] ; then
             BUILD_GROUP="Master";
           elif [[ "${GITHUB_REF}" =~ "releases/" ]] ; then


### PR DESCRIPTION
Items in the merge queue currently get added to the "Master" build group, which leads to false concerns when queued PRs fail our CI checks.  The build group is already present on open.cdash.org.