### PR TITLE
Set up basic build group Eloquent relationships

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -202,4 +202,12 @@ class Build extends Model
     {
         return $this->hasMany(Comment::class, 'buildid');
     }
+
+    /**
+     * @return BelongsToMany<BuildGroup>
+     */
+    public function buildgroups(): BelongsToMany
+    {
+        return $this->belongsToMany(BuildGroup::class, 'build2group', 'groupid', 'buildid');
+    }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -206,7 +206,7 @@ class Build extends Model
     /**
      * @return BelongsToMany<BuildGroup>
      */
-    public function buildgroups(): BelongsToMany
+    public function buildGroups(): BelongsToMany
     {
         return $this->belongsToMany(BuildGroup::class, 'build2group', 'groupid', 'buildid');
     }

--- a/app/Models/BuildGroup.php
+++ b/app/Models/BuildGroup.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -67,5 +68,16 @@ class BuildGroup extends Model
     public function builds(): BelongsToMany
     {
         return $this->belongsToMany(Build::class, 'build2group', 'buildid', 'groupid');
+    }
+
+    /**
+     * All the positions this group has ever been in.  Most users probably want to use a scoped
+     * version of this relationship instead.
+     *
+     * @return HasMany<BuildGroupPosition>
+     */
+    public function positions(): HasMany
+    {
+        return $this->hasMany(BuildGroupPosition::class, 'buildgroupid');
     }
 }

--- a/app/Models/BuildGroup.php
+++ b/app/Models/BuildGroup.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -58,5 +59,13 @@ class BuildGroup extends Model
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class, 'id', 'projectid');
+    }
+
+    /**
+     * @return BelongsToMany<Build>
+     */
+    public function builds(): BelongsToMany
+    {
+        return $this->belongsToMany(Build::class, 'build2group', 'buildid', 'groupid');
     }
 }

--- a/app/Models/BuildGroupPosition.php
+++ b/app/Models/BuildGroupPosition.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $buildgroupid
+ * @property int $position
+ * @property Carbon $starttime
+ * @property Carbon $endtime
+ *
+ * @mixin Builder<BuildGroupPosition>
+ */
+class BuildGroupPosition extends Model
+{
+    protected $table = 'buildgroup';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'position',
+        'starttime',
+        'endtime',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'buildgroupid' => 'integer',
+        'position' => 'integer',
+        'starttime' => 'datetime',
+        'endtime' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<BuildGroup,self>
+     */
+    public function buildGroup(): BelongsTo
+    {
+        return $this->belongsTo(BuildGroup::class, 'buildgroupid');
+    }
+}

--- a/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+++ b/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -29,6 +29,7 @@ use CDash\Test\CDashUseCaseTestCase;
 use CDash\Test\UseCase\UseCase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 
 class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
 {
@@ -118,6 +119,13 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
                     'uuid' => 'TestBuild' . $i,
                 ]);
             }
+
+            // Do the same for build groups
+            DB::table('buildgroup')->insertOrIgnore([
+                'id' => 0,
+                'projectid' => self::$projectid,
+                'description' => 'MultipleSubprojectsEmailTest-' . Str::uuid()->toString(),
+            ]);
         }
     }
 

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -11,6 +11,7 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 use CDash\Model\Build;
 use CDash\Model\BuildError;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class BuildModelTestCase extends KWWebTestCase
 {
@@ -29,7 +30,15 @@ class BuildModelTestCase extends KWWebTestCase
         $this->testDataFiles = ['build1.xml', 'build2.xml', 'build3.xml', 'build4.xml',
                                      'build5.xml', 'configure1.xml'];
 
-        DB::insert("INSERT INTO project (name) VALUES ('BuildModel')");
+        $project = \App\Models\Project::create([
+            'name' => 'BuildModel',
+        ]);
+
+        DB::table('buildgroup')->insertOrIgnore([
+            'id' => 0,
+            'projectid' => $project->id,
+            'description' => 'MultipleSubprojectsEmailTest-' . Str::uuid()->toString(),
+        ]);
 
         foreach ($this->testDataFiles as $testDataFile) {
             if (!$this->submission('BuildModel', $this->testDataDir . '/' . $testDataFile)) {

--- a/database/migrations/2024_08_27_173953_build2group_foreign_key_constraints.php
+++ b/database/migrations/2024_08_27_173953_build2group_foreign_key_constraints.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $num_deleted = DB::delete('
+            DELETE FROM build2group
+            WHERE groupid NOT IN (
+                SELECT id FROM buildgroup
+            )
+        ');
+
+        if ($num_deleted > 0) {
+            echo "Deleted $num_deleted invalid build2group rows.";
+        }
+
+        Schema::table('build2group', function (Blueprint $table) {
+            $table->dropPrimary();
+            $table->unique(['buildid', 'groupid']);
+            $table->unique(['groupid', 'buildid']);
+            $table->foreign('groupid')->references('id')->on('buildgroup')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('build2group', function (Blueprint $table) {
+            $table->primary(['buildid']);
+            $table->dropUnique(['buildid', 'groupid']);
+            $table->dropUnique(['groupid', 'buildid']);
+            $table->dropForeign(['groupid']);
+        });
+    }
+};

--- a/database/migrations/2024_08_27_173953_build2group_foreign_key_constraints.php
+++ b/database/migrations/2024_08_27_173953_build2group_foreign_key_constraints.php
@@ -20,7 +20,9 @@ return new class extends Migration {
         }
 
         Schema::table('build2group', function (Blueprint $table) {
+            $table->dropForeign(['buildid']); // Drop the foreign key so we can drop the primary key (MySQL is particular about this)
             $table->dropPrimary();
+            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
             $table->unique(['buildid', 'groupid']);
             $table->unique(['groupid', 'buildid']);
             $table->foreign('groupid')->references('id')->on('buildgroup')->cascadeOnDelete();

--- a/database/migrations/2024_08_27_191729_buildgroupposition_relationships.php
+++ b/database/migrations/2024_08_27_191729_buildgroupposition_relationships.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $num_deleted = DB::delete('
+            DELETE FROM buildgroupposition
+            WHERE buildgroupid NOT IN (
+                SELECT id
+                FROM buildgroup
+            )
+        ');
+
+        if ($num_deleted > 0) {
+            echo "Deleted $num_deleted invalid buildgroupposition rows.";
+        }
+
+        Schema::table('buildgroupposition', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreign('buildgroupid')
+                ->references('id')
+                ->on('buildgroup')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('buildgroupposition', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->dropForeign(['buildgroupid']);
+        });
+    }
+};


### PR DESCRIPTION
This PR is incremental progress towards an entirely Eloquent-based query system, and ultimately an introduction of build groups to the GraphQL API.  In addition to setting up Eloquent relationships between build group-related models, this PR also adds additional constraints and indexes for better performance and data integrity.