### PR TITLE
Suppress spammy DaisyUI build log messages

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,5 +11,8 @@ module.exports = {
   plugins: [
     require('daisyui'),
   ],
+  daisyui: {
+    logs: false,
+  },
 };
 


### PR DESCRIPTION
DaisyUI injects an unnecessary message into the build log by default.  This PR disables the message.