### PR TITLE
Remove MySQL query info from test output

### DIFF
--- a/app/cdash/tests/kwtest/kw_db.php
+++ b/app/cdash/tests/kwtest/kw_db.php
@@ -207,7 +207,6 @@ class dbo_mysql extends dbo
     {
         $this->connectToDb();
         $resource = pdo_query($query);
-        var_dump($resource);
         if (!$resource || $resource === true) {
             return false;
         }


### PR DESCRIPTION
The test suite currently prints every MySQL query to the test log.  This PR removes the unnecessary logging statement to bring the MySQL test output in line with the Postgres test output.