### PR TITLE
Switch legacy DB to Laravel DB facade in XML handlers

### DIFF
--- a/app/cdash/xml_handlers/JSCoverTar_handler.php
+++ b/app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -16,7 +16,6 @@
 require_once 'xml_handlers/NonSaxHandler.php';
 
 use CDash\Config;
-use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Coverage;
 use CDash\Model\CoverageFile;
@@ -147,21 +146,20 @@ class JSCoverTarHandler extends NonSaxHandler
                 $coverageFile->FullPath = trim($path);
                 // Get the ID for this coverage file, or create a new empty one
                 //if it doesn't already exist.
-                $db = Database::getInstance();
-                $coveragefile_array = $db->executePrepared('
+                $coveragefile_array = DB::select('
                                           SELECT id
                                           FROM coveragefile
                                           WHERE fullpath=? AND file IS NULL
                                       ', [$path]);
-                if (count($coveragefile_array) == 0) {
+                if (count($coveragefile_array) === 0) {
                     DB::insert('INSERT INTO coveragefile (fullpath) VALUES (?)', [$path]);
-                    $coveragefile_array = $db->executePrepared('
+                    $coveragefile_array = DB::select('
                                               SELECT id
                                               FROM coveragefile
                                               WHERE fullpath=? AND file IS NULL
                                           ', [$path]);
                 }
-                $coverageFile->Id = $coveragefile_array[0]['id'];
+                $coverageFile->Id = $coveragefile_array[0]?->id;
 
                 $coverage = new Coverage();
                 $coverage->CoverageFile = $coverageFile;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26164,20 +26164,7 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
-			message: """
-				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 2
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: "#^Cannot access offset 0 on array\\|false\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
@@ -26188,7 +26175,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
@@ -26232,11 +26219,6 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
 			message: "#^Property JSCoverTarHandler\\:\\:\\$CoverageSummaries has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
@@ -26250,20 +26232,7 @@ parameters:
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
@@ -26309,11 +26278,6 @@ parameters:
 
 		-
 			message: "#^Method JavaJSONTarHandler\\:\\:__construct\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: "#^Only booleans are allowed in &&, array\\|false\\|null given on the left side\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
@@ -28057,16 +28021,8 @@ parameters:
 			path: app/cdash/xml_handlers/project_handler.php
 
 		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/xml_handlers/project_handler.php
 
 		-


### PR DESCRIPTION
This PR is a small amount of incremental progress towards fully switching from the legacy database connection to Laravel's DB facade, or Eloquent, as appropriate.  This PR specifically converts all legacy database code in the XML handlers.  Changes like this lay the groundwork for the eventual ability to log the queries being executed for every request.