### PR TITLE
Remove references to 'layouts.app' view

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,6 +1,8 @@
-@extends('layouts.app')
+@extends('cdash', [
+    'title' => 'Reset Password'
+])
 
-@section('content')
+@section('main_content')
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,6 +1,9 @@
-@extends('layouts.app')
+@extends('cdash', [
+    'title' => 'Reset Password'
+])
 
-@section('content')
+@section('main_content')
+
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -1,6 +1,8 @@
-@extends('layouts.app')
+@extends('cdash', [
+    'title' => 'Verify Email'
+])
 
-@section('content')
+@section('main_content')
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">


### PR DESCRIPTION
This was removed in #1351

Update these lingering references to use our base 'cdash' view instead.