### PR TITLE
Expose build errors and warnings via GraphQL

### DIFF
--- a/app/Models/BasicBuildAlert.php
+++ b/app/Models/BasicBuildAlert.php
@@ -19,9 +19,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $crc32
  * @property boolean $newstatus
  *
- * @mixin Builder<BuildError>
+ * @mixin Builder<BasicBuildAlert>
  */
-class BuildError extends Model
+class BasicBuildAlert extends Model
 {
     protected $table = 'builderror';
 

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -172,20 +172,20 @@ class Build extends Model
     }
 
     /**
-     * @return HasMany<BuildError>
+     * @return HasMany<BasicBuildAlert>
      */
     public function errors(): HasMany
     {
-        return $this->hasMany(BuildError::class, 'buildid')
+        return $this->hasMany(BasicBuildAlert::class, 'buildid')
             ->where('type', self::TYPE_ERROR);
     }
 
     /**
-     * @return HasMany<BuildError>
+     * @return HasMany<BasicBuildAlert>
      */
     public function warnings(): HasMany
     {
-        return $this->hasMany(BuildError::class, 'buildid')
+        return $this->hasMany(BasicBuildAlert::class, 'buildid')
             ->where('type', self::TYPE_WARN);
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -47,6 +47,9 @@ use Illuminate\Support\Carbon;
  */
 class Build extends Model
 {
+    public const TYPE_ERROR = 0;
+    public const TYPE_WARN = 1;
+
     protected $table = 'build';
 
     public $timestamps = false;
@@ -166,5 +169,23 @@ class Build extends Model
     public function site(): BelongsTo
     {
         return $this->belongsTo(Site::class, 'siteid', 'id');
+    }
+
+    /**
+     * @return HasMany<BuildError>
+     */
+    public function errors(): HasMany
+    {
+        return $this->hasMany(BuildError::class, 'buildid')
+            ->where('type', self::TYPE_ERROR);
+    }
+
+    /**
+     * @return HasMany<BuildError>
+     */
+    public function warnings(): HasMany
+    {
+        return $this->hasMany(BuildError::class, 'buildid')
+            ->where('type', self::TYPE_WARN);
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -174,18 +174,26 @@ class Build extends Model
     /**
      * @return HasMany<BasicBuildAlert>
      */
-    public function errors(): HasMany
+    public function basicAlerts(): HasMany
     {
-        return $this->hasMany(BasicBuildAlert::class, 'buildid')
+        return $this->hasMany(BasicBuildAlert::class, 'buildid');
+    }
+
+    /**
+     * @return HasMany<BasicBuildAlert>
+     */
+    public function basicErrors(): HasMany
+    {
+        return $this->basicAlerts()
             ->where('type', self::TYPE_ERROR);
     }
 
     /**
      * @return HasMany<BasicBuildAlert>
      */
-    public function warnings(): HasMany
+    public function basicWarnings(): HasMany
     {
-        return $this->hasMany(BasicBuildAlert::class, 'buildid')
+        return $this->basicAlerts()
             ->where('type', self::TYPE_WARN);
     }
 }

--- a/app/Models/BuildError.php
+++ b/app/Models/BuildError.php
@@ -6,17 +6,18 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * @property int $id
  * @property int $buildid
  * @property int $type
- * @property int $ogline
+ * @property int $logline
  * @property string $text
  * @property string $sourcefile
  * @property int $sourceline
- * @property string $precontext
- * @property string $postcontext
+ * @property string|null $precontext
+ * @property string|null $postcontext
  * @property int $repeatcount
  * @property int $crc32
- * @property int $newstatus
+ * @property boolean $newstatus
  *
  * @mixin Builder<BuildError>
  */
@@ -38,5 +39,16 @@ class BuildError extends Model
         'repeatcount',
         'crc32',
         'newstatus',
+    ];
+
+    protected $casts = [
+        'buildid' => 'integer',
+        'type' => 'integer', // TODO: Convert this to an enum
+        'logline' => 'integer',
+        'text' => 'string',
+        'sourceline' => 'integer',
+        'repeatcount' => 'integer',
+        'crc32' => 'integer',
+        'newstatus' => 'boolean',
     ];
 }

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -37,8 +37,8 @@ use App\Models\Build as EloquentBuild;
 
 class Build
 {
-    public const TYPE_ERROR = 0;
-    public const TYPE_WARN = 1;
+    public const TYPE_ERROR = EloquentBuild::TYPE_ERROR;
+    public const TYPE_WARN = EloquentBuild::TYPE_WARN;
     public const STATUS_NEW = 1;
 
     public const PARENT_BUILD = -1;

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -18,7 +18,7 @@ namespace CDash\Model;
 use App\Utils\RepositoryUtils;
 
 use PDO;
-use App\Models\BuildError as EloquentBuildError;
+use App\Models\BasicBuildAlert;
 
 /** BuildError */
 class BuildError
@@ -54,7 +54,7 @@ class BuildError
             $crc32 = crc32($this->Text . $this->SourceFile . $this->SourceLine); // some warnings can be on the same line
         }
 
-        EloquentBuildError::create([
+        BasicBuildAlert::create([
             'buildid' => (int) $this->BuildId,
             'type' => $this->Type,
             'logline' => intval($this->LogLine),
@@ -79,7 +79,7 @@ class BuildError
             return false;
         }
 
-        $result = EloquentBuildError::where('buildid', $this->BuildId)
+        $result = BasicBuildAlert::where('buildid', $this->BuildId)
             ->orderBy('logline')
             ->get();
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -176,32 +176,30 @@ type Build {
   "The site associated with this build."
   site: Site! @belongsTo
 
-  "A list of errors submitted for this build."
-  errors: [BuildError!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  # TODO: Make an "errors" field which returns the union of basic and rich errors
+  """
+  A list of "basic" errors submitted for this build.
+  """
+  basicErrors: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
-  "A list of warnings submitted for this build."
-  warnings: [BuildError!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  # TODO: Make a "warnings" field which returns the union of basic and rich warnings
+  """
+  A list of "basic" warnings submitted for this build.
+  """
+  basicWarnings: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
   # TODO: Figure out project relation.  project{build{project}} currently throws an error.
 }
 
 
-type BuildError {
-  logLine: Int! @rename(attribute: "logline")
+"""
+"Basic" alerts are warnings or errors scraped from the build log, as opposed to "rich" alerts which
+come from CTest launchers.  A given build should either have all "basic" alerts or all "rich" alerts.
+Users should take both types into account when querying the alerts for a given build.
 
-  text: String!
-
-  sourceFile: String! @rename(attribute: "sourcefile")
-
-  sourceLine: Int! @rename(attribute: "sourceline")
-
-  preContext: String @rename(attribute: "precontext")
-
-  postContext: String @rename(attribute: "postcontext")
-}
-
-
-type BuildWarning {
+https://cmake.org/cmake/help/latest/manual/ctest.1.html#ctest-build-step
+"""
+type BasicBuildAlert {
   logLine: Int! @rename(attribute: "logline")
 
   text: String!

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -176,7 +176,43 @@ type Build {
   "The site associated with this build."
   site: Site! @belongsTo
 
+  "A list of errors submitted for this build."
+  errors: [BuildError!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
+  "A list of warnings submitted for this build."
+  warnings: [BuildError!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
   # TODO: Figure out project relation.  project{build{project}} currently throws an error.
+}
+
+
+type BuildError {
+  logLine: Int! @rename(attribute: "logline")
+
+  text: String!
+
+  sourceFile: String! @rename(attribute: "sourcefile")
+
+  sourceLine: Int! @rename(attribute: "sourceline")
+
+  preContext: String @rename(attribute: "precontext")
+
+  postContext: String @rename(attribute: "postcontext")
+}
+
+
+type BuildWarning {
+  logLine: Int! @rename(attribute: "logline")
+
+  text: String!
+
+  sourceFile: String! @rename(attribute: "sourcefile")
+
+  sourceLine: Int! @rename(attribute: "sourceline")
+
+  preContext: String @rename(attribute: "precontext")
+
+  postContext: String @rename(attribute: "postcontext")
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2978,7 +2978,7 @@ parameters:
 			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
 
 		-
-			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\BuildError\\>\\:\\:where\\(\\)\\.$#"
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\BasicBuildAlert\\>\\:\\:where\\(\\)\\.$#"
 			count: 2
 			path: app/Models/Build.php
 
@@ -7177,7 +7177,7 @@ parameters:
 			path: app/cdash/app/Model/BuildError.php
 
 		-
-			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\BuildError\\>\\:\\:orderBy\\(\\)\\.$#"
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\BasicBuildAlert\\>\\:\\:orderBy\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2978,6 +2978,11 @@ parameters:
 			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\BuildError\\>\\:\\:where\\(\\)\\.$#"
+			count: 2
+			path: app/Models/Build.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Models/BuildTest.php

--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -129,7 +129,7 @@ class BuildTypeTest extends TestCase
         ], true);
     }
 
-    public function testNoWarningsOrErrorsReturnsEmptyArray(): void
+    public function testNoBasicWarningsOrBasicErrorsReturnsEmptyArray(): void
     {
         $this->project->builds()->create([
             'name' => 'build1',
@@ -143,14 +143,14 @@ class BuildTypeTest extends TestCase
                         edges {
                             node {
                                 name
-                                warnings {
+                                basicWarnings {
                                     edges {
                                         node {
                                             text
                                         }
                                     }
                                 }
-                                errors {
+                                basicErrors {
                                     edges {
                                         node {
                                             text
@@ -172,10 +172,10 @@ class BuildTypeTest extends TestCase
                             [
                                 'node' => [
                                     'name' => 'build1',
-                                    'warnings' => [
+                                    'basicWarnings' => [
                                         'edges' => [],
                                     ],
-                                    'errors' => [
+                                    'basicErrors' => [
                                         'edges' => [],
                                     ],
                                 ],
@@ -193,7 +193,7 @@ class BuildTypeTest extends TestCase
             'name' => 'build1',
             'uuid' => Str::uuid()->toString(),
         ]);
-        $build->warnings()->create([
+        $build->basicAlerts()->create([
             'type' => Build::TYPE_WARN,
             'logline' => 5,
             'text' => 'def',
@@ -210,7 +210,7 @@ class BuildTypeTest extends TestCase
                         edges {
                             node {
                                 name
-                                warnings {
+                                basicWarnings {
                                     edges {
                                         node {
                                             logLine
@@ -222,7 +222,7 @@ class BuildTypeTest extends TestCase
                                         }
                                     }
                                 }
-                                errors {
+                                basicErrors {
                                     edges {
                                         node {
                                             text
@@ -244,7 +244,7 @@ class BuildTypeTest extends TestCase
                             [
                                 'node' => [
                                     'name' => 'build1',
-                                    'warnings' => [
+                                    'basicWarnings' => [
                                         'edges' => [
                                             [
                                                 'node' => [
@@ -258,7 +258,7 @@ class BuildTypeTest extends TestCase
                                             ],
                                         ],
                                     ],
-                                    'errors' => [
+                                    'basicErrors' => [
                                         'edges' => [],
                                     ],
                                 ],
@@ -276,7 +276,7 @@ class BuildTypeTest extends TestCase
             'name' => 'build1',
             'uuid' => Str::uuid()->toString(),
         ]);
-        $build->warnings()->create([
+        $build->basicAlerts()->create([
             'type' => Build::TYPE_ERROR,
             'logline' => 5,
             'text' => 'def',
@@ -293,14 +293,14 @@ class BuildTypeTest extends TestCase
                         edges {
                             node {
                                 name
-                                warnings {
+                                basicWarnings {
                                     edges {
                                         node {
                                             text
                                         }
                                     }
                                 }
-                                errors {
+                                basicErrors {
                                     edges {
                                         node {
                                             logLine
@@ -327,10 +327,10 @@ class BuildTypeTest extends TestCase
                             [
                                 'node' => [
                                     'name' => 'build1',
-                                    'warnings' => [
+                                    'basicWarnings' => [
                                         'edges' => [],
                                     ],
-                                    'errors' => [
+                                    'basicErrors' => [
                                         'edges' => [
                                             [
                                                 'node' => [
@@ -353,7 +353,7 @@ class BuildTypeTest extends TestCase
         ]);
     }
 
-    public function testMultipleWarningsAndErrors(): void
+    public function testMultipleBasicWarningsAndBasicErrors(): void
     {
         $build = $this->project->builds()->create([
             'name' => 'build1',
@@ -370,8 +370,8 @@ class BuildTypeTest extends TestCase
                 'text' => Str::uuid()->toString(),
             ];
 
-            $build->warnings()->create(array_merge($warning, ['type' => Build::TYPE_WARN]));
-            $build->errors()->create(array_merge($error, ['type' => Build::TYPE_ERROR]));
+            $build->basicAlerts()->create(array_merge($warning, ['type' => Build::TYPE_WARN]));
+            $build->basicAlerts()->create(array_merge($error, ['type' => Build::TYPE_ERROR]));
 
             $warnings[] = [
                 'node' => $warning,
@@ -388,14 +388,14 @@ class BuildTypeTest extends TestCase
                         edges {
                             node {
                                 name
-                                warnings {
+                                basicWarnings {
                                     edges {
                                         node {
                                             text
                                         }
                                     }
                                 }
-                                errors {
+                                basicErrors {
                                     edges {
                                         node {
                                             text
@@ -417,10 +417,10 @@ class BuildTypeTest extends TestCase
                             [
                                 'node' => [
                                     'name' => 'build1',
-                                    'warnings' => [
+                                    'basicWarnings' => [
                                         'edges' => array_reverse($warnings),
                                     ],
-                                    'errors' => [
+                                    'basicErrors' => [
                                         'edges' => array_reverse($errors),
                                     ],
                                 ],


### PR DESCRIPTION
This PR continues our ongoing effort to expose most of the database schema via GraphQL.  