### PR TITLE
Move HeadController from `<head>` to `<html>`

### DIFF
--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -10,11 +10,12 @@
     lang="{{ str_replace('_', '-', app()->getLocale()) }}"
     @if(isset($angular) && $angular === true)
         ng-app="CDash"
+        ng-controller="HeadController"
         ng-strict-di
         ng-cloak
     @endif
 >
-<head @if(isset($angular) && $angular === true) ng-controller="HeadController" @endif>
+<head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="robots" content="noindex,nofollow"/>
     <meta name="csrf-token" content="{{ csrf_token() }}"/>


### PR DESCRIPTION
We received a report of some CDash instances failing to load index.php properly. The error in the web console was:

  TypeError: $rootScope.queryString is undefined

After further investigation, we discovered that the `<head>` element did not contain the `ng-controller="HeadController"` attribute. We are not sure what caused this behavior, and why it only occurs on some CDash instances and not others, but moving the controller to the top-level `<html>` element seems to fix the problem.