### PR TITLE
Stop assuming "full name" in OAuth

### DIFF
--- a/app/Http/Controllers/OAuthController.php
+++ b/app/Http/Controllers/OAuthController.php
@@ -36,7 +36,14 @@ final class OAuthController extends AbstractController
         };
 
         $email =  $authUser->getEmail();
-        [$fname, $lname] = explode(" ", $authUser->getName() ?? '');
+        $name = $authUser->getName() ?? '';
+
+        // Check if name has space.  Avoid issue where username = "Real" name
+        if (str_contains($name, " ")) {
+            [$fname, $lname] = explode(" ", $name);
+        } else {
+            [$fname, $lname] = [$name, ""];
+        }
 
         // TODO: What if, for whatever reason, there is more than one user found?
         $user = User::firstWhere('email', $email);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27071,12 +27071,12 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mockery\\\\Expectation\\:\\:shouldReceive\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: tests/Feature/LoginAndRegistration.php
 
 		-
 			message: "#^Call to method shouldReceive\\(\\) on an unknown class Laravel\\\\Socialite\\\\PingIdentity\\\\Provider\\.$#"
-			count: 1
+			count: 2
 			path: tests/Feature/LoginAndRegistration.php
 
 		-

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -290,6 +290,31 @@ class LoginAndRegistration extends TestCase
         $response->assertRedirect("/register?fname=Arlette&lname=Laguiller&email=cdash%40test.com");
     }
 
+    public function testNoFullNamePingIdentityProvider() : void
+    {
+        // Stolen from: https://laracasts.com/discuss/channels/testing/testing-laravel-socialite-callback
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser->shouldReceive('getId')
+        ->andReturn(1234567890)
+        ->shouldReceive('getEmail')
+        ->andReturn('cdash@test.com')
+        ->shouldReceive('getNickname')
+        ->andReturn('Pseudo')
+        ->shouldReceive('getName')
+        ->andReturn('Pseudo')
+        ->shouldReceive('getAvatar')
+        ->andReturn('https://en.gravatar.com/userimage');
+
+        $provider = Mockery::mock('Laravel\Socialite\PingIdentity\Provider');
+        $provider->shouldReceive('user')->andReturn($abstractUser);
+
+        Socialite::shouldReceive('driver')->with('pingidentity')->andReturn($provider);
+
+        $response = $this->get("auth/pingidentity/callback");
+        $response->assertRedirect("/register?fname=Pseudo&lname=&email=cdash%40test.com");
+    }
+
+
     public function testRegisterUserWhenDisabled() : void
     {
         // Create a user by sending proper data


### PR DESCRIPTION
Per a bug report, if an OAuth account name doesn't use a real name, CDash will 500 if a space doesn't exist in the name.

Check for the space before trying to separate into first and last names. If no space, use the whole string as the first name.

Fixes: #2435