### PR TITLE
Fail when unfillable Eloquent attributes provided

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
@@ -64,6 +65,8 @@ class AppServiceProvider extends ServiceProvider
         });
 
         URL::forceRootUrl(Config::get('app.url'));
+
+        Model::preventSilentlyDiscardingAttributes(!$this->app->isProduction());
     }
 
     /**

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -43,6 +43,8 @@ endif()
 
 add_laravel_test(/Unit/app/ControllerNameTest)
 
+add_laravel_test(/Unit/app/FillableAttributesTest)
+
 cdash_install()
 set_tests_properties(install_2 PROPERTIES DEPENDS cypress/e2e/user-profile)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2991,6 +2991,11 @@ parameters:
 			path: app/Policies/ProjectPolicy.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Foundation\\\\Application\\:\\:isProduction\\(\\)\\.$#"
+			count: 1
+			path: app/Providers/AppServiceProvider.php
+
+		-
 			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\|false given\\.$#"
 			count: 1
 			path: app/Providers/AppServiceProvider.php

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -462,7 +462,7 @@ class SiteTypeTest extends TestCase
         return [
             [['processoris64bits' => true]],
             [['processorvendor' => 'GenuineIntel']],
-            [['processorvendord' => 'Intel Corporation']],
+            [['processorvendorid' => 'Intel Corporation']],
             [['processorfamilyid' => 6]],
             [['processormodelid' => 7]],
             [['processorcachesize' => 123]],

--- a/tests/Unit/app/FillableAttributesTest.php
+++ b/tests/Unit/app/FillableAttributesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\app;
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * TODO: Figure out how to switch the APP_ENV to "production" in the tests.
+ */
+class FillableAttributesTest extends TestCase
+{
+    public function testCreatesModelWhenValidFillableAttributesProvided(): void
+    {
+        self::expectNotToPerformAssertions();
+        new User([
+            'firstname' => Str::uuid()->toString(),
+            'lastname' => Str::uuid()->toString(),
+            'email' => Str::uuid()->toString() . Str::uuid()->toString(),
+        ]);
+    }
+
+    public function testFailsToCreateModelWhenInvalidFillableAttribute(): void
+    {
+        self::expectException(\Illuminate\Database\Eloquent\MassAssignmentException::class);
+        new User([
+            'firstname' => Str::uuid()->toString(),
+            'lastname' => Str::uuid()->toString(),
+            'email' => Str::uuid()->toString() . Str::uuid()->toString(),
+            'admin' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
Eloquent discards attributes which are not explicitly listed as "fillable" by default.  In most cases, discarded attributes are probably discarded due to inadvertent errors, such as the test typo fixed in this PR.  This PR enables one of Eloquent's "strict" modes in the development environment, in the hope that doing so will prevent some types of Eloquent errors.  In the future, it may be desirable to enable this feature in production as well, but I haven't done so yet due to the possibility of errors being exposed in untested code.