### PR TITLE
Add schema for the `Coverage` xml submission type

### DIFF
--- a/app/Validators/Schemas/Coverage.xsd
+++ b/app/Validators/Schemas/Coverage.xsd
@@ -14,14 +14,14 @@
               <xs:element name="File" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element name="LOCTested" type="xs:unsignedInt" />
-                    <xs:element name="LOCUnTested" type="xs:unsignedInt" />
+                    <xs:element name="LOCTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="LOCUnTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="BranchesTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="BranchedUnTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="FunctionsTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="FunctionsUnTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="PercentCoverage" type="xs:decimal" />
-                    <xs:element name="CoverageMetric" type="xs:decimal" />
+                    <xs:element name="PercentCoverage" type="xs:decimal" minOccurs="0" />
+                    <xs:element name="CoverageMetric" type="xs:decimal" minOccurs="0" />
                     <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
                   </xs:sequence>
                   <xs:attribute name="Name" type="xs:string" use="optional" />

--- a/app/Validators/Schemas/Coverage.xsd
+++ b/app/Validators/Schemas/Coverage.xsd
@@ -17,7 +17,7 @@
                     <xs:element name="LOCTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="LOCUnTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="BranchesTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="BranchedUnTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="BranchesUnTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="FunctionsTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="FunctionsUnTested" type="xs:unsignedInt" minOccurs="0" />
                     <xs:element name="PercentCoverage" type="xs:decimal" minOccurs="0" />

--- a/app/Validators/Schemas/Coverage.xsd
+++ b/app/Validators/Schemas/Coverage.xsd
@@ -9,33 +9,37 @@
         <xs:element name="Coverage">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="StartDateTime" type="xs:string" />
-              <xs:element name="StartTime" type="xs:string" />
-              <xs:element name="File" minOccurs="0" maxOccurs="unbounded">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="LOCTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="LOCUnTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="BranchesTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="BranchesUnTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="FunctionsTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="FunctionsUnTested" type="xs:unsignedInt" minOccurs="0" />
-                    <xs:element name="PercentCoverage" type="xs:decimal" minOccurs="0" />
-                    <xs:element name="CoverageMetric" type="xs:decimal" minOccurs="0" />
-                    <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
-                  </xs:sequence>
-                  <xs:attribute name="Name" type="xs:string" use="optional" />
-                  <xs:attribute name="FullPath" type="xs:string" use="required" />
-                  <xs:attribute name="Covered" type="xs:boolean" use="required" />
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="LOCTested" type="xs:unsignedInt" />
-              <xs:element name="LOCUntested" type="xs:unsignedInt" />
-              <xs:element name="LOC" type="xs:unsignedInt" />
-              <xs:element name="PercentCoverage" type="xs:decimal" />
-              <xs:element name="EndDateTime" type="xs:string" />
-              <xs:element name="EndTime" type="xs:string" />
-              <xs:element name="ElapsedMinutes" type="xs:decimal" />
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="StartDateTime" type="xs:string" />
+                <xs:element name="StartTime" type="xs:string" />
+                <xs:element name="File">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="LOCTested" type="xs:unsignedInt" />
+                        <xs:element name="LOCUnTested" type="xs:unsignedInt" />
+                        <xs:element name="BranchesTested" type="xs:unsignedInt" />
+                        <xs:element name="BranchesUnTested" type="xs:unsignedInt" />
+                        <xs:element name="FunctionsTested" type="xs:unsignedInt" />
+                        <xs:element name="FunctionsUnTested" type="xs:unsignedInt" />
+                        <xs:element name="PercentCoverage" type="xs:decimal" />
+                        <xs:element name="CoverageMetric" type="xs:decimal" />
+                        <xs:element name="Labels" type="LabelsType" />
+                      </xs:choice>
+                    </xs:sequence>
+                    <xs:attribute name="Name" type="xs:string" use="optional" />
+                    <xs:attribute name="FullPath" type="xs:string" use="required" />
+                    <xs:attribute name="Covered" type="xs:boolean" use="required" />
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="LOCTested" type="xs:unsignedInt" />
+                <xs:element name="LOCUntested" type="xs:unsignedInt" />
+                <xs:element name="LOC" type="xs:unsignedInt" />
+                <xs:element name="PercentCoverage" type="xs:decimal" />
+                <xs:element name="EndDateTime" type="xs:string" />
+                <xs:element name="EndTime" type="xs:string" />
+                <xs:element name="ElapsedMinutes" type="xs:decimal" />
+              </xs:choice>
             </xs:sequence>
           </xs:complexType>
         </xs:element>

--- a/app/Validators/Schemas/Coverage.xsd
+++ b/app/Validators/Schemas/Coverage.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Subproject" type="SubprojectType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="Coverage">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="StartDateTime" type="xs:string" />
+              <xs:element name="StartTime" type="xs:string" />
+              <xs:element name="File" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="LOCTested" type="xs:unsignedInt" />
+                    <xs:element name="LOCUnTested" type="xs:unsignedInt" />
+                    <xs:element name="BranchesTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="BranchedUnTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="FunctionsTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="FunctionsUnTested" type="xs:unsignedInt" minOccurs="0" />
+                    <xs:element name="PercentCoverage" type="xs:decimal" />
+                    <xs:element name="CoverageMetric" type="xs:decimal" />
+                    <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
+                  </xs:sequence>
+                  <xs:attribute name="Name" type="xs:string" use="optional" />
+                  <xs:attribute name="FullPath" type="xs:string" use="required" />
+                  <xs:attribute name="Covered" type="xs:boolean" use="required" />
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="LOCTested" type="xs:unsignedInt" />
+              <xs:element name="LOCUntested" type="xs:unsignedInt" />
+              <xs:element name="LOC" type="xs:unsignedInt" />
+              <xs:element name="PercentCoverage" type="xs:decimal" />
+              <xs:element name="EndDateTime" type="xs:string" />
+              <xs:element name="EndTime" type="xs:string" />
+              <xs:element name="ElapsedMinutes" type="xs:decimal" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attributeGroup ref="SiteAttrs" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for "Coverage" XML file types accepted by the CDash submission process. The schema has been tested against all configure XML data files in the CDash repo.