### PR TITLE
Eliminate route cache

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,6 @@ echo "Running migrations..."
 php artisan migrate --force
 
 echo "Clearing caches..."
-php artisan route:cache
 php artisan view:cache
 php artisan lighthouse:cache
 


### PR DESCRIPTION
As discussed [here](https://github.com/Kitware/CDash/pull/2270#issuecomment-2173717653), Laravel's route cache does not work for CDash-in-a-subpath installations.  Since the route cache provides a negligible speedup, this PR simply removes it for all systems.  This fixes an issue observed on some CDash-in-a-subpath installations where the `/` route does not behave correctly.