### PR TITLE
Generate passwords with Laravel helper

### DIFF
--- a/app/Console/Commands/CheckKey.php
+++ b/app/Console/Commands/CheckKey.php
@@ -3,8 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-
-require_once 'include/common.php';
+use Illuminate\Support\Str;
 
 class CheckKey extends Command
 {
@@ -41,7 +40,7 @@ class CheckKey extends Command
             echo "Error: APP_KEY environment variable is not set.  You can use the following randomly generated key:" . PHP_EOL;
             // Print a new key to the screen.  Note: we can't use Artisan's key:generate command if there is no .env,
             // so we generate a random key ourselves.
-            echo generate_password(32) . PHP_EOL;
+            echo Str::password(32, true, true, false) . PHP_EOL;
             return 1;
         } else {
             return 0;

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -9,6 +9,7 @@ use CDash\Model\UserProject;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 use RuntimeException;
 
@@ -452,7 +453,7 @@ final class ManageProjectRolesController extends AbstractProjectController
 
         // Register the user
         // Create a new password
-        $pass = generate_password(10);
+        $pass = Str::password(10);
         $passwordHash = password_hash($pass, PASSWORD_DEFAULT);
 
         $user = new User();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 require_once 'include/cdashmail.php';
@@ -488,7 +489,7 @@ final class UserController extends AbstractController
                 $message = 'A confirmation message has been sent to your inbox.';
             } else {
                 // Create a new password
-                $password = generate_password(10);
+                $password = Str::password(10);
 
                 $url = url('/user');
 

--- a/app/Utils/AuthTokenUtil.php
+++ b/app/Utils/AuthTokenUtil.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
@@ -30,7 +31,7 @@ class AuthTokenUtil
     public static function generateToken(int $user_id, int $project_id, string $scope, string $description): array
     {
         // 86 characters generates more than 512 bits of entropy (and is thus limited by the entropy of the hash)
-        $token = generate_password(86);
+        $token = Str::password(86, true, true, false);
         $params['hash'] = hash('sha512', $token);
 
         $params['userid'] = $user_id;

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1090,17 +1090,6 @@ function getByteValueWithExtension($value, $base = 1024): string
     return round($value, 2) . $valueext;
 }
 
-function generate_password(int $length): string
-{
-    $keychars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    $max = strlen($keychars) - 1;
-    $key = '';
-    for ($i = 0; $i < $length; $i++) {
-        $key .= substr($keychars, random_int(0, $max), 1);
-    }
-    return $key;
-}
-
 /**
  * Check if user has specified a preference for color scheme.
  */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12901,11 +12901,6 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			message: "#^Function generate_password\\(\\) throws checked exception Random\\\\RandomException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			message: "#^Function getByteValueWithExtension\\(\\) has parameter \\$base with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/common.php


### PR DESCRIPTION
We currently use our own homemade password generation function.  This PR removes our homemade password generation function in favor of Laravel's officially supported password generation helper.