### PR TITLE
Remove unnecessary mix build after test

### DIFF
--- a/.github/workflows/ctest_driver_script.cmake
+++ b/.github/workflows/ctest_driver_script.cmake
@@ -51,7 +51,3 @@ file(RENAME
   "${CTEST_BINARY_DIRECTORY}/env_backup/.env"
   "${CTEST_SOURCE_DIRECTORY}/.env"
 )
-execute_process(
-  COMMAND npm run prod
-  WORKING_DIRECTORY "${CTEST_SOURCE_DIRECTORY}"
-)


### PR DESCRIPTION
As of https://github.com/Kitware/CDash/pull/2153, the `APP_URL` environment variable is no longer built into the website code, and it is no longer necessary to run a Mix build after the test suite to restore the original `.env`.  This change will save a few seconds on every CI run.