### PR TITLE
Schedule periodic tasks with Laravel

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\PruneAuthTokens;
 use App\Jobs\PruneJobs;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -34,6 +35,10 @@ class Kernel extends ConsoleKernel
             ->sendOutputTo($output_filename);
 
         $schedule->job(new PruneJobs())
+            ->hourly()
+            ->withoutOverlapping();
+
+        $schedule->job(new PruneAuthTokens())
             ->hourly()
             ->withoutOverlapping();
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\PruneJobs;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -28,7 +29,13 @@ class Kernel extends ConsoleKernel
         $cdash_app_dir = realpath(app_path($cdash_directory_name));
         $output_filename = $cdash_app_dir . "/AuditReport.log";
 
-        $schedule->command('dependencies:audit')->everySixHours()->sendOutputTo($output_filename);
+        $schedule->command('dependencies:audit')
+            ->everySixHours()
+            ->sendOutputTo($output_filename);
+
+        $schedule->job(new PruneJobs())
+            ->hourly()
+            ->withoutOverlapping();
     }
 
     /**

--- a/app/Jobs/PruneAuthTokens.php
+++ b/app/Jobs/PruneAuthTokens.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AuthToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Removes expired auth tokens.
+ */
+class PruneAuthTokens implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        AuthToken::expired()->delete();
+    }
+}

--- a/app/Jobs/PruneJobs.php
+++ b/app/Jobs/PruneJobs.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\SuccessfulJob;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Removes job results which are expired.  Job lifetime is controlled by the BACKUP_TIMEFRAME
+ * configuration option.
+ */
+class PruneJobs implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $lifetime = config('cdash.backup_timeframe');
+
+        Artisan::call("queue:prune-failed --hours=$lifetime");
+
+        // The successful_jobs table is a CDash specific table, so we have to prune it manually
+        SuccessfulJob::where('finished_at', '<', Carbon::now()->subHours($lifetime))->delete();
+    }
+}

--- a/app/Models/AuthToken.php
+++ b/app/Models/AuthToken.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $hash
+ * @property int $userid
+ * @property Carbon $created
+ * @property Carbon $expires
+ * @property string $description
+ * @property int $projectid
+ * @property string $scope
+ *
+ * @method static Builder<AuthToken> expired()
+ *
+ * @mixin Builder<AuthToken>
+ */
 class AuthToken extends Model
 {
     public const SCOPE_FULL_ACCESS = 'full_access';
@@ -31,4 +46,19 @@ class AuthToken extends Model
         'projectid',
         'scope',
     ];
+
+    protected $casts = [
+        'userid' => 'integer',
+        'created' => 'datetime',
+        'expires' => 'datetime',
+        'projectid' => 'integer',
+    ];
+
+    /**
+     * @param Builder<AuthToken> $query
+     */
+    public function scopeExpired(Builder $query): void
+    {
+        $query->where('expires', '<', Carbon::now());
+    }
 }

--- a/app/Models/SuccessfulJob.php
+++ b/app/Models/SuccessfulJob.php
@@ -3,9 +3,26 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $filename
+ * @property Carbon $finished_at
+ *
+ * @mixin Builder<SuccessfulJob>
+ */
 class SuccessfulJob extends Model
 {
+    protected $table = 'successful_jobs';
+
     public $timestamps = false;
-    protected $fillable = ['filename'];
+
+    protected $fillable = [
+        'filename',
+    ];
+
+    protected $casts = [
+        'finished_at' => 'datetime',
+    ];
 }

--- a/app/Utils/AuthTokenUtil.php
+++ b/app/Utils/AuthTokenUtil.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
@@ -242,7 +243,7 @@ class AuthTokenUtil
      */
     public static function isTokenExpired(AuthToken $auth_token): bool
     {
-        if (strtotime($auth_token['expires']) < time()) {
+        if ($auth_token['expires'] < Carbon::now()) {
             $auth_token->delete();
             return true;
         }

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -1136,9 +1136,6 @@ function addDailyChanges(int $projectid): void
             }
         }
 
-        // Delete expired authentication tokens.
-        DB::delete('DELETE FROM authtoken WHERE expires < NOW()');
-
         // Delete expired buildgroups and rules.
         $current_date = gmdate(FMT_DATETIME);
         $datetime = new \DateTime();

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -1049,16 +1049,6 @@ function addDailyChanges(int $projectid): void
         cleanBuildEmail();
         cleanUserTemp();
 
-        // Delete old records from the successful & failed jobs database table.
-        $dt = new DateTime();
-        $dt->setTimestamp(time() - (config('cdash.backup_timeframe') * 3600));
-        DB::table('failed_jobs')
-            ->where('failed_at', '<', $dt)
-            ->delete();
-        DB::table('successful_jobs')
-            ->where('finished_at', '<', $dt)
-            ->delete();
-
         // If the status of daily update is set to 2 that means we should send an email
         $dailyupdate_array = $db->executePreparedSingleRow('
                                  SELECT status

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -57,6 +57,9 @@ set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_2)
 add_laravel_test(/Feature/Jobs/PruneJobsTest)
 set_tests_properties(/Feature/Jobs/PruneJobsTest PROPERTIES DEPENDS install_2)
 
+add_laravel_test(/Feature/Jobs/PruneAuthTokensTest)
+set_tests_properties(/Feature/Jobs/PruneAuthTokensTest PROPERTIES DEPENDS install_2)
+
 add_laravel_test(/Feature/LoginAndRegistration)
 set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /Feature/CDashTest)
 

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -54,6 +54,9 @@ set_tests_properties(/Feature/LdapIntegration PROPERTIES DEPENDS install_2)
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_2)
 
+add_laravel_test(/Feature/Jobs/PruneJobsTest)
+set_tests_properties(/Feature/Jobs/PruneJobsTest PROPERTIES DEPENDS install_2)
+
 add_laravel_test(/Feature/LoginAndRegistration)
 set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /Feature/CDashTest)
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,7 +9,13 @@ php artisan key:check || exit 1
 
 # If the "start-website" argument was provided, start the web server
 if [ "$1" = "start-website" ] ; then
-   echo "Starting Apache..."
+  echo "Starting background jobs..."
+  # Output will show up in the logs, but the system will not crash if the schedule process fails.
+  # In the future, it would be better to do this with a dedicated container which starts on a schedule.
+  # Bare metal systems should use cron instead (using cron in Docker is problematic).
+  php artisan schedule:work & # & puts the task in the background.
+
+  echo "Starting Apache..."
 
   # Start Apache under the current user, in case the current user isn't www-data.  Kubernetes-based systems
   # typically run under a random user.  We start Apache before running the install scripts so the system can

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14226,11 +14226,6 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Parameter \\#1 \\$timestamp of method DateTime\\:\\:setTimestamp\\(\\) expects int, \\(float\\|int\\) given\\.$#"
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
 			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
@@ -29319,6 +29314,11 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
 			count: 5
 			path: tests/Feature/GraphQL/ProjectTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SuccessfulJob\\>\\:\\:count\\(\\)\\.$#"
+			count: 4
+			path: tests/Feature/Jobs/PruneJobsTest.php
 
 		-
 			message: "#^Call to an undefined method Mockery\\\\Expectation\\:\\:shouldReceive\\(\\)\\.$#"

--- a/tests/Feature/Jobs/PruneAuthTokensTest.php
+++ b/tests/Feature/Jobs/PruneAuthTokensTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\PruneAuthTokens;
+use App\Models\AuthToken;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class PruneAuthTokensTest extends TestCase
+{
+    use CreatesUsers;
+
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->makeNormalUser();
+    }
+
+    public function tearDown(): void
+    {
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testExpiredAuthTokenDeleted(): void
+    {
+        $hash = Str::uuid()->toString();
+        AuthToken::create([
+            'hash' => $hash,
+            'expires' => Carbon::now()->subMinute(),
+            'scope' => 'test',
+            'userid' => $this->user->id,
+        ]);
+
+        self::assertNotNull(Authtoken::find($hash));
+
+        PruneAuthTokens::dispatch();
+
+        self::assertNull(Authtoken::find($hash));
+    }
+
+    public function testValidAuthTokenNotDeleted(): void
+    {
+        $hash = Str::uuid()->toString();
+        AuthToken::create([
+            'hash' => $hash,
+            'expires' => Carbon::now()->addMinute(),
+            'scope' => 'test',
+            'userid' => $this->user->id,
+        ]);
+
+        self::assertNotNull(Authtoken::find($hash));
+
+        PruneAuthTokens::dispatch();
+
+        self::assertNotNull(Authtoken::find($hash));
+    }
+}

--- a/tests/Feature/Jobs/PruneJobsTest.php
+++ b/tests/Feature/Jobs/PruneJobsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\PruneJobs;
+use App\Models\SuccessfulJob;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class PruneJobsTest extends TestCase
+{
+    /**
+     * Changing the config is difficult since multiple processes are involved.
+     * Instead, we just rely upon the default value of 48 hours.
+     */
+    public function testExpiredSuccessfulJobDeleted(): void
+    {
+        $filename = 'test-filename' . Str::uuid()->toString();
+        $job = new SuccessfulJob([
+            'filename' => $filename,
+        ]);
+        $job->finished_at = Carbon::now()->subHours(1000); // finished_at isn't fillable...
+        $job->save();
+
+        self::assertEquals(1, SuccessfulJob::where('filename', $filename)->count());
+
+        PruneJobs::dispatch();
+
+        self::assertEquals(0, SuccessfulJob::where('filename', $filename)->count());
+    }
+
+    public function testRecentSuccessfulJobNotDeleted(): void
+    {
+        $filename = 'test-filename' . Str::uuid()->toString();
+        // The timestamp defaults to NOW().
+        SuccessfulJob::create([
+            'filename' => $filename,
+        ]);
+
+        self::assertEquals(1, SuccessfulJob::where('filename', $filename)->count());
+
+        PruneJobs::dispatch();
+
+        self::assertEquals(1, SuccessfulJob::where('filename', $filename)->count());
+    }
+}


### PR DESCRIPTION
NOTE: This PR moves cleanup logic out of the request-triggered daily update script.  To continue having these cleanup tasks performed automatically, administrators of non-Docker systems must run `php artisan schedule:run` via cron or similar.

The current "daily update" process is clunky, and in dire need of a refactor.  This PR takes the first step towards modernizing the daily update process by separating out a few small portions of the process into independent "tasks" managed by Laravel.  This PR also develops the infrastructure needed to eventually perform LDAP syncing for https://github.com/Kitware/CDash/issues/1983.

Laravel overhauled the task system in Laravel 11, but we can't upgrade to Laravel 11 until Red Hat releases a UBI image with PHP 8.2+.