### PR TITLE
Add schema for `Configure` XML types

### DIFF
--- a/app/Validators/Schemas/Configure.xsd
+++ b/app/Validators/Schemas/Configure.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Subproject" type="SubprojectType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="Labels" type="LabelsType" minOccurs="0"/>
+        <xs:element name="Configure">
+          <xs:complexType mixed="true">
+            <xs:sequence>
+              <xs:element name="StartDateTime" type="xs:string" minOccurs="0" />
+              <xs:element name="StartConfigureTime" type="xs:unsignedInt" minOccurs="0" />
+              <xs:element name="ConfigureCommand" type="xs:string" />
+              <xs:element name="Log" type="LogType" />
+              <xs:element name="ConfigureStatus" type="xs:string" />
+              <xs:element name="EndDateTime" type="xs:string" minOccurs="0" />
+              <xs:element name="EndConfigureTime" type="xs:unsignedInt" minOccurs="0" />
+              <xs:element name="ElapsedMinutes" type="xs:decimal" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attributeGroup ref="SiteAttrs"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR follows up on https://github.com/Kitware/CDash/pull/2277 and introduces an initial schema for "Configure" XML file types accepted by the CDash submission process. The schema has been tested against all configure XML data files in the CDash repo.

The changes also pull out some common element types into a `common.xsd` file to be reused by the other schema files.