### PR TITLE
Randomize testing user emails and passwords

### DIFF
--- a/tests/Feature/RouteAccessTest.php
+++ b/tests/Feature/RouteAccessTest.php
@@ -27,10 +27,10 @@ class RouteAccessTest extends TestCase
         URL::forceRootUrl('http://localhost');
 
         $this->normal_user = $this->makeNormalUser();
-        $this->assertDatabaseHas('user', ['email' => 'jane@smith']);
+        $this->assertDatabaseHas('user', ['email' => $this->normal_user->email]);
 
         $this->admin_user = $this->makeAdminUser();
-        $this->assertDatabaseHas('user', ['email' => 'admin@user', 'admin' => '1']);
+        $this->assertDatabaseHas('user', ['email' => $this->admin_user->email, 'admin' => '1']);
 
         $this->public_project = $this->makePublicProject();
     }

--- a/tests/Feature/UniqueEmailsMigration.php
+++ b/tests/Feature/UniqueEmailsMigration.php
@@ -33,8 +33,8 @@ class UniqueEmailsMigration extends MigrationTest
             '--force' => true]);
 
         // Create two users with the same email address.
-        $user1 = $this->makeNormalUser();
-        $user2 = $this->makeNormalUser();
+        $user1 = $this->makeNormalUser('Jane', 'Smith', 'jane@smith');
+        $user2 = $this->makeNormalUser('Jane', 'Smith', 'jane@smith');
 
         // Verify that they both exist and have different ids.
         self::assertIsNumeric($user1->id);

--- a/tests/Traits/CreatesUsers.php
+++ b/tests/Traits/CreatesUsers.php
@@ -3,33 +3,72 @@
 namespace Tests\Traits;
 
 use App\Models\User;
+use Illuminate\Support\Str;
 
 trait CreatesUsers
 {
-    public function makeAdminUser() : User
-    {
-        // Create an admin user.
-        $admin = new User();
-        $admin->firstname = 'Admin';
-        $admin->lastname = 'User';
-        $admin->email = 'admin@user';
-        $admin->password = '45678';
-        $admin->institution = 'me';
-        $admin->admin = true;
-        $admin->save();
-        return $admin;
+    /**
+     * Create an admin user.
+     */
+    public function makeAdminUser(
+        ?string $firstname = null,
+        ?string $lastname = null,
+        ?string $email = null,
+        ?string $password = null,
+        ?string $institution = null
+    ): User {
+
+
+        return $this->makeUser(
+            $firstname ?? 'Admin',
+            $lastname ?? 'User',
+            $email ?? 'admin_' . Str::uuid()->toString() . '@example.com',
+            $password ?? Str::uuid()->toString(),
+            $institution ?? 'institution placeholder',
+            true
+        );
     }
 
-    public function makeNormalUser() : User
-    {
-        // Create a non-administrator user.
-        $user = new User();
-        $user->firstname = 'Jane';
-        $user->lastname = 'Smith';
-        $user->email = 'jane@smith';
-        $user->password = '12345';
-        $user->institution = 'me';
-        $user->admin = false;
+    /**
+     * Create a non-administrator user.
+     */
+    public function makeNormalUser(
+        ?string $firstname = null,
+        ?string $lastname = null,
+        ?string $email = null,
+        ?string $password = null,
+        ?string $institution = null
+    ): User {
+        return $this->makeUser(
+            $firstname ?? 'Normal',
+            $lastname ?? 'User',
+            $email ?? 'user_' . Str::uuid()->toString() . '@example.com',
+            $password ?? Str::uuid()->toString(),
+            $institution ?? 'institution placeholder',
+            false
+        );
+    }
+
+    /**
+     * Developers are encouraged to use the makeNormalUser() and makeAdminUser() helpers unless
+     * special functionality is required.
+     */
+    public function makeUser(
+        string $firstname,
+        string $lastname,
+        string $email,
+        string $password,
+        string $institution,
+        bool $admin
+    ): User {
+        $user = new User([
+            'firstname' => $firstname,
+            'lastname' => $lastname,
+            'email' => $email,
+            'institution' => $institution,
+        ]);
+        $user->password = $password;
+        $user->admin = $admin;
         $user->save();
         return $user;
     }


### PR DESCRIPTION
The tests currently create users with a fixed email address and password, which can cause conflicts if multiple tests are running at the same time.  See [this](https://open.cdash.org/tests/1583834204) failed test, for example.  This PR resolves the issue by creating users with email addresses and passwords containing UUIDs.

<details>
<summary>Output from a test with conflicts for reference</summary>

```
PHPUnit 9.6.4 by Sebastian Bergmann and contributors.

E.                                                                  2 / 2 (100%)

Time: 00:00.206, Memory: 32.00 MB

There was 1 error:

1) Tests\Feature\Jobs\PruneAuthTokensTest::testExpiredAuthTokenDeleted
Illuminate\Database\UniqueConstraintViolationException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'jane@smith' for key 'user.user_email_unique' (Connection: mysql, SQL: insert into `user` (`firstname`, `lastname`, `email`, `password`, `institution`, `admin`, `updated_at`, `created_at`) values (Jane, Smith, jane@smith, 12345, me, 0, 2024-06-04 15:05:28, 2024-06-04 15:05:28))

/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:824
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:783
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:576
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:540
/cdash/vendor/laravel/framework/src/Illuminate/Database/Query/Processors/Processor.php:32
/cdash/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:3507
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1982
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1333
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1298
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1137
/cdash/tests/Traits/CreatesUsers.php:33
/cdash/tests/Feature/Jobs/PruneAuthTokensTest.php:23

Caused by
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'jane@smith' for key 'user.user_email_unique'

/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:587
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:816
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:783
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:576
/cdash/vendor/laravel/framework/src/Illuminate/Database/Connection.php:540
/cdash/vendor/laravel/framework/src/Illuminate/Database/Query/Processors/Processor.php:32
/cdash/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:3507
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1982
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1333
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1298
/cdash/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1137
/cdash/tests/Traits/CreatesUsers.php:33
/cdash/tests/Feature/Jobs/PruneAuthTokensTest.php:23

ERRORS!
Tests: 2, Assertions: 2, Errors: 1.
```
</details>