### PR TITLE
Change how Composer is installed for UBI-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,22 +143,11 @@ ENV TZ=UTC \
 
 USER 0
 
-# core pkg update & epel enable (https://docs.fedoraproject.org/en-US/epel/)
-RUN dnf upgrade -y \
-        --refresh \
-        --nodocs \
-        --noplugins \
-        --setopt=install_weak_deps=0 \
-        && \
-    dnf reinstall -y \
-        --refresh \
-        --nodocs \
-        --noplugins \
-        --setopt=install_weak_deps=0 \
-        tzdata \
-        && \
-    rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9 && \
-    rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+# Install Composer
+RUN TEMPFILE=$(mktemp) && \
+    curl -o "$TEMPFILE" "https://getcomposer.org/installer" && \
+    php < "$TEMPFILE" && \
+    mv composer.phar /usr/local/bin/composer
 
 # install dependencies
 RUN dnf install -y \
@@ -176,7 +165,6 @@ RUN dnf install -y \
       unzip \
       zip \
       #> cdash
-      composer-2.* \
       php-bcmath \
       php-fpm \
       php-gd \


### PR DESCRIPTION
The CDash UBI-based image currently fails to start with the following error:
```
(13)Permission denied: AH00058: Error retrieving pid file run/httpd.pid
AH00059: Remove it before continuing if it is corrupted.
```

This error is coming from an attempt to set up the prerequisites for Composer to be installed, which is inadvertently breaking httpd.

This PR resolves the issue by installing Composer the preferred way, by downloading it directly from the Composer website.