### PR TITLE
Remove obsolete `MIX_APP_URL` env variable

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -3,7 +3,6 @@ APP_ENV=testing
 APP_KEY=DV5SQLqXCbpnme4z2pKNujd6gFW9hrj5
 APP_DEBUG=true
 APP_URL=http://localhost:8080
-MIX_APP_URL="${APP_URL}"
 APP_TIMEZONE=America/New_York
 
 LOG_CHANNEL=single

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ APP_ENV=production
 APP_DEBUG=false
 APP_KEY=
 APP_URL=https://localhost
-MIX_APP_URL="${APP_URL}"
 
 # The following two variables are only used for docker compose production installations.
 SSL_CERTIFICATE_FILE=/etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/docs/config.md
+++ b/docs/config.md
@@ -30,13 +30,6 @@ Please see that file for a full list of configuration options.
 | DB_USERNAME | The database user used by CDash | root |
 | DB_PASSWORD | The password of CDash's database user | secret |
 
-It is required that your `.env` file has a `APP_URL` entry, and that the following line
-appears somewhere further down in the file:
-
-```
-MIX_APP_URL="${APP_URL}"
-```
-
 ## Email
 
 | Variable  | Description | Default |


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2153 removed the the last dependency on environment variables from the Mix build, so `MIX_APP_URL` is no longer needed.