### PR TITLE
Display viewTest.php system info table for all builds

### DIFF
--- a/resources/views/test/view-test.blade.php
+++ b/resources/views/test/view-test.blade.php
@@ -13,7 +13,7 @@
     @verbatim
         <h3>Testing started on {{::cdash.build.testtime}}</h3>
 
-        <table ng-if="::!cdash.parentBuild" class="tabb striped">
+        <table class="tabb striped">
             <thead>
                 <tr class="table-heading1">
                     <th colspan="2" class="header">System Information</th>


### PR DESCRIPTION
`viewTest.php` currently only displays the system information table at the top of the page for child builds.  This PR simplifies the confusion behavior of this page by simply displaying the system information table for all builds, regardless of parent or child status.