### PR TITLE
Bump required PHP to 8.2 for all systems

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ $finder = PhpCsFixer\Finder::create()
 $config = new PhpCsFixer\Config();
 return $config->setRules([
         '@PSR2' => true,
-        '@PHP81Migration' => true,
+        '@PHP82Migration' => true,
         'method_argument_space' => ['on_multiline' => 'ignore'],
         'no_unused_imports' => true,
     ])

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -1079,13 +1079,13 @@ function get_filterdata_from_request($page_id = '')
             ];
             for ($j = 1; $j <= $subfiltercount; ++$j) {
                 $filter['filters'][] = parse_filter_from_request(
-                    "field{$i}field{$j}", "field{$i}compare${j}",
+                    "field{$i}field{$j}", "field{$i}compare{$j}",
                     "field{$i}value{$j}", $filterdata);
             }
             $filters[] = $filter;
         } else {
             $filters[] = parse_filter_from_request(
-                "field{$i}", "compare${i}", "value{$i}", $filterdata);
+                "field{$i}", "compare{$i}", "value{$i}", $filterdata);
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "wiki": "http://public.kitware.com/Wiki/CDash"
   },
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89a7e01829b83005f5a8c33621b2343d",
+    "content-hash": "843f5d7e5deff0009f55172fa7db4c93",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -12582,7 +12582,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",


### PR DESCRIPTION
As per the [release schedule](https://www.php.net/supported-versions.php), PHP 8.1 is only receiving security fixes at this time.  The official end-of-life date has been extended to January 1, 2026.  PRs https://github.com/Kitware/CDash/pull/2113 and https://github.com/Kitware/CDash/pull/2226 increased the version of PHP to 8.2 for each of our Docker images.  This PR bumps the version of PHP to 8.2 for all systems.