### PR TITLE
Add basic Test type to GraphQL API

### DIFF
--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use App\Utils\PageTimer;
 use CDash\Controller\Api\TestOverview as LegacyTestOverviewController;
 use CDash\Controller\Api\TestDetails as LegacyTestDetailsController;
@@ -25,7 +25,7 @@ final class TestController extends AbstractProjectController
     // Render the test details page.
     public function details($buildtest_id = null)
     {
-        $buildtest = BuildTest::findOrFail((int) $buildtest_id);
+        $buildtest = Test::findOrFail((int) $buildtest_id);
         $projectid = $buildtest->build?->projectid;
 
         if ($projectid === null) {
@@ -45,7 +45,7 @@ final class TestController extends AbstractProjectController
             abort(400, 'A valid test was not specified.');
         }
 
-        $buildtest = BuildTest::where('id', '=', $buildtestid)->first();
+        $buildtest = Test::where('id', '=', $buildtestid)->first();
         if ($buildtest === null) {
             // Create a dummy project object to prevent information leakage between different error cases
             $project = new Project();
@@ -537,7 +537,7 @@ final class TestController extends AbstractProjectController
 
         $testname = request()->input('testname');
 
-        $buildtest = BuildTest::where('buildid', '=', $buildid)
+        $buildtest = Test::where('buildid', '=', $buildid)
             ->where('testname', '=', $testname)
             ->first();
         if ($buildtest === null) {

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -146,11 +146,11 @@ class Build extends Model
     }
 
     /**
-     * @return HasMany<BuildTest>
+     * @return HasMany<Test>
      */
-    public function buildtests(): HasMany
+    public function tests(): HasMany
     {
-        return $this->hasMany(BuildTest::class, 'buildid');
+        return $this->hasMany(Test::class, 'buildid');
     }
 
     /**

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -25,9 +25,9 @@ use Illuminate\Support\Facades\Config;
  * @property string $details
  * @property string $testname
  *
- * @mixin Builder<BuildTest>
+ * @mixin Builder<Test>
  */
-class BuildTest extends Model
+class Test extends Model
 {
     public $timestamps = false;
 
@@ -199,7 +199,7 @@ class BuildTest extends Model
         }
 
         if (config('database.default') == 'pgsql' && $marshaledData['buildtestid']) {
-            $buildtest = BuildTest::where('id', '=', $data['buildtestid'])->first();
+            $buildtest = Test::where('id', '=', $data['buildtestid'])->first();
             if ($buildtest) {
                 $marshaledData['labels'] = $buildtest->getLabels()->keys()->all();
             }

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -37,7 +37,6 @@ class Test extends Model
     // TODO: Put these in an enum somewhere
     public const FAILED = 'failed';
     public const PASSED = 'passed';
-    public const OTHER_FAULT = 'OTHER_FAULT';
     public const TIMEOUT = 'Timeout';
     public const NOTRUN = 'notrun';
     public const DISABLED = 'Disabled';
@@ -45,6 +44,19 @@ class Test extends Model
     protected $attributes = [
         'timemean' => 0.0,
         'timestd' => 0.0,
+    ];
+
+    protected $fillable = [
+        'buildid',
+        'outputid',
+        'status',
+        'time',
+        'timemean',
+        'timestd',
+        'timestatus',
+        'newstatus',
+        'details',
+        'testname',
     ];
 
     protected $casts = [

--- a/app/Models/TestOutput.php
+++ b/app/Models/TestOutput.php
@@ -34,11 +34,11 @@ class TestOutput extends Model
     ];
 
     /**
-     * @return HasMany<BuildTest>
+     * @return HasMany<Test>
      */
     public function buildTests(): HasMany
     {
-        return $this->hasMany(BuildTest::class, 'outputid');
+        return $this->hasMany(Test::class, 'outputid');
     }
 
     /**

--- a/app/Models/TestOutput.php
+++ b/app/Models/TestOutput.php
@@ -36,7 +36,7 @@ class TestOutput extends Model
     /**
      * @return HasMany<Test>
      */
-    public function buildTests(): HasMany
+    public function tests(): HasMany
     {
         return $this->hasMany(Test::class, 'outputid');
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -72,7 +72,7 @@ class AuthServiceProvider extends ServiceProvider
             // Make sure the current user has access to a test result with this image
             $outputs_with_image = TestImage::where('imgid', '=', $image->Id)->get();
             foreach ($outputs_with_image as $output) {
-                $buildtests = $output->testOutput?->buildTests;
+                $buildtests = $output->testOutput?->tests;
                 if ($buildtests === null) {
                     continue;
                 }

--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -16,7 +16,7 @@
 
 namespace App\Utils;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use App\Models\TestImage;
 
 use CDash\Model\Build;
@@ -206,7 +206,7 @@ class TestCreator
         }
 
         // build2test
-        $buildtest = new BuildTest;
+        $buildtest = new Test;
         $buildtest->buildid = $build->Id;
         $buildtest->outputid = $outputid;
         $buildtest->status = $this->testStatus;

--- a/app/cdash/app/Controller/Api/BuildTestApi.php
+++ b/app/cdash/app/Controller/Api/BuildTestApi.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Controller\Api;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 
 use CDash\Database;
 use CDash\Model\Build;
@@ -36,7 +36,7 @@ abstract class BuildTestApi extends BuildApi
     public $testHistoryQueryOrder;
     public $testHistoryQueryParams;
 
-    public function __construct(Database $db, BuildTest $buildtest)
+    public function __construct(Database $db, Test $buildtest)
     {
         $this->buildtest = $buildtest;
 

--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Controller\Api;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use CDash\Database;
 
 require_once 'include/api_common.php';
@@ -27,7 +27,7 @@ class TestGraph extends BuildTestApi
     public $buildtest;
     public $validTypes;
 
-    public function __construct(Database $db, BuildTest $buildtest)
+    public function __construct(Database $db, Test $buildtest)
     {
         $this->echoResponse = true;
         $this->validTypes = ['time', 'status', 'measurement'];

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Controller\Api;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use App\Models\Project as EloquentProject;
 
 use CDash\Database;
@@ -378,7 +378,7 @@ class ViewTest extends BuildApi
 
         // Generate a response for each test found.
         while ($row = $stmt->fetch()) {
-            $marshaledTest = BuildTest::marshal($row, $row['buildid'], $this->build->ProjectId, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus, $testdate);
+            $marshaledTest = Test::marshal($row, $row['buildid'], $this->build->ProjectId, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus, $testdate);
 
             if ($marshaledTest['status'] == 'Passed') {
                 $numPassed++;
@@ -415,7 +415,7 @@ class ViewTest extends BuildApi
 
         if ($numMissing > 0) {
             foreach ($this->build->MissingTests as $name) {
-                $marshaledTest = BuildTest::marshalMissing($name, $buildid, $this->build->ProjectId, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus, $testdate);
+                $marshaledTest = Test::marshalMissing($name, $buildid, $this->build->ProjectId, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus, $testdate);
                 array_unshift($tests, $marshaledTest);
             }
         }

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -18,7 +18,7 @@ namespace CDash\Model;
 
 require_once 'include/ctestparserutils.php';
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use App\Models\Site;
 use App\Utils\RepositoryUtils;
 use App\Utils\TestingDay;
@@ -1346,7 +1346,7 @@ class Build
                 $timemean = $testtime;
             }
 
-            $buildtest = BuildTest::findOrFail((int) $buildtestid);
+            $buildtest = Test::findOrFail((int) $buildtestid);
             $buildtest->timestatus = (int) $timestatus;
 
             $buildtest->timemean = $timemean;
@@ -2331,7 +2331,7 @@ class Build
     /**
      * Given a $buildtest, this method adds a BuildTest to the current Build's TestCollection.
      */
-    public function AddTest(BuildTest $buildtest): self
+    public function AddTest(Test $buildtest): self
     {
         $this->TestCollection->put($buildtest->testname, $buildtest);
         return $this;
@@ -2726,15 +2726,15 @@ class Build
                     return $count;
                 }, 0);
                 $passed = array_reduce($this->TestCollection->toArray(), function ($count, $test) {
-                    $count += $test['status'] === BuildTest::PASSED ? 1 : 0;
+                    $count += $test['status'] === Test::PASSED ? 1 : 0;
                     return $count;
                 }, 0);
                 $failed = array_reduce($this->TestCollection->toArray(), function ($count, $test) {
-                    $count += $test['status'] === BuildTest::FAILED ? 1 : 0;
+                    $count += $test['status'] === Test::FAILED ? 1 : 0;
                     return $count;
                 }, 0);
                 $notrun = array_reduce($this->TestCollection->toArray(), function ($count, $test) {
-                    $count += $test['status'] === BuildTest::NOTRUN ? 1 : 0;
+                    $count += $test['status'] === Test::NOTRUN ? 1 : 0;
                     return $count;
                 }, 0);
 

--- a/app/cdash/include/Messaging/Topic/MissingTestTopic.php
+++ b/app/cdash/include/Messaging/Topic/MissingTestTopic.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Messaging\Topic;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 
 use CDash\Model\Build;
 
@@ -50,7 +50,7 @@ class MissingTestTopic extends Topic
         // GetMissingTests currently returns array
         $rows = $build->GetMissingTests();
         foreach ($rows as $id => $name) {
-            $buildTest = new BuildTest();
+            $buildTest = new Test();
             $buildTest->buildid = $build->Id;
             $buildTest->testname = $name;
             $collection->put($name, $buildTest);

--- a/app/cdash/include/Messaging/Topic/TestFailureTopic.php
+++ b/app/cdash/include/Messaging/Topic/TestFailureTopic.php
@@ -16,7 +16,7 @@
 
 namespace CDash\Messaging\Topic;
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use Illuminate\Support\Collection;
 
 use CDash\Messaging\Notification\NotifyOn;
@@ -126,12 +126,12 @@ class TestFailureTopic extends Topic implements Decoratable, Fixable, Labelable
      * topic's TestCollection.
      *
      * @param Build $build
-     * @param BuildTest $item
+     * @param Test $item
      * @return boolean
      */
     public function itemHasTopicSubject(Build $build, $item)
     {
-        return $item->status === BuildTest::FAILED;
+        return $item->status === Test::FAILED;
     }
 
     /**
@@ -163,7 +163,7 @@ class TestFailureTopic extends Topic implements Decoratable, Fixable, Labelable
     {
         $collection = $this->getTopicCollection();
         $buildtests = $build->GetTestCollection();
-        /** @var BuildTest $buildtest */
+        /** @var Test $buildtest */
         foreach ($buildtests as $test_name => $buildtest) {
             if ($this->itemHasTopicSubject($build, $buildtest)) {
                 $testLabels = $buildtest->getLabels();

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -207,8 +207,11 @@ set_tests_properties(/Feature/GraphQL/SiteTypeTest PROPERTIES DEPENDS /Feature/G
 add_laravel_test(/Feature/GraphQL/BuildTypeTest)
 set_tests_properties(/Feature/GraphQL/BuildTypeTest PROPERTIES DEPENDS /Feature/GraphQL/SiteTypeTest)
 
+add_laravel_test(/Feature/GraphQL/TestTypeTest)
+set_tests_properties(/Feature/GraphQL/TestTypeTest PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
+
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
-set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
+set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS /Feature/GraphQL/TestTypeTest)
 
 add_laravel_test(/Feature/TestSchemaMigration)
 set_tests_properties(/Feature/TestSchemaMigration PROPERTIES DEPENDS /Feature/PurgeUnusedProjectsCommand)

--- a/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
@@ -14,7 +14,7 @@
  * =========================================================================
  */
 
-use App\Models\BuildTest;
+use App\Models\Test;
 
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
@@ -50,25 +50,25 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
     {
         $sut = new TestFailureTopic();
         $build = new Build();
-        $buildTest = new BuildTest();
+        $buildTest = new Test();
 
         $build->AddTest($buildTest);
 
         $this->assertFalse($sut->itemHasTopicSubject($build, $buildTest));
 
-        $buildTest->status = BuildTest::PASSED;
+        $buildTest->status = Test::PASSED;
 
         $this->assertFalse($sut->itemHasTopicSubject($build, $buildTest));
 
-        $buildTest->status = BuildTest::NOTRUN;
+        $buildTest->status = Test::NOTRUN;
 
         $this->assertFalse($sut->itemHasTopicSubject($build, $buildTest));
 
-        $buildTest->details = BuildTest::DISABLED;
+        $buildTest->details = Test::DISABLED;
 
         $this->assertFalse($sut->itemHasTopicSubject($build, $buildTest));
 
-        $buildTest->status = BuildTest::FAILED;
+        $buildTest->status = Test::FAILED;
 
         $this->assertTrue($sut->itemHasTopicSubject($build, $buildTest));
     }
@@ -78,21 +78,21 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         $sut = new TestFailureTopic();
         $build = new Build();
 
-        $passed = new BuildTest();
-        $passed->status = BuildTest::PASSED;
+        $passed = new Test();
+        $passed->status = Test::PASSED;
         $passed->testname = 'Passed';
 
-        $failed = new BuildTest();
-        $failed->status = BuildTest::FAILED;
+        $failed = new Test();
+        $failed->status = Test::FAILED;
         $failed->testname = 'Failed';
 
-        $notrun = new BuildTest();
-        $notrun->status = BuildTest::NOTRUN;
+        $notrun = new Test();
+        $notrun->status = Test::NOTRUN;
         $notrun->testname = 'NotRun';
 
-        $disabled = new BuildTest();
-        $disabled->status = BuildTest::NOTRUN;
-        $disabled->details = BuildTest::DISABLED;
+        $disabled = new Test();
+        $disabled->status = Test::NOTRUN;
+        $disabled->details = Test::DISABLED;
         $disabled->testname = 'Disabled';
 
         $build
@@ -181,24 +181,24 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         // Create a test that has a label we're searching for but has passed, does not get added
         $labelForOne = new Label();
         $labelForOne->Text = 'One';
-        $buildTestOne = new BuildTest();
-        $buildTestOne->status = BuildTest::PASSED;
+        $buildTestOne = new Test();
+        $buildTestOne->status = Test::PASSED;
         $buildTestOne->addLabel($labelForOne);
         $buildTestOne->testname = 'TestOne';
 
         // Create a test that has failed but does not have a label we're searching for
         $labelForTwo = new Label();
         $labelForTwo->Text = 'Two';
-        $buildTestTwo = new BuildTest();
-        $buildTestTwo->status = BuildTest::FAILED;
+        $buildTestTwo = new Test();
+        $buildTestTwo->status = Test::FAILED;
         $buildTestTwo->addLabel($labelForTwo);
         $buildTestTwo->testname = 'TestTwo';
 
         // Create a test that has failed and has a label that we're searching for
         $labelForThree = new Label();
         $labelForThree->Text = 'Three';
-        $buildTestThree = new BuildTest();
-        $buildTestThree->status = BuildTest::FAILED;
+        $buildTestThree = new Test();
+        $buildTestThree->status = Test::FAILED;
         $buildTestThree->addLabel($labelForThree);
         $buildTestThree->testname = 'TestThree';
 
@@ -234,24 +234,24 @@ class TestFailureTopicTest extends \CDash\Test\CDashTestCase
         // Create a test that has a label we're searching for but has passed, does not get added
         $labelForOne = new Label();
         $labelForOne->Text = 'One';
-        $buildTestOne = new BuildTest();
-        $buildTestOne->status = BuildTest::PASSED;
+        $buildTestOne = new Test();
+        $buildTestOne->status = Test::PASSED;
         $buildTestOne->addLabel($labelForOne);
         $buildTestOne->testname = 'TestOne';
 
         // Create a test that has failed but does not have a label we're searching for
         $labelForTwo = new Label();
         $labelForTwo->Text = 'Two';
-        $buildTestTwo = new BuildTest();
-        $buildTestTwo->status = BuildTest::FAILED;
+        $buildTestTwo = new Test();
+        $buildTestTwo->status = Test::FAILED;
         $buildTestTwo->addLabel($labelForTwo);
         $buildTestTwo->testname = 'TestTwo';
 
         // Create a test that is not run and has a label that we're searching for
         $labelForThree = new Label();
         $labelForThree->Text = 'Three';
-        $buildTestThree = new BuildTest();
-        $buildTestThree->status = BuildTest::NOTRUN;
+        $buildTestThree = new Test();
+        $buildTestThree->status = Test::NOTRUN;
         $buildTestThree->addLabel($labelForThree);
         $buildTestThree->testname = 'TestThree';
 

--- a/app/cdash/tests/test_multiplelabelsfortests.php
+++ b/app/cdash/tests/test_multiplelabelsfortests.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__) . '/cdash_test_case.php';
 
-use App\Models\BuildTest;
+use App\Models\Test;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;
 
@@ -53,7 +53,7 @@ class MultipleLabelsForTestsTestCase extends KWWebTestCase
 
         // Verify that the test has multiple labels.
         $buildid = $results[0]->id;
-        $buildtest = BuildTest::where('buildid', '=', $buildid)->first();
+        $buildtest = Test::where('buildid', '=', $buildid)->first();
         $this->assertTrue(3 === count($buildtest->getLabels()));
 
         // Verify that these labels are correctly returned by the testDetails API.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -198,6 +198,11 @@ type Build {
   "The site associated with this build."
   site: Site! @belongsTo
 
+  "Test results associated with this build."
+  tests(
+    filters: _ @filter(inputType: "TestFilterInput")
+  ): [Test!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
   # TODO: Make an "errors" field which returns the union of basic and rich errors
   """
   A list of "basic" errors submitted for this build.
@@ -221,6 +226,35 @@ input BuildFilterInput {
   submissionTime: DateTimeTz @rename(attribute: "submittime")
   stamp: String
   uuid: String
+}
+
+
+"Test."
+type Test {
+  "Unique primary key."
+  id: ID!
+
+  name: String! @rename(attribute: "testname")
+
+  status: TestStatus!
+}
+
+enum TestStatus {
+  PASSED @enum(value: "passed")
+
+  FAILED @enum(value: "failed")
+
+  TIMEOUT @enum(value: "Timeout")
+
+  NOT_RUN @enum(value: "notrun")
+
+  DISABLED @enum(value: "Disabled")
+}
+
+input TestFilterInput {
+  id: ID
+  name: String
+  status: TestStatus
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2861,116 +2861,6 @@ parameters:
 			path: app/Models/Build.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 2
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:getLabels\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$projectid with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$projectshowtesttime with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$testdate with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) has parameter \\$testtimemaxstatus with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshal\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$buildid with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$projectid with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$projectshowtesttime with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$testdate with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) has parameter \\$testtimemaxstatus with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalMissing\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalStatus\\(\\) has parameter \\$status with no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Method App\\\\Models\\\\BuildTest\\:\\:marshalStatus\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, App\\\\Models\\\\BuildTest\\|null given\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$attributes type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
-			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$labels has no type specified\\.$#"
-			count: 1
-			path: app/Models/BuildTest.php
-
-		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\Site\\>\\:\\:distinct\\(\\)\\.$#"
 			count: 1
 			path: app/Models/Project.php
@@ -3009,6 +2899,116 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:where\\(\\)\\.$#"
 			count: 2
 			path: app/Models/SubProject.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
+			count: 2
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:getLabels\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$buildid with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$projectid with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$projectshowtesttime with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$testdate with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) has parameter \\$testtimemaxstatus with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshal\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$buildid with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$projectid with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$projectshowtesttime with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$testdate with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) has parameter \\$testtimemaxstatus with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalMissing\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalStatus\\(\\) has parameter \\$status with no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Method App\\\\Models\\\\Test\\:\\:marshalStatus\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, App\\\\Models\\\\Test\\|null given\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Property App\\\\Models\\\\Test\\:\\:\\$attributes type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Property App\\\\Models\\\\Test\\:\\:\\$labels has no type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
 
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
@@ -4511,7 +4511,7 @@ parameters:
 			path: app/Utils/RepositoryUtils.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\BuildTest\\:\\:\\$measurements\\.$#"
+			message: "#^Access to an undefined property App\\\\Models\\\\Test\\:\\:\\$measurements\\.$#"
 			count: 1
 			path: app/Utils/TestCreator.php
 
@@ -4556,7 +4556,7 @@ parameters:
 			path: app/Utils/TestCreator.php
 
 		-
-			message: "#^Property App\\\\Models\\\\BuildTest\\:\\:\\$time \\(float\\) does not accept string\\.$#"
+			message: "#^Property App\\\\Models\\\\Test\\:\\:\\$time \\(float\\) does not accept string\\.$#"
 			count: 1
 			path: app/Utils/TestCreator.php
 
@@ -11606,12 +11606,12 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
 		-
-			message: "#^Parameter \\#2 \\$item \\(App\\\\Models\\\\BuildTest\\) of method CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:itemHasTopicSubject\\(\\) should be contravariant with parameter \\$item \\(mixed\\) of method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:itemHasTopicSubject\\(\\)$#"
+			message: "#^Parameter \\#2 \\$item \\(App\\\\Models\\\\Test\\) of method CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:itemHasTopicSubject\\(\\) should be contravariant with parameter \\$item \\(mixed\\) of method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:itemHasTopicSubject\\(\\)$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
 		-
-			message: "#^Parameter \\#2 \\$item \\(App\\\\Models\\\\BuildTest\\) of method CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:itemHasTopicSubject\\(\\) should be contravariant with parameter \\$item \\(mixed\\) of method CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\:\\:itemHasTopicSubject\\(\\)$#"
+			message: "#^Parameter \\#2 \\$item \\(App\\\\Models\\\\Test\\) of method CDash\\\\Messaging\\\\Topic\\\\TestFailureTopic\\:\\:itemHasTopicSubject\\(\\) should be contravariant with parameter \\$item \\(mixed\\) of method CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\:\\:itemHasTopicSubject\\(\\)$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
@@ -21949,12 +21949,12 @@ parameters:
 			path: app/cdash/tests/test_multicoverage.php
 
 		-
-			message: "#^Cannot access property \\$id on App\\\\Models\\\\BuildTest\\|null\\.$#"
+			message: "#^Cannot access property \\$id on App\\\\Models\\\\Test\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplelabelsfortests.php
 
 		-
-			message: "#^Cannot call method getLabels\\(\\) on App\\\\Models\\\\BuildTest\\|null\\.$#"
+			message: "#^Cannot call method getLabels\\(\\) on App\\\\Models\\\\Test\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplelabelsfortests.php
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -133,7 +133,7 @@ Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
     $testid = $request->query('test');
-    $buildtest = \App\Models\BuildTest::where('buildid', $buildid)->where('testid', $testid)->first();
+    $buildtest = \App\Models\Test::where('buildid', $buildid)->where('testid', $testid)->first();
     if ($buildtest !== null) {
         return redirect("/tests/{$buildtest->id}", 301);
     }

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Project;
+use App\Models\TestOutput;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class TestTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+    private TestOutput $test_output;
+
+    /**
+     * @throws \Random\RandomException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = Project::findOrFail((int) $this->makePublicProject()->Id);
+
+        // A common test output to share among all of our tests
+        $this->test_output = TestOutput::create([
+            'crc32' => random_int(0, 100000),
+            'path' => 'a',
+            'command' => 'b',
+            'output' => 'c',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Deleting the project will delete all corresponding builds and tests
+        $this->project->delete();
+
+        $this->test_output->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic test to ensure that each of the fields works
+     */
+    public function testBasicFieldAccess(): void
+    {
+        $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ])->tests()->create([
+            'testname' => 'test1',
+            'status' => 'failed',
+            'outputid' => $this->test_output->id,
+        ]);
+
+        $this->graphQL('
+            query project($id: ID) {
+                project(id: $id) {
+                    builds {
+                        edges {
+                            node {
+                                name
+                                tests {
+                                    edges {
+                                        node {
+                                            name
+                                            status
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $this->project->id,
+        ])->assertJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'build1',
+                                    'tests' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'name' => 'test1',
+                                                    'status' => 'FAILED',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function statuses(): array
+    {
+        return [
+            ['passed', 'PASSED'],
+            ['failed', 'FAILED'],
+            ['Timeout', 'TIMEOUT'],
+            ['notrun', 'NOT_RUN'],
+            ['Disabled', 'DISABLED'],
+        ];
+    }
+
+    /**
+     * @dataProvider statuses
+     */
+    public function testStatusEnum(string $db_value, string $enum_value): void
+    {
+        $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ])->tests()->create([
+            'testname' => 'test1',
+            'status' => $db_value,
+            'outputid' => $this->test_output->id,
+        ]);
+
+        $this->graphQL('
+            query project($id: ID) {
+                project(id: $id) {
+                    builds {
+                        edges {
+                            node {
+                                name
+                                tests {
+                                    edges {
+                                        node {
+                                            name
+                                            status
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $this->project->id,
+        ])->assertJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'build1',
+                                    'tests' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'name' => 'test1',
+                                                    'status' => $enum_value,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+}


### PR DESCRIPTION
Our current representation of test results is complex, and will take a significant amount of work to expose via the GraphQL API safely.  This PR starts that process by exposing test names and statuses via the GraphQL API.  In addition, this PR renames the `BuildTest` model to `Test`.  The underlying table will be renamed at a future point.