### PR TITLE
Add try/catch block to account for OAuth permission denials

### DIFF
--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -31,6 +31,7 @@ final class OAuthController extends AbstractController
         try {
             $authUser = Socialite::driver($service)->user();
         } catch (\Exception $e) {
+            Log::error("Problem logging in with $service.  Error was ". $e->getMessage());
             return redirect("/login");
         };
 

--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -27,7 +27,13 @@ final class OAuthController extends AbstractController
 
     public function callback(string $service): RedirectResponse|Redirector
     {
-        $authUser = Socialite::driver($service)->user();
+        // Try/Catch to prevent 500  error when access is denied at provider
+        try {
+            $authUser = Socialite::driver($service)->user();
+        } catch (\Exception $e) {
+            return redirect("/login");
+        };
+
         $email =  $authUser->getEmail();
         [$fname, $lname] = explode(" ", $authUser->getName() ?? '');
 


### PR DESCRIPTION
Add a try/catch block to the OAuth controller which will catch an exception thrown when trying to get a user from an auth call that was rejected.

Fixes #2189