### PR TITLE
Add schema for the `CoverageLog` XML submission type

### DIFF
--- a/app/Validators/Schemas/CoverageLog.xsd
+++ b/app/Validators/Schemas/CoverageLog.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Subproject" type="SubprojectType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="CoverageLog">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="StartDateTime" type="xs:string" />
+              <xs:element name="StartTime" type="xs:string" />
+              <xs:element name="File" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="Report">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="Line" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute name="Number" type="xs:int" use="required" />
+                                  <xs:attribute name="Count" type="xs:int" use="required" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="Name" type="xs:string" use="optional" />
+                  <xs:attribute name="FullPath" type="xs:string" use="required" />
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="EndDateTime" type="xs:string" />
+              <xs:element name="EndTime" type="xs:string" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    <xs:attributeGroup ref="SiteAttrs" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for "CoverageLog" XML file types accepted by the CDash submission process. The schema has been tested against all ConfigureLog XML data files in the CDash repo.