### PR TITLE
Enable GraphQL pagination

### DIFF
--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -191,7 +191,7 @@ return [
          * Allow clients to query paginated lists without specifying the amount of items.
          * Setting this to `null` means clients have to explicitly ask for the count.
          */
-        'default_count' => null,
+        'default_count' => 100,
 
         /*
          * Limit the maximum amount of items that clients can request from paginated lists.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -16,7 +16,7 @@ type Query {
   "List the projects available to the current user."
   projects(
     id: ID @in
-  ): [Project!]! @all(scopes: ["forUser"]) @orderBy(column: "id")
+  ): [Project!]! @paginate(scopes: ["forUser"], type: CONNECTION) @orderBy(column: "id")
 }
 
 
@@ -68,13 +68,13 @@ type Project {
   "A boolean indicating whether authenticated submissions are required."
   authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions")
 
-  builds: [Build!]! @hasMany @orderBy(column: "id")
+  builds: [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
 
   "The sites which have submitted a build to this project."
-  sites: [Site!]! @belongsToMany @orderBy(column: "id")
+  sites: [Site!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 
   "Users with the administrator role for this project."
-  administrators: [User!]! @belongsToMany @orderBy(column: "id")
+  administrators: [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 }
 
 enum ProjectVisibility {

--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -63,26 +63,30 @@ class BuildTypeTest extends TestCase
             query project($id: ID) {
                 project(id: $id) {
                     builds {
-                        stamp
-                        name
-                        buildType
-                        generator
-                        startTime
-                        endTime
-                        submissionTime
-                        command
-                        configureErrorsCount
-                        configureWarningsCount
-                        configureDuration
-                        buildErrorsCount
-                        buildWarningsCount
-                        buildDuration
-                        notRunTestsCount
-                        failedTestsCount
-                        passedTestsCount
-                        timeStatusFailedTestsCount
-                        testDuration
-                        uuid
+                        edges {
+                            node {
+                                stamp
+                                name
+                                buildType
+                                generator
+                                startTime
+                                endTime
+                                submissionTime
+                                command
+                                configureErrorsCount
+                                configureWarningsCount
+                                configureDuration
+                                buildErrorsCount
+                                buildWarningsCount
+                                buildDuration
+                                notRunTestsCount
+                                failedTestsCount
+                                passedTestsCount
+                                timeStatusFailedTestsCount
+                                testDuration
+                                uuid
+                            }
+                        }
                     }
                 }
             }
@@ -92,27 +96,31 @@ class BuildTypeTest extends TestCase
             'data' => [
                 'project' => [
                     'builds' => [
-                        [
-                            'stamp' => 'abcdefg',
-                            'name' => 'build1',
-                            'buildType' => 'Continuous',
-                            'generator' => 'ctest-2.9.20091218',
-                            'startTime' => '2011-07-22 15:11:41',
-                            'endTime' => '2011-07-22 15:29:30',
-                            'submissionTime' => '2024-03-21 20:30:51',
-                            'command' => 'foo bar',
-                            'configureErrorsCount' => 1,
-                            'configureWarningsCount' => 2,
-                            'configureDuration' => 10,
-                            'buildErrorsCount' => 3,
-                            'buildWarningsCount' => 4,
-                            'buildDuration' => 20,
-                            'notRunTestsCount' => 5,
-                            'failedTestsCount' => 6,
-                            'passedTestsCount' => 7,
-                            'timeStatusFailedTestsCount' => 8,
-                            'testDuration' => 30,
-                            'uuid' => $uuid,
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'stamp' => 'abcdefg',
+                                    'name' => 'build1',
+                                    'buildType' => 'Continuous',
+                                    'generator' => 'ctest-2.9.20091218',
+                                    'startTime' => '2011-07-22 15:11:41',
+                                    'endTime' => '2011-07-22 15:29:30',
+                                    'submissionTime' => '2024-03-21 20:30:51',
+                                    'command' => 'foo bar',
+                                    'configureErrorsCount' => 1,
+                                    'configureWarningsCount' => 2,
+                                    'configureDuration' => 10,
+                                    'buildErrorsCount' => 3,
+                                    'buildWarningsCount' => 4,
+                                    'buildDuration' => 20,
+                                    'notRunTestsCount' => 5,
+                                    'failedTestsCount' => 6,
+                                    'passedTestsCount' => 7,
+                                    'timeStatusFailedTestsCount' => 8,
+                                    'testDuration' => 30,
+                                    'uuid' => $uuid,
+                                ],
+                            ],
                         ],
                     ],
                 ],

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -178,12 +178,16 @@ class ProjectTypeTest extends TestCase
     {
         $expected_json_response = [
             'data' => [
-                'projects' => [],
+                'projects' => [
+                    'edges' => [],
+                ],
             ],
         ];
         foreach ($allowable_projects as $project_name) {
-            $expected_json_response['data']['projects'][] = [
-                'name' => $this->projects[$project_name]->name,
+            $expected_json_response['data']['projects']['edges'][] = [
+                'node' => [
+                    'name' => $this->projects[$project_name]->name,
+                ],
             ];
         }
 
@@ -191,7 +195,11 @@ class ProjectTypeTest extends TestCase
             ->graphQL('
                 query {
                     projects {
-                        name
+                        edges {
+                            node {
+                                name
+                            }
+                        }
                     }
                 }
             ')->assertJson($expected_json_response, true);
@@ -261,37 +269,65 @@ class ProjectTypeTest extends TestCase
         $this->graphQL('
             query {
                 projects {
-                    name
-                    builds {
-                        name
+                    edges {
+                        node {
+                            name
+                            builds {
+                                edges {
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'builds' => [
-                            [
-                                'name' => 'build1',
-                            ],
-                            [
-                                'name' => 'build2',
-                            ],
-                            [
-                                'name' => 'build3',
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'builds' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => 'build1',
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => 'build2',
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => 'build3',
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                    ],
-                    [
-                        'name' => $this->projects['public2']->name,
-                        'builds' => [
-                            [
-                                'name' => 'build4',
-                            ],
-                            [
-                                'name' => 'build5',
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'builds' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => 'build4',
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => 'build5',
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -455,29 +491,49 @@ class ProjectTypeTest extends TestCase
         $this->graphQL('
             query {
                 projects {
-                    name
-                    administrators {
-                        id
+                    edges {
+                        node {
+                            name
+                            administrators {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'administrators' => [
-                            [
-                                'id' => (string) $this->users['normal']->id,
-                            ],
-                            [
-                                'id' => (string) $this->users['admin']->id,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'administrators' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['normal']->id,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['admin']->id,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                    ],
-                    [
-                        'name' => $this->projects['public2']->name,
-                        'administrators' => [],
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'administrators' => [],
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -489,47 +545,79 @@ class ProjectTypeTest extends TestCase
         $this->actingAs($this->users['normal'])->graphQL('
             query {
                 projects {
-                    name
-                    administrators {
-                        id
+                    edges {
+                        node {
+                            name
+                            administrators {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'administrators' => [
-                            [
-                                'id' => (string) $this->users['normal']->id,
-                            ],
-                            [
-                                'id' => (string) $this->users['admin']->id,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'administrators' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['normal']->id,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['admin']->id,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                    ],
-                    [
-                        'name' => $this->projects['public2']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['protected1']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['protected2']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['private1']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['private2']->name,
-                        'administrators' => [
-                            [
-                                'id' => (string) $this->users['normal']->id,
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected1']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected2']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private1']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private2']->name,
+                                'administrators' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['normal']->id,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -543,53 +631,87 @@ class ProjectTypeTest extends TestCase
         $this->actingAs($this->users['admin'])->graphQL('
             query {
                 projects {
-                    name
-                    administrators {
-                        id
+                    edges {
+                        node {
+                            name
+                            administrators {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'administrators' => [
-                            [
-                                'id' => (string) $this->users['normal']->id,
-                            ],
-                            [
-                                'id' => (string) $this->users['admin']->id,
-                            ],
-                        ],
-                    ],
-                    [
-                        'name' => $this->projects['public2']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['protected1']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['protected2']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['private1']->name,
-                        'administrators' => [],
-                    ],
-                    [
-                        'name' => $this->projects['private2']->name,
-                        'administrators' => [
-                            [
-                                'id' => (string) $this->users['normal']->id,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'administrators' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['normal']->id,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['admin']->id,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                    ],
-                    [
-                        'name' => $this->projects['private3']->name,
-                        'administrators' => [],
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected1']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected2']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private1']->name,
+                                'administrators' => [],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private2']->name,
+                                'administrators' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'id' => (string) $this->users['normal']->id,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private3']->name,
+                                'administrators' => [],
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -601,40 +723,60 @@ class ProjectTypeTest extends TestCase
         $this->actingAs($this->users['admin'])->graphQL('
             query {
                 projects {
-                    name
-                    visibility
+                    edges {
+                        node {
+                            name
+                            visibility
+                        }
+                    }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'visibility' => 'PUBLIC',
-                    ],
-                    [
-                        'name' => $this->projects['public2']->name,
-                        'visibility' => 'PUBLIC',
-                    ],
-                    [
-                        'name' => $this->projects['protected1']->name,
-                        'visibility' => 'PROTECTED',
-                    ],
-                    [
-                        'name' => $this->projects['protected2']->name,
-                        'visibility' => 'PROTECTED',
-                    ],
-                    [
-                        'name' => $this->projects['private1']->name,
-                        'visibility' => 'PRIVATE',
-                    ],
-                    [
-                        'name' => $this->projects['private2']->name,
-                        'visibility' => 'PRIVATE',
-                    ],
-                    [
-                        'name' => $this->projects['private3']->name,
-                        'visibility' => 'PRIVATE',
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'visibility' => 'PUBLIC',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'visibility' => 'PUBLIC',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected1']->name,
+                                'visibility' => 'PROTECTED',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['protected2']->name,
+                                'visibility' => 'PROTECTED',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private1']->name,
+                                'visibility' => 'PRIVATE',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private2']->name,
+                                'visibility' => 'PRIVATE',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private3']->name,
+                                'visibility' => 'PRIVATE',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -95,9 +95,17 @@ class SiteTypeTest extends TestCase
         $this->graphQL('
             query {
                 projects {
-                    builds {
-                        site {
-                            name
+                    edges {
+                        node {
+                            builds {
+                                edges {
+                                    node {
+                                        site {
+                                            name
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -105,11 +113,19 @@ class SiteTypeTest extends TestCase
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'builds' => [
-                            [
-                                'site' => [
-                                    'name' => $this->sites['site1']->name,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'builds' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'site' => [
+                                                    'name' => $this->sites['site1']->name,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],
@@ -169,23 +185,41 @@ class SiteTypeTest extends TestCase
         $this->graphQL('
             query {
                 projects {
-                    name
-                    sites {
-                        name
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'sites' => [
-                            [
-                                'name' => $this->sites['public_submission']->name,
-                            ],
-                            [
-                                'name' => $this->sites['public_private_submission']->name,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_submission']->name,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_private_submission']->name,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -196,23 +230,41 @@ class SiteTypeTest extends TestCase
         $this->actingAs($this->users['normal'])->graphQL('
             query {
                 projects {
-                    name
-                    sites {
-                        name
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'sites' => [
-                            [
-                                'name' => $this->sites['public_submission']->name,
-                            ],
-                            [
-                                'name' => $this->sites['public_private_submission']->name,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_submission']->name,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_private_submission']->name,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -223,34 +275,60 @@ class SiteTypeTest extends TestCase
         $this->actingAs($this->users['admin'])->graphQL('
             query {
                 projects {
-                    name
-                    sites {
-                        name
+                    edges {
+                        node {
+                            name
+                            sites {
+                                edges {
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         ')->assertJson([
             'data' => [
                 'projects' => [
-                    [
-                        'name' => $this->projects['public1']->name,
-                        'sites' => [
-                            [
-                                'name' => $this->sites['public_submission']->name,
-                            ],
-                            [
-                                'name' => $this->sites['public_private_submission']->name,
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_submission']->name,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_private_submission']->name,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
-                    ],
-                    [
-                        'name' => $this->projects['private1']->name,
-                        'sites' => [
-                            [
-                                'name' => $this->sites['private_submission']->name,
-                            ],
-                            [
-                                'name' => $this->sites['public_private_submission']->name,
+                        [
+                            'node' => [
+                                'name' => $this->projects['private1']->name,
+                                'sites' => [
+                                    'edges' => [
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['private_submission']->name,
+                                            ],
+                                        ],
+                                        [
+                                            'node' => [
+                                                'name' => $this->sites['public_private_submission']->name,
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
Requiring pagination is important for ensuring that queries remain efficient at scale.  GraphQL pagination via the [Relay](https://facebook.github.io/relay/graphql/connections.htm) specification is the best way to implement pagination.  This PR converts all of the relations to paginated relations with a default batch size of 100.