### PR TITLE
Update GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
       - dependencies
       - "release notes: external dependencies"
     open-pull-requests-limit: 100
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - dependencies
+      - "release notes: external dependencies"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
This PR allows Dependabot to provide dependency updates for our GitHub Actions.