### PR TITLE
RepositoryUtils: fix GitLab URL generation

### DIFF
--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -357,23 +357,6 @@ class RepositoryUtils
         return make_cdash_url($diff_url);
     }
 
-    /** Return the Gitorious/GitHub diff URL */
-    public static function get_gitoriousish_diff_url($projecturl, $directory, $file, $revision, $blobs, $branch = 'master')
-    {
-        if ($revision != '') {
-            $diff_url = $projecturl . '/commit/' . $revision;
-        } elseif ($file != '') {
-            $diff_url = $projecturl . '/' . $blobs . '/' . $branch . '/';
-            if ($directory != '') {
-                $diff_url .= $directory . '/';
-            }
-            $diff_url .= $file;
-        } else {
-            return '';
-        }
-        return make_cdash_url($diff_url);
-    }
-
     /** Return the Stash diff URL */
     public static function get_stash_diff_url($projecturl, $directory, $file, $revision)
     {
@@ -388,8 +371,18 @@ class RepositoryUtils
     /** Return the Gitorious diff URL */
     public static function get_gitorious_diff_url($projecturl, $directory, $file, $revision)
     {
-        // Gitorious uses 'blobs' or 'trees' (plural)
-        return self::get_gitoriousish_diff_url($projecturl, $directory, $file, $revision, 'blobs');
+        if ($revision !== '') {
+            $diff_url = $projecturl . '/commit/' . $revision;
+        } elseif ($file !== '') {
+            $diff_url = $projecturl . '/blobs/master/';
+            if ($directory !== '') {
+                $diff_url .= $directory . '/';
+            }
+            $diff_url .= $file;
+        } else {
+            return '';
+        }
+        return make_cdash_url($diff_url);
     }
 
     /** Return the source directory for a source file */
@@ -449,8 +442,20 @@ class RepositoryUtils
     /** Return the GitLab diff URL */
     public static function get_gitlab_diff_url($projecturl, $directory, $file, $revision)
     {
-        // GitLab uses 'blob' or 'tree' (singular, no s)
-        return self::get_gitoriousish_diff_url($projecturl, $directory, $file, $revision, 'blob');
+        // Since GitLab supports arbitrarily nested groups, there is a `/-/`
+        // component to start per-project resources.
+        if ($revision !== '') {
+            $diff_url = $projecturl . '/-/commit/' . $revision;
+        } elseif ($file !== '') {
+            $diff_url = $projecturl . '/-/blob/master/';
+            if ($directory !== '') {
+                $diff_url .= $directory . '/';
+            }
+            $diff_url .= $file;
+        } else {
+            return '';
+        }
+        return make_cdash_url($diff_url);
     }
 
     /** Return the cgit diff URL */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3201,7 +3201,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 29
+			count: 26
 			path: app/Utils/RepositoryUtils.php
 
 		-
@@ -3651,41 +3651,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitorious_revision_url\\(\\) has parameter \\$revision with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$blobs with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$branch with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$directory with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$file with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$projecturl with no type specified\\.$#"
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			message: "#^Method App\\\\Utils\\\\RepositoryUtils\\:\\:get_gitoriousish_diff_url\\(\\) has parameter \\$revision with no type specified\\.$#"
 			count: 1
 			path: app/Utils/RepositoryUtils.php
 


### PR DESCRIPTION
GitLab started using a `/-/` component to act as a separator between project paths and project resources.