### PR TITLE
Use Eloquent Project model for test project creation

### DIFF
--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -20,7 +20,7 @@ class BuildTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->project = Project::findOrFail((int) $this->makePublicProject()->Id);
+        $this->project = $this->makePublicProject();
     }
 
     protected function tearDown(): void

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -28,15 +28,15 @@ class FilterTest extends TestCase
     {
         parent::setUp();
 
-        $this->projects['public1'] = Project::findOrFail((int) $this->makePublicProject('public1')->Id);
-        $this->projects['public2'] = Project::findOrFail((int) $this->makePublicProject('public2')->Id);
-        $this->projects['public4'] = Project::findOrFail((int) $this->makePublicProject('public4')->Id); // Out of order to check DB ordering
-        $this->projects['public3'] = Project::findOrFail((int) $this->makePublicProject('public3')->Id);
-        $this->projects['public5'] = Project::findOrFail((int) $this->makePublicProject('public5')->Id);
+        $this->projects['public1'] = $this->makePublicProject('public1');
+        $this->projects['public2'] = $this->makePublicProject('public2');
+        $this->projects['public4'] = $this->makePublicProject('public4'); // Out of order to check DB ordering
+        $this->projects['public3'] = $this->makePublicProject('public3');
+        $this->projects['public5'] = $this->makePublicProject('public5');
 
         // A couple private projects so we can check visibility (enum) filtering
-        $this->projects['private1'] = Project::findOrFail((int) $this->makePrivateProject('private1')->Id);
-        $this->projects['private2'] = Project::findOrFail((int) $this->makePrivateProject('private2')->Id);
+        $this->projects['private1'] = $this->makePrivateProject('private1');
+        $this->projects['private2'] = $this->makePrivateProject('private2');
 
         // Wipe any existing users before creating new ones
         User::query()->delete();

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -30,13 +30,13 @@ class ProjectTypeTest extends TestCase
         parent::setUp();
 
         $this->projects = [
-            'public1' => Project::findOrFail((int) $this->makePublicProject()->Id),
-            'public2' => Project::findOrFail((int) $this->makePublicProject()->Id),
-            'protected1' => Project::findOrFail((int) $this->makeProtectedProject()->Id),
-            'protected2' => Project::findOrFail((int) $this->makeProtectedProject()->Id),
-            'private1' => Project::findOrFail((int) $this->makePrivateProject()->Id),
-            'private2' => Project::findOrFail((int) $this->makePrivateProject()->Id),
-            'private3' => Project::findOrFail((int) $this->makePrivateProject()->Id),
+            'public1' => $this->makePublicProject(),
+            'public2' => $this->makePublicProject(),
+            'protected1' => $this->makeProtectedProject(),
+            'protected2' => $this->makeProtectedProject(),
+            'private1' => $this->makePrivateProject(),
+            'private2' => $this->makePrivateProject(),
+            'private3' => $this->makePrivateProject(),
         ];
 
         // Wipe any existing users before creating new ones

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -38,8 +38,8 @@ class SiteTypeTest extends TestCase
         parent::setUp();
 
         $this->projects = [
-            'public1' => Project::findOrFail((int) $this->makePublicProject()->Id),
-            'private1' => Project::findOrFail((int) $this->makePrivateProject()->Id),
+            'public1' => $this->makePublicProject(),
+            'private1' => $this->makePrivateProject(),
         ];
 
         $this->users = [

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -24,7 +24,7 @@ class TestTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->project = Project::findOrFail((int) $this->makePublicProject()->Id);
+        $this->project = $this->makePublicProject();
 
         // A common test output to share among all of our tests
         $this->test_output = TestOutput::create([

--- a/tests/Feature/LdapIntegration.php
+++ b/tests/Feature/LdapIntegration.php
@@ -96,11 +96,11 @@ class LdapIntegration extends TestCase
         ]);
 
         // Create a pair of projects which are restricted to specific LDAP groups
-        $this->projects['only_group_1'] = Project::findOrFail((int) $this->makePrivateProject()->Id);
+        $this->projects['only_group_1'] = $this->makePrivateProject();
         $this->projects['only_group_1']->ldapfilter = "(uid=*group_1*)";
         $this->projects['only_group_1']->save();
 
-        $this->projects['only_group_2'] = Project::findOrFail((int) $this->makePrivateProject()->Id);
+        $this->projects['only_group_2'] =$this->makePrivateProject();
         $this->projects['only_group_2']->ldapfilter = "(uid=*group_2*)";
         $this->projects['only_group_2']->save();
     }

--- a/tests/Feature/ProjectPermissions.php
+++ b/tests/Feature/ProjectPermissions.php
@@ -5,7 +5,7 @@ namespace Tests\Feature;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
 use App\Models\User;
-use CDash\Model\Project;
+use App\Models\Project;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
 use Tests\TestCase;
@@ -37,10 +37,10 @@ class ProjectPermissions extends TestCase
 
     protected function tearDown(): void
     {
-        $this->public_project->Delete();
-        $this->protected_project->Delete();
-        $this->private_project1->Delete();
-        $this->private_project2->Delete();
+        $this->public_project->delete();
+        $this->protected_project->delete();
+        $this->private_project1->delete();
+        $this->private_project2->delete();
         $this->normal_user->delete();
         $this->admin_user->delete();
 
@@ -58,10 +58,10 @@ class ProjectPermissions extends TestCase
         $missing_project_response = $this->get('/api/v2/projects/9999999')->json();
 
         // Verify that we can access the public project.
-        $_GET['project'] = $this->public_project->Name;
+        $_GET['project'] = $this->public_project->name;
         $response = $this->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->public_project->Name,
+            'projectname' => $this->public_project->name,
             'public' => Project::ACCESS_PUBLIC,
         ]);
 
@@ -73,43 +73,43 @@ class ProjectPermissions extends TestCase
         $response->assertJson([
             'nprojects' => 1,
             'projects' => [
-                ['name' => $this->public_project->Name],
+                ['name' => $this->public_project->name],
             ],
         ]);
 
         // Verify that we cannot access the protected project or the private projects.
-        $_GET['project'] = $this->protected_project->Name;
+        $_GET['project'] = $this->protected_project->name;
         $response = $this->get('/api/v1/index.php');
         $response->assertJson(['requirelogin' => 1]);
-        $_GET['project'] = $this->private_project1->Name;
+        $_GET['project'] = $this->private_project1->name;
         $response = $this->get('/api/v1/index.php');
         $response->assertJson(['requirelogin' => 1]);
-        $_GET['project'] = $this->private_project2->Name;
+        $_GET['project'] = $this->private_project2->name;
         $response = $this->get('/api/v1/index.php');
         $response->assertJson(['requirelogin' => 1]);
 
         // Verify that we can still access the public project when logged in
         // as this user.
-        $_GET['project'] = $this->public_project->Name;
+        $_GET['project'] = $this->public_project->name;
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->public_project->Name,
+            'projectname' => $this->public_project->name,
             'public' => Project::ACCESS_PUBLIC,
         ]);
 
         // Verify that we can access the protected project when logged in
         // as this user.
-        $_GET['project'] = $this->protected_project->Name;
+        $_GET['project'] = $this->protected_project->name;
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->protected_project->Name,
+            'projectname' => $this->protected_project->name,
             'public' => Project::ACCESS_PROTECTED,
         ]);
 
         // Add the user to PrivateProject1.
         DB::table('user2project')->insert([
             'userid' => $this->normal_user->id,
-            'projectid' => $this->private_project1->Id,
+            'projectid' => $this->private_project1->id,
             'role' => 0,
             'emailtype' => 0,
             'emailcategory' => 0,
@@ -118,15 +118,15 @@ class ProjectPermissions extends TestCase
         ]);
 
         // Verify that she can access it.
-        $_GET['project'] = $this->private_project1->Name;
+        $_GET['project'] = $this->private_project1->name;
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->private_project1->Name,
+            'projectname' => $this->private_project1->name,
             'public' => Project::ACCESS_PRIVATE,
         ]);
 
         // Verify that she cannot access PrivateProject2.
-        $_GET['project'] = $this->private_project2->Name;
+        $_GET['project'] = $this->private_project2->name;
         $response = $this->actingAs($this->normal_user)->get('/api/v1/index.php');
         $response->assertJson(['error' => 'You do not have access to the requested project or the requested project does not exist.']);
 
@@ -138,35 +138,35 @@ class ProjectPermissions extends TestCase
         $response->assertJson([
             'nprojects' => 3,
             'projects' => [
-                ['name' => $this->private_project1->Name],
-                ['name' => $this->protected_project->Name],
-                ['name' => $this->public_project->Name],
+                ['name' => $this->private_project1->name],
+                ['name' => $this->protected_project->name],
+                ['name' => $this->public_project->name],
             ],
         ]);
 
         // Verify that they can access all 4 projects.
-        $_GET['project'] = $this->public_project->Name;
+        $_GET['project'] = $this->public_project->name;
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->public_project->Name,
+            'projectname' => $this->public_project->name,
             'public' => Project::ACCESS_PUBLIC,
         ]);
-        $_GET['project'] = $this->protected_project->Name;
+        $_GET['project'] = $this->protected_project->name;
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->protected_project->Name,
+            'projectname' => $this->protected_project->name,
             'public' => Project::ACCESS_PROTECTED,
         ]);
-        $_GET['project'] = $this->private_project1->Name;
+        $_GET['project'] = $this->private_project1->name;
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->private_project1->Name,
+            'projectname' => $this->private_project1->name,
             'public' => Project::ACCESS_PRIVATE,
         ]);
-        $_GET['project'] = $this->private_project2->Name;
+        $_GET['project'] = $this->private_project2->name;
         $response = $this->actingAs($this->admin_user)->get('/api/v1/index.php');
         $response->assertJson([
-            'projectname' => $this->private_project2->Name,
+            'projectname' => $this->private_project2->name,
             'public' => Project::ACCESS_PRIVATE,
         ]);
 
@@ -178,9 +178,9 @@ class ProjectPermissions extends TestCase
         $response = $this->actingAs($this->admin_user)->get('/api/v1/viewProjects.php');
         $response->assertJsonPath('nprojects', 4);
         $response->assertJsonCount(4, 'projects');
-        $response->assertJsonFragment(['name' => $this->private_project1->Name]);
-        $response->assertJsonFragment(['name' => $this->private_project2->Name]);
-        $response->assertJsonFragment(['name' => $this->protected_project->Name]);
-        $response->assertJsonFragment(['name' => $this->public_project->Name]);
+        $response->assertJsonFragment(['name' => $this->private_project1->name]);
+        $response->assertJsonFragment(['name' => $this->private_project2->name]);
+        $response->assertJsonFragment(['name' => $this->protected_project->name]);
+        $response->assertJsonFragment(['name' => $this->public_project->name]);
     }
 }

--- a/tests/Feature/RouteAccessTest.php
+++ b/tests/Feature/RouteAccessTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use CDash\Model\Project;
+use App\Models\Project;
 use Illuminate\Support\Facades\URL;
 use App\Models\User;
 use LogicException;
@@ -43,7 +43,7 @@ class RouteAccessTest extends TestCase
     {
         $this->normal_user->delete();
         $this->admin_user->delete();
-        $this->public_project->Delete();
+        $this->public_project->delete();
 
         parent::tearDown();
     }

--- a/tests/Traits/CreatesProjects.php
+++ b/tests/Traits/CreatesProjects.php
@@ -2,38 +2,32 @@
 
 namespace Tests\Traits;
 
-use CDash\Model\Project;
+use App\Models\Project;
 use Illuminate\Support\Str;
 
 trait CreatesProjects
 {
     public function makePublicProject(?string $name = null): Project
     {
-        $project = new Project();
-        $project->Name = $name ?? 'PublicProject_' . Str::uuid()->toString();
-        $project->Public = Project::ACCESS_PUBLIC;
-        $project->Save();
-        $project->InitialSetup();
-        return $project;
+        return Project::create([
+            'name' => $name ?? 'PublicProject_' . Str::uuid()->toString(),
+            'public' => Project::ACCESS_PUBLIC,
+        ]);
     }
 
     public function makeProtectedProject(?string $name = null): Project
     {
-        $project = new Project();
-        $project->Name = $name ?? 'ProtectedProject_' . Str::uuid()->toString();
-        $project->Public = Project::ACCESS_PROTECTED;
-        $project->Save();
-        $project->InitialSetup();
-        return $project;
+        return Project::create([
+            'name' => $name ?? 'ProtectedProject_' . Str::uuid()->toString(),
+            'public' => Project::ACCESS_PROTECTED,
+        ]);
     }
 
     public function makePrivateProject(?string $name = null): Project
     {
-        $project = new Project();
-        $project->Name = $name ?? 'PrivateProject_' . Str::uuid()->toString();
-        $project->Public = Project::ACCESS_PRIVATE;
-        $project->Save();
-        $project->InitialSetup();
-        return $project;
+        return Project::create([
+            'name' => $name ?? 'PrivateProject_' . Str::uuid()->toString(),
+            'public' => Project::ACCESS_PRIVATE,
+        ]);
     }
 }


### PR DESCRIPTION
The functions used to create projects for much of the test suite currently return legacy project models, even though most tests immediately convert them to Eloquent models.  This make the test-writing process extra painful for most tests, and is completely unnecessary.

This PR changes the project creation functions to instead return Eloquent projects.  This also removes some of the last references to the InitialSetup method in the legacy project model, which paves the way for that method to be completely removed in the follow-up to #2396.