### PR TITLE
Use filter-based approach for LDAP project membership

### DIFF
--- a/app/Ldap/Rules/FilterRules.php
+++ b/app/Ldap/Rules/FilterRules.php
@@ -20,8 +20,14 @@ class FilterRules implements Rule
             return true;
         }
 
-        return $user->groups()
-            ->recursive()
-            ->exists(\LdapRecord\Models\Entry::find($filter));
+        if (!($model instanceof \App\Models\User)) {
+            return false;
+        }
+
+        if (env('LDAP_PROVIDER', 'openldap') === 'activedirectory') {
+            return \LdapRecord\Models\ActiveDirectory\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\ActiveDirectory\User;
+        } else {
+            return  \LdapRecord\Models\OpenLDAP\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\OpenLDAP\User;
+        }
     }
 }

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -29,7 +29,7 @@ return [
     'connections' => [
 
         'default' => [
-            'hosts' => [env('LDAP_HOST', '127.0.0.1')],
+            'hosts' => [env('LDAP_HOSTS', '127.0.0.1')],
             'username' => env('LDAP_USERNAME', ''),
             'password' => env('LDAP_PASSWORD', ''),
             'port' => env('LDAP_PORT', 389),

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -32,7 +32,7 @@ LDAP_USERNAME=cn=admin,dc=example,dc=org
 LDAP_PASSWORD=password
 CDASH_AUTHENTICATION_PROVIDER=ldap
 LDAP_PROVIDER=openldap
-LDAP_HOST=ldap
+LDAP_HOSTS=ldap
 LDAP_BASE_DN="dc=example,dc=org"
 LDAP_LOGGING=true
 LDAP_LOCATE_USERS_BY=mail
@@ -45,7 +45,7 @@ Here's a description of the `.env` variables involved in the LDAP authentication
 | LDAP_BASE_DN | The base distinguished name you'd like to perform query operations on. | dc=local,dc=com |
 | LDAP_BIND_USERS_BY | The LDAP users attribute used for authentication | distinguishedname |
 | LDAP_FILTERS_ON | Additional LDAP query filters to restrict authorized user list. For example, to restrict users to a specific Active Directory group: `cn=myRescrictedGroup,dc=example,dc=com` | false |
-| LDAP_HOST | The IP address or host name of your LDAP server. | 127.0.0.1 |
+| LDAP_HOSTS | The IP address or host name of your LDAP server. | 127.0.0.1 |
 | LDAP_LOCATE_USERS_BY | The LDAP users attribute used to locate your users. | mail |
 | LDAP_LOGGING | Whether or not to log LDAP activities. Useful for debugging. | true |
 | LDAP_USERNAME | Username for account that can query and run operations on your LDAP server(s). | '' |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2780,11 +2780,6 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			message: "#^Call to an undefined method LdapRecord\\\\Models\\\\Model\\:\\:groups\\(\\)\\.$#"
-			count: 1
-			path: app/Ldap/Rules/FilterRules.php
-
-		-
 			message: "#^Method App\\\\Listeners\\\\ConfiguredSendEmailVerificationNotification\\:\\:handle\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Listeners/ConfiguredSendEmailVerificationNotification.php
@@ -3073,11 +3068,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int given\\.$#"
 			count: 1
 			path: app/Utils/AuthTokenUtil.php
-
-		-
-			message: "#^Call to an undefined method LdapRecord\\\\Models\\\\Model\\:\\:groups\\(\\)\\.$#"
-			count: 1
-			path: app/Utils/LdapUtils.php
 
 		-
 			message: """

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -424,7 +424,7 @@
                   <td />
                   <td>
                     <div align="right">
-                      <strong>LDAP Group:</strong>
+                      <strong>LDAP Filter:</strong>
                     </div>
                   </td>
                   <td>


### PR DESCRIPTION
In response to user feedback about the new LDAP-based project membership feature added in https://github.com/Kitware/CDash/pull/2282, this PR changes the project LDAP field to accept a filter instead of a group name for consistency with our existing `LDAP_FILTERS_ON` environment variable.

This PR also addresses an issue with `LDAP_FILTERS_ON` related to the switch from Adldap2 in #2206 and reverts the environment variable rename from `LDAP_HOSTS` to `LDAP_HOST` to maintain backwards compatibility with existing systems.