### PR TITLE
Bump PHP from 8.1 to 8.2 in UBI-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ ENTRYPOINT ["/bin/bash", "/cdash/docker/docker-entrypoint.sh"]
 # The base image for UBI-based images
 ###############################################################################
 
-FROM registry.access.redhat.com/ubi9/php-81 AS cdash-ubi-intermediate
+FROM registry.access.redhat.com/ubi9/php-82 AS cdash-ubi-intermediate
 
 ARG BASE_IMAGE
 ARG DEVELOPMENT_BUILD


### PR DESCRIPTION
Following #2113, Red Hat now offers a UBI image with PHP 8.2.