### PR TITLE
Convert misc. legacy PDO usages to Laravel DB facade

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -271,15 +271,14 @@ final class AdminController extends AbstractController
                 $projectid = $build_array['projectid'];
                 $submittime = $build_array['submittime'];
 
-                $build2grouprule = pdo_query("SELECT b2g.groupid FROM build2grouprule AS b2g, buildgroup as bg
+                $build2grouprule = DB::select("SELECT b2g.groupid FROM build2grouprule AS b2g, buildgroup as bg
                                     WHERE b2g.buildtype='$type' AND b2g.siteid='$siteid' AND b2g.buildname='$name'
                                     AND (b2g.groupid=bg.id AND bg.projectid='$projectid')
                                     AND '$submittime'>b2g.starttime AND ('$submittime'<b2g.endtime OR b2g.endtime='1980-01-01 00:00:00')");
                 echo pdo_error();
-                if (pdo_num_rows($build2grouprule) > 0) {
-                    $build2grouprule_array = pdo_fetch_array($build2grouprule);
-                    $groupid = $build2grouprule_array['groupid'];
-                    pdo_query("UPDATE build2group SET groupid='$groupid' WHERE buildid='$buildid'");
+                if (count($build2grouprule) > 0) {
+                    $groupid = $build2grouprule[0]->groupid;
+                    DB::update("UPDATE build2group SET groupid='$groupid' WHERE buildid='$buildid'");
                 }
             }
         }

--- a/app/Http/Controllers/UserStatisticsController.php
+++ b/app/Http/Controllers/UserStatisticsController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use App\Utils\PageTimer;
+use CDash\Database;
 use Illuminate\Http\JsonResponse;
 
 final class UserStatisticsController extends AbstractProjectController
@@ -58,7 +59,7 @@ final class UserStatisticsController extends AbstractProjectController
         $end_UTCDate = gmdate(FMT_DATETIME, $timestamp);
 
         // Lookup stats for this time period.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->prepare(
             'SELECT * FROM userstatistics
         WHERE checkindate<:end AND checkindate>=:beginning

--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -871,7 +871,7 @@ class RepositoryUtils
         $subproject_name = $build->GetSubProjectName();
         if ($subproject_name) {
             // Get users to notify for this SubProject.
-            $pdo = get_link_identifier()->getPdo();
+            $pdo = Database::getInstance()->getPdo();
             $user_table = qid('user');
             $stmt = $pdo->prepare(
                 "SELECT email FROM $user_table

--- a/app/cdash/app/Controller/Api/ViewProjects.php
+++ b/app/cdash/app/Controller/Api/ViewProjects.php
@@ -55,11 +55,6 @@ class ViewProjects extends \CDash\Controller\Api
         $response['hostname'] = $_SERVER['SERVER_NAME'];
         $response['date'] = date('r');
 
-        // Check if the database is up to date.
-        if ($this->db->query('SELECT authenticatesubmissions FROM project LIMIT 1') === false) {
-            $response['upgradewarning'] = 1;
-        }
-
         $response['title'] = 'Projects';
         $response['subtitle'] = 'Projects';
         $response['googletracker'] = config('cdash.default_google_analytics');

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -15,6 +15,7 @@
 =========================================================================*/
 namespace CDash\Model;
 
+use Illuminate\Support\Facades\DB;
 use PDO;
 use CDash\Database;
 use App\Models\Configure as EloquentConfigure;
@@ -207,7 +208,7 @@ class BuildConfigure
             try {
                 if ($stmt->execute()) {
                     $new_configure_inserted = true;
-                    $this->Id = pdo_insert_id('configure');
+                    $this->Id = DB::getPdo()->lastInsertId();
                 } else {
                     $error_info = $stmt->errorInfo();
                     $error = $error_info[2];

--- a/app/cdash/app/Model/BuildUserNote.php
+++ b/app/cdash/app/Model/BuildUserNote.php
@@ -84,7 +84,6 @@ class BuildUserNote
     // Get JSON representation of this object.
     public function marshal()
     {
-        $pdo = get_link_identifier()->getPdo();
         $marshaledNote = [];
 
         $user = User::find($this->UserId);

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -152,12 +152,10 @@ class CoverageFile
             } else {
                 // If we still haven't found an existing fileid
                 // we insert one here.
-                $stmt = $this->PDO->prepare(
-                    'INSERT INTO coveragefile (fullpath, crc32)
-                        VALUES (:fullpath, 0)');
-                $stmt->bindParam(':fullpath', $this->FullPath);
-                pdo_execute($stmt);
-                $this->Id = pdo_insert_id('coveragefile');
+                $this->Id = DB::table('coveragefile')->insertGetId([
+                    'fullpath' => $this->FullPath,
+                    'crc32' => 0,
+                ]);
             }
 
             $stmt = $this->PDO->prepare(

--- a/app/cdash/app/Model/CoverageFile2User.php
+++ b/app/cdash/app/Model/CoverageFile2User.php
@@ -76,15 +76,11 @@ class CoverageFile2User
             $db = Database::getInstance();
 
             if ($this->FileId == 0) {
-                $insert_result = $db->executePrepared('
-                                     INSERT INTO coveragefilepriority (projectid, fullpath, priority)
-                                     VALUES (?, ?, 0)
-                                 ', [intval($this->ProjectId), $this->FullPath]);
-                if ($insert_result === false) {
-                    add_last_sql_error('CoverageFile2User:Insert');
-                    return false;
-                }
-                $this->FileId = intval(pdo_insert_id('coveragefilepriority'));
+                $this->FileId = DB::table('coveragefilepriority')->insertGetId([
+                    'projectid' => $this->ProjectId,
+                    'fullpath' => $this->FullPath,
+                    'priority' => 0,
+                ]);
             }
 
             // Find the new position

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -229,7 +229,7 @@ class DynamicAnalysis
         }
 
         if (!$this->Id) {
-            $this->Id = intval(pdo_insert_id('dynamicanalysis'));
+            $this->Id = DB::getPdo()->lastInsertId();
         }
 
         // Add the defects

--- a/app/cdash/app/Model/SubProjectGroup.php
+++ b/app/cdash/app/Model/SubProjectGroup.php
@@ -354,7 +354,7 @@ class SubProjectGroup
             }
 
             if ($this->Id < 1) {
-                $this->Id = intval(pdo_insert_id('subprojectgroup'));
+                $this->Id = DB::getPdo()->lastInsertId();
             }
         }
 

--- a/app/cdash/app/Model/UploadFile.php
+++ b/app/cdash/app/Model/UploadFile.php
@@ -16,6 +16,7 @@
 namespace CDash\Model;
 
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 
 class UploadFile
 {
@@ -73,16 +74,13 @@ class UploadFile
 
         if (empty($filequery)) {
             // Insert the file into the database
-            $query = $db->executePrepared('
-                         INSERT INTO uploadfile (filename, filesize, sha1sum, isurl)
-                         VALUES (?, ?, ?, ?)
-                     ', [$filename, intval($this->Filesize), $this->Sha1Sum, $this->IsUrl]);
-
-            if ($query === false) {
-                add_last_sql_error('Uploadfile::Insert', 0, $this->BuildId);
-                return false;
-            }
-            $this->Id = pdo_insert_id('uploadfile');
+            $this->Id = DB::table('uploadfile')
+                ->insertGetId([
+                    'filename' => $filename,
+                    'filesize' => intval($this->Filesize),
+                    'sha1sum' => $this->Sha1Sum,
+                    'isurl' => $this->IsUrl,
+                ]);
         } else {
             $this->Id = $filequery['id'];
         }

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -17,7 +17,9 @@ namespace CDash\Model;
 
 use App\Models\Password;
 use CDash\Database;
+use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
+use \App\Models\User as EloquentUser;
 
 class User
 {
@@ -112,22 +114,15 @@ class User
                 throw new InvalidArgumentException('Id set before user insert operation.');
             }
 
-            $stmt = $this->PDO->prepare(
-                "INSERT INTO $this->TableName
-                (email, password, firstname, lastname, institution, admin)
-                VALUES (:email, :password, :firstname, :lastname, :institution, :admin)");
-            $stmt->bindParam(':email', $this->Email);
-            $stmt->bindParam(':password', $this->Password);
-            $stmt->bindParam(':firstname', $this->FirstName);
-            $stmt->bindParam(':lastname', $this->LastName);
-            $stmt->bindParam(':institution', $this->Institution);
-            $stmt->bindParam(':admin', $this->Admin);
-
-            if (!pdo_execute($stmt)) {
-                return false;
-            }
-
-            $this->Id = pdo_insert_id('user');
+            $this->Id = DB::table('user')
+                ->insertGetId([
+                    'email' => $this->Email,
+                    'password' => $this->Password,
+                    'firstname' => $this->FirstName,
+                    'lastname' => $this->LastName,
+                    'institution' => $this->Institution,
+                    'admin' => $this->Admin,
+                ]);
             $this->RecordPassword();
         }
         return true;

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -19,7 +19,6 @@ use App\Models\Password;
 use CDash\Database;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
-use \App\Models\User as EloquentUser;
 
 class User
 {

--- a/app/cdash/include/CDash/Database.php
+++ b/app/cdash/include/CDash/Database.php
@@ -127,11 +127,10 @@ class Database extends Singleton
         $stmt = $this->prepare($sql);
         $this->execute($stmt, $params);
 
-        $num_rows = pdo_num_rows($stmt);
-        if ($num_rows === false) {
+        if ($stmt === false) {
             return false;
         }
-        if ($num_rows === 0) {
+        if ($stmt->rowCount() === 0) {
             return [];
         }
         return $stmt->fetch();

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -745,7 +745,7 @@ function delete_rows_chunked(string $query, array $ids): void
  */
 function unlink_uploaded_file($fileid)
 {
-    $pdo = get_link_identifier()->getPdo();
+    $pdo = Database::getInstance()->getPdo();
     $stmt = $pdo->prepare(
         'SELECT sha1sum, filename, filesize FROM uploadfile
         WHERE id = ? AND isurl = 0');

--- a/app/cdash/include/ctestparserutils.php
+++ b/app/cdash/include/ctestparserutils.php
@@ -2,6 +2,7 @@
 
 use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
+use CDash\Database;
 
 /** Add a new build */
 function add_build(Build $build)
@@ -47,7 +48,7 @@ function extract_date_from_buildstamp($buildstamp)
  *  for the previous and current build */
 function compute_error_difference($buildid, $previousbuildid, $warning)
 {
-    $pdo = get_link_identifier()->getPdo();
+    $pdo = Database::getInstance()->getPdo();
     // Look at the difference positive and negative test errors
     $stmt = $pdo->prepare(
         'UPDATE builderror SET newstatus=1

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -976,11 +976,14 @@ function addDailyChanges(int $projectid): void
     if (intval($query['c']) === 0) {
         $cvsauthors = [];
 
-        $db->executePrepared("
-            INSERT INTO dailyupdate (projectid, date, command, type, status)
-            VALUES (?, ?,'NA','NA','0')
-        ", [$projectid, $date]);
-        $updateid = intval(pdo_insert_id('dailyupdate'));
+        $updateid = DB::table('dailyupdate')
+            ->insertGetId([
+                'projectid' => $projectid,
+                'date' => $date,
+                'command' => 'NA',
+                'type' => 'NA',
+                'status' => '0',
+            ]);
         $dates = get_related_dates($project->NightlyTime, $date);
         $commits = get_repository_commits($projectid, $dates);
 

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -50,20 +50,6 @@ function pdo_fetch_array(PDOStatement|false $result, int $result_type = PDO::FET
 }
 
 /**
- * Emulate mysql_insert_id using PDO
- *
- * @deprecated 04/01/2023
- */
-function pdo_insert_id(string $table_name): string|false
-{
-    $seq = '';
-    if (config('database.default') === 'pgsql') {
-        $seq = $table_name . '_id_seq';
-    }
-    return Database::getInstance()->getPdo()->lastInsertId($seq);
-}
-
-/**
  * Emulate mysql_query with PDO.
  *
  * @deprecated 04/01/2023

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -17,39 +17,6 @@
 use CDash\Database;
 
 /**
- * pdo_single_row_query returns a single row. Useful for SELECT
- * queries that are expected to return 0 or 1 rows.
- *
- * @deprecated 04/01/2023
- */
-function pdo_single_row_query($qry): array|null|false
-{
-    $result = pdo_query($qry);
-    if (false === $result) {
-        add_log('error: pdo_query failed: ' . pdo_error(),
-            'pdo_single_row_query', LOG_ERR);
-        return [];
-    }
-
-    $num_rows = pdo_num_rows($result);
-    if (0 !== $num_rows && 1 !== $num_rows) {
-        add_log('error: at most 1 row should be returned, not ' . $num_rows,
-            'pdo_single_row_query', LOG_ERR);
-        add_log('warning: returning the first row anyway even though result ' .
-            'contains ' . $num_rows . ' rows',
-            'pdo_single_row_query', LOG_WARNING);
-    }
-
-    $row = pdo_fetch_array($result);
-
-    if ($result instanceof \PDOStatement && !$result->closeCursor()) {
-        return false;
-    }
-
-    return $row;
-}
-
-/**
  * @deprecated 04/22/2023
  */
 function get_link_identifier(): Database

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -17,14 +17,6 @@
 use CDash\Database;
 
 /**
- * @deprecated 04/22/2023
- */
-function get_link_identifier(): Database
-{
-    return Database::getInstance();
-}
-
-/**
  * Get the last pdo error or empty string in the case of no error.
  *
  * @deprecated 04/01/2023

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -32,7 +32,7 @@ function get_link_identifier(): Database
  */
 function pdo_error(): string
 {
-    $error_info = get_link_identifier()->getPdo()->errorInfo();
+    $error_info = Database::getInstance()->getPdo()->errorInfo();
     if (isset($error_info[2]) && $error_info[0] !== '00000') {
         if (config('app.env') === 'production') {
             return 'SQL error encountered, query hidden.';
@@ -68,7 +68,7 @@ function pdo_insert_id(string $table_name): string|false
     if (config('database.default') === 'pgsql') {
         $seq = $table_name . '_id_seq';
     }
-    return get_link_identifier()->getPdo()->lastInsertId($seq);
+    return Database::getInstance()->getPdo()->lastInsertId($seq);
 }
 
 /**
@@ -89,7 +89,7 @@ function pdo_query(string $query): PDOStatement|false
  */
 function pdo_real_escape_string(mixed $unescaped_string): string
 {
-    $str = get_link_identifier()->getPdo()->quote($unescaped_string ?? '');
+    $str = Database::getInstance()->getPdo()->quote($unescaped_string ?? '');
     return substr($str, 1, strlen($str) - 2); // remove enclosing quotes
 }
 

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -160,17 +160,3 @@ function pdo_execute(PDOStatement $stmt, array|null $input_parameters=null): boo
     $db = Database::getInstance();
     return $db->execute($stmt, $input_parameters);
 }
-
-function pdo_get_vendor_version()
-{
-    $version = get_link_identifier()->getPdo()->query('SELECT version()')->fetchColumn();
-
-    if (config('database.default') === 'pgsql') {
-        // Postgress returns version string similar to:
-        //   PostgreSQL 9.6.1 on x86_64-apple-darwin16.1.0, compiled by Apple LLVM version 8.0.0 (clang-800.0.42.1), 64-bit
-        $build = explode(" ", $version);
-        $version = $build[1];
-    }
-
-    return $version;
-}

--- a/app/cdash/include/pdo.php
+++ b/app/cdash/include/pdo.php
@@ -72,28 +72,6 @@ function pdo_insert_id(string $table_name): string|false
 }
 
 /**
- * Emulate mysql_num_rows with PDO.
- * Do not use for select queries.
- *
- * @deprecated 04/01/2023
- * @param PDOStatement $result
- */
-function pdo_num_rows($result): int|false
-{
-    if (!$result) {
-        return false;
-    } else {
-        // The documentation here: http://us.php.net/manual/en/pdostatement.rowcount.php
-        // suggests that rowCount may be inappropriate for using on SELECT
-        // queries. It is the equivalent of the mysql_affected_rows function
-        // not the mysql_num_rows function. This seems like it might be a bug
-        // waiting to be reported. This can be fixed by running a COUNT(*) with
-        // the same predicates as the SELECT. TODO.
-        return $result->rowCount();
-    }
-}
-
-/**
  * Emulate mysql_query with PDO.
  *
  * @deprecated 04/01/2023

--- a/app/cdash/include/upgrade_functions.php
+++ b/app/cdash/include/upgrade_functions.php
@@ -40,25 +40,25 @@ function ComputeTestTiming($days = 4)
         $now = gmdate(FMT_DATETIME, time() - 3600 * 24 * $days);
 
         // Find the builds
-        $builds = pdo_query("SELECT starttime,siteid,name,type,id
+        $builds = DB::select("SELECT starttime,siteid,name,type,id
                 FROM build
                 WHERE build.projectid='$projectid' AND build.starttime>'$now'
                 ORDER BY build.starttime ASC");
 
-        $total = pdo_num_rows($builds);
+        $total = count($builds);
         echo pdo_error();
 
         $i = 0;
         $previousperc = 0;
-        while ($build_array = pdo_fetch_array($builds)) {
-            $buildid = $build_array['id'];
-            $buildname = $build_array['name'];
-            $buildtype = $build_array['type'];
-            $starttime = $build_array['starttime'];
-            $siteid = $build_array['siteid'];
+        foreach ($builds as $build) {
+            $buildid = $build->id;
+            $buildname = $build->name;
+            $buildtype = $build->type;
+            $starttime = $build->starttime;
+            $siteid = $build->siteid;
 
             // Find the previous build
-            $previousbuild = pdo_query("SELECT id FROM build
+            $previousbuild = DB::select("SELECT id FROM build
                     WHERE build.siteid='$siteid'
                     AND build.type='$buildtype' AND build.name='$buildname'
                     AND build.projectid='$projectid'
@@ -69,10 +69,9 @@ function ComputeTestTiming($days = 4)
             echo pdo_error();
 
             // If we have one
-            if (pdo_num_rows($previousbuild) > 0) {
+            if (count($previousbuild) > 0) {
                 // Loop through the tests
-                $previousbuild_array = pdo_fetch_array($previousbuild);
-                $previousbuildid = $previousbuild_array ['id'];
+                $previousbuildid = $previousbuild->id;
 
                 $tests = pdo_query("SELECT build2test.time,build2test.testid,test.name
                         FROM build2test,test WHERE build2test.buildid='$buildid'
@@ -193,19 +192,19 @@ function ComputeUpdateStatistics($days = 4)
         $now = gmdate(FMT_DATETIME, time() - 3600 * 24 * $days);
 
         // Find the builds
-        $builds = pdo_query("SELECT starttime,siteid,name,type,id
+        $builds = DB::select("SELECT starttime,siteid,name,type,id
                 FROM build
                 WHERE build.projectid='$projectid' AND build.starttime>'$now'
                 ORDER BY build.starttime ASC");
 
-        $total = pdo_num_rows($builds);
+        $total = count($builds);
         echo pdo_error();
 
         $i = 0;
         $previousperc = 0;
-        while ($build_array = pdo_fetch_array($builds)) {
+        foreach ($builds as $build) {
             $Build = new Build();
-            $Build->Id = $build_array['id'];
+            $Build->Id = $build->id;
             $Build->ProjectId = $projectid;
             $Build->ComputeUpdateStatistics();
 

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -18,6 +18,7 @@ namespace CDash\Api\v1\BuildGroup;
 
 require_once 'include/api_common.php';
 
+use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildGroup;
 use CDash\Model\BuildGroupRule;
@@ -38,7 +39,7 @@ if (!can_administrate_project($projectid)) {
     return;
 }
 
-$pdo = get_link_identifier()->getPdo();
+$pdo = Database::getInstance()->getPdo();
 
 // Route based on what type of request this is.
 $method = $_SERVER['REQUEST_METHOD'];

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -302,7 +302,7 @@ class KWWebTestCase extends WebTestCase
 
     public function userExists($email)
     {
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = CDash\Database::getInstance()->getPdo();
         $user_table = qid('user');
         $stmt = $pdo->prepare("SELECT id FROM $user_table WHERE email = ?");
         $stmt->execute([$email]);

--- a/app/cdash/tests/test_aggregatecoverage.php
+++ b/app/cdash/tests/test_aggregatecoverage.php
@@ -16,6 +16,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -91,8 +93,8 @@ class AggregateCoverageTestCase extends KWWebTestCase
         $query = "SELECT buildid, fileid FROM coverage AS c
             INNER JOIN coveragefile AS cf ON (cf.id=c.fileid)
             WHERE cf.fullpath='./diff.cxx'";
-        $result = pdo_query($query);
-        $num_rows = pdo_num_rows($result);
+        $result = DB::select($query);
+        $num_rows = count($result);
         if ($num_rows != 3) {
             $this->fail("Expected 3 rows, found $num_rows");
             return 1;
@@ -100,17 +102,17 @@ class AggregateCoverageTestCase extends KWWebTestCase
         $debug_fileid = 0;
         $release_fileid = 0;
         $aggregate_fileid = 0;
-        while ($row = pdo_fetch_array($result)) {
-            $buildid = $row['buildid'];
+        foreach ($result as $row) {
+            $buildid = $row->buildid;
             switch ($buildid) {
                 case $debug_buildid:
-                    $debug_fileid = $row['fileid'];
+                    $debug_fileid = $row->fileid;
                     break;
                 case $release_buildid:
-                    $release_fileid = $row['fileid'];
+                    $release_fileid = $row->fileid;
                     break;
                 case $aggregate_buildid:
-                    $aggregate_fileid = $row['fileid'];
+                    $aggregate_fileid = $row->fileid;
                     break;
                 default:
                     $this->fail("Unexpected buildid $buildid");

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -1,13 +1,12 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
 use App\Models\AuthToken;
 use App\Utils\AuthTokenUtil;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
 use Illuminate\Support\Facades\DB;
+use CDash\Database;
 
 class AuthTokenTestCase extends KWWebTestCase
 {
@@ -23,7 +22,7 @@ class AuthTokenTestCase extends KWWebTestCase
     {
         parent::__construct();
         $this->Hash = '';
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
         $this->PostBuildId = 0;
         $this->Project = null;
         $this->Token = '';

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -10,6 +10,7 @@ use CDash\Model\BuildGroup;
 use CDash\Model\Project;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
@@ -57,9 +58,6 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
 
         /** @var \CDash\Database $db */
         $db = Database::getInstance();
-
-        /** @var PDO $pdo */
-        $pdo = $db->getPdo();
 
         $result = $db->query("SELECT id FROM project WHERE name = 'EmailProjectExample'");
         $projectid = $result->fetchColumn();
@@ -129,19 +127,11 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         // in order for the process to be done
         sleep(10); // seconds
 
-        $sql = "SELECT id FROM build WHERE projectid=:id AND stamp=:stamp";
+        $sql = "SELECT id FROM build WHERE projectid=? AND stamp=?";
 
-        $stmt = $db->prepare($sql);
-        $stmt->bindValue(':id', $projectid);
-        $stmt->bindValue(':stamp', '20090223-0100-Nightly');
+        $results = DB::select($sql, [$projectid, '20090223-0100-Nightly']);
 
-        // Check that the first test is gone
-        if (!$stmt->execute()) {
-            $this->fail('pdo_query returned false');
-            return 1;
-        }
-
-        if (pdo_num_rows($stmt) > 0) {
+        if (count($results) > 0) {
             $this->fail('Auto remove build on submit failed');
             return 1;
         }

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -1,9 +1,8 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
 use CDash\Model\Project;
+use CDash\Database;
 
 class BazelJSONTestCase extends KWWebTestCase
 {
@@ -12,7 +11,7 @@ class BazelJSONTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
     }
 
     public function testBazelJSON()

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -110,8 +112,8 @@ class BuildDetailsTestCase extends KWWebTestCase
             return 1;
         }
 
-        $buildId = pdo_single_row_query("SELECT id FROM build WHERE name = 'BuildDetails-Linux-g++-4.1-LesionSizingSandbox_Debug'");
-        $json = $this->get("{$this->url}/api/v1/viewTest.php?buildid={$buildId['id']}");
+        $buildId = DB::select("SELECT id FROM build WHERE name = 'BuildDetails-Linux-g++-4.1-LesionSizingSandbox_Debug'")[0];
+        $json = $this->get("{$this->url}/api/v1/viewTest.php?buildid={$buildId->id}");
         $actualResponse = json_decode($json);
         $expectedResponse = json_decode(
             file_get_contents($this->testDataDir . '/' . 'InsightExperimentalExample_Expected.json'));
@@ -123,7 +125,7 @@ class BuildDetailsTestCase extends KWWebTestCase
         $this->assertEqual($actualResponse->numNotRun, $expectedResponse->numNotRun);
         $this->assertEqual($actualResponse->numTimeFailed, $expectedResponse->numTimeFailed);
 
-        remove_build($buildId['id']);
+        remove_build($buildId->id);
     }
 
     public function testViewTestReturnsProperFormatForParentBuilds()
@@ -134,9 +136,9 @@ class BuildDetailsTestCase extends KWWebTestCase
             return 1;
         }
 
-        $buildId = pdo_single_row_query("SELECT id FROM build WHERE name = 'BuildDetails-Linux-g++-4.1-LesionSizingSandbox_Debug-has-subbuild' AND parentid=-1");
+        $buildId = DB::select("SELECT id FROM build WHERE name = 'BuildDetails-Linux-g++-4.1-LesionSizingSandbox_Debug-has-subbuild' AND parentid=-1")[0];
 
-        $response = json_decode($this->get($this->url . '/api/v1/viewTest.php?buildid=' . $buildId['id']));
+        $response = json_decode($this->get($this->url . '/api/v1/viewTest.php?buildid=' . $buildId->id));
 
         $this->assertTrue($response->parentBuild);
 
@@ -145,6 +147,6 @@ class BuildDetailsTestCase extends KWWebTestCase
             $this->assertTrue($test->subprojectname == 'some-subproject');
         }
 
-        remove_build($buildId['id']);
+        remove_build($buildId->id);
     }
 }

--- a/app/cdash/tests/test_buildfailuredetails.php
+++ b/app/cdash/tests/test_buildfailuredetails.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -48,20 +50,20 @@ class BuildFailureDetailsTestCase extends KWWebTestCase
       FROM buildfailure AS bf
       LEFT JOIN build AS b ON (b.id=bf.buildid)
       WHERE b.name='test_buildfailure'";
-        $count_results = pdo_single_row_query($count_query);
-        if ($count_results['numfails'] != 4) {
+        $count_results = DB::select($count_query)[0];
+        if ((int) $count_results->numfails !== 4) {
             $this->fail(
-                'Expected 4 buildfailures, found ' . $count_results['numfails']);
+                'Expected 4 buildfailures, found ' . $count_results->numfails);
             return 1;
         }
-        if ($count_results['numbuilds'] != 2) {
+        if ((int) $count_results->numbuilds !== 2) {
             $this->fail(
-                'Expected 2 builds, found ' . $count_results['numbuilds']);
+                'Expected 2 builds, found ' . $count_results->numbuilds);
             return 1;
         }
-        if ($count_results['numdetails'] != 2) {
+        if ((int) $count_results->numdetails !== 2) {
             $this->fail(
-                'Expected 2 buildfailuredetails, found ' . $count_results['numdetails']);
+                'Expected 2 buildfailuredetails, found ' . $count_results->numdetails);
             return 1;
         }
 
@@ -69,20 +71,20 @@ class BuildFailureDetailsTestCase extends KWWebTestCase
         remove_build($buildids[0]);
 
         // Verify 2 buildfailures, 1 build, and 2 details.
-        $count_results = pdo_single_row_query($count_query);
-        if ($count_results['numfails'] != 2) {
+        $count_results = DB::select($count_query)[0];
+        if ((int) $count_results->numfails !== 2) {
             $this->fail(
-                'Expected 2 buildfailures, found ' . $count_results['numfails']);
+                'Expected 2 buildfailures, found ' . $count_results->numfails);
             return 1;
         }
-        if ($count_results['numbuilds'] != 1) {
+        if ((int) $count_results->numbuilds !== 1) {
             $this->fail(
-                'Expected 1 build, found ' . $count_results['numbuilds']);
+                'Expected 1 build, found ' . $count_results->numbuilds);
             return 1;
         }
-        if ($count_results['numdetails'] != 2) {
+        if ((int) $count_results->numdetails !== 2) {
             $this->fail(
-                'Expected 2 buildfailuredetails, found ' . $count_results['numdetails']);
+                'Expected 2 buildfailuredetails, found ' . $count_results->numdetails);
             return 1;
         }
 
@@ -90,20 +92,20 @@ class BuildFailureDetailsTestCase extends KWWebTestCase
         remove_build($buildids[1]);
 
         // Verify that the rest of our data is now gone.
-        $count_results = pdo_single_row_query($count_query);
-        if ($count_results['numfails'] != 0) {
+        $count_results = DB::select($count_query)[0];
+        if ((int) $count_results->numfails !== 0) {
             $this->fail(
-                'Expected 0 buildfailures, found ' . $count_results['numfails']);
+                'Expected 0 buildfailures, found ' . $count_results->numfails);
             return 1;
         }
-        if ($count_results['numbuilds'] != 0) {
+        if ((int) $count_results->numbuilds !== 0) {
             $this->fail(
-                'Expected 0 builds, found ' . $count_results['numbuilds']);
+                'Expected 0 builds, found ' . $count_results->numbuilds);
             return 1;
         }
-        if ($count_results['numdetails'] != 0) {
+        if ((int) $count_results->numdetails !== 0) {
             $this->fail(
-                'Expected 0 buildfailuredetails, found ' . $count_results['numdetails']);
+                'Expected 0 buildfailuredetails, found ' . $count_results->numdetails);
             return 1;
         }
 

--- a/app/cdash/tests/test_crosssubprojectcoverage.php
+++ b/app/cdash/tests/test_crosssubprojectcoverage.php
@@ -13,6 +13,9 @@
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
+
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -197,21 +200,21 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
         $success = true;
 
         // Get parentid.
-        $row = pdo_single_row_query(
+        $row = DB::select(
             "SELECT id FROM build
                 WHERE name = 'Aggregate Coverage' AND
                 parentid=-1 AND
                 projectid=
-                (SELECT id FROM project WHERE name='CrossSubProjectExample')");
-        $parentid = $row['id'];
+                (SELECT id FROM project WHERE name='CrossSubProjectExample')")[0];
+        $parentid = $row->id;
         if (empty($parentid) || $parentid < 1) {
             $this->fail('No aggregate parentid found when expected');
             return false;
         }
 
         // Verify parent results.
-        $row = pdo_single_row_query("
-                SELECT * from coveragesummary WHERE buildid='$parentid'");
+        $row = collect(DB::select("
+                SELECT * from coveragesummary WHERE buildid='$parentid'")[0])->toArray();
         $success &= $this->checkCoverage($row, 25, 10, 'aggregate parent');
 
         // Verify child results.

--- a/app/cdash/tests/test_crosssubprojectcoverage.php
+++ b/app/cdash/tests/test_crosssubprojectcoverage.php
@@ -213,12 +213,11 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
         }
 
         // Verify parent results.
-        $row = collect(DB::select("
-                SELECT * from coveragesummary WHERE buildid='$parentid'")[0])->toArray();
+        $row = DB::select("SELECT * from coveragesummary WHERE buildid='$parentid'")[0];
         $success &= $this->checkCoverage($row, 25, 10, 'aggregate parent');
 
         // Verify child results.
-        $result = pdo_query("
+        $result = DB::select("
                 SELECT cs.loctested, cs.locuntested, spg.name
                 FROM build AS b
                 INNER JOIN coveragesummary AS cs ON (b.id=cs.buildid)
@@ -226,13 +225,13 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
                 INNER JOIN subproject AS sp ON (sp2b.subprojectid=sp.id)
                 INNER JOIN subprojectgroup AS spg ON (sp.groupid=spg.id)
                 WHERE parentid='$parentid'");
-        $num_builds = pdo_num_rows($result);
-        if ($num_builds != 3) {
+        $num_builds = count($result);
+        if ($num_builds !== 3) {
             $this->fail("Expected 3 aggregate children, found $num_builds");
             return false;
         }
-        while ($row = pdo_fetch_array($result)) {
-            $group_name = $row['name'];
+        foreach ($result as $row) {
+            $group_name = $row->name;
             switch ($group_name) {
                 case 'Third Party':
                     $success &=
@@ -253,9 +252,9 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
         return $success;
     }
 
-    public function checkCoverage($coverage, $expected_loctested,
-        $expected_locuntested, $name)
+    public function checkCoverage($coverage, $expected_loctested, $expected_locuntested, $name)
     {
+        $coverage = collect($coverage)->toArray();
         if ($coverage['loctested'] != $expected_loctested) {
             $this->fail("Expected $name loctested to be $expected_loctested, found " . $coverage['loctested']);
             return false;

--- a/app/cdash/tests/test_disabledtests.php
+++ b/app/cdash/tests/test_disabledtests.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
+use CDash\Database;
 
 class DisabledTestsTestCase extends KWWebTestCase
 {
@@ -26,7 +26,7 @@ class DisabledTestsTestCase extends KWWebTestCase
         }
 
         // Find the buildid we just created.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->query("SELECT id FROM build WHERE name = 'test_disabled'");
         $row = $stmt->fetch();
         $buildid = $row['id'];

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -15,6 +15,8 @@
 =========================================================================*/
 
 
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -84,12 +86,12 @@ class DynamicAnalysisSummaryTestCase extends KWWebTestCase
     {
         // Verify the expected number of defects.
         // Get the ID of this build.
-        $row = pdo_single_row_query("
+        $row = DB::select("
                 SELECT b.id, das.numdefects FROM build AS b
                 INNER JOIN dynamicanalysissummary AS das ON (das.buildid=b.id)
-                WHERE name = 'Linux-g++-4.1-LesionSizingSandbox_Debug'");
-        $this->StandaloneBuildId = $row['id'];
-        $numdefects = $row['numdefects'];
+                WHERE name = 'Linux-g++-4.1-LesionSizingSandbox_Debug'")[0];
+        $this->StandaloneBuildId = $row->id;
+        $numdefects = $row->numdefects;
         if ($numdefects != 225) {
             $this->fail("Expected 225, found $numdefects\n");
         }

--- a/app/cdash/tests/test_dynamicanalysissummary.php
+++ b/app/cdash/tests/test_dynamicanalysissummary.php
@@ -71,12 +71,12 @@ class DynamicAnalysisSummaryTestCase extends KWWebTestCase
         remove_build($this->ParentId);
 
         // Verify that the dynamicanalysisssummary rows got deleted.
-        $result = pdo_query("
+        $result = DB::select("
                 SELECT b.id, b.parentid, das.numdefects FROM build AS b
                 INNER JOIN dynamicanalysissummary AS das ON (das.buildid=b.id)
                 WHERE b.name = 'cross_subproject_DA_example'");
-        $num_builds = pdo_num_rows($result);
-        if ($num_builds != 0) {
+        $num_builds = count($result);
+        if ($num_builds !== 0) {
             $this->fail("Expected 0 builds after deletion, found $num_builds");
         }
         $this->pass('Test passed');
@@ -99,28 +99,28 @@ class DynamicAnalysisSummaryTestCase extends KWWebTestCase
 
     public function VerifySubProjectBuild()
     {
-        $result = pdo_query("
+        $result = DB::select("
                 SELECT b.id, b.parentid, das.numdefects FROM build AS b
                 INNER JOIN dynamicanalysissummary AS das ON (das.buildid=b.id)
                 WHERE b.name = 'cross_subproject_DA_example'");
-        $num_builds = pdo_num_rows($result);
-        if ($num_builds != 4) {
+        $num_builds = count($result);
+        if ($num_builds !== 4) {
             $this->fail("Expected 4 builds, found $num_builds");
         }
 
         $this->ParentId = 0;
-        while ($row = pdo_fetch_array($result)) {
-            $numdefects = $row['numdefects'];
-            if ($row['parentid'] == -1) {
+        foreach ($result as $row) {
+            $numdefects = (int) $row->numdefects;
+            if ((int) $row->parentid === -1) {
                 // Parent case.
-                $this->ParentId = $row['id'];
-                if ($numdefects != 3) {
+                $this->ParentId = $row->id;
+                if ($numdefects !== 3) {
                     $this->fail("Expected 3 defects for parent, found $numdefects");
                 }
             } else {
                 // Child case.
-                $this->ChildIds[] = $row['id'];
-                if ($numdefects != 1) {
+                $this->ChildIds[] = $row->id;
+                if ($numdefects !== 1) {
                     $this->fail("Expected 1 defect for child, found $numdefects");
                 }
             }

--- a/app/cdash/tests/test_externallinksfromtests.php
+++ b/app/cdash/tests/test_externallinksfromtests.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -25,13 +27,13 @@ class ExternalLinksFromTestsTestCase extends KWWebTestCase
         }
 
         // Get the IDs for the build and test that we just created.
-        $result = pdo_single_row_query(
-            "SELECT id FROM build WHERE name = 'test_output_link'");
-        $buildid = $result['id'];
+        $result = DB::select(
+            "SELECT id FROM build WHERE name = 'test_output_link'")[0];
+        $buildid = $result->id;
 
-        $result = pdo_single_row_query(
-            "SELECT id FROM build2test WHERE buildid=$buildid");
-        $buildtestid = $result['id'];
+        $result = DB::select(
+            "SELECT id FROM build2test WHERE buildid=$buildid")[0];
+        $buildtestid = $result->id;
 
         // Use the API to verify that our external link was parsed properly.
         $this->get($this->url . "/api/v1/testDetails.php?buildtestid=$buildtestid");

--- a/app/cdash/tests/test_filterbuilderrors.php
+++ b/app/cdash/tests/test_filterbuilderrors.php
@@ -5,8 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
+use CDash\Database;
 use CDash\Model\Project;
 
 class FilterBuildErrorsTestCase extends KWWebTestCase
@@ -16,7 +15,7 @@ class FilterBuildErrorsTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
     }
 
     public function testFilterBuildErrors()

--- a/app/cdash/tests/test_hidecolumns.php
+++ b/app/cdash/tests/test_hidecolumns.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -90,9 +92,9 @@ class HideColumnsTestCase extends KWWebTestCase
         }
 
         // Remove the build that we just created.
-        $buildid_results = pdo_single_row_query(
-            "SELECT id FROM build WHERE name='HideColumns'");
-        $buildid = $buildid_results['id'];
+        $buildid_results = DB::select(
+            "SELECT id FROM build WHERE name='HideColumns'")[0];
+        $buildid = $buildid_results->id;
         remove_build($buildid);
         return $retval;
     }

--- a/app/cdash/tests/test_imagecomparison.php
+++ b/app/cdash/tests/test_imagecomparison.php
@@ -5,8 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
+use CDash\Database;
 use CDash\Model\Image;
 
 class ImageComparisonTestCase extends KWWebTestCase
@@ -28,7 +27,7 @@ class ImageComparisonTestCase extends KWWebTestCase
         }
 
         // Get the images created by this test.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->query(
             "SELECT b.id AS buildid, i.id AS imgid FROM build b
             JOIN build2test b2t ON (b2t.buildid=b.id)

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -5,6 +5,7 @@ use App\Utils\RepositoryUtils;
 use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\Model\UserProject;
+use CDash\Database;
 
 class IssueCreationTestCase extends KWWebTestCase
 {
@@ -17,7 +18,7 @@ class IssueCreationTestCase extends KWWebTestCase
         parent::__construct();
         $this->Builds = [];
         $this->Projects = [];
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
     }
 
     public function __destruct()

--- a/app/cdash/tests/test_junithandler.php
+++ b/app/cdash/tests/test_junithandler.php
@@ -1,8 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
+use CDash\Database;
 use CDash\Model\Project;
 
 class JUnitHandlerTestCase extends KWWebTestCase
@@ -13,7 +12,7 @@ class JUnitHandlerTestCase extends KWWebTestCase
     public function __construct()
     {
         parent::__construct();
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
         $this->Project = null;
     }
 

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
+use CDash\Database;
 
 class MultipleSubprojectsTestCase extends KWWebTestCase
 {
@@ -32,7 +32,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
             $this->restoreState();
         }
 
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $sql = "SELECT id FROM project WHERE name='SubProjectExample'";
         $stmt = $pdo->query($sql, PDO::FETCH_COLUMN, 0);
         $this->projectId = $stmt->fetchColumn();
@@ -102,7 +102,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         }
 
         // Get the buildids that we just created so we can delete it later.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $build_results = $pdo->query(
             "SELECT id, buildduration, configureduration FROM build
             WHERE name='CTestTest-Linux-c++-Subprojects'");
@@ -146,7 +146,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
     private function setEmailPreference($status, $chars)
     {
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
 
         $sql = "
             SELECT
@@ -187,7 +187,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
 
     private function restoreEmailPreference()
     {
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
 
         if ($this->summaryEmail) {
             $sql = "
@@ -242,8 +242,7 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         // Get the buildids that we just created so we can delete it later.
         $this->submitBuild();
 
-        $pdo = get_link_identifier()->getPdo();
-        $parentid = null;
+        $pdo = Database::getInstance()->getPdo();
 
         $subprojects = ["MyThirdPartyDependency", "MyExperimentalFeature", "MyProductionCode", "EmptySubproject"];
 

--- a/app/cdash/tests/test_nobackup.php
+++ b/app/cdash/tests/test_nobackup.php
@@ -5,7 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
+use CDash\Database;
 
 class NoBackupTestCase extends KWWebTestCase
 {
@@ -70,7 +70,7 @@ class NoBackupTestCase extends KWWebTestCase
         }
 
         // Make sure they were both parsed correctly.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->prepare(
             'SELECT b.builderrors, cs.loctested FROM build b
                 JOIN coveragesummary cs ON (cs.buildid=b.id)

--- a/app/cdash/tests/test_notesapi.php
+++ b/app/cdash/tests/test_notesapi.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -22,14 +24,14 @@ class NotesAPICase extends KWWebTestCase
         // Find the smallest buildid that has more than one note.
         // This was 13 at the time this test was written, but things
         // like this have a habit of changing.
-        $buildid_result = pdo_single_row_query(
+        $buildid_result = DB::select(
             'SELECT buildid, COUNT(1) FROM build2note
-       GROUP BY buildid HAVING COUNT(1) > 1 ORDER BY buildid LIMIT 1');
-        if (empty($buildid_result)) {
+       GROUP BY buildid HAVING COUNT(1) > 1 ORDER BY buildid LIMIT 1')[0] ?? [];
+        if ($buildid_result === []) {
             $this->fail('No build found with multiple notes');
             return 1;
         }
-        $buildid = $buildid_result['buildid'];
+        $buildid = $buildid_result->buildid;
 
         // Use the API to get the notes for this build.
         $this->get($this->url . "/api/v1/viewNotes.php?buildid=$buildid");

--- a/app/cdash/tests/test_pdoexecutelogserrors.php
+++ b/app/cdash/tests/test_pdoexecutelogserrors.php
@@ -5,6 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
+use CDash\Database;
 
 class PdoExecuteLogsErrorsTestCase extends KWWebTestCase
 {
@@ -15,7 +16,7 @@ class PdoExecuteLogsErrorsTestCase extends KWWebTestCase
 
     public function testPdoExecuteLogsErrors()
     {
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->prepare('SELECT notarealcolumn FROM build');
         pdo_execute($stmt);
 

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -50,15 +50,11 @@ class RemoveBuildsTestCase extends KWWebTestCase
 
     public function testBuildRemovalWorksAsExpected()
     {
-
-
-
-
         $time = gmdate(FMT_DATETIME);
 
         // Find an existing site.
-        $row = pdo_single_row_query('SELECT id FROM site LIMIT 1');
-        $siteid = $row['id'];
+        $row = DB::select('SELECT id FROM site LIMIT 1')[0];
+        $siteid = $row->id;
 
         // Label
         $label = new Label();

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -487,7 +487,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         if ($deleted) {
             $delete_msg = 'after deletion';
         }
-        $num_rows = pdo_num_rows(pdo_query("SELECT $field FROM $table WHERE $field $compare $value"));
+        $num_rows = count(DB::select("SELECT $field FROM $table WHERE $field $compare $value"));
         if ($num_rows !== $expected) {
             $this->fail("Expected $expected for $table $delete_msg, found $num_rows");
         }
@@ -496,34 +496,33 @@ class RemoveBuildsTestCase extends KWWebTestCase
     public function verify_get_columns($table, $columns, $field, $compare, $value, $expected)
     {
         $col_arg = implode(',', $columns);
-        $result = pdo_query("SELECT $col_arg FROM $table WHERE $field $compare $value");
-        $num_rows = pdo_num_rows($result);
+        $result = DB::select("SELECT $col_arg FROM $table WHERE $field $compare $value");
+        $num_rows = count($result);
         if ($num_rows !== $expected) {
             $this->fail("Expected $expected for $table, found $num_rows");
         }
-        $row = pdo_fetch_array($result);
+        $row = $result[0];
         $retval = [];
         foreach ($columns as $c) {
-            $retval[] = $row[$c];
+            $retval[] = $row->$c;
         }
         return $retval;
     }
 
     public function verify_get_rows($table, $column, $field, $compare, $value, $expected)
     {
-        $result = pdo_query("SELECT $column FROM $table WHERE $field $compare $value");
-        $num_rows = pdo_num_rows($result);
+        $result = DB::select("SELECT $column FROM $table WHERE $field $compare $value");
+        $num_rows = count($result);
         if ($num_rows !== $expected) {
             $this->fail("Expected $expected for $table, found $num_rows");
         }
         $arr = [];
-        while ($row = pdo_fetch_array($result)) {
-            $arr[] = $row[$column];
+        foreach ($result as $row) {
+            $arr[] = $row->$column;
         }
         if (count($arr) === 1) {
             return $arr[0];
         }
-        $retval = '(' . implode(',', $arr) . ')';
-        return $retval;
+        return '(' . implode(',', $arr) . ')';
     }
 }

--- a/app/cdash/tests/test_replacebuild.php
+++ b/app/cdash/tests/test_replacebuild.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -30,10 +32,9 @@ class ReplaceBuildTestCase extends KWWebTestCase
         }
 
         // Verify details about the build that we just created.
-        $row = pdo_single_row_query(
-            "SELECT id, generator FROM build WHERE name='ReplaceBuild'");
-        $first_buildid = $row['id'];
-        $first_generator = $row['generator'];
+        $row = DB::select("SELECT id, generator FROM build WHERE name='ReplaceBuild'")[0];
+        $first_buildid = $row->id;
+        $first_generator = $row->generator;
         if ($first_generator !== 'ctest-3.0') {
             $error_msg = "Expected 'ctest-3.0', found '$first_generator'";
             echo "$error_msg\n";
@@ -71,10 +72,9 @@ class ReplaceBuildTestCase extends KWWebTestCase
         }
 
         // Verify the replacement build.
-        $row = pdo_single_row_query(
-            "SELECT id, generator FROM build WHERE name='ReplaceBuild'");
-        $second_buildid = $row['id'];
-        $second_generator = $row['generator'];
+        $row = DB::select("SELECT id, generator FROM build WHERE name='ReplaceBuild'")[0];
+        $second_buildid = $row->id;
+        $second_generator = $row->generator;
         if ($second_generator !== 'ctest-3.1') {
             $error_msg = "Expected 'ctest-3.1', found '$second_generator'";
             echo "$error_msg\n";

--- a/app/cdash/tests/test_replacebuild.php
+++ b/app/cdash/tests/test_replacebuild.php
@@ -56,14 +56,8 @@ class ReplaceBuildTestCase extends KWWebTestCase
         }
 
         // Make sure the first build doesn't exist anymore.
-        if (!$query = pdo_query(
-            "SELECT * FROM build WHERE id=$first_buildid")
-        ) {
-            $error_msg = 'SELECT query returned false';
-            echo "$error_msg\n";
-            $success = false;
-        }
-        $num_rows = pdo_num_rows($query);
+        $query = DB::select("SELECT * FROM build WHERE id=$first_buildid");
+        $num_rows = count($query);
         if ($num_rows !== 0) {
             $error_msg = "Expected 0 rows, found $num_rows";
             echo "$error_msg\n";

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -209,90 +209,82 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             configureduration, builderrors, buildwarnings, buildduration, testnotrun,
             testfailed, testpassed
             FROM build WHERE name='Linux-g++-4.1-LesionSizingSandbox_Debug'";
-        $build_result = pdo_query($build_query);
-        if (!$build_result) {
-            $this->fail('build query returned false');
-            return false;
-        }
+        $build_result = DB::select($build_query);
 
         // Make sure we only found one matching result.
-        $num_builds = pdo_num_rows($build_result);
-        if ($num_builds != 1) {
+        $num_builds = count($build_result);
+        if ($num_builds !== 1) {
             $this->fail("Expected 1 build, found $num_builds");
             return false;
         }
 
         // Verify the result from the build table.
-        $build_row = pdo_fetch_array($build_result);
-        if ($build_row['starttime'] != '2009-02-23 07:10:37') {
-            $this->fail("Expected starttime to be '2009-02-23 07:10:37', found " . $build_row['starttime']);
+        $build_row = $build_result[0];
+        if ($build_row->starttime !== '2009-02-23 07:10:37') {
+            $this->fail("Expected starttime to be '2009-02-23 07:10:37', found " . $build_row->starttime);
             return false;
         }
-        if ($build_row['endtime'] != '2009-02-23 12:32:22') {
-            $this->fail("Expected endtime to be '2009-02-23 12:32:22', found " . $build_row['endtime']);
+        if ($build_row->endtime !== '2009-02-23 12:32:22') {
+            $this->fail("Expected endtime to be '2009-02-23 12:32:22', found " . $build_row->endtime);
             return false;
         }
-        if ($build_row['configureerrors'] != 0) {
-            $this->fail('Expected configureerrors to be 0, found ' . $build_row['configureerrors']);
+        if ((int) $build_row->configureerrors !== 0) {
+            $this->fail('Expected configureerrors to be 0, found ' . $build_row->configureerrors);
             return false;
         }
-        if ($build_row['configurewarnings'] != 0) {
-            $this->fail('Expected configurewarnings to be 0, found ' . $build_row['configurewarnings']);
+        if ((int) $build_row->configurewarnings !== 0) {
+            $this->fail('Expected configurewarnings to be 0, found ' . $build_row->configurewarnings);
             return false;
         }
-        if ($build_row['configureduration'] != 0.00) {
-            $this->fail('Expected configureduration to be 0.00, found ' . $build_row['configureduration']);
+        if ($build_row->configureduration != 0.00) {
+            $this->fail('Expected configureduration to be 0.00, found ' . $build_row->configureduration);
             return false;
         }
-        if ($build_row['builderrors'] != 0) {
-            $this->fail('Expected builderrors to be 0, found ' . $build_row['builderrors']);
+        if ((int) $build_row->builderrors !== 0) {
+            $this->fail('Expected builderrors to be 0, found ' . $build_row->builderrors);
             return false;
         }
-        if ($build_row['buildwarnings'] != 3) {
-            $this->fail('Expected buildwarnings to be 3, found ' . $build_row['buildwarnings']);
+        if ((int) $build_row->buildwarnings !== 3) {
+            $this->fail('Expected buildwarnings to be 3, found ' . $build_row->buildwarnings);
             return false;
         }
-        if ($build_row['buildduration'] != 3103) {
-            $this->fail('Expected buildduration to be 3103, found ' . $build_row['buildduration']);
+        if ((int) $build_row->buildduration !== 3103) {
+            $this->fail('Expected buildduration to be 3103, found ' . $build_row->buildduration);
             return false;
         }
-        if ($build_row['testnotrun'] != 1) {
-            $this->fail('Expected testnotrun to be 1, found ' . $build_row['testnotrun']);
+        if ((int) $build_row->testnotrun !== 1) {
+            $this->fail('Expected testnotrun to be 1, found ' . $build_row->testnotrun);
             return false;
         }
-        if ($build_row['testfailed'] != 5) {
-            $this->fail('Expected testfailed to be 5, found ' . $build_row['testfailed']);
+        if ((int) $build_row->testfailed !== 5) {
+            $this->fail('Expected testfailed to be 5, found ' . $build_row->testfailed);
             return false;
         }
-        if ($build_row['testpassed'] != 46) {
-            $this->fail('Expected testpassed to be 46, found ' . $build_row['testpassed']);
+        if ((int) $build_row->testpassed !== 46) {
+            $this->fail('Expected testpassed to be 46, found ' . $build_row->testpassed);
             return false;
         }
 
         // Verify note.
-        $buildid = $build_row['id'];
+        $buildid = $build_row->id;
         $note_query = "
             SELECT b2n.time, n.name
             FROM build2note AS b2n
             INNER JOIN note AS n ON (n.id=b2n.noteid)
             WHERE b2n.buildid=$buildid";
-        $note_result = pdo_query($note_query);
-        if (!$note_result) {
-            $this->fail('note query returned false');
-            return false;
-        }
-        $num_notes = pdo_num_rows($note_result);
-        if ($num_notes != 1) {
+        $note_result = DB::select($note_query);
+        $num_notes = count($note_result);
+        if ($num_notes !== 1) {
             $this->fail("Expected 1 note, found $num_notes");
             return false;
         }
-        $note_row = pdo_fetch_array($note_result);
-        if ($note_row['time'] != '2009-02-23 12:32:00') {
-            $this->fail("Expected note time to be '2009-02-23 12:32:00', found " . $note_row['time']);
+        $note_row = $note_result[0];
+        if ($note_row->time !== '2009-02-23 12:32:00') {
+            $this->fail("Expected note time to be '2009-02-23 12:32:00', found " . $note_row->time);
             return false;
         }
-        if ($note_row['name'] != '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake') {
-            $this->fail("Expected note name to be '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake', found " . $note_row['name']);
+        if ($note_row->name != '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake') {
+            $this->fail("Expected note name to be '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake', found " . $note_row->name);
             return false;
         }
 
@@ -346,19 +338,19 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             FROM buildupdate AS bu
             INNER JOIN build2update AS b2u ON (b2u.updateid=bu.id)
             WHERE b2u.buildid='$buildid'";
-        $update_result = pdo_query($update_query);
-        if (!$update_result) {
+        $update_result = DB::select($update_query);
+        if ($update_result === []) {
             $this->fail('update query returned false');
             return false;
         }
-        $num_updates = pdo_num_rows($update_result);
-        if ($num_updates != 1) {
+        $num_updates = count($update_result);
+        if ($num_updates !== 1) {
             $this->fail("Expected 1 update, found $num_updates");
             return false;
         }
-        $update_row = pdo_fetch_array($update_result);
-        if ($update_row['nfiles'] != 0) {
-            $this->fail('Expected number of update files to be 0, found ' . $update_row['nfiles']);
+        $update_row = $update_result[0];
+        if ((int) $update_row->nfiles !== 0) {
+            $this->fail('Expected number of update files to be 0, found ' . $update_row->nfiles);
             return false;
         }
 
@@ -368,19 +360,19 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             FROM uploadfile AS uf
             INNER JOIN build2uploadfile AS b2uf ON (b2uf.fileid=uf.id)
             WHERE b2uf.buildid='$buildid'";
-        $upload_result = pdo_query($upload_query);
-        if (!$upload_result) {
+        $upload_result = DB::select($upload_query);
+        if ($upload_result === []) {
             $this->fail('upload query returned false');
             return false;
         }
-        $num_uploads = pdo_num_rows($upload_result);
+        $num_uploads = count($upload_result);
         if ($num_uploads != 1) {
             $this->fail("Expected 1 upload, found $num_uploads");
             return false;
         }
-        $upload_row = pdo_fetch_array($upload_result);
-        if ($upload_row['filename'] != 'tmp.txt') {
-            $this->fail("Expected uploaded file to be named 'tmp.txt', found " . $upload_row['filename']);
+        $upload_row = $upload_result[0];
+        if ($upload_row->filename !== 'tmp.txt') {
+            $this->fail("Expected uploaded file to be named 'tmp.txt', found " . $upload_row->filename);
             return false;
         }
         return true;

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -328,11 +330,11 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             return false;
         }
 
-        $num_files_row = pdo_single_row_query(
+        $num_files_row = DB::select(
             "SELECT COUNT(1) AS numfiles
                 FROM coveragefilelog
-                WHERE buildid='$buildid'");
-        $num_files_covered = $num_files_row['numfiles'];
+                WHERE buildid='$buildid'")[0];
+        $num_files_covered = $num_files_row->numfiles;
         if ($num_files_covered != 2) {
             $this->fail("Expected 2 files covered, found $num_files_covered");
             return false;

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -3,6 +3,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -157,15 +159,12 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
         }
 
         // Make sure that the parent builds link to each other correctly.
-        $result = pdo_single_row_query(
-            "SELECT parentid FROM build WHERE id=$first_buildid");
-        $first_parentid = $result['parentid'];
-        $result = pdo_single_row_query(
-            "SELECT parentid FROM build WHERE id=$second_buildid");
-        $second_parentid = $result['parentid'];
-        $result = pdo_single_row_query(
-            "SELECT parentid FROM build WHERE id=$third_buildid");
-        $third_parentid = $result['parentid'];
+        $result = DB::select("SELECT parentid FROM build WHERE id=$first_buildid")[0];
+        $first_parentid = $result->parentid;
+        $result = DB::select("SELECT parentid FROM build WHERE id=$second_buildid")[0];
+        $second_parentid = $result->parentid;
+        $result = DB::select("SELECT parentid FROM build WHERE id=$third_buildid")[0];
+        $third_parentid = $result->parentid;
 
         $this->get($this->url . "/api/v1/index.php?project=Trilinos&parentid=$first_parentid");
         $content = $this->getBrowser()->getContent();

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -40,22 +40,22 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
         }
 
         // Get the ids for the three subsequent builds of Didasko.
-        $result = pdo_query("
+        $result = DB::select("
                 SELECT b.id FROM build AS b
                 LEFT JOIN subproject2build AS sp2b ON sp2b.buildid=b.id
                 LEFT JOIN subproject AS sp ON sp.id = sp2b.subprojectid
                 WHERE sp.name = 'Didasko'
                 ORDER BY b.starttime");
 
-        $num_rows = pdo_num_rows($result);
+        $num_rows = count($result);
         if ($num_rows !== 3) {
             $this->fail("Expected 3 rows, found $num_rows");
             return 1;
         }
 
         $buildids = [];
-        while ($row = pdo_fetch_array($result)) {
-            $buildids[] = $row['id'];
+        foreach ($result as $row) {
+            $buildids[] = $row->id;
         }
         $first_buildid = $buildids[0];
         $second_buildid = $buildids[1];

--- a/app/cdash/tests/test_testoverview.php
+++ b/app/cdash/tests/test_testoverview.php
@@ -5,6 +5,7 @@
 //
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
+use CDash\Database;
 
 class TestOverviewTestCase extends KWWebTestCase
 {
@@ -52,7 +53,7 @@ class TestOverviewTestCase extends KWWebTestCase
         }
 
         // Find the buildgroup id for Trilinos Experimental builds.
-        $PDO = get_link_identifier()->getPdo();
+        $PDO = Database::getInstance()->getPdo();
         $stmt = $PDO->query(
             "SELECT id FROM buildgroup WHERE name = 'Experimental' AND projectid = (SELECT id FROM project WHERE name = 'Trilinos')");
         $groupid = $stmt->fetchColumn();

--- a/app/cdash/tests/test_timeoutsandmissingtests.php
+++ b/app/cdash/tests/test_timeoutsandmissingtests.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
+
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 
@@ -24,8 +26,8 @@ class TimeoutsAndMissingTestsTestCase extends KWWebTestCase
           LIMIT 1
          ";
 
-        $query = pdo_single_row_query($sql);
-        return $query['id'];
+        $query = DB::select($sql)[0];
+        return $query->id;
     }
 
     public function testMissingTestsSummarizedInEmail()

--- a/app/cdash/tests/test_truncateoutput.php
+++ b/app/cdash/tests/test_truncateoutput.php
@@ -61,9 +61,8 @@ class TruncateOutputTestCase extends KWWebTestCase
             }
 
             // Query for the ID of the build that we just created.
-            $buildid_results = pdo_single_row_query(
-                "SELECT id FROM build WHERE name='TruncateOutput'");
-            $this->BuildId = $buildid_results['id'];
+            $buildid_results = DB::select("SELECT id FROM build WHERE name='TruncateOutput'")[0];
+            $this->BuildId = $buildid_results->id;
 
             // Verify that the output was properly truncated.
             $fields = [];
@@ -91,9 +90,8 @@ class TruncateOutputTestCase extends KWWebTestCase
         // Test removing suppressed warnings.
         $expected = "[CTest: warning matched] This part survives\n";
         $this->submission('InsightExample', "$rep/Build_suppressed.xml");
-        $buildid_results = pdo_single_row_query(
-            "SELECT id FROM build WHERE name='TruncateOutput'");
-        $this->BuildId = $buildid_results['id'];
+        $buildid_results = DB::select("SELECT id FROM build WHERE name='TruncateOutput'")[0];
+        $this->BuildId = $buildid_results->id;
         $this->get($this->url . "/api/v1/viewBuildError.php?type=1&buildid=" . $this->BuildId);
         $content = $this->getBrowser()->getContent();
         $jsonobj = json_decode($content, true);

--- a/app/cdash/tests/test_updateonlyuserstats.php
+++ b/app/cdash/tests/test_updateonlyuserstats.php
@@ -15,8 +15,7 @@
 =========================================================================*/
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-
-
+use CDash\Database;
 use App\Models\User;
 use CDash\Model\UserProject;
 
@@ -158,7 +157,7 @@ class UpdateOnlyUserStatsTestCase extends KWWebTestCase
         }
 
         // Delete builds.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->prepare(
             "SELECT id FROM build WHERE name='GithubUserStats'");
         $stmt->execute();

--- a/app/cdash/tests/test_upgrade.php
+++ b/app/cdash/tests/test_upgrade.php
@@ -90,19 +90,6 @@ class UpgradeTestCase extends KWWebTestCase
         $this->assertText('Database cleanup complete.');
     }
 
-    public function testGetVendorVersion()
-    {
-
-
-        $version = pdo_get_vendor_version();
-        [$major, $minor, ] = $version? explode(".", $version) : [null,null,null];
-
-        $this->assertTrue(is_numeric($major));
-        $this->assertTrue(is_numeric($minor));
-
-        return;
-    }
-
     public function getMaintenancePage()
     {
         $this->login();

--- a/app/cdash/tests/test_usernotes.php
+++ b/app/cdash/tests/test_usernotes.php
@@ -15,7 +15,7 @@ class UserNotesAPICase extends KWWebTestCase
     public function testAddNoteRequiresAuth(): void
     {
         // Change the Trilinos project to a private project
-        $id = pdo_single_row_query("SELECT id FROM project WHERE name='TrilinosDriver'")['id'];
+        $id = DB::select("SELECT id FROM project WHERE name='TrilinosDriver'")[0]->id;
         $project = new Project();
         $project->Id = $id;
         $project->Fill();

--- a/app/cdash/tests/test_viewdynamicanalysisfile.php
+++ b/app/cdash/tests/test_viewdynamicanalysisfile.php
@@ -7,6 +7,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 use CDash\Model\Build;
 use CDash\Model\DynamicAnalysis;
+use CDash\Database;
 
 class ViewDynamicAnalysisFileTestCase extends KWWebTestCase
 {
@@ -25,7 +26,7 @@ class ViewDynamicAnalysisFileTestCase extends KWWebTestCase
     public function testNextPrevious()
     {
         // Get id of existing build.
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         $stmt = $pdo->query(
             "SELECT id FROM build
             WHERE name = 'Linux-g++-4.1-LesionSizingSandbox_Debug'");

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -23,6 +23,7 @@ use CDash\Model\BuildError;
 use CDash\Model\BuildErrorFilter;
 use CDash\Model\Project;
 use App\Models\Project as EloquentProject;
+use CDash\Database;
 
 class BazelJSONHandler extends NonSaxHandler
 {
@@ -87,7 +88,7 @@ class BazelJSONHandler extends NonSaxHandler
 
         $this->BuildErrorFilter = new BuildErrorFilter($this->Project);
 
-        $this->PDO = get_link_identifier()->getPdo();
+        $this->PDO = Database::getInstance()->getPdo();
     }
 
     /**
@@ -763,7 +764,7 @@ class BazelJSONHandler extends NonSaxHandler
      */
     private static function GetSubProjectForPath(string $filepath, int $projectid): string
     {
-        $pdo = get_link_identifier()->getPdo();
+        $pdo = Database::getInstance()->getPdo();
         // Get all the subprojects for this project that have a path defined.
         // Sort by longest paths first.
         $stmt = $pdo->prepare(

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -234,15 +234,7 @@ parameters:
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 7
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 6
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -250,12 +242,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 8
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: "#^Cannot access offset 'groupid' on array\\|false\\|null\\.$#"
-			count: 1
+			count: 6
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -321,11 +308,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 10
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 1
 			path: app/Http/Controllers/AdminController.php
 
 		-
@@ -2415,14 +2397,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/Http/Controllers/UserStatisticsController.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
@@ -3094,14 +3068,6 @@ parameters:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
 			count: 4
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
 			path: app/Utils/RepositoryUtils.php
 
 		-
@@ -6590,14 +6556,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -7063,7 +7021,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 5
+			count: 2
 			path: app/cdash/app/Model/BuildFailure.php
 
 		-
@@ -7084,18 +7042,10 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/cdash/app/Model/BuildFailure.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 4
+			count: 1
 			path: app/cdash/app/Model/BuildFailure.php
 
 		-
@@ -7868,14 +7818,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/BuildUserNote.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
@@ -7887,7 +7829,7 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/BuildUserNote.php
 
 		-
@@ -8058,15 +8000,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 13
-			path: app/cdash/app/Model/CoverageFile.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 12
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-
@@ -8212,15 +8146,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 10
-			path: app/cdash/app/Model/CoverageFile2User.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 9
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -8228,7 +8154,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 8
+			count: 7
 			path: app/cdash/app/Model/CoverageFile2User.php
 
 		-
@@ -8672,14 +8598,6 @@ parameters:
 				v2\\.5\\.0 01/22/2018$#
 			"""
 			count: 2
-			path: app/cdash/app/Model/DynamicAnalysis.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -10079,14 +9997,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/SubProjectGroup.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -10117,6 +10027,11 @@ parameters:
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
+			message: "#^Method CDash\\\\Model\\\\SubProjectGroup\\:\\:Save\\(\\) throws checked exception TypeError but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: app/cdash/app/Model/SubProjectGroup.php
+
+		-
 			message: "#^Offset 'c' might not exist on array\\|null\\.$#"
 			count: 2
 			path: app/cdash/app/Model/SubProjectGroup.php
@@ -10124,6 +10039,11 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 3
+			path: app/cdash/app/Model/SubProjectGroup.php
+
+		-
+			message: "#^Property CDash\\\\Model\\\\SubProjectGroup\\:\\:\\$Id \\(int\\) does not accept string\\|false\\.$#"
+			count: 1
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
@@ -10201,7 +10121,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/UploadFile.php
 
 		-
@@ -10214,18 +10134,10 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/app/Model/UploadFile.php
-
-		-
-			message: """
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/app/Model/UploadFile.php
 
 		-
@@ -10275,14 +10187,6 @@ parameters:
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
-			"""
-			count: 2
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
 			"""
 			count: 1
 			path: app/cdash/app/Model/User.php
@@ -10611,11 +10515,6 @@ parameters:
 			path: app/cdash/bootstrap/cdash_autoload.php
 
 		-
-			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
-			count: 1
-			path: app/cdash/include/CDash/Database.php
-
-		-
 			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
@@ -10652,11 +10551,6 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Database\\:\\:prepare\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/CDash/Database.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
 
@@ -12753,14 +12647,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
@@ -13513,14 +13399,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/include/ctestparserutils.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
@@ -13653,14 +13531,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_insert_id\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
-			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -13672,7 +13542,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 10
+			count: 9
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -14554,63 +14424,12 @@ parameters:
 			path: app/cdash/include/log.php
 
 		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
 			message: "#^Function pdo_execute\\(\\) has parameter \\$input_parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
 		-
 			message: "#^Function pdo_fetch_array\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_get_vendor_version\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_single_row_query\\(\\) has parameter \\$qry with no type specified\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Function pdo_single_row_query\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Instanceof between PDOStatement and PDOStatement will always evaluate to true\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, PDOStatement given\\.$#"
-			count: 1
-			path: app/cdash/include/pdo.php
-
-		-
-			message: "#^Parameter \\#2 \\$string of function explode expects string, int\\|string\\|false\\|null given\\.$#"
 			count: 1
 			path: app/cdash/include/pdo.php
 
@@ -14791,15 +14610,7 @@ parameters:
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 9
-			path: app/cdash/include/upgrade_functions.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
+			count: 6
 			path: app/cdash/include/upgrade_functions.php
 
 		-
@@ -14807,12 +14618,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 11
-			path: app/cdash/include/upgrade_functions.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
+			count: 8
 			path: app/cdash/include/upgrade_functions.php
 
 		-
@@ -14822,6 +14628,11 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'timestd' on array\\|false\\|null\\.$#"
+			count: 1
+			path: app/cdash/include/upgrade_functions.php
+
+		-
+			message: "#^Cannot access property \\$id on array\\.$#"
 			count: 1
 			path: app/cdash/include/upgrade_functions.php
 
@@ -14886,16 +14697,6 @@ parameters:
 			path: app/cdash/include/upgrade_functions.php
 
 		-
-			message: "#^Only numeric types are allowed in /, int\\|false given on the right side\\.$#"
-			count: 2
-			path: app/cdash/include/upgrade_functions.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 3
-			path: app/cdash/include/upgrade_functions.php
-
-		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 2
 			path: app/cdash/include/upgrade_functions.php
@@ -14940,14 +14741,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$data of function hash_hmac expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
 			message: """
@@ -18813,14 +18606,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/kwtest/kw_web_tester.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -19626,30 +19411,6 @@ parameters:
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_aggregatecoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_aggregatecoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_aggregatecoverage.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatecoverage.php
@@ -19701,11 +19462,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|true given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_aggregatecoverage.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatecoverage.php
 
@@ -19857,14 +19613,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\AuthToken\\:\\:\\$Hash\\.$#"
-			count: 1
-			path: app/cdash/tests/test_authtoken.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
 
@@ -20074,26 +19822,10 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 4
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
@@ -20106,7 +19838,7 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 7
+			count: 6
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
@@ -20120,16 +19852,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 0 on array\\|false\\|null\\.$#"
 			count: 2
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: "#^Cannot call method bindValue\\(\\) on PDOStatement\\|false\\.$#"
-			count: 2
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
-			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
@@ -20163,11 +19885,6 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 4
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -20181,14 +19898,6 @@ parameters:
 			message: "#^Property AutoRemoveBuildsOnSubmitTestCase\\:\\:\\$config_file has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_bazeljson.php
 
 		-
 			message: """
@@ -20308,14 +20017,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_branchcoverage.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -20329,7 +20030,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 3
+			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
@@ -20359,11 +20060,6 @@ parameters:
 
 		-
 			message: "#^Method BranchCoverageTestCase\\:\\:verifyResults\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_branchcoverage.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|false\\|null given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_branchcoverage.php
 
@@ -20475,19 +20171,6 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_builddetails.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 4
-			path: app/cdash/tests/test_builddetails.php
-
-		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_builddetails.php
@@ -20574,26 +20257,8 @@ parameters:
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/cdash/tests/test_buildfailuredetails.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
-			path: app/cdash/tests/test_buildfailuredetails.php
-
-		-
-			message: "#^Cannot access offset 'numfails' on array\\|false\\|null\\.$#"
-			count: 6
-			path: app/cdash/tests/test_buildfailuredetails.php
-
-		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 9
 			path: app/cdash/tests/test_buildfailuredetails.php
 
 		-
@@ -21224,45 +20889,8 @@ parameters:
 			path: app/cdash/tests/test_createpublicdashboard.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
-			path: app/cdash/tests/test_crosssubprojectcoverage.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
@@ -21271,8 +20899,13 @@ parameters:
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
+			message: "#^Foreach overwrites \\$row with its value variable\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 6
+			count: 5
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
@@ -21371,12 +21004,17 @@ parameters:
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
+			message: "#^Property CoverageAcrossSubProjectsTestCase\\:\\:\\$DataDir has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
-			message: "#^Property CoverageAcrossSubProjectsTestCase\\:\\:\\$DataDir has no type specified\\.$#"
+			message: "#^Unable to resolve the template type TKey in call to function collect$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Unable to resolve the template type TValue in call to function collect$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
@@ -21550,14 +21188,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_disabledtests.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -21688,59 +21318,12 @@ parameters:
 			path: app/cdash/tests/test_dynamicanalysislogs.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 3
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: "#^Cannot access offset 'numdefects' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 5
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
@@ -21767,11 +21350,6 @@ parameters:
 		-
 			message: "#^Method DynamicAnalysisSummaryTestCase\\:\\:testSubProjectDynamicAnalysisSummary\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/cdash/tests/test_dynamicanalysissummary.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 2
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
@@ -22030,21 +21608,8 @@ parameters:
 			path: app/cdash/tests/test_expiredbuildrules.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_externallinksfromtests.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
-			path: app/cdash/tests/test_externallinksfromtests.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 2
 			path: app/cdash/tests/test_externallinksfromtests.php
 
 		-
@@ -22101,14 +21666,6 @@ parameters:
 			message: "#^Method FilterBlocksTestCase\\:\\:verifyTwoHutBuilds\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_filterblocks.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_filterbuilderrors.php
 
 		-
 			message: """
@@ -22181,20 +21738,7 @@ parameters:
 			path: app/cdash/tests/test_filtertestlabels.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_hidecolumns.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
-			count: 1
-			path: app/cdash/tests/test_hidecolumns.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_hidecolumns.php
 
@@ -22242,14 +21786,6 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_image.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_imagecomparison.php
 
 		-
 			message: """
@@ -22341,14 +21877,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_issuecreation.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
@@ -22412,14 +21940,6 @@ parameters:
 			message: "#^Method JSCoverCoverageTestCase\\:\\:testJSCoverCoverage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_jscovercoverage.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_junithandler.php
 
 		-
 			message: """
@@ -22783,14 +22303,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 5
-			path: app/cdash/tests/test_multiplesubprojects.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -23014,14 +22526,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_nobackup.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -23059,20 +22563,7 @@ parameters:
 			path: app/cdash/tests/test_nobackup.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_notesapi.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
-			count: 1
-			path: app/cdash/tests/test_notesapi.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/cdash/tests/test_notesapi.php
 
@@ -23205,14 +22696,6 @@ parameters:
 			message: "#^Property PasswordComplexityTestCase\\:\\:\\$validator has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_passwordcomplexity.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_pdoexecutelogserrors.php
 
 		-
 			message: """
@@ -23530,48 +23013,14 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
-			message: """
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 10
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 7
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
-			count: 1
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
-			message: "#^Cannot access offset mixed on array\\|false\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_removebuilds.php
 
@@ -23691,11 +23140,6 @@ parameters:
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 3
-			path: app/cdash/tests/test_removebuilds.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_removebuilds.php
@@ -23711,42 +23155,21 @@ parameters:
 			path: app/cdash/tests/test_removebuilds.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_replacebuild.php
+			message: "#^Variable property access on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_removebuilds.php
 
 		-
 			message: """
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 2
-			path: app/cdash/tests/test_replacebuild.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
-			path: app/cdash/tests/test_replacebuild.php
-
-		-
-			message: "#^Cannot access offset 'generator' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_replacebuild.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 2
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
@@ -23756,11 +23179,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
-			count: 2
-			path: app/cdash/tests/test_replacebuild.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_replacebuild.php
 
@@ -23799,15 +23217,7 @@ parameters:
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 6
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 4
+			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -23815,15 +23225,7 @@ parameters:
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 8
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
+			count: 4
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -23832,17 +23234,7 @@ parameters:
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'filename' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
 			message: "#^Cannot access offset 'loctested' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
-			message: "#^Cannot access offset 'nfiles' on array\\|false\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_sequenceindependence.php
 
@@ -23852,23 +23244,8 @@ parameters:
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
-			message: "#^Cannot access offset 'numfiles' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
-			message: "#^Cannot access offset 'starttime' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
-			message: "#^Cannot access offset 'time' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_sequenceindependence.php
-
-		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 23
+			count: 7
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -23943,7 +23320,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
-			count: 7
+			count: 3
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -24095,54 +23472,12 @@ parameters:
 			path: app/cdash/tests/test_subprojectemail.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_num_rows\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 3
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
 		-
-			message: "#^Cannot access offset 'parentid' on array\\|false\\|null\\.$#"
-			count: 3
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
 			message: "#^Method SubProjectNextPreviousTestCase\\:\\:testSubProjectNextPrevious\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_subprojectnextprevious.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of function pdo_num_rows expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
@@ -24328,14 +23663,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_testoverview.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -24461,21 +23788,8 @@ parameters:
 			path: app/cdash/tests/test_timeline.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_timeoutsandmissingtests.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
-			path: app/cdash/tests/test_timeoutsandmissingtests.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
 		-
@@ -24608,19 +23922,6 @@ parameters:
 			message: "#^Variable \\$build might not be defined\\.$#"
 			count: 4
 			path: app/cdash/tests/test_timesummary.php
-
-		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/test_truncateoutput.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/tests/test_truncateoutput.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -24768,14 +24069,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_updateonlyuserstats.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
@@ -24868,11 +24161,6 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
-			message: "#^Method UpgradeTestCase\\:\\:testGetVendorVersion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/test_upgrade.php
-
-		-
 			message: "#^Property UpgradeTestCase\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_upgrade.php
@@ -24913,19 +24201,6 @@ parameters:
 			path: app/cdash/tests/test_uploadfile.php
 
 		-
-			message: """
-				#^Call to deprecated function pdo_single_row_query\\(\\)\\:
-				04/01/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_usernotes.php
-
-		-
-			message: "#^Cannot access offset 'id' on array\\|false\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/test_usernotes.php
-
-		-
 			message: "#^Method UserStatisticsTestCase\\:\\:testUserStatistics\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_userstatistics.php
@@ -24949,14 +24224,6 @@ parameters:
 			message: "#^Method ViewDynamicAnalysisTestCase\\:\\:testViewDynamicAnalysis\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewdynamicanalysis.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_viewdynamicanalysisfile.php
 
 		-
 			message: """
@@ -25128,14 +24395,6 @@ parameters:
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
-			"""
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: """
-				#^Call to deprecated function get_link_identifier\\(\\)\\:
-				04/22/2023$#
 			"""
 			count: 2
 			path: app/cdash/xml_handlers/BazelJSON_handler.php


### PR DESCRIPTION
This PR contains miscellaneous changes I've accumulated over time while waiting for the tests to run.  This is a small incremental piece of the larger goal of using the Laravel DB facade for all database interactions.  Doing so will enable us to accurately log queries being executed, amongst other things.