### PR TITLE
Increase default Cypress timeout

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   downloadsFolder: 'tests/cypress/downloads',
   trashAssetsBeforeRuns: true,
   pageLoadTimeout: 300000,
-  defaultCommandTimeout: 30000,
+  defaultCommandTimeout: 120000,
   retries: 2,
   e2e: {
     setupNodeEvents(on, config) {


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2263 bumped the default Cypress timeout, which reduced the test flakiness, but did not eliminate it entirely.  This PR bumps the limit again in an attempt to resolve the issue.  In the future, I plan to rewrite the flaky tests.