### PR TITLE
Add SiteInformation type to GraphQL API

### DIFF
--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -8,6 +8,7 @@ use App\Utils\TestingDay;
 use CDash\Database;
 use CDash\Model\Project;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -122,7 +123,7 @@ final class SiteController extends AbstractController
         }
 
         @$claimsite = $_POST['claimsite'];
-        @$claimsiteid = $_POST['claimsiteid'];
+        $claimsiteid = intval($_POST['claimsiteid'] ?? -1);
         if ($claimsite) {
             self::add_site2user(intval($claimsiteid), intval($userid));
         }
@@ -141,75 +142,83 @@ final class SiteController extends AbstractController
         }
 
         if ($updatesite || $geolocation) {
-            $site_name = $_POST['site_name'];
-            $site_description = $_POST['site_description'];
-            $site_processoris64bits = $_POST['site_processoris64bits'];
-            $site_processorvendor = $_POST['site_processorvendor'];
-            $site_processorvendorid = $_POST['site_processorvendorid'];
-            $site_processorfamilyid = $_POST['site_processorfamilyid'];
-            $site_processormodelid = $_POST['site_processormodelid'];
-            $site_processorcachesize = $_POST['site_processorcachesize'];
-            $site_numberlogicalcpus = $_POST['site_numberlogicalcpus'];
-            $site_numberphysicalcpus = $_POST['site_numberphysicalcpus'];
-            $site_totalvirtualmemory = $_POST['site_totalvirtualmemory'];
-            $site_totalphysicalmemory = $_POST['site_totalphysicalmemory'];
-            $site_logicalprocessorsperphysical = $_POST['site_logicalprocessorsperphysical'];
-            $site_processorclockfrequency = $_POST['site_processorclockfrequency'];
+            $site_name = request()->string('site_name');
+            $site_description = request()->post('site_description');
+            $site_processoris64bits = request()->post('site_processoris64bits');
+            $site_processorvendor = request()->post('site_processorvendor');
+            $site_processorvendorid = request()->post('site_processorvendorid');
+            $site_processorfamilyid = request()->post('site_processorfamilyid');
+            $site_processormodelid = request()->post('site_processormodelid');
+            $site_processorcachesize = request()->post('site_processorcachesize');
+            $site_numberlogicalcpus = request()->post('site_numberlogicalcpus');
+            $site_numberphysicalcpus = request()->post('site_numberphysicalcpus');
+            $site_totalvirtualmemory = request()->post('site_totalvirtualmemory');
+            $site_totalphysicalmemory = request()->post('site_totalphysicalmemory');
+            $site_logicalprocessorsperphysical = request()->post('site_logicalprocessorsperphysical');
+            $site_processorclockfrequency = request()->post('site_processorclockfrequency');
             $site_ip = $_POST['site_ip'];
             $site_longitude = $_POST['site_longitude'];
             $site_latitude = $_POST['site_latitude'];
 
             if (isset($_POST['outoforder'])) {
-                $outoforder = 1;
+                $outoforder = true;
             } else {
-                $outoforder = 0;
-            }
-
-            if (isset($_POST['newdescription_revision'])) {
-                $newdescription_revision = 1;
-            } else {
-                $newdescription_revision = 0;
+                $outoforder = false;
             }
         }
 
         if ($updatesite) {
-            self::update_site($claimsiteid, $site_name,
-                $site_processoris64bits,
-                $site_processorvendor,
-                $site_processorvendorid,
-                $site_processorfamilyid,
-                $site_processormodelid,
-                $site_processorcachesize,
-                $site_numberlogicalcpus,
-                $site_numberphysicalcpus,
-                $site_totalvirtualmemory,
-                $site_totalphysicalmemory,
-                $site_logicalprocessorsperphysical,
-                $site_processorclockfrequency,
-                $site_description,
-                $site_ip, $site_latitude,
-                $site_longitude, !$newdescription_revision,
-                $outoforder);
+            self::update_site(
+                $claimsiteid,
+                $site_name,
+                [
+                    'processoris64bits' => $site_processoris64bits,
+                    'processorvendor' => $site_processorvendor,
+                    'processorvendorid' => $site_processorvendorid,
+                    'processorfamilyid' => $site_processorfamilyid,
+                    'processormodelid' => $site_processormodelid,
+                    'processorcachesize' => $site_processorcachesize,
+                    'numberlogicalcpus' => $site_numberlogicalcpus,
+                    'numberphysicalcpus' => $site_numberphysicalcpus,
+                    'totalvirtualmemory' => $site_totalvirtualmemory,
+                    'totalphysicalmemory' => $site_totalphysicalmemory,
+                    'logicalprocessorsperphysical' => $site_logicalprocessorsperphysical,
+                    'processorclockfrequency' => $site_processorclockfrequency,
+                    'description' => $site_description,
+                ],
+                $site_ip,
+                $site_latitude,
+                $site_longitude,
+                $outoforder
+            );
         }
 
         // If we should retrieve the geolocation
         if ($geolocation) {
             $location = get_geolocation($site_ip);
-            self::update_site($claimsiteid, $site_name,
-                $site_processoris64bits,
-                $site_processorvendor,
-                $site_processorvendorid,
-                $site_processorfamilyid,
-                $site_processormodelid,
-                $site_processorcachesize,
-                $site_numberlogicalcpus,
-                $site_numberphysicalcpus,
-                $site_totalvirtualmemory,
-                $site_totalphysicalmemory,
-                $site_logicalprocessorsperphysical,
-                $site_processorclockfrequency,
-                $site_description, $site_ip, $location['latitude'], $location['longitude'],
-                false, $outoforder);
+            self::update_site(
+                $claimsiteid,
+                $site_name,
+                [
+                    'processoris64bits' => $site_processoris64bits,
+                    'processorvendor' => $site_processorvendor,
+                    'processorvendorid' => $site_processorvendorid,
+                    'processorfamilyid' => $site_processorfamilyid,
+                    'processormodelid' => $site_processormodelid,
+                    'processorcachesize' => $site_processorcachesize,
+                    'numberlogicalcpus' => $site_numberlogicalcpus,
+                    'numberphysicalcpus' => $site_numberphysicalcpus,
+                    'totalvirtualmemory' => $site_totalvirtualmemory,
+                    'totalphysicalmemory' => $site_totalphysicalmemory,
+                    'logicalprocessorsperphysical' => $site_logicalprocessorsperphysical,
+                    'processorclockfrequency' => $site_processorclockfrequency,
+                    'description' => $site_description,
+                ],
+                $site_ip,
+                $location['latitude'],
+                $location['longitude'],
+                $outoforder
+            );
         }
 
         // If we have a projectid that means we should list all the sites
@@ -258,89 +267,29 @@ final class SiteController extends AbstractController
         // If we have a siteid we look if the user has claimed the site or not
         $siteid = $_GET['siteid'] ?? null;
         if ($siteid !== null) {
-            $siteid = (int) $siteid;
-        }
-        if ($siteid !== null) {
             $xml .= '<user>';
             $xml .= '<site>';
-            $site_array = $db->executePreparedSingleRow('SELECT * FROM site WHERE id=?', [$siteid]);
+            $site = Site::findOrFail((int) $siteid);
 
-            $siteinformation_array = [];
-            $siteinformation_array['description'] = 'NA';
-            $siteinformation_array['processoris64bits'] = 'NA';
-            $siteinformation_array['processorvendor'] = 'NA';
-            $siteinformation_array['processorvendorid'] = 'NA';
-            $siteinformation_array['processorfamilyid'] = 'NA';
-            $siteinformation_array['processormodelid'] = 'NA';
-            $siteinformation_array['processorcachesize'] = 'NA';
-            $siteinformation_array['numberlogicalcpus'] = 'NA';
-            $siteinformation_array['numberphysicalcpus'] = 'NA';
-            $siteinformation_array['totalvirtualmemory'] = 'NA';
-            $siteinformation_array['totalphysicalmemory'] = 'NA';
-            $siteinformation_array['logicalprocessorsperphysical'] = 'NA';
-            $siteinformation_array['processorclockfrequency'] = 'NA';
-
-            // Get the last information about the size
-            $query = $db->executePreparedSingleRow('
-                         SELECT *
-                         FROM siteinformation
-                         WHERE siteid=?
-                         ORDER BY timestamp DESC
-                         LIMIT 1
-                     ', [$siteid]);
-            if (!empty($query)) {
-                $siteinformation_array = $query;
-                if ($siteinformation_array['processoris64bits'] == -1) {
-                    $siteinformation_array['processoris64bits'] = 'NA';
-                }
-                if ($siteinformation_array['processorfamilyid'] == -1) {
-                    $siteinformation_array['processorfamilyid'] = 'NA';
-                }
-                if ($siteinformation_array['processormodelid'] == -1) {
-                    $siteinformation_array['processormodelid'] = 'NA';
-                }
-                if ($siteinformation_array['processorcachesize'] == -1) {
-                    $siteinformation_array['processorcachesize'] = 'NA';
-                }
-                if ($siteinformation_array['numberlogicalcpus'] == -1) {
-                    $siteinformation_array['numberlogicalcpus'] = 'NA';
-                }
-                if ($siteinformation_array['numberphysicalcpus'] == -1) {
-                    $siteinformation_array['numberphysicalcpus'] = 'NA';
-                }
-                if ($siteinformation_array['totalvirtualmemory'] == -1) {
-                    $siteinformation_array['totalvirtualmemory'] = 'NA';
-                }
-                if ($siteinformation_array['totalphysicalmemory'] == -1) {
-                    $siteinformation_array['totalphysicalmemory'] = 'NA';
-                }
-                if ($siteinformation_array['logicalprocessorsperphysical'] == -1) {
-                    $siteinformation_array['logicalprocessorsperphysical'] = 'NA';
-                }
-                if ($siteinformation_array['processorclockfrequency'] == -1) {
-                    $siteinformation_array['processorclockfrequency'] = 'NA';
-                }
-            }
-
-            $xml .= add_XML_value('id', $siteid);
-            $xml .= add_XML_value('name', $site_array['name']);
-            $xml .= add_XML_value('description', stripslashes($siteinformation_array['description']));
-            $xml .= add_XML_value('processoris64bits', $siteinformation_array['processoris64bits']);
-            $xml .= add_XML_value('processorvendor', $siteinformation_array['processorvendor']);
-            $xml .= add_XML_value('processorvendorid', $siteinformation_array['processorvendorid']);
-            $xml .= add_XML_value('processorfamilyid', $siteinformation_array['processorfamilyid']);
-            $xml .= add_XML_value('processormodelid', $siteinformation_array['processormodelid']);
-            $xml .= add_XML_value('processorcachesize', $siteinformation_array['processorcachesize']);
-            $xml .= add_XML_value('numberlogicalcpus', $siteinformation_array['numberlogicalcpus']);
-            $xml .= add_XML_value('numberphysicalcpus', $siteinformation_array['numberphysicalcpus']);
-            $xml .= add_XML_value('totalvirtualmemory', $siteinformation_array['totalvirtualmemory']);
-            $xml .= add_XML_value('totalphysicalmemory', $siteinformation_array['totalphysicalmemory']);
-            $xml .= add_XML_value('logicalprocessorsperphysical', $siteinformation_array['logicalprocessorsperphysical']);
-            $xml .= add_XML_value('processorclockfrequency', $siteinformation_array['processorclockfrequency']);
-            $xml .= add_XML_value('ip', $site_array['ip']);
-            $xml .= add_XML_value('latitude', $site_array['latitude']);
-            $xml .= add_XML_value('longitude', $site_array['longitude']);
-            $xml .= add_XML_value('outoforder', $site_array['outoforder']);
+            $xml .= add_XML_value('id', $site->id);
+            $xml .= add_XML_value('name', $site->name);
+            $xml .= add_XML_value('description', stripslashes($site->mostRecentInformation->description ?? ''));
+            $xml .= add_XML_value('processoris64bits', $site->mostRecentInformation?->processoris64bits);
+            $xml .= add_XML_value('processorvendor', $site->mostRecentInformation?->processorvendor);
+            $xml .= add_XML_value('processorvendorid', $site->mostRecentInformation?->processorvendorid);
+            $xml .= add_XML_value('processorfamilyid', $site->mostRecentInformation?->processorfamilyid);
+            $xml .= add_XML_value('processormodelid', $site->mostRecentInformation?->processormodelid);
+            $xml .= add_XML_value('processorcachesize', $site->mostRecentInformation?->processorcachesize);
+            $xml .= add_XML_value('numberlogicalcpus', $site->mostRecentInformation?->numberlogicalcpus);
+            $xml .= add_XML_value('numberphysicalcpus', $site->mostRecentInformation?->numberphysicalcpus);
+            $xml .= add_XML_value('totalvirtualmemory', $site->mostRecentInformation?->totalvirtualmemory);
+            $xml .= add_XML_value('totalphysicalmemory', $site->mostRecentInformation?->totalphysicalmemory);
+            $xml .= add_XML_value('logicalprocessorsperphysical', $site->mostRecentInformation?->logicalprocessorsperphysical);
+            $xml .= add_XML_value('processorclockfrequency', $site->mostRecentInformation?->processorclockfrequency);
+            $xml .= add_XML_value('ip', $site->ip);
+            $xml .= add_XML_value('latitude', $site->latitude);
+            $xml .= add_XML_value('longitude', $site->longitude);
+            $xml .= add_XML_value('outoforder', $site->outoforder);
             $xml .= '</site>';
 
             $user2site = $db->executePreparedSingleRow('
@@ -375,76 +324,19 @@ final class SiteController extends AbstractController
     {
         $db = Database::getInstance();
 
-        $site_array = $db->executePreparedSingleRow("SELECT * FROM site WHERE id=?", [$siteid]);
-        $sitename = $site_array['name'];
+        $site = Site::findOrFail($siteid);
 
         $currenttime = $_GET['currenttime'] ?? null;
         if ($currenttime !== null) {
             $currenttime = (int) $currenttime;
+
+            // Current timestamp is the beginning of the dashboard and we want the end
+            $currenttimestamp = Carbon::createFromTimestamp($currenttime + 3600 * 24);
+        } else {
+            $currenttimestamp = Carbon::maxValue();
         }
 
-        $siteinformation_array = [
-            'description' => 'NA',
-            'processoris64bits' => 'NA',
-            'processorvendor' => 'NA',
-            'processorvendorid' => 'NA',
-            'processorfamilyid' => 'NA',
-            'processormodelid' => 'NA',
-            'processorcachesize' => 'NA',
-            'numberlogicalcpus' => 'NA',
-            'numberphysicalcpus' => 'NA',
-            'totalvirtualmemory' => 'NA',
-            'totalphysicalmemory' => 'NA',
-            'logicalprocessorsperphysical' => 'NA',
-            'processorclockfrequency' => 'NA',
-        ];
-
-        // Current timestamp is the beginning of the dashboard and we want the end
-        $currenttimestamp = gmdate(FMT_DATETIME, $currenttime + 3600 * 24);
-
-        $query = $db->executePrepared("
-                     SELECT *
-                     FROM siteinformation
-                     WHERE
-                         siteid=?
-                         AND timestamp<=?
-                     ORDER BY timestamp DESC
-                     LIMIT 1
-                 ", [$siteid, $currenttimestamp]);
-
-        if (count($query) > 0) {
-            $siteinformation_array = $query[0];
-            if ($siteinformation_array['processoris64bits'] == -1) {
-                $siteinformation_array['processoris64bits'] = 'NA';
-            }
-            if ($siteinformation_array['processorfamilyid'] == -1) {
-                $siteinformation_array['processorfamilyid'] = 'NA';
-            }
-            if ($siteinformation_array['processormodelid'] == -1) {
-                $siteinformation_array['processormodelid'] = 'NA';
-            }
-            if ($siteinformation_array['processorcachesize'] == -1) {
-                $siteinformation_array['processorcachesize'] = 'NA';
-            }
-            if ($siteinformation_array['numberlogicalcpus'] == -1) {
-                $siteinformation_array['numberlogicalcpus'] = 'NA';
-            }
-            if ($siteinformation_array['numberphysicalcpus'] == -1) {
-                $siteinformation_array['numberphysicalcpus'] = 'NA';
-            }
-            if ($siteinformation_array['totalvirtualmemory'] == -1) {
-                $siteinformation_array['totalvirtualmemory'] = 'NA';
-            }
-            if ($siteinformation_array['totalphysicalmemory'] == -1) {
-                $siteinformation_array['totalphysicalmemory'] = 'NA';
-            }
-            if ($siteinformation_array['logicalprocessorsperphysical'] == -1) {
-                $siteinformation_array['logicalprocessorsperphysical'] = 'NA';
-            }
-            if ($siteinformation_array['processorclockfrequency'] == -1) {
-                $siteinformation_array['processorclockfrequency'] = 'NA';
-            }
-        }
+        $siteinformation = $site->mostRecentInformation($currenttimestamp)->first();
 
         $xml = begin_XML_for_XSLT();
 
@@ -459,10 +351,11 @@ final class SiteController extends AbstractController
             $xml .= '&#38;date=' . $date;
             $xml .= '</backurl>';
         } else {
+            $project = null;
             $xml .= '<backurl>index.php</backurl>';
         }
-        $xml .= "<title>CDash - $sitename</title>";
-        $xml .= "<menusubtitle>$sitename</menusubtitle>";
+        $xml .= "<title>CDash - {$site->name}</title>";
+        $xml .= "<menusubtitle>{$site->name}</menusubtitle>";
 
         $xml .= '<dashboard>';
         $xml .= '<title>CDash</title>';
@@ -472,53 +365,53 @@ final class SiteController extends AbstractController
 
         $MB = 1048576;
 
-        $total_virtual_memory = 0;
-        if (is_numeric($siteinformation_array['totalvirtualmemory'])) {
-            $total_virtual_memory = $siteinformation_array['totalvirtualmemory'] * $MB;
+        $total_virtual_memory = $siteinformation?->totalvirtualmemory;
+        if ($total_virtual_memory !== null) {
+            $total_virtual_memory = getByteValueWithExtension($total_virtual_memory * $MB) . 'iB';
         }
 
-        $total_physical_memory = 0;
-        if (is_numeric($siteinformation_array['totalphysicalmemory'])) {
-            $total_physical_memory = $siteinformation_array['totalphysicalmemory'] * $MB;
+        $total_physical_memory = $siteinformation?->totalphysicalmemory;
+        if ($total_physical_memory !== null) {
+            $total_physical_memory = getByteValueWithExtension($total_physical_memory * $MB) . 'iB';
         }
 
-        $processor_clock_frequency = 0;
-        if (is_numeric($siteinformation_array['processorclockfrequency'])) {
-            $processor_clock_frequency = $siteinformation_array['processorclockfrequency'] * 10**6;
+        $processor_clock_frequency = $siteinformation?->processorclockfrequency;
+        if ($processor_clock_frequency !== null) {
+            $processor_clock_frequency = getByteValueWithExtension($processor_clock_frequency * 10**6, 1000) . 'Hz';
         }
 
         $xml .= add_XML_value('googlemapkey', $apikey);
         $xml .= '</dashboard>';
         $xml .= '<site>';
-        $xml .= add_XML_value('id', $site_array['id']);
-        $xml .= add_XML_value('name', $site_array['name']);
-        $xml .= add_XML_value('description', stripslashes($siteinformation_array['description']));
-        $xml .= add_XML_value('processoris64bits', $siteinformation_array['processoris64bits']);
-        $xml .= add_XML_value('processorvendor', $siteinformation_array['processorvendor']);
-        $xml .= add_XML_value('processorvendorid', $siteinformation_array['processorvendorid']);
-        $xml .= add_XML_value('processorfamilyid', $siteinformation_array['processorfamilyid']);
-        $xml .= add_XML_value('processormodelid', $siteinformation_array['processormodelid']);
-        $xml .= add_XML_value('processorcachesize', $siteinformation_array['processorcachesize']);
-        $xml .= add_XML_value('numberlogicalcpus', $siteinformation_array['numberlogicalcpus']);
-        $xml .= add_XML_value('numberphysicalcpus', $siteinformation_array['numberphysicalcpus']);
-        $xml .= add_XML_value('totalvirtualmemory', getByteValueWithExtension($total_virtual_memory) . 'iB');
-        $xml .= add_XML_value('totalphysicalmemory', getByteValueWithExtension($total_physical_memory) . 'iB');
-        $xml .= add_XML_value('logicalprocessorsperphysical', $siteinformation_array['logicalprocessorsperphysical']);
-        $xml .= add_XML_value('processorclockfrequency', getByteValueWithExtension($processor_clock_frequency, 1000) . 'Hz');
-        $xml .= add_XML_value('outoforder', $site_array['outoforder']);
-        if ($projectid > 0 && $project->ShowIPAddresses) {
-            $xml .= add_XML_value('ip', $site_array['ip']);
-            $xml .= add_XML_value('latitude', $site_array['latitude']);
-            $xml .= add_XML_value('longitude', $site_array['longitude']);
+        $xml .= add_XML_value('id', $site->id);
+        $xml .= add_XML_value('name', $site->name);
+        $xml .= add_XML_value('description', stripslashes($siteinformation->description ?? ''));
+        $xml .= add_XML_value('processoris64bits', $siteinformation?->processoris64bits);
+        $xml .= add_XML_value('processorvendor', $siteinformation?->processorvendor);
+        $xml .= add_XML_value('processorvendorid', $siteinformation?->processorvendorid);
+        $xml .= add_XML_value('processorfamilyid', $siteinformation?->processorfamilyid);
+        $xml .= add_XML_value('processormodelid', $siteinformation?->processormodelid);
+        $xml .= add_XML_value('processorcachesize', $siteinformation?->processorcachesize);
+        $xml .= add_XML_value('numberlogicalcpus', $siteinformation?->numberlogicalcpus);
+        $xml .= add_XML_value('numberphysicalcpus', $siteinformation?->numberphysicalcpus);
+        $xml .= add_XML_value('totalvirtualmemory', $total_virtual_memory);
+        $xml .= add_XML_value('totalphysicalmemory', $total_physical_memory);
+        $xml .= add_XML_value('logicalprocessorsperphysical', $siteinformation?->logicalprocessorsperphysical);
+        $xml .= add_XML_value('processorclockfrequency', $processor_clock_frequency);
+        $xml .= add_XML_value('outoforder', $site->outoforder);
+        if ($project !== null && $project->ShowIPAddresses) {
+            $xml .= add_XML_value('ip', $site->ip);
+            $xml .= add_XML_value('latitude', $site->latitude);
+            $xml .= add_XML_value('longitude', $site->longitude);
         }
         $xml .= '</site>';
 
         // List the claimers of the site
         $siteclaimer = $db->executePrepared("
-                           SELECT firstname, lastname, email
-                           FROM user, site2user
+                           SELECT u.firstname, u.lastname, u.email
+                           FROM " . qid('user') . " as u, site2user
                            WHERE
-                               user.id=site2user.userid
+                               u.id=site2user.userid
                                AND site2user.siteid=?
                            ORDER BY firstname
                        ", [$siteid]);
@@ -544,8 +437,8 @@ final class SiteController extends AbstractController
                             GROUP BY projectid
                         ', [$siteid]);
 
-        foreach ($site2project as $site) {
-            $projectid = $site['projectid'];
+        foreach ($site2project as $project_site) {
+            $projectid = $project_site['projectid'];
 
             $project = new Project();
             $project->Id = $projectid;
@@ -553,7 +446,7 @@ final class SiteController extends AbstractController
             if (Gate::allows('view-project', $project)) {
                 $xml .= '<project>';
                 $xml .= add_XML_value('id', $projectid);
-                $xml .= add_XML_value('submittime', $site['maxtime']);
+                $xml .= add_XML_value('submittime', $project_site['maxtime']);
                 $xml .= add_XML_value('name', $project->Name);
                 $xml .= add_XML_value('name_encoded', urlencode($project->Name));
                 $xml .= '</project>';
@@ -649,7 +542,7 @@ final class SiteController extends AbstractController
 
         $xml .= '</cdash>';
 
-        return $this->view('cdash', $sitename)
+        return $this->view('cdash', $site->name)
             ->with('xsl', true)
             ->with('xsl_content', generate_XSLT($xml, base_path() . '/app/cdash/public/viewSite', true));
     }
@@ -676,59 +569,21 @@ final class SiteController extends AbstractController
 
     /**
      * Update a site
+     *
+     * @param array<string,mixed> $information
      */
     private static function update_site(
-        $siteid,
-        $name,
-        $processoris64bits,
-        $processorvendor,
-        $processorvendorid,
-        $processorfamilyid,
-        $processormodelid,
-        $processorcachesize,
-        $numberlogicalcpus,
-        $numberphysicalcpus,
-        $totalvirtualmemory,
-        $totalphysicalmemory,
-        $logicalprocessorsperphysical,
-        $processorclockfrequency,
-        $description,
+        int $siteid,
+        string $name,
+        array $information,
         $ip,
         $latitude,
         $longitude,
-        $nonewrevision = false,
-        $outoforder = 0): void
-    {
-        // Security checks
-        if (!is_numeric($siteid)) {
-            return;
-        }
-        $siteid = (int) $siteid;
-
-        $db = Database::getInstance();
-
-        // TODO: (williamjallen) Refactor this to eliminate the messy usage of the $$ operator below
-        $latitude = pdo_real_escape_string($latitude);
-        $longitude = pdo_real_escape_string($longitude);
-        $outoforder = pdo_real_escape_string($outoforder);
-        $ip = pdo_real_escape_string($ip);
-        $name = pdo_real_escape_string($name);
-        $processoris64bits = pdo_real_escape_string($processoris64bits);
-        $processorvendor = pdo_real_escape_string($processorvendor);
-        $processorvendorid = pdo_real_escape_string($processorvendorid);
-        $processorfamilyid = pdo_real_escape_string($processorfamilyid);
-        $processormodelid = pdo_real_escape_string($processormodelid);
-        $processorcachesize = pdo_real_escape_string($processorcachesize);
-        $numberlogicalcpus = pdo_real_escape_string($numberlogicalcpus);
-        $numberphysicalcpus = pdo_real_escape_string($numberphysicalcpus);
-        $totalvirtualmemory = round(pdo_real_escape_string($totalvirtualmemory));
-        $totalphysicalmemory = round(pdo_real_escape_string($totalphysicalmemory));
-        $logicalprocessorsperphysical = round(pdo_real_escape_string($logicalprocessorsperphysical));
-        $processorclockfrequency = round(pdo_real_escape_string($processorclockfrequency));
-        $description = pdo_real_escape_string($description);
-
+        bool $outoforder = false
+    ): void {
         // Update the basic information first
-        Site::findOrFail($siteid)->where([
+        $site = Site::findOrFail($siteid);
+        $site->updateOrFail([
             'name' => $name,
             'ip' => $ip,
             'latitude' => $latitude,
@@ -736,118 +591,7 @@ final class SiteController extends AbstractController
             'outoforder' => $outoforder,
         ]);
 
-        add_last_sql_error('update_site');
-
-        $names = [];
-        $names[] = 'processoris64bits';
-        $names[] = 'processorvendor';
-        $names[] = 'processorvendorid';
-        $names[] = 'processorfamilyid';
-        $names[] = 'processormodelid';
-        $names[] = 'processorcachesize';
-        $names[] = 'numberlogicalcpus';
-        $names[] = 'numberphysicalcpus';
-        $names[] = 'totalvirtualmemory';
-        $names[] = 'totalphysicalmemory';
-        $names[] = 'logicalprocessorsperphysical';
-        $names[] = 'processorclockfrequency';
-        $names[] = 'description';
-
-        // Check that we have a valid input
-        $isinputvalid = 0;
-        foreach ($names as $name) {
-            if ($$name != 'NA' && strlen($$name) > 0) {
-                $isinputvalid = 1;
-                break;
-            }
-        }
-
-        if (!$isinputvalid) {
-            return;
-        }
-
-        // Check if we have valuable information and the siteinformation doesn't exist
-        $newrevision2 = false;
-        $query = $db->executePreparedSingleRow('
-                         SELECT *
-                         FROM siteinformation
-                         WHERE siteid=?
-                         ORDER BY timestamp DESC
-                         LIMIT 1
-                     ', [$siteid]);
-        if (empty($query)) {
-            $noinformation = 1;
-            foreach ($names as $name) {
-                if ($$name != 'NA' && strlen($$name) > 0) {
-                    $nonewrevision = false;
-                    $newrevision2 = true;
-                    $noinformation = 0;
-                    break;
-                }
-            }
-            if ($noinformation) {
-                return; // we have nothing to add
-            }
-        } else {
-            // Check if the information are different from what we have in the database, then that means
-            // the system has been upgraded and we need to create a new revision
-            foreach ($names as $name) {
-                if ($$name != 'NA' && $query[$name] != $$name && strlen($$name) > 0) {
-                    // Take care of rounding issues
-                    if (is_numeric($$name)) {
-                        if (round($$name) != $query[$name]) {
-                            $newrevision2 = true;
-                            break;
-                        }
-                    } else {
-                        $newrevision2 = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if ($newrevision2 && !$nonewrevision) {
-            $now = gmdate(FMT_DATETIME);
-            $sql = 'INSERT INTO siteinformation(siteid,timestamp';
-            foreach ($names as $name) {
-                if ($$name != 'NA' && strlen($$name) > 0) {
-                    $sql .= ", $name";
-                }
-            }
-
-            $prepared_values = [$siteid, $now];
-            $sql .= ') VALUES(?, ?';
-            foreach ($names as $name) {
-                if ($$name != 'NA' && strlen($$name) > 0) {
-                    $sql .= ', ?';
-                    $prepared_values[] = $$name;
-                }
-            }
-            $sql .= ')';
-            $db->executePrepared($sql, $prepared_values);
-            add_last_sql_error('update_site', $sql);
-        } else {
-            $sql = 'UPDATE siteinformation SET ';
-            $prepared_values = [];
-            $i = 0;
-            foreach ($names as $name) {
-                if ($$name != 'NA' && strlen($$name) > 0) {
-                    if ($i > 0) {
-                        $sql .= ',';
-                    }
-                    $sql .= " $name=?";
-                    $prepared_values[] = $$name;
-                    $i++;
-                }
-            }
-
-            $sql .= " WHERE siteid=? AND timestamp=?";
-            $prepared_values[] = $siteid;
-            $prepared_values[] = $query['timestamp'];
-
-            $db->executePrepared($sql, $prepared_values);
-            add_last_sql_error('update_site', $sql);
-        }
+        // Create a new information row if something has changed since the most recent update
+        $site->mostRecentInformation()->firstOrCreate($information);
     }
 }

--- a/app/Models/SiteInformation.php
+++ b/app/Models/SiteInformation.php
@@ -8,19 +8,19 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property string $timestamp
- * @property int $processoris64bits
- * @property string $processorvendor
- * @property string $processorvendorid
- * @property int $processorfamilyid
- * @property int $processormodelid
- * @property int $processorcachesize
- * @property int $numberlogicalcpus
- * @property int $numberphysicalcpus
- * @property int $totalvirtualmemory
- * @property int $totalphysicalmemory
- * @property int $logicalprocessorsperphysical
- * @property int $processorclockfrequency
- * @property string $description
+ * @property boolean|null $processoris64bits
+ * @property string|null $processorvendor
+ * @property string|null $processorvendorid
+ * @property int|null $processorfamilyid
+ * @property int|null $processormodelid
+ * @property int|null $processorcachesize
+ * @property int|null $numberlogicalcpus
+ * @property int|null $numberphysicalcpus
+ * @property int|null $totalvirtualmemory
+ * @property int|null $totalphysicalmemory
+ * @property int|null $logicalprocessorsperphysical
+ * @property int|null $processorclockfrequency
+ * @property string|null $description
  * @property int $siteid
  *
  * @mixin Builder<SiteInformation>
@@ -46,7 +46,20 @@ class SiteInformation extends Model
         'logicalprocessorsperphysical',
         'processorclockfrequency',
         'description',
-        'siteid',
+    ];
+
+    protected $casts = [
+        'timestamp' => 'datetime',
+        'processoris64bits' => 'boolean',
+        'processorfamilyid' => 'int',
+        'processormodelid' => 'int',
+        'processorcachesize' => 'int',
+        'numberlogicalcpus' => 'int',
+        'numberphysicalcpus' => 'int',
+        'totalvirtualmemory' => 'int',
+        'totalphysicalmemory' => 'int',
+        'logicalprocessorsperphysical' => 'int',
+        'processorclockfrequency' => 'int',
     ];
 
     /**
@@ -61,16 +74,16 @@ class SiteInformation extends Model
     {
         switch ($tag) {
             case 'DESCRIPTION':
-                $this->description = $value;
+                $this->description = (string) $value;
                 break;
             case 'IS64BITS':
-                $this->processoris64bits = (int) $value;
+                $this->processoris64bits = (bool) $value;
                 break;
             case 'VENDORSTRING':
-                $this->processorvendor = $value;
+                $this->processorvendor = (string) $value;
                 break;
             case 'VENDORID':
-                $this->processorvendorid = $value;
+                $this->processorvendorid = (string) $value;
                 break;
             case 'FAMILYID':
                 $this->processorfamilyid = (int) $value;

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -104,19 +104,19 @@ class TestUseCaseTest extends CDashUseCaseTestCase
         $build = $builds->current();
         $information = $build->GetSite()->mostRecentInformation;
 
-        $this->assertEquals($siteInformation['Description'], $information->description);
-        $this->assertEquals($siteInformation['Is64Bits'], $information->processoris64bits);
-        $this->assertEquals($siteInformation['VendorString'], $information->processorvendor);
-        $this->assertEquals($siteInformation['VendorID'], $information->processorvendorid);
-        $this->assertEquals($siteInformation['FamilyID'], $information->processorfamilyid);
-        $this->assertEquals($siteInformation['ModelID'], $information->processormodelid);
-        $this->assertEquals($siteInformation['ProcessorCacheSize'], $information->processorcachesize);
-        $this->assertEquals($siteInformation['NumberOfLogicalCPU'], $information->numberlogicalcpus);
-        $this->assertEquals($siteInformation['NumberOfPhysicalCPU'], $information->numberphysicalcpus);
-        $this->assertEquals($siteInformation['TotalVirtualMemory'], $information->totalvirtualmemory);
-        $this->assertEquals($siteInformation['TotalPhysicalMemory'], $information->totalphysicalmemory);
-        $this->assertEquals($siteInformation['LogicalProcessorsPerPhysical'], $information->logicalprocessorsperphysical);
-        $this->assertEquals($siteInformation['ProcessorClockFrequency'], $information->processorclockfrequency);
+        $this->assertEquals($siteInformation['Description'], $information?->description);
+        $this->assertEquals($siteInformation['Is64Bits'], $information?->processoris64bits);
+        $this->assertEquals($siteInformation['VendorString'], $information?->processorvendor);
+        $this->assertEquals($siteInformation['VendorID'], $information?->processorvendorid);
+        $this->assertEquals($siteInformation['FamilyID'], $information?->processorfamilyid);
+        $this->assertEquals($siteInformation['ModelID'], $information?->processormodelid);
+        $this->assertEquals($siteInformation['ProcessorCacheSize'], $information?->processorcachesize);
+        $this->assertEquals($siteInformation['NumberOfLogicalCPU'], $information?->numberlogicalcpus);
+        $this->assertEquals($siteInformation['NumberOfPhysicalCPU'], $information?->numberphysicalcpus);
+        $this->assertEquals($siteInformation['TotalVirtualMemory'], $information?->totalvirtualmemory);
+        $this->assertEquals($siteInformation['TotalPhysicalMemory'], $information?->totalphysicalmemory);
+        $this->assertEquals($siteInformation['LogicalProcessorsPerPhysical'], $information?->logicalprocessorsperphysical);
+        $this->assertEquals($siteInformation['ProcessorClockFrequency'], $information?->processorclockfrequency);
 
         $this->assertEquals($siteInformation['OSName'], $build->Information->osname);
         $this->assertEquals($siteInformation['OSRelease'], $build->Information->osrelease);

--- a/app/cdash/tests/test_projectwebpage.php
+++ b/app/cdash/tests/test_projectwebpage.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Carbon;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 class ProjectWebPageTestCase extends KWWebTestCase
@@ -189,7 +191,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
         $buildgroup = array_pop($jsonobj['buildgroups']);
         $siteid = $buildgroup['builds'][0]['siteid'];
 
-        $content = $this->connect($this->url . "/sites/$siteid?project=4&currenttime=1235354400");
+        $content = $this->connect($this->url . "/sites/$siteid?project=4&currenttime=" . Carbon::now()->getTimestamp());
         if (!$content) {
             return;
         } elseif (!$this->findString($content, '<b>Total Physical Memory: </b>15MiB<br />')) {

--- a/database/migrations/2024_04_28_215829_site_information_nullable.php
+++ b/database/migrations/2024_04_28_215829_site_information_nullable.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Make all of the user-controlled fields nullable
+        Schema::table('siteinformation', function (Blueprint $table) {
+            $table->dateTime('timestamp')->default('CURRENT_TIMESTAMP')->change();
+            $table->smallInteger('processoris64bits')->nullable()->default(null)->change();
+            $table->string('processorvendor', 255)->nullable()->default(null)->change();
+            $table->string('processorvendorid', 255)->nullable()->default(null)->change();
+            $table->integer('processorfamilyid')->nullable()->default(null)->change();
+            $table->integer('processormodelid')->nullable()->default(null)->change();
+            $table->integer('processorcachesize')->nullable()->default(null)->change();
+            $table->smallInteger('numberlogicalcpus')->nullable()->default(null)->change();
+            $table->smallInteger('numberphysicalcpus')->nullable()->default(null)->change();
+            $table->integer('totalvirtualmemory')->nullable()->default(null)->change();
+            $table->integer('totalphysicalmemory')->nullable()->default(null)->change();
+            $table->integer('logicalprocessorsperphysical')->nullable()->default(null)->change();
+            $table->integer('processorclockfrequency')->nullable()->default(null)->change();
+            $table->string('description', 255)->nullable()->default(null)->change();
+        });
+
+        // Set any field with the default value to null.
+        DB::update("UPDATE siteinformation SET processoris64bits = NULL WHERE processoris64bits = -1");
+        DB::update("UPDATE siteinformation SET processorvendor = NULL WHERE processorvendor = 'NA'");
+        DB::update("UPDATE siteinformation SET processorvendorid = NULL WHERE processorvendorid = 'NA'");
+        DB::update("UPDATE siteinformation SET processorfamilyid = NULL WHERE processorfamilyid = -1");
+        DB::update("UPDATE siteinformation SET processormodelid = NULL WHERE processormodelid = -1");
+        DB::update("UPDATE siteinformation SET processorcachesize = NULL WHERE processorcachesize = -1");
+        DB::update("UPDATE siteinformation SET numberlogicalcpus = NULL WHERE numberlogicalcpus = 0");
+        DB::update("UPDATE siteinformation SET numberphysicalcpus = NULL WHERE numberphysicalcpus = 0");
+        DB::update("UPDATE siteinformation SET totalvirtualmemory = NULL WHERE totalvirtualmemory = -1");
+        DB::update("UPDATE siteinformation SET totalphysicalmemory = NULL WHERE totalphysicalmemory = -1");
+        DB::update("UPDATE siteinformation SET logicalprocessorsperphysical = NULL WHERE logicalprocessorsperphysical = -1");
+        DB::update("UPDATE siteinformation SET processorclockfrequency = NULL WHERE processorclockfrequency = -1");
+        DB::update("UPDATE siteinformation SET description = NULL WHERE description = 'NA'");
+
+        // Change these to integer columns for consistency with other columns
+        Schema::table('siteinformation', function (Blueprint $table) {
+            $table->integer('numberlogicalcpus')->nullable()->change();
+            $table->integer('numberphysicalcpus')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Set values back to default where null
+        DB::update("UPDATE siteinformation SET processoris64bits = -1 WHERE processoris64bits IS NULL");
+        DB::update("UPDATE siteinformation SET processorvendor = 'NA' WHERE processorvendor IS NULL");
+        DB::update("UPDATE siteinformation SET processorvendorid = 'NA' WHERE processorvendorid IS NULL");
+        DB::update("UPDATE siteinformation SET processorfamilyid = -1 WHERE processorfamilyid IS NULL");
+        DB::update("UPDATE siteinformation SET processormodelid = -1 WHERE processormodelid IS NULL");
+        DB::update("UPDATE siteinformation SET processorcachesize = -1 WHERE processorcachesize IS NULL");
+        DB::update("UPDATE siteinformation SET numberlogicalcpus = 0 WHERE numberlogicalcpus IS NULL");
+        DB::update("UPDATE siteinformation SET numberphysicalcpus = 0 WHERE numberphysicalcpus IS NULL");
+        DB::update("UPDATE siteinformation SET totalvirtualmemory = -1 WHERE totalvirtualmemory IS NULL");
+        DB::update("UPDATE siteinformation SET totalphysicalmemory = -1 WHERE totalphysicalmemory IS NULL");
+        DB::update("UPDATE siteinformation SET logicalprocessorsperphysical = -1 WHERE logicalprocessorsperphysical IS NULL");
+        DB::update("UPDATE siteinformation SET processorclockfrequency = -1 WHERE processorclockfrequency IS NULL");
+        DB::update("UPDATE siteinformation SET description = 'NA' WHERE description IS NULL");
+
+        // Change the column constraints back to the original constraints
+        Schema::table('siteinformation', function (Blueprint $table) {
+            $table->dateTime('timestamp')->default('1980-01-01 00:00:00')->change();
+            $table->smallInteger('processoris64bits')->nullable(false)->default(-1)->change();
+            $table->string('processorvendor', 255)->nullable(false)->default('NA')->change();
+            $table->string('processorvendorid', 255)->nullable(false)->default('NA')->change();
+            $table->integer('processorfamilyid')->nullable(false)->default(-1)->change();
+            $table->integer('processormodelid')->nullable(false)->default(-1)->change();
+            $table->integer('processorcachesize')->nullable(false)->default(-1)->change();
+            $table->smallInteger('numberlogicalcpus')->nullable(false)->default(0)->change();
+            $table->smallInteger('numberphysicalcpus')->nullable(false)->default(0)->change();
+            $table->integer('totalvirtualmemory')->nullable(false)->default(-1)->change();
+            $table->integer('totalphysicalmemory')->nullable(false)->default(-1)->change();
+            $table->integer('logicalprocessorsperphysical')->nullable(false)->default(-1)->change();
+            $table->integer('processorclockfrequency')->nullable(false)->default(-1)->change();
+            $table->string('description', 255)->nullable(false)->default('NA')->change();
+        });
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -193,4 +193,44 @@ type Site {
   latitude: Float!
 
   longitude: Float!
+
+  "Every edit of this site's information."
+  information: [SiteInformation!]! @hasMany(type: CONNECTION) @orderBy(column: "timestamp")
+
+  "The most recent information we have about this site."
+  # TODO: Figure out how to support the date parameter. Perhaps it would be better to use a scope instead.
+  mostRecentInformation: SiteInformation @hasOne
+}
+
+
+"Details about a site at a given point in time."
+type SiteInformation {
+  "Creation timestamp."
+  timestamp: DateTime!
+
+  processorIs64Bits: Boolean @rename(attribute: "processoris64bits")
+
+  processorVendor: String @rename(attribute: "processorvendor")
+
+  processorVendorId: String @rename(attribute: "processorvendorid")
+
+  processorFamilyId: Int @rename(attribute: "processorfamilyid")
+
+  processorModelId: Int @rename(attribute: "processormodelid")
+
+  processorCacheSize: Int @rename(attribute: "processorcachesize")
+
+  numberLogicalCpus: Int @rename(attribute: "numberlogicalcpus")
+
+  numberPhysicalCpus: Int @rename(attribute: "numberphysicalcpus")
+
+  totalVirtualMemory: Int @rename(attribute: "totalvirtualmemory")
+
+  totalPhysicalMemory: Int @rename(attribute: "totalphysicalmemory")
+
+  logicalProcessorsPerPhysical: Int @rename(attribute: "logicalprocessorsperphysical")
+
+  processorClockFrequency: Int @rename(attribute: "processorclockfrequency")
+
+  description: String
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1995,18 +1995,10 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_real_escape_string\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 14
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 8
+			count: 7
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2014,7 +2006,7 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 6
+			count: 3
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2023,37 +2015,7 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Cannot access offset 'ip' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Cannot access offset 'latitude' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Cannot access offset 'longitude' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: "#^Cannot access offset 'name' on array\\|false\\|null\\.$#"
-			count: 4
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Cannot access offset 'outoforder' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Cannot access offset 0 on array\\|false\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
@@ -2064,7 +2026,12 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasOne\\<App\\\\Models\\\\SiteInformation\\>\\:\\:first\\(\\)\\.$#"
+			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2074,16 +2041,11 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 22
+			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:siteStatistics\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$description with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
@@ -2098,93 +2060,13 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$logicalprocessorsperphysical with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$longitude with no type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$nonewrevision with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$numberlogicalcpus with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$numberphysicalcpus with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$outoforder with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processorcachesize with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processorclockfrequency with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processorfamilyid with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processoris64bits with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processormodelid with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processorvendor with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$processorvendorid with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$siteid with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$totalphysicalmemory with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\SiteController\\:\\:update_site\\(\\) has parameter \\$totalvirtualmemory with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
-			count: 2
+			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2203,28 +2085,8 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
-			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, string given\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
-			count: 3
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/Http/Controllers/SiteController.php
-
-		-
-			message: "#^Variable \\$newdescription_revision might not be defined\\.$#"
-			count: 1
+			count: 2
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -3124,21 +2986,6 @@ parameters:
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Models/Site.php
-
-		-
-			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$description \\(string\\) does not accept int\\|string\\.$#"
-			count: 1
-			path: app/Models/SiteInformation.php
-
-		-
-			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$processorvendor \\(string\\) does not accept int\\|string\\.$#"
-			count: 1
-			path: app/Models/SiteInformation.php
-
-		-
-			message: "#^Property App\\\\Models\\\\SiteInformation\\:\\:\\$processorvendorid \\(string\\) does not accept int\\|string\\.$#"
-			count: 1
-			path: app/Models/SiteInformation.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:orWhere\\(\\)\\.$#"

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\GraphQL;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\User;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
@@ -325,6 +326,565 @@ class SiteTypeTest extends TestCase
                                         [
                                             'node' => [
                                                 'name' => $this->sites['public_private_submission']->name,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    /**
+     * Insert and retrieve each site information value.
+     */
+    public function testBasicSiteInformationRelationship(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->sites['site1']->information()->create([
+            'processoris64bits' => true,
+            'processorvendor' => 'GenuineIntel',
+            'processorvendorid' => 'Intel Corporation',
+            'processorfamilyid' => 6,
+            'processormodelid' => 7,
+            'processorcachesize' => 123,
+            'numberlogicalcpus' => 4,
+            'numberphysicalcpus' => 2,
+            'totalvirtualmemory' => 2048,
+            'totalphysicalmemory' => 15,
+            'logicalprocessorsperphysical' => 3,
+            'processorclockfrequency' => 2672,
+            'description' => 'site 1 description',
+        ]);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        information {
+                                            edges {
+                                                node {
+                                                    processorIs64Bits
+                                                    processorVendor
+                                                    processorVendorId
+                                                    processorFamilyId
+                                                    processorModelId
+                                                    processorCacheSize
+                                                    numberLogicalCpus
+                                                    numberPhysicalCpus
+                                                    totalVirtualMemory
+                                                    totalPhysicalMemory
+                                                    logicalProcessorsPerPhysical
+                                                    processorClockFrequency
+                                                    description
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'information' => [
+                                                    'edges' => [
+                                                        [
+                                                            'node' => [
+                                                                'processorIs64Bits' => true,
+                                                                'processorVendor' => 'GenuineIntel',
+                                                                'processorVendorId' => 'Intel Corporation',
+                                                                'processorFamilyId' => 6,
+                                                                'processorModelId' => 7,
+                                                                'processorCacheSize' => 123,
+                                                                'numberLogicalCpus' => 4,
+                                                                'numberPhysicalCpus' => 2,
+                                                                'totalVirtualMemory' => 2048,
+                                                                'totalPhysicalMemory' => 15,
+                                                                'logicalProcessorsPerPhysical' => 3,
+                                                                'processorClockFrequency' => 2672,
+                                                                'description' => 'site 1 description',
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    /**
+     * @return array{
+     *     array{
+     *         array<string,mixed>
+     *     }
+     * }
+     */
+    public function nullabilityTestCases(): array
+    {
+        return [
+            [['processoris64bits' => true]],
+            [['processorvendor' => 'GenuineIntel']],
+            [['processorvendord' => 'Intel Corporation']],
+            [['processorfamilyid' => 6]],
+            [['processormodelid' => 7]],
+            [['processorcachesize' => 123]],
+            [['numberlogicalcpus' => 4]],
+            [['numberphysicalcpus' => 2]],
+            [['totalvirtualmemory' => 2048]],
+            [['totalphysicalmemory' => 15]],
+            [['logicalprocessorsperphysical' => 3]],
+            [['processorclockfrequency' => 2672]],
+            [['description' => 'site 1 description']],
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $params
+     *
+     * @dataProvider nullabilityTestCases
+     */
+    public function testSiteInformationColumnNullability(array $params): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->sites['site1']->information()->create($params);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        information {
+                                            edges {
+                                                node {
+                                                    processorIs64Bits
+                                                    processorVendor
+                                                    processorVendorId
+                                                    processorFamilyId
+                                                    processorModelId
+                                                    processorCacheSize
+                                                    numberLogicalCpus
+                                                    numberPhysicalCpus
+                                                    totalVirtualMemory
+                                                    totalPhysicalMemory
+                                                    logicalProcessorsPerPhysical
+                                                    processorClockFrequency
+                                                    description
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'information' => [
+                                                    'edges' => [
+                                                        [
+                                                            'node' => [
+                                                                'processorIs64Bits' => $params['processoris64bits'] ?? null,
+                                                                'processorVendor' => $params['processorvendor'] ?? null,
+                                                                'processorVendorId' => $params['processorvendorid'] ?? null,
+                                                                'processorFamilyId' => $params['processorfamilyid'] ?? null,
+                                                                'processorModelId' => $params['processormodelid'] ?? null,
+                                                                'processorCacheSize' => $params['processorcachesize'] ?? null,
+                                                                'numberLogicalCpus' => $params['numberlogicalcpus'] ?? null,
+                                                                'numberPhysicalCpus' => $params['numberphysicalcpus'] ?? null,
+                                                                'totalVirtualMemory' => $params['totalvirtualmemory'] ?? null,
+                                                                'totalPhysicalMemory' => $params['totalphysicalmemory'] ?? null,
+                                                                'logicalProcessorsPerPhysical' => $params['logicalprocessorsperphysical'] ?? null,
+                                                                'processorClockFrequency' => $params['processorclockfrequency'] ?? null,
+                                                                'description' => $params['description'] ?? null,
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testSiteInformationTimestampDefault(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->sites['site1']->information()->create();
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $result = $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            sites {
+                                edges {
+                                    node {
+                                        information {
+                                            edges {
+                                                node {
+                                                    timestamp
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ');
+
+        // Assert that the resulting timestamp is correct +- one minute to account for
+        // delay between creation and query, as well as any clock drift between the
+        // database and web servers.
+        $result_timestamp = $result['data']['projects']['edges'][0]['node']['sites']['edges'][0]['node']['information']['edges'][0]['node']['timestamp'];
+        self::assertGreaterThan(Carbon::now('UTC')->subMinute(), $result_timestamp);
+        self::assertLessThan(Carbon::now('UTC')->addMinute(), $result_timestamp);
+    }
+
+    public function testMultipleSiteInformation(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->sites['site1']->information()->createMany([
+            [
+                'description' => 'site 1 information 1',
+            ],
+            [
+                'description' => 'site 1 information 2',
+            ],
+            [
+                'description' => 'site 1 information 3',
+            ],
+        ]);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        information {
+                                            edges {
+                                                node {
+                                                    description
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'information' => [
+                                                    'edges' => [
+                                                        [
+                                                            'node' => [
+                                                                'description' => 'site 1 information 1',
+                                                            ],
+                                                        ],
+                                                        [
+                                                            'node' => [
+                                                                'description' => 'site 1 information 2',
+                                                            ],
+                                                        ],
+                                                        [
+                                                            'node' => [
+                                                                'description' => 'site 1 information 3',
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testNoSiteInformationReturnsEmptyArray(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        information {
+                                            edges {
+                                                node {
+                                                    description
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'information' => [
+                                                    'edges' => [],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testMostRecentSiteInformation(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        // We want to be explicit about creating these in order, so we can't use createMany
+        $this->sites['site1']->information()->create(['description' => 'site 1 information 1']);
+        $this->sites['site1']->information()->create(['description' => 'site 1 information 2']);
+        $this->sites['site1']->information()->create(['description' => 'site 1 information 3']);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        mostRecentInformation {
+                                            description
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'mostRecentInformation' => [
+                                                    'description' => 'site 1 information 3',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testMostRecentSiteInformationReturnsNull(): void
+    {
+        $this->sites['site1'] = $this->makeSite([
+            'name' => 'site1',
+        ]);
+
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid(),
+            'siteid' => $this->sites['site1']->id,
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                        mostRecentInformation {
+                                            description
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['site1']->name,
+                                                'mostRecentInformation' => null,
                                             ],
                                         ],
                                     ],

--- a/tests/cypress/e2e/sites.cy.js
+++ b/tests/cypress/e2e/sites.cy.js
@@ -37,13 +37,20 @@ describe('site page', () => {
     cy.get('tbody').contains('a', 'hut11.kitware').click();
 
     cy.get('#subheadername').should('contain', 'hut11.kitware');
+
+    // Since the site created timestamp isn't the same time as the submission, no site information exists.
+    // We clear the timestamp to get the latest information.  TODO: Find a better way to do this...
+    cy.url().then(url => {
+      cy.visit(url.slice(0, -23));
+    });
+
+    cy.get('#subheadername').should('contain', 'hut11.kitware');
     cy.get('#main_content')
       .should('contain', 'Processor Speed:')
       .and('contain', 'Processor Vendor:')
       .and('contain', 'Number of CPUs:')
       .and('contain', 'Number of Cores:')
       .and('contain', 'Total Physical Memory:')
-      .and('contain', 'Description:')
       .and('contain', 'This site belongs to the following projects:');
     cy.get('#main_content').find('a').each(project_url => {
       cy.wrap(project_url).should('have.attr', 'href').and('contain', 'index.php?project=');


### PR DESCRIPTION
The current network of site-related CDash pages is filled with inconsistencies, and at times, incorrect behavior, and is in dire need of a refactor.  I plan to use an overhaul of these site pages as a testing ground for the new GraphQL API in the near future.  To support that upcoming work, this PR exposes SiteInformation data via the GraphQL API and cleans up a bunch of related logic.