### PR TITLE
Add GraphQL query filtering capability

### DIFF
--- a/app/GraphQL/Directives/FilterDirective.php
+++ b/app/GraphQL/Directives/FilterDirective.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace App\GraphQL\Directives;
+
+use GraphQL\Language\AST\FieldDefinitionNode;
+use GraphQL\Language\AST\InputObjectTypeDefinitionNode;
+use GraphQL\Language\AST\InputValueDefinitionNode;
+use GraphQL\Language\AST\InterfaceTypeDefinitionNode;
+use GraphQL\Language\AST\ObjectTypeDefinitionNode;
+use GraphQL\Language\Parser;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Nuwave\Lighthouse\Schema\AST\ASTHelper;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;
+use Nuwave\Lighthouse\Support\Contracts\ArgManipulator;
+
+final class FilterDirective extends BaseDirective implements ArgBuilderDirective, ArgManipulator
+{
+    public static function definition(): string
+    {
+        return /** @lang GraphQL */ <<<'GRAPHQL'
+                directive @filter(
+                    "Input type to filter on.  This should be of the form: <...>FilterInput"
+                    inputType: String!
+                ) on ARGUMENT_DEFINITION
+            GRAPHQL;
+    }
+
+    /**
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws \JsonException
+     */
+    public function manipulateArgDefinition(
+        DocumentAST                                          &$documentAST,
+        InputValueDefinitionNode                             &$argDefinition,
+        FieldDefinitionNode                                  &$parentField,
+        ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode &$parentType,
+    ): void {
+        $multiFilterName = ASTHelper::qualifiedArgType($argDefinition, $parentField, $parentType) . 'MultiFilterInput';
+        $argDefinition->type = Parser::namedType($multiFilterName);
+
+        $documentAST->setTypeDefinition($this->createMultiFilterInput($multiFilterName, $this->directiveArgValue('inputType')));
+    }
+
+    /**
+     * Add additional constraints to the builder based on the given argument value.
+     *
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model>  $builder  the builder used to resolve the field
+     * @param  mixed  $value  the client given value of the argument
+     *
+     * @return \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>|\Illuminate\Database\Eloquent\Relations\Relation<\Illuminate\Database\Eloquent\Model> the modified builder
+     */
+    public function handleBuilder(QueryBuilder|EloquentBuilder|Relation $builder, mixed $value): QueryBuilder|EloquentBuilder|Relation
+    {
+        if (!is_array($value)) {
+            throw new \InvalidArgumentException('$value parameter must be array');
+        }
+
+        $this->applyFilters($builder, $value);
+
+        return $builder;
+    }
+
+    protected function applyFilters(QueryBuilder|EloquentBuilder|Relation $builder, mixed $filter, string $context = 'and', ?string $table = null): void
+    {
+        // The query builder isn't able to provide the table being queried, so we pass it down the chain from
+        // eloquent-derived builders which can.
+        if ($builder instanceof EloquentBuilder || $builder instanceof Relation) {
+            $table = $builder->getModel()->getTable();
+        }
+
+        if (array_key_exists('all', $filter)) {
+            $builder->whereNested(
+                function ($subfilterBuilder) use ($filter, $table): void {
+                    foreach ($filter['all'] as $subfilter) {
+                        $this->applyFilters($subfilterBuilder, $subfilter, 'and', $table);
+                    }
+                },
+                $context
+            );
+        } elseif (array_key_exists('any', $filter)) {
+            $builder->whereNested(
+                function ($subfilterBuilder) use ($filter, $table): void {
+                    foreach ($filter['any'] as $subfilter) {
+                        $this->applyFilters($subfilterBuilder, $subfilter, 'or', $table);
+                    }
+                },
+                $context,
+            );
+        } else {
+            $operators = [
+                'eq' => '=',
+                'ne' => '!=',
+                'gt' => '>',
+                'lt' => '<',
+            ];
+
+            foreach ($operators as $operator => $sqlOperator) {
+                if (array_key_exists($operator, $filter)) {
+                    $key = array_key_first($filter[$operator]);
+                    $value = $filter[$operator][$key];
+
+                    if ($context === 'and') {
+                        $builder->where($table . '.' . $key, $sqlOperator, $value);
+                    } elseif ($context === 'or') {
+                        $builder->orWhere($table . '.' . $key, $sqlOperator, $value);
+                    } else {
+                        throw new \InvalidArgumentException('$context must be "and" or "or"');
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @throws \GraphQL\Error\SyntaxError
+     * @throws \JsonException
+     */
+    protected function createMultiFilterInput(string $multiFilterName, string $filterName): InputObjectTypeDefinitionNode
+    {
+        return Parser::inputObjectTypeDefinition(/** @lang GraphQL */ <<<GRAPHQL
+                input {$multiFilterName} {
+                    "Find nodes which match at least one of the provided filters."
+                    any: [{$multiFilterName}]
+                    "Find nodes which match all of the provided filters."
+                    all: [{$multiFilterName}]
+                    "Find nodes where the provided field is equal to the provided value."
+                    eq: {$filterName}
+                    "Find nodes where the provided field is not equal to the provided value."
+                    ne: {$filterName}
+                    "Find nodes where the provided field is greater than the provided value."
+                    gt: {$filterName}
+                    "Find nodes where the provided field is less than the provided value."
+                    lt: {$filterName}
+                }
+            GRAPHQL
+        );
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -158,11 +158,13 @@ class Project extends Model
         if ($user === null) {
             $query->where('public', self::ACCESS_PUBLIC);
         } elseif (!$user->admin) {
-            $query->whereHas('users', function ($query2) use ($user) {
-                $query2->where('user.id', $user->id);
-            })
-            ->orWhere('public', self::ACCESS_PUBLIC)
-            ->orWhere('public', self::ACCESS_PROTECTED);
+            $query->where(function ($subquery) use ($user) {
+                $subquery->whereHas('users', function ($subquery2) use ($user) {
+                    $subquery2->where('user.id', $user->id);
+                })
+                    ->orWhere('public', self::ACCESS_PUBLIC)
+                    ->orWhere('public', self::ACCESS_PROTECTED);
+            });
         }
         // Else, this is an admin user, so we shouldn't apply any filters...
     }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -195,8 +195,11 @@ set_tests_properties(/CDash/XmlHandler/TestingHandler PROPERTIES DEPENDS /CDash/
 add_unit_test(/CDash/XmlHandler/UpdateHandler)
 set_tests_properties(/CDash/XmlHandler/UpdateHandler PROPERTIES DEPENDS /CDash/XmlHandler/TestingHandler)
 
+add_laravel_test(/Feature/GraphQL/FilterTest)
+set_tests_properties(/Feature/GraphQL/FilterTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_laravel_test(/Feature/GraphQL/ProjectTypeTest)
-set_tests_properties(/Feature/GraphQL/ProjectTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+set_tests_properties(/Feature/GraphQL/ProjectTypeTest PROPERTIES DEPENDS /Feature/GraphQL/FilterTest)
 
 add_laravel_test(/Feature/GraphQL/SiteTypeTest)
 set_tests_properties(/Feature/GraphQL/SiteTypeTest PROPERTIES DEPENDS /Feature/GraphQL/ProjectTypeTest)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -68,7 +68,9 @@ type Project {
   "A boolean indicating whether authenticated submissions are required."
   authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions")
 
-  builds: [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
+  builds(
+    filters: _ @filter(inputType: "BuildFilterInput")
+  ): [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
 
   "The sites which have submitted a build to this project."
   sites: [Site!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
@@ -195,6 +197,16 @@ type Build {
   basicWarnings: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
   # TODO: Figure out project relation.  project{build{project}} currently throws an error.
+}
+
+input BuildFilterInput {
+  id: ID
+  name: String
+  startTime: DateTime @rename(attribute: "starttime")
+  endTime: DateTime @rename(attribute: "endtime")
+  submissionTime: DateTime @rename(attribute: "submittime")
+  stamp: String
+  uuid: String
 }
 
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -15,7 +15,7 @@ type Query {
 
   "List the projects available to the current user."
   projects(
-    id: ID @in
+    filters: _ @filter(inputType: "ProjectFilterInput")
   ): [Project!]! @paginate(scopes: ["forUser"], type: CONNECTION) @orderBy(column: "id")
 }
 
@@ -103,6 +103,12 @@ input CreateProjectInput {
 
   "A boolean indicating whether authenticated submissions are required."
   authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions") @rules(attribute: "authenticatesubmissions", apply: ["App\\Rules\\ProjectAuthenticateSubmissions"])
+}
+
+input ProjectFilterInput {
+  id: ID
+  name: String
+  visibility: ProjectVisibility @rename(attribute: "public")
 }
 
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -73,7 +73,9 @@ type Project {
   ): [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
 
   "The sites which have submitted a build to this project."
-  sites: [Site!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
+  sites(
+    filters: _ @filter(inputType: "SiteFilterInput")
+  ): [Site!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 
   "Users with the administrator role for this project."
   administrators: [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
@@ -252,6 +254,14 @@ type Site {
   "The most recent information we have about this site."
   # TODO: Figure out how to support the date parameter. Perhaps it would be better to use a scope instead.
   mostRecentInformation: SiteInformation @hasOne
+}
+
+input SiteFilterInput {
+  id: ID
+  name: String
+  ip: String
+  latitude: Float
+  longitude: Float
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -222,6 +222,36 @@ parameters:
 			path: app/Exceptions/Handler.php
 
 		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\:\\:getModel\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:orWhere\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:where\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:whereNested\\(\\)\\.$#"
+			count: 2
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:applyFilters\\(\\) has parameter \\$builder with generic class Illuminate\\\\Database\\\\Eloquent\\\\Builder but does not specify its types\\: TModelClass$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:applyFilters\\(\\) has parameter \\$builder with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation but does not specify its types\\: TRelatedModel$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			message: "#^Class App\\\\Http\\\\Controllers\\\\AbstractBuildController has an uninitialized property \\$build\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/Http/Controllers/AbstractBuildController.php

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Project;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class FilterTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+
+    /**
+     * @var array<Project> $projects
+     */
+    private array $projects;
+
+    /**
+     * @var array<User> $users
+     */
+    private array $users;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projects['public1'] = Project::findOrFail((int) $this->makePublicProject('public1')->Id);
+        $this->projects['public2'] = Project::findOrFail((int) $this->makePublicProject('public2')->Id);
+        $this->projects['public4'] = Project::findOrFail((int) $this->makePublicProject('public4')->Id); // Out of order to check DB ordering
+        $this->projects['public3'] = Project::findOrFail((int) $this->makePublicProject('public3')->Id);
+        $this->projects['public5'] = Project::findOrFail((int) $this->makePublicProject('public5')->Id);
+
+        // A couple private projects so we can check visibility (enum) filtering
+        $this->projects['private1'] = Project::findOrFail((int) $this->makePrivateProject('private1')->Id);
+        $this->projects['private2'] = Project::findOrFail((int) $this->makePrivateProject('private2')->Id);
+
+        // Wipe any existing users before creating new ones
+        User::query()->delete();
+
+        $this->users = [
+            'normal' => $this->makeNormalUser(),
+            'admin' => $this->makeAdminUser(),
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->projects as $project) {
+            $project->delete();
+        }
+        $this->projects = [];
+
+        foreach ($this->users as $user) {
+            $user->delete();
+        }
+        $this->users = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string> $visible_projects
+     */
+    protected function constructNameFilterQuery(string $filters, array $visible_projects): void
+    {
+        $expected_edges = [];
+        foreach ($visible_projects as $project) {
+            $expected_edges[] = [
+                'node' => [
+                    'name' => $project,
+                ],
+            ];
+        }
+
+        $this->actingAs($this->users['admin'])->graphQL("
+            query {
+                projects(filters: {
+                    {$filters}
+                }) {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        ")->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => $expected_edges,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testEqualOperator(): void
+    {
+        $this->constructNameFilterQuery('
+            eq: {
+                name: "public4"
+            }
+        ', [
+            'public4',
+        ]);
+    }
+
+    public function testNotEqualOperator(): void
+    {
+        $this->constructNameFilterQuery('
+            ne: {
+                name: "public4"
+            }
+        ', [
+            'public1',
+            'public2',
+            'public3',
+            'public5',
+            'private1',
+            'private2',
+        ]);
+    }
+
+    public function testGreaterThanOperator(): void
+    {
+        $this->constructNameFilterQuery('
+            gt: {
+                name: "public4"
+            }
+        ', [
+            'public5',
+        ]);
+    }
+
+    public function testLessThanOperator(): void
+    {
+        $this->constructNameFilterQuery('
+            lt: {
+                name: "public4"
+            }
+        ', [
+            'public1',
+            'public2',
+            'public3',
+        ]);
+    }
+
+    public function testAllOperatorWithMultipleEqualOperators(): void
+    {
+        $this->constructNameFilterQuery('
+            all: [
+                {
+                    eq: {
+                        name: "public2"
+                    }
+                },
+                {
+                    eq: {
+                        name: "public4"
+                    }
+                }
+            ]
+        ', []);
+    }
+
+    public function testAnyOperatorWithMultipleEqualOperators(): void
+    {
+        $this->constructNameFilterQuery('
+            any: [
+                {
+                    eq: {
+                        name: "public2"
+                    }
+                },
+                {
+                    eq: {
+                        name: "public4"
+                    }
+                }
+            ]
+        ', [
+            'public2',
+            'public4',
+        ]);
+    }
+
+    public function testAllOperatorWithLtGtRange(): void
+    {
+        $this->constructNameFilterQuery('
+            all: [
+                {
+                    gt: {
+                        name: "public1"
+                    },
+                },
+                {
+                    lt: {
+                        name: "public4"
+                    }
+                }
+            ]
+        ', [
+            'public2',
+            'public3',
+        ]);
+    }
+
+    public function testEnumFiltering(): void
+    {
+        $this->actingAs($this->users['admin'])->graphQL("
+            query {
+                projects(filters: {
+                    eq: {
+                        visibility: PRIVATE
+                    }
+                }) {
+                    edges {
+                        node {
+                            name
+                            visibility
+                        }
+                    }
+                }
+            }
+        ")->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => 'private1',
+                                'visibility' => 'PRIVATE',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => 'private2',
+                                'visibility' => 'PRIVATE',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testFilterByAttributeNotInQuery(): void
+    {
+        $this->actingAs($this->users['admin'])->graphQL("
+            query {
+                projects(filters: {
+                    eq: {
+                        visibility: PRIVATE
+                    }
+                }) {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        ")->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => 'private1',
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => 'private2',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testNestedFilters(): void
+    {
+        $this->constructNameFilterQuery('
+            any: [
+                {
+                    all: [
+                        {
+                            any: [
+                                {
+                                    eq: {
+                                        name: "public1"
+                                    }
+                                },
+                                {
+                                    eq: {
+                                        name: "private1"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            eq: {
+                                visibility: PRIVATE
+                            }
+                        }
+                    ]
+                }
+                {
+                    eq: {
+                        name: "public2"
+                    }
+                },
+                {
+                    eq: {
+                        name: "public4"
+                    }
+                }
+            ]
+        ', [
+            'public2',
+            'public4',
+            'private1',
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -933,4 +933,45 @@ class ProjectTypeTest extends TestCase
             $response->assertGraphQLErrorMessage('Validation failed for the field [createProject].');
         }
     }
+
+    /**
+     * This test isn't intended to be a complete test of the GraphQL filtering
+     * capability, but rather a quick smoke check to verify that the most basic
+     * filters work for the projects relation, and that extra information is not leaked.
+     */
+    public function testBasicProjectFiltering(): void
+    {
+        $this->actingAs($this->users['normal'])->graphQL('
+            query {
+                projects(filters: {
+                    eq: {
+                        visibility: PRIVATE
+                    }
+                }) {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['private1']->name,
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['private2']->name,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
 }


### PR DESCRIPTION
This PR introduces the ability to add conditions to aggregate queries in the GraphQL API.  This allows users to select only public projects or all the builds submitted after a given timestamp, for example.  This introductory PR adds the =, !=, <, and > operators.  Future PRs will add additional operators to the filter set.

How is this PR different from Lighthouse-PHP's [existing](https://lighthouse-php.com/master/eloquent/complex-where-conditions.html) filtering functionality?  The approach Lighthouse takes is not type safe, which makes the API confusing to use and difficult to maintain.  It also lacks the flexibility CDash needs, and does not support enumeration filtering.  This PR builds upon Lighthouse's existing approach, by introducing type-safe filters.

In the future, these filters can be improved by restricting the operators available on a per-type basis.  For example, it doesn't make sense to perform a less-than operation on an enumeration in most cases, but we still offer the less-than operator.