### PR TITLE
LDAP: Default to anonymous binding

### DIFF
--- a/config/ldap.php
+++ b/config/ldap.php
@@ -30,8 +30,8 @@ return [
 
         'default' => [
             'hosts' => [env('LDAP_HOST', '127.0.0.1')],
-            'username' => env('LDAP_USERNAME', 'cn=user,dc=local,dc=com'),
-            'password' => env('LDAP_PASSWORD', 'secret'),
+            'username' => env('LDAP_USERNAME', ''),
+            'password' => env('LDAP_PASSWORD', ''),
             'port' => env('LDAP_PORT', 389),
             'base_dn' => env('LDAP_BASE_DN', 'dc=local,dc=com'),
             'timeout' => env('LDAP_TIMEOUT', 5),


### PR DESCRIPTION
To use anonymous binding, it is currently necessary to set `LDAP_USERNAME` and `LDAP_PASSWORD` to empty strings.  This PR changes the default values to empty strings, so anonymous binding is the default behavior.