### PR TITLE
Refactor common element types to resuable schema component

### DIFF
--- a/app/Validators/Schemas/Build.xsd
+++ b/app/Validators/Schemas/Build.xsd
@@ -1,35 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
   <xs:element name="Site">
     <xs:complexType>
       <xs:sequence>
         <xs:choice maxOccurs="unbounded">
-          <xs:element name="Subproject">
-            <xs:complexType>
-              <xs:sequence minOccurs="0">
-                <xs:element name="Label" type="xs:string" />
-              </xs:sequence>
-              <xs:attribute name="name" type="xs:string" use="required" />
-            </xs:complexType>
-          </xs:element>
-          <xs:element name="Labels">
-            <xs:complexType>
-              <xs:sequence>
-                <xs:element name="Label" type="xs:string" />
-              </xs:sequence>
-            </xs:complexType>
-          </xs:element>
+          <xs:element name="Subproject" type="SubprojectType" />
+          <xs:element name="Labels" type="LabelsType" />
           <xs:element name="Build">
             <xs:complexType>
               <xs:sequence>
                 <xs:choice maxOccurs="unbounded">
-                  <xs:element name="Labels">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element maxOccurs="unbounded" name="Label" type="xs:string" />
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
+                  <xs:element name="Labels" type="LabelsType" />
                   <xs:element name="StartDateTime" type="xs:string" />
                   <xs:element name="StartBuildTime" type="xs:unsignedInt" />
                   <xs:element name="BuildCommand" type="xs:string" />
@@ -93,28 +75,13 @@
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="Labels" minOccurs="0">
-                            <xs:complexType>
-                              <xs:sequence>
-                                <xs:element name="Label" type="xs:string" />
-                              </xs:sequence>
-                            </xs:complexType>
-                          </xs:element>
+                          <xs:element name="Labels" type="LabelsType" minOccurs="0" />
                         </xs:choice>
                       </xs:sequence>
                       <xs:attribute name="type" type="xs:string" use="required" />
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="Log">
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:string">
-                          <xs:attribute name="Encoding" type="xs:string" use="required" />
-                          <xs:attribute name="Compression" type="xs:string" use="required" />
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
+                  <xs:element name="Log" type="LogType" />
                   <xs:element name="EndDateTime" type="xs:string" />
                   <xs:element name="EndBuildTime" type="xs:unsignedInt" />
                   <xs:element name="ElapsedMinutes" type="xs:decimal" />
@@ -124,31 +91,7 @@
           </xs:element>
         </xs:choice>
       </xs:sequence>
-      <xs:attribute name="BuildName" type="xs:string" use="required" />
-      <xs:attribute name="BuildStamp" type="xs:string" use="required" />
-      <xs:attribute name="Name" type="xs:string" use="required" />
-      <xs:attribute name="Generator" type="xs:string" />
-      <xs:attribute name="Append" type="xs:boolean" />
-      <xs:attribute name="CompilerName" type="xs:string" />
-      <xs:attribute name="CompilerVersion" type="xs:string" />
-      <xs:attribute name="OSName" type="xs:string" />
-      <xs:attribute name="Hostname" type="xs:string" />
-      <xs:attribute name="OSRelease" type="xs:string" />
-      <xs:attribute name="OSVersion" type="xs:string" />
-      <xs:attribute name="OSPlatform" type="xs:string" />
-      <xs:attribute name="Is64Bits" type="xs:short" />
-      <xs:attribute name="VendorString" type="xs:string" />
-      <xs:attribute name="VendorID" type="xs:string" />
-      <xs:attribute name="FamilyID" type="xs:int" />
-      <xs:attribute name="ModelID" type="xs:int" />
-      <xs:attribute name="ProcessorCacheSize" type="xs:int" />
-      <xs:attribute name="NumberOfLogicalCPU" type="xs:int" />
-      <xs:attribute name="NumberOfPhysicalCPU" type="xs:int" />
-      <xs:attribute name="TotalVirtualMemory" type="xs:int" />
-      <xs:attribute name="TotalPhysicalMemory" type="xs:int" />
-      <xs:attribute name="LogicalProcessorsPerPhysical" type="xs:int" />
-      <xs:attribute name="ProcessorClockFrequency" type="xs:float" />
-      <xs:attribute name="ChangeId" type="xs:string" />
+      <xs:attributeGroup ref="SiteAttrs"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/app/Validators/Schemas/common.xsd
+++ b/app/Validators/Schemas/common.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified">
+  <xs:attributeGroup name="SiteAttrs">
+    <xs:attribute name="BuildName" type="xs:string" use="required" />
+    <xs:attribute name="BuildStamp" type="xs:string" use="required" />
+    <xs:attribute name="Name" type="xs:string" use="required" />
+    <xs:attribute name="Generator" type="xs:string" />
+    <xs:attribute name="Append" type="xs:boolean" />
+    <xs:attribute name="CompilerName" type="xs:string" />
+    <xs:attribute name="CompilerVersion" type="xs:string" />
+    <xs:attribute name="OSName" type="xs:string" />
+    <xs:attribute name="Hostname" type="xs:string" />
+    <xs:attribute name="OSRelease" type="xs:string" />
+    <xs:attribute name="OSVersion" type="xs:string" />
+    <xs:attribute name="OSPlatform" type="xs:string" />
+    <xs:attribute name="Is64Bits" type="xs:short" />
+    <xs:attribute name="VendorString" type="xs:string" />
+    <xs:attribute name="VendorID" type="xs:string" />
+    <xs:attribute name="FamilyID" type="xs:int" />
+    <xs:attribute name="ModelID" type="xs:int" />
+    <xs:attribute name="ProcessorCacheSize" type="xs:int" />
+    <xs:attribute name="NumberOfLogicalCPU" type="xs:int" />
+    <xs:attribute name="NumberOfPhysicalCPU" type="xs:int" />
+    <xs:attribute name="TotalVirtualMemory" type="xs:int" />
+    <xs:attribute name="TotalPhysicalMemory" type="xs:int" />
+    <xs:attribute name="LogicalProcessorsPerPhysical" type="xs:int" />
+    <xs:attribute name="ProcessorClockFrequency" type="xs:float" />
+    <xs:attribute name="ChangeId" type="xs:string" />
+  </xs:attributeGroup>
+
+  <xs:complexType name="LabelsType">
+    <xs:sequence>
+      <xs:element name="Label" type="xs:string" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SubprojectType">
+    <xs:sequence minOccurs="0">
+      <xs:element name="Label" type="xs:string" />
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="LogType" mixed="true">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <!-- wildcard to account for formatted text, e.g., boldface -->
+      <xs:any processContents="lax" />
+    </xs:sequence>
+    <xs:attribute name="compression" type="xs:string" use="optional" />
+    <xs:attribute name="Compression" type="xs:string" use="optional" />
+    <xs:attribute name="encoding" type="xs:string" use="optional" />
+    <xs:attribute name="Encoding" type="xs:string" use="optional" />
+  </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
As part of our efforts to improve the CDash submission process, we working to introduce XML schematics to help with submission validation. The first of these PRs merged is https://github.com/Kitware/CDash/pull/2277. The changes in this PR refactor some common element types that appear in many of the different XML types, and pull them out to a common file so they can be reused and instead of redefined by the other schema files. For an example where these elements type are used, see https://github.com/Kitware/CDash/pull/2287.