### PR TITLE
Fix missing labels in queryTests.php table

### DIFF
--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -367,7 +367,7 @@ class QueryTests extends ResultsApi
                                 label2test
                             WHERE
                                 label.id=label2test.labelid
-                                AND label2test.outputid=test.id
+                                AND label2test.outputid=build2test.outputid
                                 AND label2test.buildid=b.id
                         ) AS labelstring
                         $output_select


### PR DESCRIPTION
#1455 mistakenly used the test ID instead of the test output ID to find labels for the queryTests page.  This issue was separately resolved in the 3.5 release series by the refactor in #2148.

Failures like this are a good motivation for our effort to move to a GraphQL API.  With GraphQL, there is a single source of truth about where labels come from, and there isn't a need to separately query the labels in dozens of different locations.  These types of failures are also a good motivation for more complete testing data, with most tables having at least thousands of rows.  With limited data, this failure went unnoticed because each test ID corresponds to a test output ID in the testing environment.  This limited issue was resolved by the removal of the test table in #2148.