### PR TITLE
Add automatic multi-architecture Docker builds

### DIFF
--- a/.github/workflows/build-latest-images.yml
+++ b/.github/workflows/build-latest-images.yml
@@ -20,6 +20,7 @@ jobs:
         name: Build standard production image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:latest"
           target: cdash
@@ -39,6 +40,7 @@ jobs:
         name: Build UBI production image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:latest-ubi"
           target: cdash
@@ -60,6 +62,7 @@ jobs:
         name: Build standard worker image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash-worker:latest"
           target: cdash-worker
@@ -79,6 +82,7 @@ jobs:
         name: Build UBI worker image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash-worker:latest-ubi"
           target: cdash-worker
@@ -100,6 +104,7 @@ jobs:
         name: Build standard development image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:testing"
           target: cdash
@@ -121,6 +126,7 @@ jobs:
         name: Build UBI development image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:testing-ubi"
           target: cdash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         name: Build ${{ github.ref_name }} image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:${{ github.ref_name }}"
           target: cdash
@@ -28,6 +29,7 @@ jobs:
         name: Build ${{ github.ref_name }} worker image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash-worker:${{ github.ref_name }}"
           target: cdash-worker
@@ -47,6 +49,7 @@ jobs:
         name: Build ${{ github.ref_name }} image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash:${{ github.ref_name }}-ubi"
           target: cdash
@@ -58,6 +61,7 @@ jobs:
         name: Build ${{ github.ref_name }} worker image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "kitware/cdash-worker:${{ github.ref_name }}-ubi"
           target: cdash-worker


### PR DESCRIPTION
We currently only release `amd64` images.  Some users may want to run on `arm64` platforms provided by various cloud providers, and developers may operate from arm64-based Macs.  This PR adds multi-architecture builds to our automated release process.