### PR TITLE
GraphQL: Add project field to build type

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -126,7 +126,7 @@ class Build extends Model
      */
     public function project(): BelongsTo
     {
-        return $this->belongsTo(Project::class, 'id', 'projectid');
+        return $this->belongsTo(Project::class, 'projectid');
     }
 
     /**

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -210,7 +210,7 @@ type Build {
   """
   basicWarnings: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
-  # TODO: Figure out project relation.  project{build{project}} currently throws an error.
+  project: Project! @belongsTo
 }
 
 input BuildFilterInput {


### PR DESCRIPTION
This PR adds the first field which allows for cyclic GraphQL queries, by adding a project field to the build type.