### PR TITLE
Add schema for the `DynamicAnalysis` XML submissions type

### DIFF
--- a/app/Validators/Schemas/DynamicAnalysis.xsd
+++ b/app/Validators/Schemas/DynamicAnalysis.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Subproject" type="SubprojectType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="Labels" type="LabelsType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="DynamicAnalysis">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="StartDateTime" type="xs:string" />
+              <xs:element name="StartTestTime" type="xs:string" />
+              <xs:element name="TestList">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="Test" type="xs:string" maxOccurs="unbounded" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="Test" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="Name" type="xs:string" />
+                    <xs:element name="Path" type="xs:string" />
+                    <xs:element name="FullName" type="xs:string" />
+                    <xs:element name="FullCommandLine" type="xs:string" />
+                    <xs:element name="Results">
+                      <xs:complexType mixed="true">
+                        <xs:sequence minOccurs="0">
+                          <xs:element name="Defect" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:int">
+                                  <xs:attribute name="type" type="xs:string" use="required" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Log" type="LogType" />
+                    <xs:element name="Labels" type="LabelsType" minOccurs="0" />
+                  </xs:sequence>
+                  <xs:attribute name="Status" type="xs:string" use="optional" />
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="DefectList">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="Defect" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <!-- required attribute 'type' or 'Type', but we can't enforce it in xml v1.0 -->
+                        <xs:attribute name="Type" type="xs:string" use="optional" />
+                        <xs:attribute name="type" type="xs:string" use="optional" />
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="EndDateTime" type="xs:string" />
+              <xs:element name="EndTestTime" type="xs:string" />
+              <xs:element name="ElapsedMinutes" type="xs:decimal" />
+            </xs:sequence>
+            <xs:attribute name="Checker" type="xs:string" use="required" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attributeGroup ref="SiteAttrs" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/app/Validators/Schemas/DynamicAnalysis.xsd
+++ b/app/Validators/Schemas/DynamicAnalysis.xsd
@@ -13,12 +13,12 @@
               <xs:element name="StartTestTime" type="xs:string" />
               <xs:element name="TestList">
                 <xs:complexType>
-                  <xs:sequence>
+                  <xs:sequence minOccurs="0">
                     <xs:element name="Test" type="xs:string" maxOccurs="unbounded" />
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
-              <xs:element name="Test" maxOccurs="unbounded">
+              <xs:element name="Test" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:sequence>
                     <xs:element name="Name" type="xs:string" />
@@ -48,7 +48,7 @@
               </xs:element>
               <xs:element name="DefectList">
                 <xs:complexType>
-                  <xs:sequence>
+                  <xs:sequence minOccurs="0">
                     <xs:element name="Defect" maxOccurs="unbounded">
                       <xs:complexType>
                         <!-- required attribute 'type' or 'Type', but we can't enforce it in xml v1.0 -->


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for "DynamicAnalysis" XML file types accepted by the CDash submission process. The schema has been tested against all such existing XML data files in the CDash repo.