### PR TITLE
Test LDAP against more complex group setup

### DIFF
--- a/app/Ldap/Rules/FilterRules.php
+++ b/app/Ldap/Rules/FilterRules.php
@@ -20,10 +20,8 @@ class FilterRules implements Rule
             return true;
         }
 
-        return count($user->getConnection()
-            ->query()
-            ->setDn($user->getDn())
-            ->rawFilter($filter)
-            ->get(['dn', 'cn'])) > 0;
+        return $user->groups()
+            ->recursive()
+            ->exists(\LdapRecord\Models\Entry::find($filter));
     }
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -44,7 +44,7 @@ Here's a description of the `.env` variables involved in the LDAP authentication
 | CDASH_AUTHENTICATION_PROVIDER | Set this to `ldap` to enable CDash's LDAP authentication support. | users |
 | LDAP_BASE_DN | The base distinguished name you'd like to perform query operations on. | dc=local,dc=com |
 | LDAP_BIND_USERS_BY | The LDAP users attribute used for authentication | distinguishedname |
-| LDAP_FILTERS_ON | Additional LDAP query filters to restrict authorized user list. For example, to restrict users to a specific Active Directory group: `(memberOf=cn=myRescrictedGroup,cn=Users,dc=example,dc=com)` | false |
+| LDAP_FILTERS_ON | Additional LDAP query filters to restrict authorized user list. For example, to restrict users to a specific Active Directory group: `cn=myRescrictedGroup,dc=example,dc=com` | false |
 | LDAP_HOST | The IP address or host name of your LDAP server. | 127.0.0.1 |
 | LDAP_LOCATE_USERS_BY | The LDAP users attribute used to locate your users. | mail |
 | LDAP_LOGGING | Whether or not to log LDAP activities. Useful for debugging. | true |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2761,6 +2761,11 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
+			message: "#^Call to an undefined method LdapRecord\\\\Models\\\\Model\\:\\:groups\\(\\)\\.$#"
+			count: 1
+			path: app/Ldap/Rules/FilterRules.php
+
+		-
 			message: "#^Method App\\\\Listeners\\\\ConfiguredSendEmailVerificationNotification\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
@@ -28882,6 +28887,11 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SuccessfulJob\\>\\:\\:count\\(\\)\\.$#"
 			count: 4
 			path: tests/Feature/Jobs/PruneJobsTest.php
+
+		-
+			message: "#^Cannot call method assertSuccessful\\(\\) on Illuminate\\\\Testing\\\\PendingCommand\\|int\\.$#"
+			count: 1
+			path: tests/Feature/LdapIntegration.php
 
 		-
 			message: "#^Call to an undefined method Mockery\\\\Expectation\\:\\:shouldReceive\\(\\)\\.$#"

--- a/tests/Feature/LdapIntegration.php
+++ b/tests/Feature/LdapIntegration.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
+use Illuminate\Support\Str;
+use LdapRecord\Models\OpenLDAP\Group;
+use LdapRecord\Models\OpenLDAP\User;
 use Tests\TestCase;
 
 /**
@@ -10,7 +12,18 @@ use Tests\TestCase;
  */
 class LdapIntegration extends TestCase
 {
-    protected function setUp() : void
+    protected Group $group_1;
+    protected Group $group_2;
+
+    /**
+     * @var array<string,User>
+     */
+    protected array $users;
+
+    /**
+     * @throws \LdapRecord\LdapRecordException
+     */
+    protected function setUp(): void
     {
         // There isn't necessarily a one-to-one mapping between env vars and config values for LDAP
         putenv('LDAP_USERNAME=cn=admin,dc=example,dc=org');
@@ -23,8 +36,83 @@ class LdapIntegration extends TestCase
         putenv('LDAP_LOCATE_USERS_BY=uid');
 
         parent::setUp();
+
+        // Create two groups
+        $this->group_1 = Group::create([
+            'cn' => 'cdash_users_1_' . Str::uuid()->toString(),
+            'uniqueMember' => 'ou=users,dc=example,dc=org',
+        ]);
+
+        $this->group_2 = Group::create([
+            'cn' => 'cdash_users_2_' . Str::uuid()->toString(),
+            'uniqueMember' => 'ou=users,dc=example,dc=org',
+        ]);
+
+        // Create a pair of users which are only in group 1
+        $this->users['group_1_only_1'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_1->members()->attach($this->users['group_1_only_1']);
+
+        $this->users['group_1_only_2'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_1->members()->attach($this->users['group_1_only_2']);
+
+        // Create a pair of users which are only in group 2
+        $this->users['group_2_only_1'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_2->members()->attach($this->users['group_2_only_1']);
+
+        $this->users['group_2_only_2'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_2->members()->attach($this->users['group_2_only_2']);
+
+        // Create a pair of users which are in both groups
+        $this->users['groups_1_and_2_1'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_1->members()->attach($this->users['groups_1_and_2_1']);
+        $this->group_2->members()->attach($this->users['groups_1_and_2_1']);
+
+        $this->users['groups_1_and_2_2'] = User::create([
+            'uid' => Str::uuid()->toString(),
+            'cn' => Str::uuid()->toString(),
+            'userpassword' => Str::uuid()->toString(),
+            'objectclass' => 'inetOrgPerson',
+            'sn' => Str::uuid()->toString(),
+        ]);
+        $this->group_1->members()->attach($this->users['groups_1_and_2_2']);
+        $this->group_2->members()->attach($this->users['groups_1_and_2_2']);
     }
 
+    /**
+     * @throws \LdapRecord\LdapRecordException
+     * @throws \LdapRecord\Models\ModelDoesNotExistException
+     * @throws \Mockery\Exception\InvalidCountException
+     */
     protected function tearDown(): void
     {
         // Unset the env variables we set previously
@@ -37,64 +125,100 @@ class LdapIntegration extends TestCase
         putenv('LDAP_LOGGING');
         putenv('LDAP_LOCATE_USERS_BY');
 
+        $this->group_1->delete(true);
+        $this->group_2->delete(true);
+
+        foreach ($this->users as $key => $user) {
+            $user->delete(true);
+        }
+        $this->users = [];
+
         parent::tearDown();
     }
 
-    public function testLiveLdapLogin(): void
+    public function testLdapConnection(): void
     {
-        User::where('email', 'ldapuser01')->delete();
+        $this->artisan('ldap:test')
+            ->assertSuccessful();
+    }
+
+    public function testLdapLogin(): void
+    {
+        $user = $this->users['group_1_only_1'];
 
         // Just a brief sanity check to make sure sending incorrect data is blocked
         $this->post('/login', [
-            'email' => 'ldapuser01',
+            'email' => $user->getAttribute('uid')[0],
             'password' => 'wrongpassword',
         ])->assertUnauthorized();
 
         // Username and password hardcoded in LDAP development container
         $this->post('/login', [
-            'email' => 'ldapuser01',
-            'password' => 'password1',
+            'email' => $user->getAttribute('uid')[0],
+            'password' => $user->getAttribute('userpassword')[0],
         ])->assertRedirect('/');
 
         // Ensure the user was actually created in the database, and then clean it up
-        User::where(['email' => 'ldapuser01'])->firstOrFail()->delete();
+        \App\Models\User::where(['email' => $user->getAttribute('uid')[0]])->firstOrFail()->delete();
     }
 
-    public function testLiveLdapLoginWithFilters(): void
+    public function testLdapLoginWithFilters(): void
     {
-        User::where('email', 'ldapuser01')->delete();
-        User::where('email', 'ldapuser02')->delete();
+        $user_group_1 = $this->users['group_1_only_1'];
+        $user_group_2 = $this->users['group_2_only_1'];
+        $user_all_groups = $this->users['groups_1_and_2_1'];
 
-        // Make sure we can log in with both users
+        self::assertEmpty(\App\Models\User::where('email', $user_group_1->getAttribute('uid')[0])->get());
+        self::assertEmpty(\App\Models\User::where('email', $user_group_2->getAttribute('uid')[0])->get());
+        self::assertEmpty(\App\Models\User::where('email', $user_all_groups->getAttribute('uid')[0])->get());
+
+        // Make sure we can log in with all users
         $this->post('/login', [
-            'email' => 'ldapuser01',
-            'password' => 'password1',
+            'email' => $user_group_1->getAttribute('uid')[0],
+            'password' => $user_group_1->getAttribute('userpassword')[0],
         ])->assertRedirect('/');
         $this->get('/logout')->assertRedirect('/');
+
         $this->post('/login', [
-            'email' => 'ldapuser02',
-            'password' => 'password2',
+            'email' => $user_group_2->getAttribute('uid')[0],
+            'password' => $user_group_2->getAttribute('userpassword')[0],
         ])->assertRedirect('/');
         $this->get('/logout')->assertRedirect('/');
 
-        User::where(['email' => 'ldapuser01'])->firstOrFail()->delete();
-        User::where(['email' => 'ldapuser02'])->firstOrFail()->delete();
-
-        putenv('LDAP_FILTERS_ON=cn=ldapuser01');
         $this->post('/login', [
-            'email' => 'ldapuser01',
-            'password' => 'password1',
+            'email' => $user_all_groups->getAttribute('uid')[0],
+            'password' => $user_all_groups->getAttribute('userpassword')[0],
         ])->assertRedirect('/');
         $this->get('/logout')->assertRedirect('/');
+
+        \App\Models\User::where(['email' => $user_group_1->getAttribute('uid')[0]])->firstOrFail()->delete();
+        \App\Models\User::where(['email' => $user_group_2->getAttribute('uid')[0]])->firstOrFail()->delete();
+        \App\Models\User::where(['email' => $user_all_groups->getAttribute('uid')[0]])->firstOrFail()->delete();
+
+        // Restrict login to members of group 1 only
+        putenv("LDAP_FILTERS_ON=cn={$this->group_1->getAttribute('cn')[0]},dc=example,dc=org");
         $this->post('/login', [
-            'email' => 'ldapuser02',
-            'password' => 'password2',
+            'email' => $user_group_1->getAttribute('uid')[0],
+            'password' => $user_group_1->getAttribute('userpassword')[0],
+        ])->assertRedirect('/');
+        $this->get('/logout')->assertRedirect('/');
+
+        $this->post('/login', [
+            'email' => $user_group_2->getAttribute('uid')[0],
+            'password' => $user_group_2->getAttribute('userpassword')[0],
         ])->assertUnauthorized();
+
+        $this->post('/login', [
+            'email' => $user_all_groups->getAttribute('uid')[0],
+            'password' => $user_all_groups->getAttribute('userpassword')[0],
+        ])->assertRedirect('/');
+        $this->get('/logout')->assertRedirect('/');
+
+        \App\Models\User::where(['email' => $user_group_1->getAttribute('uid')[0]])->firstOrFail()->delete();
+        self::assertCount(0, User::where(['email' => $user_group_2->getAttribute('uid')[0]])->get());
+        \App\Models\User::where(['email' => $user_all_groups->getAttribute('uid')[0]])->firstOrFail()->delete();
 
         // "Delete" the env variable
         putenv('LDAP_FILTERS_ON');
-
-        User::where(['email' => 'ldapuser01'])->firstOrFail()->delete();
-        self::assertCount(0, User::where(['email' => 'ldapuser02'])->get());
     }
 }


### PR DESCRIPTION
While the current LDAP testing setup introduced in #2206 is an improvement over the previous mocking approach, it still lacks the robustness needed to test more complex features.  This PR improves the tests by programmatically creating multiple users and groups, instead of just using a few hardcoded users in a single group.