### PR TITLE
Skip peer SSL certificate verification in healthcheck

### DIFF
--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -4,4 +4,4 @@ set -e
 
 # Ping both the http and https routes, and fail if neither of them is successful
 curl -s -o /dev/null -w "%{http_code}" http://cdash:8080/ping | grep 200 > /dev/null || \
-curl -s -o /dev/null -w "%{http_code}" https://cdash:8080/ping | grep 200 > /dev/null || exit 1
+curl -k -s -o /dev/null -w "%{http_code}" https://cdash:8080/ping | grep 200 > /dev/null || exit 1


### PR DESCRIPTION
Some users have reported problems using our production docker compose system when behind a proxy server due to the healthcheck failing.

One way to alleviate this problem is by passing the -k (--insecure) option to curl when attempting to ping a CDash site served over https.