### PR TITLE
Add schema for the `Done` XML submission type

### DIFF
--- a/app/Validators/Schemas/Done.xsd
+++ b/app/Validators/Schemas/Done.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="Windows-1252"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="Done">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="buildId" type="xs:string" />
+        <xs:element name="time" type="xs:string" />
+      </xs:sequence>
+      <xs:attribute name="retries" type="xs:int" use="optional" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for the "Done" XML file type accepted by the CDash submission process. As in the other PRs, this schema has been tested against all such existing XML data files in the CDash repo.