### PR TITLE
Fix incorrect relationship between Build and Project models

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -126,7 +126,7 @@ class Build extends Model
      */
     public function project(): BelongsTo
     {
-        return $this->belongsTo(Project::class, 'id', 'projectid');
+        return $this->belongsTo(Project::class, 'projectid');
     }
 
     /**


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2330 fixed the inverse relationship between the Build and Project models after the 3.5 release branch was created.  The broken relationship breaks image test results in 3.5.  This PR backports the fix in https://github.com/Kitware/CDash/pull/2330 to the 3.5 release branch.