### PR TITLE
Return success if files accepted regardless of DB status

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -108,7 +108,9 @@ final class SubmissionController extends AbstractProjectController
             if (!Storage::exists("DB_WAS_DOWN")) {
                 Storage::put("DB_WAS_DOWN", "");
             }
-            abort(Response::HTTP_SERVICE_UNAVAILABLE, 'Cannot connect to the database.');
+            $statusarray['status'] = 'OK';
+            $statusarray['message'] = 'Database is unavailable.';
+            return self::displayXMLReturnStatus($statusarray);
         }
 
         // We can't use the usual $this->setProjectByName() function here because the auth token we have might not allow


### PR DESCRIPTION
CDash currently returns a 503 error if the database is unavailable, which causes CTest to print errors.  This PR changes the behavior to instead return a HTTP 200 status code if the files are successfully received, regardless of whether they can be stored in the database at that particular time.