### PR TITLE
Require "OK" in simpletest output to pass

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ function(add_php_test TestName)
   set_tests_properties(
     ${TestName} PROPERTIES
     FAIL_REGULAR_EXPRESSION ".*Failures: [1-9]+.*;.*Exceptions: [1-9]+.*"
+    PASS_REGULAR_EXPRESSION ".*OK.*"
   )
 endfunction()
 

--- a/app/cdash/tests/test_lotsofsubprojects.php
+++ b/app/cdash/tests/test_lotsofsubprojects.php
@@ -24,10 +24,10 @@ class LotsOfSubProjectsTestCase extends KWWebTestCase
         }
 
         // Delete all the extra labels we created.
-        DB::table('label')->where('text', 'LIKE', 'LotsOfSubprojects%')->delete();
+        DB::table('label')->where('text', 'LIKE', 'LotsOfSubProjects%')->delete();
 
         // Delete generated XML file.
-        unlink('LotsOfSubprojects_Configure.xml');
+        unlink('LotsOfSubProjects_Configure.xml');
     }
 
     public function testLotsOfSubProjects()
@@ -66,7 +66,7 @@ class LotsOfSubProjectsTestCase extends KWWebTestCase
         $this->assertEqual(101, count($results));
 
         // Verify 100 labels.
-        $results = DB::select("SELECT id FROM label WHERE text LIKE 'LotsOfSubprojects%'");
+        $results = DB::select("SELECT id FROM label WHERE text LIKE 'LotsOfSubProjects%'");
         $this->assertEqual(100, count($results));
     }
 }


### PR DESCRIPTION
It is currently possible for exceptions to go unnoticed in our simpletest test cases, because the CTest regex is not strict enough.  For example, this error has been in our test logs for a very long time: [(source)](https://open.cdash.org/tests/1591195781)

```
/cdash/app/cdash/tests/test_lotsofsubprojects.php
All Tests
unlink '/cdash/storage/logs/cdash.log'

In test_lotsofsubprojects.php line 30:
                                                                      
  unlink(LotsOfSubprojects_Configure.xml): No such file or directory
```