### PR TITLE
Add TestMeasurement type to GraphQL API

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -210,8 +210,11 @@ set_tests_properties(/Feature/GraphQL/BuildTypeTest PROPERTIES DEPENDS /Feature/
 add_laravel_test(/Feature/GraphQL/TestTypeTest)
 set_tests_properties(/Feature/GraphQL/TestTypeTest PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
 
+add_laravel_test(/Feature/GraphQL/TestMeasurementTypeTest)
+set_tests_properties(/Feature/GraphQL/TestMeasurementTypeTest PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
+
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
-set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS /Feature/GraphQL/TestTypeTest)
+set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS "/Feature/GraphQL/TestTypeTest;/Feature/GraphQL/TestMeasurementTypeTest")
 
 add_laravel_test(/Feature/TestSchemaMigration)
 set_tests_properties(/Feature/TestSchemaMigration PROPERTIES DEPENDS /Feature/PurgeUnusedProjectsCommand)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -237,6 +237,12 @@ type Test {
   name: String! @rename(attribute: "testname")
 
   status: TestStatus!
+
+  """
+  Test measurements for this test, sorted in descending order so newer results
+  appear first when using paginated queries.
+  """
+  testMeasurements: [TestMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 }
 
 enum TestStatus {
@@ -255,6 +261,32 @@ input TestFilterInput {
   id: ID
   name: String
   status: TestStatus
+}
+
+
+"Test Measurement."
+type TestMeasurement {
+  "Unique primary key."
+  id: ID!
+
+  """
+  Example: "Exit Value"
+  """
+  name: String!
+
+  """
+  Example: "text/string", "numeric/double", "text/preformatted", etc
+  """
+  type: String!
+
+  """
+  The value for this measurement.  Even though some values may be numeric, all
+  values are returned as strings.  There is no guarantee that the type field
+  will match the actual type of the value field.
+
+  Example: "5"
+  """
+  value: String!
 }
 
 

--- a/tests/Feature/GraphQL/TestMeasurementTypeTest.php
+++ b/tests/Feature/GraphQL/TestMeasurementTypeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Project;
+use App\Models\TestOutput;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class TestMeasurementTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+    private TestOutput $test_output;
+
+    /**
+     * @throws \Random\RandomException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        // A common test output to share among all of our tests
+        $this->test_output = TestOutput::create([
+            'crc32' => random_int(0, 100000),
+            'path' => 'a',
+            'command' => 'b',
+            'output' => 'c',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Deleting the project will delete all corresponding builds and tests
+        $this->project->delete();
+
+        $this->test_output->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic test to ensure that each of the fields works
+     */
+    public function testBasicFieldAccess(): void
+    {
+        $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ])->tests()->create([
+            'testname' => 'test1',
+            'status' => 'failed',
+            'outputid' => $this->test_output->id,
+        ])->testMeasurements()->createMany([
+            [
+                'name' => 'measurement 1',
+                'type' => 'text/string',
+                'value' => 'test',
+            ],
+            [
+                'name' => 'measurement 2',
+                'type' => 'numeric/double',
+                'value' => '6',
+            ],
+        ]);
+
+        $this->graphQL('
+            query project($id: ID) {
+                project(id: $id) {
+                    builds {
+                        edges {
+                            node {
+                                name
+                                tests {
+                                    edges {
+                                        node {
+                                            name
+                                            testMeasurements {
+                                                edges {
+                                                    node {
+                                                        name
+                                                        type
+                                                        value
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $this->project->id,
+        ])->assertJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'build1',
+                                    'tests' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'name' => 'test1',
+                                                    'testMeasurements' => [
+                                                        'edges' => [
+                                                            [
+                                                                'node' => [
+                                                                    'name' => 'measurement 2',
+                                                                    'type' => 'numeric/double',
+                                                                    'value' => '6',
+                                                                ],
+                                                            ],
+                                                            [
+                                                                'node' => [
+                                                                    'name' => 'measurement 1',
+                                                                    'type' => 'text/string',
+                                                                    'value' => 'test',
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+}


### PR DESCRIPTION
This PR exposes the `testMeasurement` relationship on the `Test` type in the GraphQL API in preparation for upcoming UI changes.