### PR TITLE
Add schema for the `Notes` XML submission type

### DIFF
--- a/app/Validators/Schemas/Notes.xsd
+++ b/app/Validators/Schemas/Notes.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Subproject" type="SubprojectType" minOccurs="0" />
+        <xs:element name="Labels" type="LabelsType" minOccurs="0" />
+        <xs:element name="Notes">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Note" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="Time" type="xs:string" minOccurs="0"/>
+                    <xs:element name="DateTime" type="xs:string" minOccurs="0"/>
+                    <xs:element name="Text" type="LogType" minOccurs="0"/>
+                  </xs:sequence>
+                  <xs:attribute name="Name" type="xs:string" use="optional" />
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attributeGroup ref="SiteAttrs" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for the "Notes" XML file types accepted by the CDash submission process. As in the other PRs, this schema has been tested against all such existing XML data files in the CDash repo.