### PR TITLE
Update release process docs

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -19,36 +19,21 @@ keep it up-to-date to ensure a consistent release process each time.
 
 ### Making a release
 
-- Create a new release branch (if this is the initial release candidate for a 
-  given branch)
-  - Note: Set configs to match [existing branches](https://github.com/Kitware/CDash/settings/branches).
-- Create an annotated tag and push it to GitHub
-  - Note: Simply creating a release in GitHub is not sufficient since it
-    only creates a lightweight tag.
-- Verify that the new tag for the `cdash` Docker image was successfully
-  pushed to [Docker Hub](https://hub.docker.com/r/kitware/cdash/tags).
-- Pull the new image locally and verify that the correct version is reported at
-  the bottom of the page.
-  - Note: The wrong version could be reported if a lightweight tag was created
-    instead of an annotated tag.
+- Create a new release branch (if this is the initial release candidate for a given branch)
+  - Note: Add branch name to list of [protected branches](https://github.com/Kitware/CDash/settings/rules/1071686).
 - Use GitHub to draft a [new release](https://github.com/Kitware/CDash/releases/new)
-  - Select the appropriate tags and click "Generate release notes" to automatically
-    generate release notes.
-  - Verify that all PRs have appropriate release notes labels and none show up
-    in the "Other Changes" section.
+  - Select the appropriate tags and click "Generate release notes" to automatically generate release notes.
+  - Verify that all PRs have appropriate release notes labels and none show up in the "Other Changes" section.
   - Select the pre-release checkbox if this is a release candidate.
   - Select the "set as latest" checkbox if this is not a release candidate.
 - Publish the new release.
 
 ### Post-release
 
+- Verify that the new tag for the `cdash` Docker image was successfully pushed to [Docker Hub](https://hub.docker.com/r/kitware/cdash/tags).
+- Pull the new image locally and verify that the correct version is reported at the bottom of the page.
 - Create a release announcement on the [Kitware blog](https://www.kitware.com/tag/cdash/).
 - Update [cdash.org](https://www.cdash.org) to advertise the new version.
-- Bump the version listed in `config/cdash.php`, `package.json`, and
-  `package-lock.json` on master to the next expected version.
-  - Note: Doing this helps differentiate between a released version and the
-    version on master when handling bug reports.
-- Lock the oldest release branch to prevent inadvertent changes.
-- Close the oldest [milestone](https://github.com/Kitware/CDash/milestones).
-- (Optional) Triage issues to determine whether any should be added to new
-  milestones or closed.
+- Close the [milestone](https://github.com/Kitware/CDash/milestones) for this release (if this is the first release candidate).
+- (Optional) Triage issues to determine whether any should be added to new milestones or closed.
+- Merge the release branch back into master


### PR DESCRIPTION
A few brief updates to the release process docs in time for the release of CDash 3.5:

- It is no longer necessary to manually create annotated tags: #2152
- Updating the version on master causes unnecessary conflicts.  Instead, it's better to just merge the release branch back into master immediately to keep the version number reported on master up-to-date.
- Removed the line about locking the oldest release branch