### PR TITLE
Add foreign key to `relatedid` column in `related_builds`

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -480,8 +480,6 @@ function remove_build($buildid)
     $db = Database::getInstance();
     $buildid_prepare_array = $db->createPreparedArray(count($buildids));
 
-    DB::delete("DELETE FROM related_builds WHERE relatedid IN $buildid_prepare_array", $buildids);
-
     // Remove the buildfailureargument
     $buildfailureids = [];
     $buildfailure = DB::select("SELECT id FROM buildfailure WHERE buildid IN $buildid_prepare_array", $buildids);

--- a/database/migrations/2024_05_27_185853_related_builds_relatedid_fk.php
+++ b/database/migrations/2024_05_27_185853_related_builds_relatedid_fk.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('related_builds')) {
+            echo "Adding relatedid foreign key to related_builds table...";
+            $num_deleted = DB::delete('DELETE FROM related_builds WHERE relatedid NOT IN (SELECT id FROM build)');
+            echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+            Schema::table('related_builds', function (Blueprint $table) {
+                $table->integer('relatedid')->change();
+                $table->foreign('relatedid')->references('id')->on('build')->cascadeOnDelete();
+            });
+        } else {
+            echo "ERROR: related_builds table does not exist!";
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('related_builds')) {
+            Schema::table('related_builds', function (Blueprint $table) {
+                $table->bigInteger('relatedid')->change();
+                $table->dropForeign(['relatedid']);
+            });
+        } else {
+            echo "ERROR: related_builds table does not exist!";
+        }
+    }
+};


### PR DESCRIPTION
Closes https://github.com/Kitware/CDash/issues/2220 by adding a foreign key constraint to the `relatedid` column` in the `related_builds` table.  Doing so allowed a small portion of our build removal process to be eliminated.