### PR TITLE
Delete submission files from remote workers

### DIFF
--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -40,6 +40,9 @@ class DoneHandlerTestCase extends KWWebTestCase
 
         $this->performTest(true);
 
+        // Verify that we didn't leave any files behind in the inbox directory.
+        $this->assertEqual(count(Storage::files('inbox')), 0);
+
         file_put_contents($this->ConfigFile, $this->Original);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2745,11 +2745,6 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			message: "#^Only booleans are allowed in &&, mixed given on the right side\\.$#"
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 3
 			path: app/Jobs/ProcessSubmission.php


### PR DESCRIPTION
Prior to this commit, remote workers would retain a copy of each parsed submission file in their storage/app/inbox/ directory.