### PR TITLE
Add FreeIPA LDAP integration

### DIFF
--- a/app/Ldap/Rules/FilterRules.php
+++ b/app/Ldap/Rules/FilterRules.php
@@ -24,10 +24,11 @@ class FilterRules implements Rule
             return false;
         }
 
-        if (env('LDAP_PROVIDER', 'openldap') === 'activedirectory') {
-            return \LdapRecord\Models\ActiveDirectory\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\ActiveDirectory\User;
-        } else {
-            return  \LdapRecord\Models\OpenLDAP\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\OpenLDAP\User;
-        }
+        return match (env('LDAP_PROVIDER', 'openldap')) {
+            'openldap' => \LdapRecord\Models\OpenLDAP\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\OpenLDAP\User,
+            'activedirectory' => \LdapRecord\Models\ActiveDirectory\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\ActiveDirectory\User,
+            'freeipa' => \LdapRecord\Models\FreeIPA\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\FreeIPA\User,
+            default => false, // this case should never happen
+        };
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -79,8 +79,12 @@ return [
         'ldap' => [
             'driver' => 'ldap',
             # Only openldap is tested
-            'model' => env('LDAP_PROVIDER', 'openldap') === 'activedirectory' ?
-                \LdapRecord\Models\ActiveDirectory\User::class : \LdapRecord\Models\OpenLDAP\User::class,
+            'model' => match (env('LDAP_PROVIDER', 'openldap')) {
+                'openldap' => \LdapRecord\Models\OpenLDAP\User::class,
+                'activedirectory' => \LdapRecord\Models\ActiveDirectory\User::class,
+                'freeipa' => \LdapRecord\Models\FreeIPA\User::class,
+                default => false, // this case should never happen
+            },
             'rules' => [
                 \App\Ldap\Rules\FilterRules::class,
             ],

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -50,7 +50,7 @@ Here's a description of the `.env` variables involved in the LDAP authentication
 | LDAP_LOGGING | Whether or not to log LDAP activities. Useful for debugging. | true |
 | LDAP_USERNAME | Username for account that can query and run operations on your LDAP server(s). | '' |
 | LDAP_PASSWORD | Password for account that can query and run operations on your LDAP server(s). | '' |
-| LDAP_PROVIDER | The type of LDAP server you are connecting to. Valid values are activedirectory and openldap. | openldap |
+| LDAP_PROVIDER | The type of LDAP server you are connecting to. Valid values are openldap, activedirectory, and freeipa. | openldap |
 | LOGIN_FIELD | The label on the "user" field for the Login form ("Email" by default).  Change this if you're authenticating against something other than an email address in LDAP. | Email |
 
 ## OAuth2


### PR DESCRIPTION
Our LDAP library, LdapRecord, supports multiple LDAP specs.  This PR adds support for FreeIPA integration for clients wishing to integrate CDash with FreeIPA LDAP servers.