### PR TITLE
Add schema for the `Upload` XML submission type

### DIFF
--- a/app/Validators/Schemas/Upload.xsd
+++ b/app/Validators/Schemas/Upload.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="common.xsd" />
+  <xs:element name="Site">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="Labels" type="LabelsType" minOccurs="0"/>
+          <xs:element name="Upload">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:choice maxOccurs="unbounded">
+                  <xs:element name="Time" type="xs:string" minOccurs="0"/>
+                  <xs:element maxOccurs="unbounded" name="File">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="Content" type="LogType" />
+                      </xs:sequence>
+                      <xs:attribute name="filename" type="xs:string" use="required" />
+                    </xs:complexType>
+                  </xs:element>
+                </xs:choice>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attributeGroup ref="SiteAttrs"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR is part of a series meant to improve the submission validation in CDash. The changes introduce an initial schema for the "Upload" XML file type accepted by the CDash submission process. As in the other PRs, this schema has been tested against all such existing XML data files in the CDash repo.