### PR TITLE
Relate test measurements to tests instead of test outputs

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -423,7 +423,6 @@ final class AdminController extends AbstractController
 
             self::delete_unused_rows('dailyupdatefile', 'dailyupdateid', 'dailyupdate');
             self::delete_unused_rows('test2image', 'outputid', 'testoutput');
-            self::delete_unused_rows('testmeasurement', 'outputid', 'testoutput');
             self::delete_unused_rows('label2test', 'outputid', 'testoutput');
 
             $xml .= add_XML_value('alert', 'Database cleanup complete.');

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -210,7 +210,7 @@ final class TestController extends AbstractProjectController
             SELECT testmeasurement.name
             FROM build2test
             JOIN build ON (build.id = build2test.buildid)
-            JOIN testmeasurement ON (build2test.outputid = testmeasurement.outputid)
+            JOIN testmeasurement ON (build2test.id = testmeasurement.testid)
             JOIN measurement ON (
                 build.projectid=measurement.projectid
                 AND testmeasurement.name=measurement.name
@@ -259,7 +259,7 @@ final class TestController extends AbstractProjectController
                     build2test.time
                 FROM build2test
                 JOIN build ON (build.id = build2test.buildid)
-                JOIN testmeasurement ON (build2test.outputid = testmeasurement.outputid)
+                JOIN testmeasurement ON (build2test.id = testmeasurement.testid)
                 JOIN measurement ON (
                     build.projectid = measurement.projectid
                     AND testmeasurement.name = measurement.name
@@ -472,7 +472,7 @@ final class TestController extends AbstractProjectController
                     build2test.time
                 FROM build2test
                 JOIN build ON (build.id = build2test.buildid)
-                JOIN testmeasurement ON (build2test.outputid = testmeasurement.outputid)
+                JOIN testmeasurement ON (build2test.id = testmeasurement.testid)
                 JOIN measurement ON (
                     build.projectid = measurement.projectid
                     AND testmeasurement.name = measurement.name

--- a/app/Models/BuildTest.php
+++ b/app/Models/BuildTest.php
@@ -7,6 +7,7 @@ use CDash\Model\Label;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -71,6 +72,14 @@ class BuildTest extends Model
     public function testOutput(): BelongsTo
     {
         return $this->belongsTo('App\Models\TestOutput', 'outputid');
+    }
+
+    /**
+     * @return HasMany<TestMeasurement>
+     */
+    public function testMeasurements(): HasMany
+    {
+        return $this->hasMany(TestMeasurement::class, 'testid');
     }
 
     /**

--- a/app/Models/TestMeasurement.php
+++ b/app/Models/TestMeasurement.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int $id
- * @property int $outputid
+ * @property int $testid
  * @property string $name
  * @property string $type
  * @property string $value
@@ -21,7 +21,7 @@ class TestMeasurement extends Model
     public $timestamps = false;
 
     protected $fillable = [
-        'outputid',
+        'testid',
         'name',
         'type',
         'value',
@@ -29,6 +29,6 @@ class TestMeasurement extends Model
 
     protected $casts = [
         'id' => 'integer',
-        'outputid' => 'integer',
+        'testid' => 'integer',
     ];
 }

--- a/app/Models/TestOutput.php
+++ b/app/Models/TestOutput.php
@@ -42,14 +42,6 @@ class TestOutput extends Model
     }
 
     /**
-     * @return HasMany<TestMeasurement>
-     */
-    public function testMeasurements(): HasMany
-    {
-        return $this->hasMany(TestMeasurement::class, 'outputid');
-    }
-
-    /**
      * Returns uncompressed test output.
      */
     public static function DecompressOutput($output)

--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -199,12 +199,6 @@ class TestCreator
                  ':crc32'   => $crc32]);
             $outputid = DB::getPdo()->lastInsertId();
 
-            // testmeasurement
-            foreach ($this->measurements as $measurement) {
-                $measurement->outputid = $outputid;
-                $measurement->save();
-            }
-
             // test2image
             foreach ($this->images as $image) {
                 $this->saveImage($image, $outputid);
@@ -224,6 +218,11 @@ class TestCreator
         // ctestparserutils::compute_test_difference. This gets updated when we call
         // Build::ComputeTestTiming.
         $buildtest->save();
+
+        foreach ($this->measurements as $measurement) {
+            $measurement->testid = $buildtest->id;
+            $measurement->save();
+        }
 
         // Give measurements to the buildtest model so we can properly calculate
         // proctime later on.

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -385,17 +385,17 @@ class QueryTests extends ResultsApi
                     $this->limitSQL
                 ", $query_params);
 
-        $outputids = [];
+        $testids = [];
         foreach ($rows as $row) {
-            $outputids[] = (int) $row->outputid;
+            $testids[] = (int) $row->buildtestid;
         }
 
-        $outputid_to_testmeasurements = [];
-        foreach (TestMeasurement::whereIn('outputid', $outputids)->get() as $testmeasurement) {
-            if (!isset($outputid_to_testmeasurements[$testmeasurement->outputid])) {
-                $outputid_to_testmeasurements[$testmeasurement->outputid] = [];
+        $testid_to_testmeasurements = [];
+        foreach (TestMeasurement::whereIn('testid', $testids)->get() as $testmeasurement) {
+            if (!isset($testid_to_testmeasurements[$testmeasurement->testid])) {
+                $testid_to_testmeasurements[$testmeasurement->testid] = [];
             }
-            $outputid_to_testmeasurements[$testmeasurement->outputid][] = $testmeasurement;
+            $testid_to_testmeasurements[$testmeasurement->testid][] = $testmeasurement;
         }
 
         // Rows of test data to be displayed to the user.
@@ -462,7 +462,7 @@ class QueryTests extends ResultsApi
             }
 
             if ($this->hasProcessors || $this->numExtraMeasurements > 0) {
-                $this->addExtraMeasurements($test, $outputid_to_testmeasurements[(int) $row->outputid] ?? []);
+                $this->addExtraMeasurements($test, $testid_to_testmeasurements[(int) $row->buildtestid] ?? []);
             }
 
             $tests[] = $test;

--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -76,7 +76,7 @@ class TestGraph extends BuildTestApi
                     'data' => [],
                 ];
                 $this->testHistoryQueryExtraColumns = ', tm.value';
-                $this->testHistoryQueryExtraJoins = 'JOIN testmeasurement tm ON (b2t.outputid = tm.outputid)';
+                $this->testHistoryQueryExtraJoins = 'JOIN testmeasurement tm ON (b2t.id = tm.testid)';
                 $this->testHistoryQueryExtraWheres = 'AND tm.name = :measurementname';
                 $this->testHistoryQueryParams[':measurementname'] = $measurement_name;
                 break;

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -328,7 +328,7 @@ class ViewTest extends BuildApi
                     build2test.time
                     FROM build2test
                     JOIN build ON (build.id = build2test.buildid)
-                    JOIN testmeasurement ON (build2test.outputid = testmeasurement.outputid)
+                    JOIN testmeasurement ON (build2test.id = testmeasurement.testid)
                     JOIN measurement ON (build.projectid=measurement.projectid AND testmeasurement.name=measurement.name)
                     WHERE build.$buildid_field = :buildid
                     $onlydelta_extra

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -635,7 +635,6 @@ function remove_build($buildid)
         // Use array_diff to get the list of tests that should be deleted.
         $testoutputs_to_delete = array_diff($all_outputids, $testoutputs_to_save);
         if (!empty($testoutputs_to_delete)) {
-            delete_rows_chunked('DELETE FROM testmeasurement WHERE outputid IN ', $testoutputs_to_delete);
             delete_rows_chunked('DELETE FROM testoutput WHERE id IN ', $testoutputs_to_delete);
 
             $testoutputs_to_delete_prepare_array = $db->createPreparedArray(count($testoutputs_to_delete));

--- a/app/cdash/tests/test_namedmeasurements.php
+++ b/app/cdash/tests/test_namedmeasurements.php
@@ -46,8 +46,7 @@ class NamedMeasurementsTestCase extends KWWebTestCase
         $results = DB::select("
             SELECT testmeasurement.value
             FROM testmeasurement
-            JOIN testoutput ON (testmeasurement.outputid = testoutput.id)
-            JOIN build2test ON (testoutput.id = build2test.outputid)
+            JOIN build2test ON (testmeasurement.testid = build2test.id)
             JOIN build ON (build2test.buildid = build.id)
             WHERE build.projectid = :projectid
             AND testmeasurement.name = 'archive directory'

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -409,7 +409,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
 
         $outputids =
             $this->verify_get_rows('build2test', 'outputid', 'buildid', '=', $build->Id, 2);
-        $this->verify('testmeasurement', 'outputid', 'IN', $outputids, 2);
         $imgids = $this->verify_get_rows('test2image', 'imgid', 'outputid', 'IN', $outputids, 2);
         $this->verify('image', 'id', 'IN', $imgids, 2);
 
@@ -476,7 +475,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('subproject2build', 'buildid', '=', $build->Id, 0, true);
         $this->verify('test2image', 'outputid', 'IN', $outputids, 1, true);
         $this->verify('testdiff', 'buildid', '=', $build->Id, 0, true);
-        $this->verify('testmeasurement', 'outputid', 'IN', $outputids, 1, true);
         $this->verify('updatefile', 'updateid', '=', $updateid, 1, true);
         $this->verify('uploadfile', 'id', 'IN', $uploadfileids, 1, true);
     }

--- a/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
+++ b/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            $table->unsignedInteger('testid')
+                ->nullable(); // Temporarily make the column nullable
+        });
+
+        DB::insert('
+            INSERT INTO testmeasurement (
+                outputid,
+                name,
+                type,
+                value,
+                testid
+            )
+            SELECT
+                testmeasurement.outputid,
+                testmeasurement.name,
+                testmeasurement.type,
+                testmeasurement.value,
+                build2test.id
+            FROM testmeasurement
+            JOIN build2test ON testmeasurement.outputid = build2test.outputid
+        ');
+
+        // Delete any entries which will fail the FK constraint (including the old values which now have a null testid)
+        DB::delete('
+            DELETE FROM testmeasurement
+            WHERE
+                testid IS NULL OR
+                testid NOT IN (
+                    SELECT id from build2test
+                )
+        ');
+
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            $table->unsignedInteger('testid')
+                ->nullable(false) // Add a not-null constraint
+                ->index()
+                ->change();
+            $table->foreign('testid')->references('id')->on('build2test')->cascadeOnDelete();
+            $table->dropColumn('outputid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            $table->unsignedInteger('testid')
+                ->nullable()
+                ->change();
+
+            $table->integer('outputid')
+                ->nullable(); // Temporarily make the column nullable
+        });
+
+        DB::insert('
+            INSERT INTO testmeasurement (
+                outputid,
+                name,
+                type,
+                value
+            )
+            SELECT
+                build2test.outputid,
+                testmeasurement.name,
+                testmeasurement.type,
+                testmeasurement.value
+            FROM testmeasurement
+            JOIN build2test ON testmeasurement.testid = build2test.id
+            GROUP BY
+                build2test.outputid,
+                testmeasurement.name,
+                testmeasurement.type,
+                testmeasurement.value
+        ');
+
+        // Delete all of the old entries
+        DB::delete('DELETE FROM testmeasurement WHERE outputid IS NULL');
+
+        Schema::table('testmeasurement', function (Blueprint $table) {
+            $table->dropForeign(['testid']);
+            $table->dropColumn('testid');
+            $table->integer('outputid')
+                ->nullable(false) // Revert back to a not-null column
+                ->index()
+                ->change();
+        });
+    }
+};

--- a/tests/Feature/TestSchemaMigration.php
+++ b/tests/Feature/TestSchemaMigration.php
@@ -21,6 +21,9 @@ class TestSchemaMigration extends TestCase
 
         // Rollback some migrations to drop the relevant tables.
         Artisan::call('migrate:rollback', [
+            '--path' => 'database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php',
+            '--force' => true]);
+        Artisan::call('migrate:rollback', [
             '--path' => 'database/migrations/2024_04_17_183212_remove_test_table.php',
             '--force' => true]);
         Artisan::call('migrate:rollback', [


### PR DESCRIPTION
Test measurements are currently related to test outputs under the faulty assumption that the output of a test is directly related to the measurements collected for that test.  This means that if the measurements change but the output doesn't, CDash may report incorrect results.  This is presumably a very rare edge case which hasn't been identified before.  There are also other issues associated with the current form of our test output table, which I plan to fix in upcoming PRs.

This PR changes the relationship of test measurements to instead be related to test results, rather than deduplicated "test outputs".