### PR TITLE
Add new filters UI and barebones viewTest.php replacement

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -57,6 +57,13 @@ final class BuildController extends AbstractBuildController
         return $this->renderBuildPage($build_id, 'update', 'Files Updated');
     }
 
+    public function tests(int $build_id): View
+    {
+        $this->setBuildById($build_id);
+
+        return $this->view('build.tests', 'Tests');
+    }
+
     protected function renderBuildPage(int $build_id, string $page_name, string $page_title = '')
     {
         $this->setBuildById($build_id);

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -61,7 +61,10 @@ final class BuildController extends AbstractBuildController
     {
         $this->setBuildById($build_id);
 
-        return $this->view('build.tests', 'Tests');
+        $filters = json_decode(request()->get('filters')) ?? ['all' => []];
+
+        return $this->view('build.tests', 'Tests')
+            ->with('filters', $filters);
     }
 
     protected function renderBuildPage(int $build_id, string $page_name, string $page_title = '')

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -1283,11 +1283,11 @@ final class CoverageController extends AbstractBuildController
             if ($status == -1) {
                 //directory view
 
-                $row[] = '<a href="viewCoverage.php?buildid=' . $this->build->Id . '&#38;status=6&#38;dir=' . $covfile['fullpath'] . '">' . $covfile['fullpath'] . '</a>';
+                $row[] = '<a class="cdash-link" href="viewCoverage.php?buildid=' . $this->build->Id . '&#38;status=6&#38;dir=' . $covfile['fullpath'] . '">' . $covfile['fullpath'] . '</a>';
             } elseif (!$covfile['covered'] || !($this->project->ShowCoverageCode || $role >= Project::PROJECT_ADMIN)) {
                 $row[] = $covfile['fullpath'];
             } else {
-                $row[] = '<a href="viewCoverageFile.php?buildid=' . $this->build->Id . '&#38;fileid=' . $covfile['fileid'] . '">' . $covfile['fullpath'] . '</a>';
+                $row[] = '<a class="cdash-link" href="viewCoverageFile.php?buildid=' . $this->build->Id . '&#38;fileid=' . $covfile['fileid'] . '">' . $covfile['fullpath'] . '</a>';
             }
 
             // Second column (Status)

--- a/app/Policies/BuildPolicy.php
+++ b/app/Policies/BuildPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Build;
+use App\Models\User;
+use BadMethodCallException;
+use Illuminate\Support\Facades\Gate;
+
+class BuildPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        throw new BadMethodCallException('Policy method viewAny not implemented for Build');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(?User $user, Build $build): bool
+    {
+        return Gate::check('view', $build->project);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        throw new BadMethodCallException('Policy method create not implemented for Build');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Build $build): bool
+    {
+        throw new BadMethodCallException('Policy method update not implemented for Build');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Build $build): bool
+    {
+        throw new BadMethodCallException('Policy method delete not implemented for Build');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Build $build): bool
+    {
+        throw new BadMethodCallException('Policy method restore not implemented for Build');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Build $build): bool
+    {
+        throw new BadMethodCallException('Policy method forceDelete not implemented for Build');
+    }
+}

--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -712,7 +712,7 @@ class RepositoryUtils
         if (strpos($projecturl, '//') === false) {
             $projecturl = '//' . $projecturl;
         }
-        $repo_link = "<a href='$projecturl/blob/$revision";
+        $repo_link = "<a class='cdash-link' href='$projecturl/blob/$revision";
         $pattern = "&$source_dir\/*([a-zA-Z0-9_\.\-\\/]+):(\d+)&";
         $replacement = "$repo_link/$1#L$2'>$1:$2</a>";
 

--- a/app/cdash/public/manageProjectRoles.xsl
+++ b/app/cdash/public/manageProjectRoles.xsl
@@ -100,15 +100,15 @@
    <div id="wizard">
       <ul>
           <li>
-            <a href="#fragment-1"><span>Current users</span></a></li>
+            <a class="cdash-link" href="#fragment-1"><span>Current users</span></a></li>
           <li>
-            <a href="#fragment-2"><span>Search for already registered users</span></a></li>
+            <a class="cdash-link" href="#fragment-2"><span>Search for already registered users</span></a></li>
           <xsl:if test="/cdash/canRegister">
             <li>
-              <a href="#fragment-3"><span>Register a new user</span></a></li>
+              <a class="cdash-link" href="#fragment-3"><span>Register a new user</span></a></li>
           </xsl:if>
           <li>
-            <a href="#fragment-4"><span>Import users from CVS file </span></a></li>
+            <a class="cdash-link" href="#fragment-4"><span>Import users from CVS file </span></a></li>
       </ul>
     <div id="fragment-1" class="tab_content" >
         <div class="tab_help"></div>

--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -52,7 +52,7 @@
           <li>
             <a class="cdash-link" href="#fragment-2"><span>Repository Credential</span></a></li>
           <li>
-            <a class="cdash-link"href="#fragment-3"><span>Email Notifications</span></a></li>
+            <a class="cdash-link" href="#fragment-3"><span>Email Notifications</span></a></li>
           <li>
             <a class="cdash-link" href="#fragment-4"><span>Email Category</span></a></li>
           <li>

--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -48,15 +48,15 @@
   <div id="wizard">
       <ul>
           <li>
-            <a href="#fragment-1"><span>Select your role in this project</span></a></li>
+            <a class="cdash-link" href="#fragment-1"><span>Select your role in this project</span></a></li>
           <li>
-            <a href="#fragment-2"><span>Repository Credential</span></a></li>
+            <a class="cdash-link" href="#fragment-2"><span>Repository Credential</span></a></li>
           <li>
-            <a href="#fragment-3"><span>Email Notifications</span></a></li>
+            <a class="cdash-link"href="#fragment-3"><span>Email Notifications</span></a></li>
           <li>
-            <a href="#fragment-4"><span>Email Category</span></a></li>
+            <a class="cdash-link" href="#fragment-4"><span>Email Category</span></a></li>
           <li>
-            <a href="#fragment-5"><span>Email Labels</span></a></li>
+            <a class="cdash-link" href="#fragment-5"><span>Email Labels</span></a></li>
       </ul>
     <div id="fragment-1" class="tab_content" >
       <div class="tab_help"></div>

--- a/app/cdash/public/viewCoverage.xsl
+++ b/app/cdash/public/viewCoverage.xsl
@@ -159,7 +159,7 @@
   <br/>
 
   <div id="labelshowfilters">
-  <a id="label_showfilters" href="javascript:filters_toggle();">
+  <a class="cdash-link" id="label_showfilters" href="javascript:filters_toggle();">
   <xsl:if test="cdash/filterdata/showfilters = 0">Show Filters<xsl:if test="cdash/filtercount > 0"> (<xsl:value-of select="cdash/filtercount"/>)</xsl:if></xsl:if>
   <xsl:if test="cdash/filterdata/showfilters != 0">Hide Filters</xsl:if>
   </a>

--- a/app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
+++ b/app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
@@ -14,7 +14,7 @@ class LinkifyCompilerOutputTest extends CDashTestCase
             'https://github.com/Kitware/CDash', "/\.\.\.", 'master',
             $compiler_output);
 
-        $expected_output = "<a href='https://github.com/Kitware/CDash/blob/master/file.cxx#L1'>file.cxx:1</a>:22: error: &lt;fakefile.h&gt;: No such file";
+        $expected_output = "<a class='cdash-link' href='https://github.com/Kitware/CDash/blob/master/file.cxx#L1'>file.cxx:1</a>:22: error: &lt;fakefile.h&gt;: No such file";
 
         $this->assertEquals($expected_output, $linkified_output);
     }

--- a/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
@@ -55,7 +55,7 @@ class BuildErrorTest extends CDashTestCase
             'logline' => '16',
             'cvsurl' => 'https://github.com/FooCo/foo/blob/12/src/main.cpp',
             'precontext' => "Scanning dependencies of target main\n[ 83%] Building CXX object src/CMakeFiles/main.dir/main.cpp.o\n/.../foo/src/main.cpp: In function `int main(int, char**)`:",
-            'text' => "<a href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` not declared in this scope",
+            'text' => "<a class='cdash-link' href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` not declared in this scope",
             'postcontext' => "   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
             'sourcefile' => 'src/main.cpp',
             'sourceline' => '2',

--- a/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildFailureTest.php
@@ -68,7 +68,7 @@ class BuildFailureTest extends CDashTestCase
             'workingdirectory' => '/projects/foo/bin',
             'exitcondition'    => '2',
             'stdoutput'        => '',
-            'stderror'         => "foo/src/main.cpp: In function `int main(int, char**)`:\n<a href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` was not declared in this scope\n   asdf = 0;",
+            'stderror'         => "foo/src/main.cpp: In function `int main(int, char**)`:\n<a class='cdash-link' href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` was not declared in this scope\n   asdf = 0;",
             'cvsurl' => 'https://github.com/FooCo/foo/blob/12/src/main.cpp',
         ];
         $this->assertEquals($expected, $marshaled);

--- a/app/cdash/tests/test_projectwebpage.php
+++ b/app/cdash/tests/test_projectwebpage.php
@@ -115,7 +115,7 @@ class ProjectWebPageTestCase extends KWWebTestCase
         $url = null;
         foreach ($jsonobj['aaData'] as $row) {
             if (strpos($row[0], 'itkCannyEdgesDistanceAdvectionFieldFeatureGenerator.h') !== false) {
-                $url = substr($row[0], 9, 43);
+                $url = substr($row[0], 28, 43);
             }
         }
         if ($url === null) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -265,7 +265,7 @@ enum TestStatus {
 
 input TestFilterInput {
   id: ID
-  name: String
+  name: String @rename(attribute: "testname")
   status: TestStatus
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,6 +17,12 @@ type Query {
   projects(
     filters: _ @filter(inputType: "ProjectFilterInput")
   ): [Project!]! @paginate(scopes: ["forUser"], type: CONNECTION) @orderBy(column: "id")
+
+  "Find a single build by ID."
+  build(
+    "Search by primary key."
+    id: ID @eq
+  ): Build @find @canResolved(ability: "view")
 }
 
 

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -29,14 +29,14 @@ body {
   font-size: 11px;
 }
 
-a:link,a:visited,a:active{
+.cdash-link a:link, .cdash-link a:visited, .cdash-link a:active{
  font-size:14px;
  color:#3B5998; /* 4A4A4A */
  font-weight: normal;
  text-decoration: none;
 }
 
-a:hover{
+.cdash-link a:hover{
  /* color:#000000; */
  text-decoration: underline;
 }

--- a/public/js/cdashCoverageGraph.js
+++ b/public/js/cdashCoverageGraph.js
@@ -16,7 +16,7 @@ function showcoveragegraph_click(buildid,zoomout)
   $("#graph").fadeIn('slow');
   $("#graph").html("fetching...<img src=img/loading.gif></img>");
   $("#grapholder").attr("style","width:800px;height:400px;");
-  $("#graphoptions").html("<a href=javascript:showcoveragegraph_click("+buildid+",true)>Zoom out</a>");
+  $("#graphoptions").html("<a class=\"cdash-link\" href=javascript:showcoveragegraph_click("+buildid+",true)>Zoom out</a>");
 
   $("#graph").load("ajax/showcoveragegraph.php?buildid="+buildid,{},function(){$("#grapholder").fadeIn('slow');
 $("#graphoptions").show();

--- a/public/js/cdashFilters.js
+++ b/public/js/cdashFilters.js
@@ -318,7 +318,7 @@ function filters_create_hyperlink()
 
   s = s + collapse_str;
 
-  $("#div_filtersAsUrl").html("<a href=\"" + s + "\">" + s + "</a>");
+  $("#div_filtersAsUrl").html("<a class=\"cdash-link\" href=\"" + s + "\">" + s + "</a>");
 }
 
 

--- a/public/js/controllers/filters.js
+++ b/public/js/controllers/filters.js
@@ -300,7 +300,7 @@ function FiltersController($scope, $rootScope, $http, $timeout) {
 
   $scope.displayHyperlink = function() {
     var url = this.createHyperlink();
-    $("#div_filtersAsUrl").html("<a href=\"" + url + "\">" + url + "</a>");
+    $("#div_filtersAsUrl").html("<a class=\"cdash-link\" href=\"" + url + "\">" + url + "</a>");
   };
 
   $scope.createHyperlink = function() {

--- a/public/views/compareCoverage.html
+++ b/public/views/compareCoverage.html
@@ -1,6 +1,6 @@
       <!-- Filters -->
       <div id="labelshowfilters">
-        <a id="label_showfilters" ng-click="showfilters_toggle()">
+        <a class="cdash-link" id="label_showfilters" ng-click="showfilters_toggle()">
           <span ng-show="showfilters == 0">Show Filters</span>
           <span ng-show="showfilters != 0">Hide Filters</span>
         </a>
@@ -49,7 +49,7 @@
             </td>
 
             <td align="center" ng-repeat="build in cdash.builds" ng-class="{'normal': group[build.key] >= group.thresholdgreen, 'warning': group[build.key] < group.thresholdgreen && group[build.key] >= group.thresholdyellow, 'error': group[build.key] < group.thresholdyellow}">
-              <a ng-if="group[build.key] >= 0"> {{group[build.key]}}% </a>
+              <a class="cdash-link"ng-if="group[build.key] >= 0"> {{group[build.key]}}% </a>
             </td>
 
           </tr>
@@ -60,10 +60,10 @@
             </td>
 
             <td align="center" ng-repeat="build in cdash.builds" ng-class="{'normal': coverage[build.key] >= group.thresholdgreen, 'warning': coverage[build.key] < group.thresholdgreen && coverage[build.key] >= group.thresholdyellow, 'error': coverage[build.key] < group.thresholdyellow}">
-              <a ng-if="coverage[build.key] >= 0 && build.key != 'aggregate'" ng-href="viewCoverage.php?buildid={{coverage[build.key +'id']}}">
+              <a class="cdash-link" ng-if="coverage[build.key] >= 0 && build.key != 'aggregate'" ng-href="viewCoverage.php?buildid={{coverage[build.key +'id']}}">
                 {{coverage[build.key]}}%
               </a>
-               <a ng-if="coverage[build.key] >= 0 && build.key == 'aggregate'">
+               <a class="cdash-link" ng-if="coverage[build.key] >= 0 && build.key == 'aggregate'">
                 {{coverage[build.key]}}%
               </a>
               <sub ng-if="coverage[build.key+'percentagediff'] > 0">+{{coverage[build.key+'percentagediff']}}%</sub>
@@ -81,10 +81,10 @@
             </td>
 
             <td align="center" ng-repeat="build in cdash.builds" ng-class="{'normal': coverage[build.key] >= cdash.thresholdgreen, 'warning': coverage[build.key] < cdash.thresholdgreen && coverage[build.key] >= cdash.thresholdyellow, 'error': coverage[build.key] < cdash.thresholdyellow}">
-              <a ng-if="coverage[build.key] >= 0 && build.key != 'aggregate'" ng-href="viewCoverage.php?buildid={{coverage[build.key+'id']}}">
+              <a class="cdash-link" ng-if="coverage[build.key] >= 0 && build.key != 'aggregate'" ng-href="viewCoverage.php?buildid={{coverage[build.key+'id']}}">
                 {{coverage[build.key]}}%
               </a>
-               <a ng-if="coverage[build.key] >= 0 && build.key == 'aggregate'">
+               <a class="cdash-link" ng-if="coverage[build.key] >= 0 && build.key == 'aggregate'">
                 {{coverage[build.key]}}%
               </a>
               <sub ng-if="coverage[build.key+'percentagediff'] > 0">+{{coverage[build.key+'percentagediff']}}%</sub>

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -14,31 +14,31 @@
                 uib-tooltip="More display options"></span>
           <ul ng-show="showsettings">
             <li>
-              <a id="label_advancedview" ng-click="toggleAdvancedView()">
+              <a class="cdash-link" id="label_advancedview" ng-click="toggleAdvancedView()">
                 <span ng-if="::cdash.advancedview == 0">Advanced View</span>
                 <span ng-if="::cdash.advancedview != 0">Simple View</span>
               </a>
             </li>
             <li>
-              <a class="autorefresh" ng-click="toggleAutoRefresh()">
+              <a class="autorefresh cdash-link" ng-click="toggleAutoRefresh()">
                 <span ng-if="::!autoRefresh">Auto-refresh</span>
                 <span ng-if="::autoRefresh">Stop auto-refresh</span>
               </a>
             </li>
             <li>
-              <a id="label_colorblind" href="" ng-click="cdash.filterdata.colorblind=!cdash.filterdata.colorblind; colorblind_toggle()">
+              <a class="cdash-link" id="label_colorblind" href="" ng-click="cdash.filterdata.colorblind=!cdash.filterdata.colorblind; colorblind_toggle()">
                 <span ng-show="cdash.filterdata.colorblind == 0" data-cy="color-mode-colorblind">Colorblind palette</span>
                 <span ng-show="cdash.filterdata.colorblind != 0" data-cy="color-mode-classic">Classic palette</span>
               </a>
             </li>
             <li>
-              <a id="label_showfilters" ng-click="showfilters_toggle()">
+              <a class="cdash-link" id="label_showfilters" ng-click="showfilters_toggle()">
                 <span ng-show="showfilters == 0">Show Filters</span>
                 <span ng-show="showfilters != 0">Hide Filters</span>
               </a>
             </li>
             <li>
-              <a href="http://public.kitware.com/Wiki/CDash:Documentation" class="helptrigger" target="_blank">
+              <a href="http://public.kitware.com/Wiki/CDash:Documentation" class="helptrigger cdash-link" target="_blank">
                 Help
               </a>
             </li>
@@ -60,7 +60,7 @@
         <tr>
           <td height="25" align="left">
             Testing data for this project can be found at:
-            <a ng-href="{{::cdash.testingdataurl}}">{{::cdash.testingdataurl}}</a>
+            <a class="cdash-link" ng-href="{{::cdash.testingdataurl}}">{{::cdash.testingdataurl}}</a>
           </td>
         </tr>
       </table>
@@ -70,7 +70,7 @@
         <br/>
         <div id="site" align="left">
           <b>Site</b>:
-          <a ng-href="sites/{{::cdash.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+          <a class="cdash-link" ng-href="sites/{{::cdash.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
             {{::cdash.site}}
           </a>
           <img ng-if="::cdash.siteoutoforder == 1" src="img/flag.png" title="flag"/>
@@ -79,19 +79,21 @@
         <div id="buildname" align="left">
           <b>Build Name</b>: {{::cdash.buildname}}
           <img ng-if="::cdash.buildplatform" class="icon" alt="platform" ng-src="img/platform_{{::cdash.buildplatform}}.png"/>
-          <a title="View notes"
+          <a class="cdash-link"
+             title="View notes"
              ng-if="::cdash.parenthasnotes"
              ng-href="build/{{::cdash.parentid}}/notes">
             <img src="img/document.png" alt="Notes" class="icon"/>
           </a>
 
-          <a ng-if="::cdash.uploadfilecount > 0"
+          <a class="cdash-link"
+             ng-if="::cdash.uploadfilecount > 0"
              ng-href="build/{{::cdash.parentid}}/files"
              title="{{::cdash.uploadfilecount}} files uploaded with this build">
             <img src="img/package.png" alt="Files" class="icon"/>
           </a>
 
-          <a ng-if="::cdash.changelink" target="_blank" ng-href="{{::cdash.changelink}}">
+          <a class="cdash-link" ng-if="::cdash.changelink" target="_blank" ng-href="{{::cdash.changelink}}">
             <img class="smallicon" ng-src="{{::cdash.changeicon}}"/>
           </a>
         </div>
@@ -157,17 +159,17 @@
       <!-- Coverage -->
       <div class="buildgroup"
            ng-if="::cdash.coverages.length > 0 || cdash.coveragegroups.length > 0">
-        <a id="Coverage"></a>
+        <a class="cdash-link" id="Coverage"></a>
         <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="coveragetable">
           <thead>
             <tr class="table-heading2">
               <td colspan="1" class="nob">
                 <h3>
-                  <a href="#" class="grouptrigger"
+                  <a href="#" class="grouptrigger cdash-link"
                      ng-click="jumpToAnchor('Coverage')">
                     Coverage
                   </a>
-                <a ng-if="::cdash.comparecoverage == 1" href="compareCoverage.php?project={{::cdash.projectname}}&date={{::cdash.date}}">Compare Coverage</a></h3>
+                <a class="cdash-link" ng-if="::cdash.comparecoverage == 1" href="compareCoverage.php?project={{::cdash.projectname}}&date={{::cdash.date}}">Compare Coverage</a></h3>
               </td>
               <td colspan="6" align="right" class="nob">
               </td>
@@ -261,7 +263,7 @@
               </td>
 
               <td align="center" ng-class="::{'normal': coverage.percentage >= group.thresholdgreen, 'warning': coverage.percentage < group.thresholdgreen && coverage.percentage >= group.thresholdyellow, 'error': coverage.percentage < group.thresholdyellow}">
-                <a ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
+                <a class="cdash-link" ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
                   {{::coverage.percentage}}%
                 </a>
                 <sub ng-if="::coverage.percentagediff > 0">+{{::coverage.percentagediff}}%</sub>
@@ -292,13 +294,13 @@
           <tbody ng-if="::!cdash.coveragegroups || cdash.coveragegroups.length == 0" id="coveragebody">
             <tr class="child_row" ng-repeat="coverage in cdash.coverages |orderBy:sortCoverage.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
               <td ng-if="::cdash.childview != 1" align="left" class="paddt">
-                <a ng-href="sites/{{::coverage.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+                <a class="cdash-link" ng-href="sites/{{::coverage.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
                   {{::coverage.site}}
                 </a>
               </td>
 
               <td ng-if="::cdash.childview != 1" align="left" class="paddt">
-                <a ng-href="build/{{::coverage.buildid}}">
+                <a class="cdash-link" ng-href="build/{{::coverage.buildid}}">
                   {{::coverage.buildname}}
                 </a>
               </td>
@@ -308,10 +310,10 @@
               </td>
 
               <td align="center" ng-class="::{'normal': coverage.percentage >= cdash.thresholdgreen, 'warning': coverage.percentage < cdash.thresholdgreen && coverage.percentage >= cdash.thresholdyellow, 'error': coverage.percentage < cdash.thresholdyellow}">
-                <a ng-if="::coverage.childlink" ng-href="{{::coverage.childlink}}">
+                <a class="cdash-link" ng-if="::coverage.childlink" ng-href="{{::coverage.childlink}}">
                   {{::coverage.percentage}}%
                 </a>
-                <a ng-if="::!coverage.childlink" ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
+                <a class="cdash-link" ng-if="::!coverage.childlink" ng-href="viewCoverage.php?buildid={{::coverage.buildid}}">
                   {{::coverage.percentage}}%
                 </a>
                 <sub ng-if="::coverage.percentagediff > 0">+{{::coverage.percentagediff}}%</sub>
@@ -347,13 +349,13 @@
       <!-- Dynamic analysis -->
       <div class="buildgroup"
            ng-if="::cdash.dynamicanalyses.length > 0">
-        <a id="DynamicAnalysis"></a>
+        <a class="cdash-link" id="DynamicAnalysis"></a>
         <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="dynamicanalysistable">
           <thead>
             <tr class="table-heading3">
               <td colspan="1" class="nob">
                 <h3>
-                  <a href="#" class="grouptrigger"
+                  <a href="#" class="grouptrigger cdash-link"
                      ng-click="jumpToAnchor('DynamicAnalysis')">
                     Dynamic Analysis
                   </a>
@@ -413,25 +415,25 @@
               </td>
 
               <td ng-if="::cdash.childview != 1" class="paddt" align="left">
-                <a ng-href="sites/{{::da.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
+                <a class="cdash-link" ng-href="sites/{{::da.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">
                   {{::da.site}}
                 </a>
               </td>
 
               <td ng-if="::cdash.childview != 1" class="paddt" align="left">
-                <a ng-href="build/{{::da.buildid}}">
+                <a class="cdash-link" ng-href="build/{{::da.buildid}}">
                   {{::da.buildname}}
                 </a>
               </td>
 
-              <td class="paddt" class="center-text">{{::da.checker}}</td>
+              <td class="center-text paddt cdash0link">{{::da.checker}}</td>
 
               <td class="paddt" align="center"
                   ng-class="::{'error': da.defectcount > 0, 'normal': da.defectcount < 1}">
-                <a ng-if="::da.childlink" ng-href="{{::da.childlink}}">
+                <a class="cdash-link" ng-if="::da.childlink" ng-href="{{::da.childlink}}">
                   {{::da.defectcount}}
                 </a>
-                <a ng-if="::!da.childlink" ng-href="build/{{::da.buildid}}/dynamic_analysis">
+                <a class="cdash-link" ng-if="::!da.childlink" ng-href="build/{{::da.buildid}}/dynamic_analysis">
                   {{::da.defectcount}}
                 </a>
               </td>

--- a/public/views/manageBuildGroup.html
+++ b/public/views/manageBuildGroup.html
@@ -12,22 +12,22 @@
       <div role="tabpanel" ng-if="cdash.projectid > -1">
         <ul class="nav nav-tabs" role="tablist" id="tabs">
           <li role="presentation" class="active">
-            <a href="#current" aria-controls="current" role="tab" data-toggle="tab">
+            <a class="cdash-link" href="#current" aria-controls="current" role="tab" data-toggle="tab">
               <strong>Current BuildGroups</strong>
             </a>
           </li>
           <li role="presentation">
-            <a href="#create" aria-controls="create" role="tab" data-toggle="tab">
+            <a class="cdash-link" href="#create" aria-controls="create" role="tab" data-toggle="tab">
               <strong>Create new BuildGroup</strong>
             </a>
           </li>
           <li role="presentation">
-            <a href="#wildcard" aria-controls="wildcard" role="tab" data-toggle="tab">
+            <a class="cdash-link" href="#wildcard" aria-controls="wildcard" role="tab" data-toggle="tab">
               <strong>Wildcard BuildGroups</strong>
             </a>
           </li>
           <li role="presentation">
-            <a href="#dynamic" aria-controls="dynamic" role="tab" data-toggle="tab">
+            <a class="cdash-link" href="#dynamic" aria-controls="dynamic" role="tab" data-toggle="tab">
               <strong>Dynamic BuildGroups</strong>
             </a>
           </li>

--- a/public/views/manageOverview.html
+++ b/public/views/manageOverview.html
@@ -76,7 +76,7 @@
               Drag the groups into the proper order (if necessary).
               Once you are satisfied, click the "Save Layout" button.
             </p>
-            <a ng-href="overview.php?project={{cdash.projectname_encoded}}">
+            <a class="cdash-link" ng-href="overview.php?project={{cdash.projectname_encoded}}">
               Go to overview
             </a>
           </div>

--- a/public/views/manageSubProject.html
+++ b/public/views/manageSubProject.html
@@ -14,13 +14,13 @@
       <div role="tabpanel" ng-if="cdash.projectid > -1">
         <ul class="nav nav-tabs" role="tablist" id="tabs">
           <li role="presentation" class="active">
-            <a href="#current" aria-controls="current" role="tab" data-toggle="tab">Current SubProjects</a>
+            <a class="cdash-link" href="#current" aria-controls="current" role="tab" data-toggle="tab">Current SubProjects</a>
           </li>
           <li role="presentation">
-            <a href="#add" aria-controls="add" role="tab" data-toggle="tab">Add a SubProject</a>
+            <a class="cdash-link" href="#add" aria-controls="add" role="tab" data-toggle="tab">Add a SubProject</a>
           </li>
           <li role="presentation">
-            <a href="#groups" aria-controls="groups" role="tab" data-toggle="tab">SubProject Groups</a>
+            <a class="cdash-link" href="#groups" aria-controls="groups" role="tab" data-toggle="tab">SubProject Groups</a>
           </li>
         </ul>
 

--- a/public/views/overview.html
+++ b/public/views/overview.html
@@ -1,5 +1,5 @@
 <div class="h4">
-  <a id="build" ng-click="jumpToAnchor('build')">
+  <a class="cdash-link" id="build" ng-click="jumpToAnchor('build')">
     Configure / Build / Test
   </a>
 </div>
@@ -37,7 +37,7 @@
 
 <div ng-if="cdash.coverages.length > 0">
   <div class="h4">
-    <a id="coverage" ng-click="jumpToAnchor('coverage')">
+    <a class="cdash-link" id="coverage" ng-click="jumpToAnchor('coverage')">
       Coverage
     </a>
   </div>
@@ -79,7 +79,7 @@
 
 <div ng-if="cdash.dynamicanalyses.length > 0">
   <div class="h4">
-    <a id="dynamic" ng-click="jumpToAnchor('dynamic')">
+    <a class="cdash-link" id="dynamic" ng-click="jumpToAnchor('dynamic')">
       Dynamic Analysis
     </a>
   </div>
@@ -110,7 +110,7 @@
 
 <div ng-if="cdash.staticanalyses.length > 0">
   <div class="h4">
-    <a id="static" ng-click="jumpToAnchor('static')">
+    <a class="cdash-link" id="static" ng-click="jumpToAnchor('static')">
       Static Analysis
     </a>
   </div>

--- a/public/views/partials/build.html
+++ b/public/views/partials/build.html
@@ -1,17 +1,18 @@
 <!-- For child view, display the label(s) as a link to the build summary -->
 <td ng-if="::cdash.childview == 1" align="left" class="paddt" colspan="2">
-  <a ng-href="build/{{::build.id}}">
+  <a class="cdash-link" ng-href="build/{{::build.id}}">
     {{::build.label}}
   </a>
 
   <!-- Icon for build errors / test failing -->
-  <a ng-if="::build.compilation.error > 0 || build.test.fail > 0" href=""
+  <a class="cdash-link" ng-if="::build.compilation.error > 0 || build.test.fail > 0" href=""
      ng-click="toggleBuildProblems(build)">
     <img src="img/Info.png" alt="info" class="icon"></img>
   </a>
 
   <!-- Link to notes specific to this subproject build -->
-  <a title="View notes"
+  <a class="cdash-link"
+     title="View notes"
      name="notesLink"
      ng-if="::build.notes > 0"
      ng-href="build/{{::build.id}}/notes">
@@ -21,7 +22,7 @@
 
 <!-- Otherwise, show build name & site on the row. -->
 <td ng-if="::cdash.childview != 1" align="left" class="paddt">
-  <a ng-href="sites/{{::build.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">{{::build.site}}</a>
+  <a class="cdash-link" ng-href="sites/{{::build.siteid}}?project={{::cdash.projectid}}&currenttime={{::cdash.unixtimestamp}}">{{::build.site}}</a>
   <img ng-if="::build.siteoutoforder == 1" border="0" src="img/flag.png" title="flag"></img>
 </td>
 
@@ -31,12 +32,12 @@
   </div>
 
   <div ng-if="::build.id" style="float: left; margin: 0px 4px;">
-    <a class="buildinfo" alt="generator"
+    <a class="buildinfo cdash-link" alt="generator"
        ng-if="::build.numchildren == 0"
        ng-href="build/{{::build.id}}">
       {{::build.buildname}}
     </a>
-    <a class="buildinfo" alt="generator"
+    <a class="buildinfo cdash-link" alt="generator"
        ng-if="::build.numchildren > 0"
        ng-href="{{::build.multiplebuildshyperlink}}">
       {{::build.buildname}}
@@ -46,14 +47,16 @@
   <div ng-if="::!build.id" style="float: left; margin: 0px 4px;">{{::build.buildname}}</div>
 
   <div style="float:left;">
-    <a title="View notes"
+    <a class="cdash-link"
+       title="View notes"
        name="notesLink"
        ng-if="::build.notes > 0"
        ng-href="build/{{::build.id}}/notes">
       <img src="img/document.png" alt="Notes" class="icon"/>
     </a>
 
-    <a href="" style="float: left;"
+    <a class="cdash-link"
+       href="" style="float: left;"
        ng-if="::build.uploadfilecount > 0"
        ng-href="build/{{::build.id}}/files"
        title="{{::build.uploadfilecount}} files uploaded with this build">
@@ -61,21 +64,23 @@
     </a>
 
     <!-- If the build has errors or test failing -->
-    <a href="" style="float: left;"
+    <a class="cdash-link"
+       href="" style="float: left;"
        ng-if="::build.compilation.error > 0 || build.test.fail > 0"
        ng-click="toggleBuildProblems(build)">
       <img src="img/Info.png" alt="info" class="icon"></img>
     </a>
 
     <!-- If the build is expected and missing -->
-    <a href="" style="float: left;"
+    <a class="cdash-link"
+       href="" style="float: left;"
        ng-if="::build.expectedandmissing == 1"
        ng-click="toggleExpectedInfo(build)">
       <img src="img/Info.png" alt="info" class="icon"></img>
     </a>
 
     <!-- Display the note icon -->
-    <a name="Build Notes" id="buildnote_{{::build.id}}"
+    <a class="cdash-link" name="Build Notes" id="buildnote_{{::build.id}}"
        ng-if="::build.buildnotes > 0"
        ng-href="ajax/buildnote.php?buildid={{::build.id}}">
       <img src="img/note.png" alt="note" class="icon"></img>
@@ -83,7 +88,7 @@
 
     <div style="float: left;" ng-if="::cdash.user.admin == 1">
       <!-- Display folder icon to edit this build for administrative users -->
-      <a href="" ng-click="toggleAdminOptions(build)">
+      <a class="cdash-link" href="" ng-click="toggleAdminOptions(build)">
         <img name="adminoptions" src="img/folder.png" class="icon"/>
       </a>
       <img src="img/loading.gif" ng-if="build.loading == 1"/>
@@ -99,7 +104,7 @@
             <font size="2">
               Build has been failing since
               <b>
-                <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.failingDate}}">
+                <a class="cdash-link" ng-href="index.php?project={{::cdash.projectname}}&date={{::build.failingDate}}">
                   {{::build.failingSince}}
                 </a>
                 (<ng-pluralize count="::build.daysWithErrors"
@@ -116,7 +121,7 @@
             <font size="2">
               Tests have been failing since
               <b>
-                <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.testsFailingDate}}">
+                <a class="cdash-link" ng-href="index.php?project={{::cdash.projectname}}&date={{::build.testsFailingDate}}">
                   {{::build.testsFailingSince}}
                 </a>
                 (<ng-pluralize count="::build.daysWithFailingTests"
@@ -145,7 +150,7 @@
               <span ng-if="::build.lastSubmission != -1">
                 This build has not submitted since
                   <b>
-                    <a ng-href="index.php?project={{::cdash.projectname}}&date={{::build.lastSubmissionDate}}">
+                    <a class="cdash-link" ng-href="index.php?project={{::cdash.projectname}}&date={{::build.lastSubmissionDate}}">
                       {{::build.lastSubmission}}
                     </a>
                 (<ng-pluralize count="::build.daysSinceLastBuild"
@@ -170,10 +175,10 @@
             <b>{{::group.name}}</b>:
           </td>
           <td ng-if="::group.name == buildgroup.name" colspan="2">
-            <a ng-if="build.expected == 0" href="" ng-click="toggleExpected(build, group.id)">
+            <a class="cdash-link" ng-if="build.expected == 0" href="" ng-click="toggleExpected(build, group.id)">
               [mark as expected]
             </a>
-            <a ng-if="build.expected == 1 || build.expectedandmissing == 1" href="" ng-click="toggleExpected(build, group.id)">
+            <a class="cdash-link" ng-if="build.expected == 1 || build.expectedandmissing == 1" href="" ng-click="toggleExpected(build, group.id)">
               [mark as non expected]
             </a>
           </td>
@@ -181,12 +186,12 @@
             <input type="checkbox" ng-model="build.expected" ng-true-value="'1'" ng-false-value="'0'"> expected</input>
           </td>
           <td ng-if="::group.name != buildgroup.name" class="nob">
-            <a href="" ng-click="moveToGroup(build, group.id)"> [move to group] </a>
+            <a class="cdash-link" href="" ng-click="moveToGroup(build, group.id)"> [move to group] </a>
           </td>
         </tr>
         <tr>
           <td colspan="3" class="nob">
-            <a href="" ng-click="showModal(build)"> [remove this build] </a>
+            <a class="cdash-link" href="" ng-click="showModal(build)"> [remove this build] </a>
           </td>
         </tr>
       </table>
@@ -195,10 +200,10 @@
            tooltip-append-to-body="true"
            uib-tooltip="Done builds will be overwritten if a new one is submitted with the same site, build name, and timestamp."
       >
-        <a ng-if="build.done == 0" href="" ng-click="toggleDone(build)">
+        <a class="cdash-link" ng-if="build.done == 0" href="" ng-click="toggleDone(build)">
           [mark as done]
         </a>
-        <a ng-if="build.done == 1" href="" ng-click="toggleDone(build)">
+        <a class="cdash-link" ng-if="build.done == 1" href="" ng-click="toggleDone(build)">
           [mark as not done]
         </a>
       </div>
@@ -207,7 +212,7 @@
 
   <!-- changeid link/icon -->
   <div ng-if="::build.changelink">
-    <a target="_blank" ng-href="{{::build.changelink}}">
+    <a class="cdash-link" target="_blank" ng-href="{{::build.changelink}}">
       <img class="smallicon" ng-src="{{::build.changeicon}}"/>
     </a>
   </div>
@@ -220,7 +225,7 @@
                 build.update.warning == 1 ? 'warning' : 'normal'))">
   <div ng-if="::build.hasupdate">
     <img ng-if="::build.userupdates > 0" src="img/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/>
-    <a ng-href="build/{{::build.id}}/update">
+    <a class="cdash-link" ng-href="build/{{::build.id}}/update">
       {{::build.update.files}}
     </a>
   </div>
@@ -235,7 +240,7 @@
 
 <td ng-if="::buildgroup.hasconfiguredata" align="center" ng-class="::{'error': build.configure.error > 0, 'normal': build.configure.error == 0}">
   <div ng-if="::build.hasconfigure">
-    <a ng-href="build/{{::build.id}}/configure">
+    <a class="cdash-link" ng-href="build/{{::build.id}}/configure">
       {{::build.configure.error}}
     </a>
   </div>
@@ -243,7 +248,7 @@
 
 <td ng-if="::buildgroup.hasconfiguredata" align="center" ng-class="::{'warning': build.configure.warning > 0, 'normal': build.configure.warning == 0}">
   <div ng-if="::build.hasconfigure">
-    <a ng-href="build/{{::build.id}}/configure">
+    <a class="cdash-link" ng-href="build/{{::build.id}}/configure">
       {{::build.configure.warning}}
     </a>
     <sub ng-if="::build.configure.warningdiff > 0">+{{::build.configure.warningdiff}}</sub>
@@ -261,14 +266,14 @@
 <td ng-if="::buildgroup.hascompilationdata" align="center" ng-class="::{'error': build.compilation.error > 0, 'normal': build.compilation.error == 0}">
   <div ng-if="::build.hascompilation"
        ng-class="::{'valuewithsub': build.compilation.nerrordiffp > 0 || build.compilation.nerrordiffn > 0}">
-    <a ng-href="viewBuildError.php?buildid={{::build.id}}">
+    <a class="cdash-link" ng-href="viewBuildError.php?buildid={{::build.id}}">
       {{::build.compilation.error}}
     </a>
-    <a ng-if="::build.compilation.nerrordiffp > 0" class="sup" ng-href="viewBuildError.php?onlydeltap&buildid={{::build.id}}">
+    <a ng-if="::build.compilation.nerrordiffp > 0" class="sup cdash-link" ng-href="viewBuildError.php?onlydeltap&buildid={{::build.id}}">
       +{{::build.compilation.nerrordiffp}}
     </a>
 
-    <a ng-if="::build.compilation.nerrordiffn > 0" ng-href="viewBuildError.php?onlydeltan&buildid={{::build.id}}">
+    <a class="cdash-link" ng-if="::build.compilation.nerrordiffn > 0" ng-href="viewBuildError.php?onlydeltan&buildid={{::build.id}}">
       <span class="sub">-{{::build.compilation.nerrordiffn}}</span>
     </a>
   </div>
@@ -277,14 +282,14 @@
 <td ng-if="::buildgroup.hascompilationdata" align="center" ng-class="::{'warning': build.compilation.warning > 0, 'normal': build.compilation.warning == 0}">
   <div ng-if="::build.hascompilation"
        ng-class="::{'valuewithsub': build.compilation.nwarningdiffp > 0 || build.compilation.nwarningdiffn > 0}">
-    <a ng-href="viewBuildError.php?type=1&buildid={{::build.id}}">
+    <a class="cdash-link" ng-href="viewBuildError.php?type=1&buildid={{::build.id}}">
       {{::build.compilation.warning}}
     </a>
 
-    <a ng-if="::build.compilation.nwarningdiffp > 0" class="sup" ng-href="viewBuildError.php?type=1&onlydeltap&buildid={{::build.id}}">
+    <a ng-if="::build.compilation.nwarningdiffp > 0" class="sup cdash-link" ng-href="viewBuildError.php?type=1&onlydeltap&buildid={{::build.id}}">
       +{{::build.compilation.nwarningdiffp}}
     </a>
-    <a ng-if="::build.compilation.nwarningdiffn > 0" ng-href="viewBuildError.php?type=1&onlydeltan&buildid={{::build.id}}">
+    <a class="cdash-link" ng-if="::build.compilation.nwarningdiffn > 0" ng-href="viewBuildError.php?type=1&onlydeltan&buildid={{::build.id}}">
       <span class="sub">-{{::build.compilation.nwarningdiffn}}</span>
     </a>
   </div>
@@ -300,10 +305,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'warning': build.test.notrun > 0, 'normal': build.test.notrun == 0}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.nnotrundiffp > 0 || build.test.nnotrundiffn > 0}">
-    <a ng-href="viewTest.php?onlynotrun&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a class="cdash-link" ng-href="viewTest.php?onlynotrun&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       {{::build.test.notrun}}
     </a>
-    <a ng-if="::build.test.nnotrundiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.nnotrundiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       +{{::build.test.nnotrundiffp}}
     </a>
     <span ng-if="::build.test.nnotrundiffn > 0" class="sub">-{{::build.test.nnotrundiffn}}</span>
@@ -313,10 +318,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'error': build.test.fail > 0, 'normal': build.test.fail < 1}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.nfaildiffp > 0 || build.test.nfaildiffn > 0}">
-    <a ng-href="viewTest.php?onlyfailed&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a class="cdash-link" ng-href="viewTest.php?onlyfailed&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       {{::build.test.fail}}
     </a>
-    <a ng-if="::build.test.nfaildiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.nfaildiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       +{{::build.test.nfaildiffp}}
     </a>
     <span ng-if="::build.test.nfaildiffn > 0" class="sub">
@@ -328,10 +333,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'normal': build.test.pass > -1}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.npassdiffp > 0 || build.test.npassdiffn > 0}">
-    <a ng-href="viewTest.php?onlypassed&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a class="cdash-link" ng-href="viewTest.php?onlypassed&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       {{::build.test.pass}}
     </a>
-    <a ng-if="::build.test.npassdiffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.npassdiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
       +{{::build.test.npassdiffp}}
     </a>
 
@@ -347,10 +352,10 @@
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.build.test.ntimediffp > 0 || build.test.ntimediffn > 0}">
     <div ng-if="::build.test.timestatus > 0">
-      <a ng-href="viewTest.php?onlytimestatus&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+      <a class="cdash-link" ng-href="viewTest.php?onlytimestatus&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
         {{::build.test.timestatus}}
       </a>
-      <a ng-if="::build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">
@@ -360,7 +365,7 @@
 
     <span ng-if="::build.test.timestatus">
       {{::build.test.time}}
-      <a ng-if="::build.test.ntimediffp > 0" class="sup" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">

--- a/public/views/partials/buildError.html
+++ b/public/views/partials/buildError.html
@@ -26,7 +26,7 @@
       <span class="nobr"> Repository </span>
     </th>
     <td>
-      <a href="{{cdash.cvsurl}}">
+      <a class="cdash-link" href="{{cdash.cvsurl}}">
         {{cdash.cvsurl}}
       </a>
     </td>

--- a/public/views/partials/buildgroup.html
+++ b/public/views/partials/buildgroup.html
@@ -1,10 +1,10 @@
 <h3 class="buildgroupname">
-  <a href="#" class="grouptrigger"
+  <a href="#" class="grouptrigger cdash-link"
      ng-click="jumpToAnchor(buildgroup.linkname)">
     {{::buildgroup.name}}
   </a>
   <span class="buildnums" align="right">{{::buildgroup.numbuildslabel}}</span>
-  <a class="grouplink"
+  <a class="grouplink cdash-link"
      ng-href="viewBuildGroup.php?project={{::cdash.projectname_encoded}}&buildgroup={{::buildgroup.linkname}}&date={{::cdash.date}}&{{::cdash.filterurl}}">[view timeline]</a>
 </h3>
 <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb" id="project_{{::cdash.projectid}}_{{::buildgroup.id}}">

--- a/public/views/partials/filterdataTemplate.html
+++ b/public/views/partials/filterdataTemplate.html
@@ -2,7 +2,8 @@
 
   <div ng-hide="showfilters == 0">
     <div class="table-heading0">
-      <a ng-href="http://public.kitware.com/Wiki/CDash:Documentation#Filters_on_{{cdash.page}}"
+      <a class="cdash-link"
+         ng-href="http://public.kitware.com/Wiki/CDash:Documentation#Filters_on_{{cdash.page}}"
          target="_blank"
          style="float: right;">Help</a>
       <h3>Filters</h3>

--- a/public/views/partials/subProjectTable.html
+++ b/public/views/partials/subProjectTable.html
@@ -72,7 +72,7 @@
   <tbody>
     <tr ng-repeat="subproject in cdash.subprojects |orderBy:sortSubProjects.orderByFields|showEmptySubProjectsLast:sortSubProjects.orderByFields" ng-class-odd="'odd'" ng-class-even="'even'">
       <td align="center" >
-        <a ng-href="index.php?subproject={{subproject.name_encoded}}&project={{::cdash.projectname_encoded}}&date={{::cdash.date}}">
+        <a class="cdash-link" ng-href="index.php?subproject={{subproject.name_encoded}}&project={{::cdash.projectname_encoded}}&date={{::cdash.date}}">
           {{subproject.name}}
         </a>
       </td>

--- a/public/views/queryTests.html
+++ b/public/views/queryTests.html
@@ -2,11 +2,11 @@
 
 <!-- Filters -->
 <div id="labelshowfilters">
-  <a id="label_showfilters" ng-click="showfilters_toggle()">
+  <a class="cdash-link" id="label_showfilters" ng-click="showfilters_toggle()">
     <span ng-show="showfilters == 0">Show Filters</span>
     <span ng-show="showfilters != 0">Hide Filters</span>
   </a>
-  <a ng-if="::cdash.filterontestoutput"
+  <a class="cdash-link" ng-if="::cdash.filterontestoutput"
      ng-click="toggleShowMatchingOutput()">
     <span ng-show="!cdash.showmatchingoutput">Show Matching Output</span>
     <span ng-show="cdash.showmatchingoutput">Hide Matching Output</span>
@@ -111,11 +111,11 @@
       ng-class-odd="'odd'"
       ng-class-even="'even'">
     <td>
-      <a href="{{build.siteLink}}">{{build.site}}</a>
+      <a class="cdash-link" href="{{build.siteLink}}">{{build.site}}</a>
     </td>
 
     <td>
-      <a href="{{build.buildSummaryLink}}">{{build.buildName}}</a>
+      <a class="cdash-link" href="{{build.buildSummaryLink}}">{{build.buildName}}</a>
     </td>
 
     <td>
@@ -123,11 +123,11 @@
     </td>
 
     <td align="center" ng-class="build.statusclass">
-      <a href="{{build.testDetailsLink}}">{{build.status}}</a>
+      <a class="cdash-link" href="{{build.testDetailsLink}}">{{build.status}}</a>
     </td>
 
     <td ng-if="cdash.project.showtesttime == 1" align="center" ng-class="build.timestatusclass">
-      <a href="{{build.testDetailsLink}}">{{build.timestatus}}</a>
+      <a class="cdash-link" href="{{build.testDetailsLink}}">{{build.timestatus}}</a>
     </td>
 
     <td>

--- a/public/views/testOverview.html
+++ b/public/views/testOverview.html
@@ -6,7 +6,7 @@
       <div class="pad4">
         <!-- Filters -->
         <div id="labelshowfilters">
-          <a id="label_showfilters" ng-click="showfilters_toggle()">
+          <a class="cdash-link" id="label_showfilters" ng-click="showfilters_toggle()">
             <span ng-show="showfilters == 0">Show Filters</span>
             <span ng-show="showfilters != 0">Hide Filters</span>
           </a>
@@ -104,7 +104,7 @@
                 {{::test.subproject}}
               </td>
               <td>
-                <a ng-href="{{::test.link}}">
+                <a class="cdash-link" ng-href="{{::test.link}}">
                   {{::test.name}}
                 </a>
               </td>

--- a/public/views/testSummary.html
+++ b/public/views/testSummary.html
@@ -6,11 +6,11 @@
       </h4>
 
       <!-- Failure Graph -->
-      <a ng-click="toggleGraph()" id="GraphLink" data-cy="toggle-plot">
+      <a class="cdash-link" ng-click="toggleGraph()" id="GraphLink" data-cy="toggle-plot">
         {{ showgraph ? 'Hide Test Failure Trend' : 'Show Test Failure Trend' }}
       </a>
       <div ng-show="showgraph" id="TestFailureGraph" data-cy="plot-wrapper">
-        <a ng-click="resetZoom()" data-cy="reset-plot">Reset zoom</a>
+        <a class="cdash-link" ng-click="resetZoom()" data-cy="reset-plot">Reset zoom</a>
         <div id="testfailuregraphoptions"></div>
         <div id="testfailuregraph">
           <ng-include src="graphurl"></ng-include>
@@ -21,7 +21,7 @@
       </div>
 
       <br/>
-      <a ng-href="{{::cdash.csvlink}}" data-cy="download-as-csv">Download Table as CSV File</a>
+      <a class="cdash-link" ng-href="{{::cdash.csvlink}}" data-cy="download-as-csv">Download Table as CSV File</a>
       <br/>
 
       <!-- Test Summary table -->
@@ -79,7 +79,7 @@
           </td>
 
           <td>
-            <a ng-href="{{::build.buildLink}}">
+            <a class="cdash-link" ng-href="{{::build.buildLink}}">
               {{::build.buildName}}
             </a>
           </td>
@@ -89,7 +89,7 @@
           </td>
 
           <td ng-class="::build.statusclass">
-            <a ng-href="{{::build.testLink}}">
+            <a class="cdash-link" ng-href="{{::build.testLink}}">
               {{::build.status}}
             </a>
           </td>
@@ -103,7 +103,7 @@
           </td>
 
           <td>
-            <a ng-href="{{::build.update.revisionurl}}">
+            <a class="cdash-link" ng-href="{{::build.update.revisionurl}}">
               {{::build.update.revision}}
             </a>
           </td>

--- a/public/views/viewBuildError.html
+++ b/public/views/viewBuildError.html
@@ -2,7 +2,7 @@
         <tr>
           <td align="left">
             <b>Site: </b>
-            <a href="sites/{{cdash.build.siteid}}">
+            <a class="cdash-link" href="sites/{{cdash.build.siteid}}">
               {{cdash.build.site}}
             </a>
           </td>
@@ -38,7 +38,7 @@
         </tr>
         <tr>
           <td align="left">
-            <a href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
+            <a class="cdash-link" href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
               {{cdash.nonerrortypename}}s are here.
             </a>
           </td>
@@ -64,7 +64,7 @@
           <tr ng-repeat="error in pagination.buildErrors">
             <td style="vertical-align:top">{{error.subprojectname}}</td>
             <td>
-              <a href="#" ng-click="showErrors = !showErrors">
+              <a class="cdash-link" href="#" ng-click="showErrors = !showErrors">
                 Error building {{error.outputfile}}
               </a>
               <div ng-hide="!showErrors">

--- a/public/views/viewDynamicAnalysisFile.html
+++ b/public/views/viewDynamicAnalysisFile.html
@@ -20,7 +20,7 @@
   </tr>
 </table>
 
-<a ng-href="{{::cdash.dynamicanalysis.href}}">
+<a class="cdash-link" ng-href="{{::cdash.dynamicanalysis.href}}">
   {{::cdash.dynamicanalysis.filename}}
 </a>
 

--- a/public/views/viewSubProjects.html
+++ b/public/views/viewSubProjects.html
@@ -41,10 +41,10 @@
         <tr class="treven">
 
           <td align="center">
-            <a ng-href="index.php?{{cdash.linkparams}}">
+            <a class="cdash-link" ng-href="index.php?{{cdash.linkparams}}">
               {{cdash.projectname}}
             </a>
-            <a ng-href="index.php?{{cdash.linkparams}}&showfilters=1">
+            <a class="cdash-link" ng-href="index.php?{{cdash.linkparams}}&showfilters=1">
               <img border="0" src="img/filter.gif"/>
             </a>
           </td>
@@ -121,6 +121,6 @@
 
       <br/>
 
-      <a ng-href="projects/{{cdash.projectname_encoded}}/subprojects/dependencies{{cdash.linkdate ? '?'+cdash.linkdate : ''}}">
+      <a class="cdash-link" ng-href="projects/{{cdash.projectname_encoded}}/subprojects/dependencies{{cdash.linkdate ? '?'+cdash.linkdate : ''}}">
         [SubProject Dependencies]
       </a>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -94,6 +94,11 @@ const apolloClient = new ApolloClient({
           projects: relayStylePagination(),
         },
       },
+      Build: {
+        fields: {
+          tests: relayStylePagination(),
+        },
+      },
     },
   }),
   uri: `${app.config.globalProperties.$baseURL}/graphql`,

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,6 +30,7 @@ import HeaderLogo from './components/page-header/HeaderLogo.vue';
 import ViewDynamicAnalysis from './components/ViewDynamicAnalysis.vue';
 import AllProjects from './components/AllProjects.vue';
 import SubProjectDependencies from './components/SubProjectDependencies.vue';
+import BuildTestsPage from './components/BuildTestsPage.vue';
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import * as FA from '@fortawesome/fontawesome-svg-core';
@@ -58,6 +59,7 @@ const cdash_components = {
   ViewDynamicAnalysis,
   AllProjects,
   SubProjectDependencies,
+  BuildTestsPage,
 };
 
 /**

--- a/resources/js/components/BuildConfigure.vue
+++ b/resources/js/components/BuildConfigure.vue
@@ -15,7 +15,7 @@
         <tr>
           <td align="left">
             <b>Site: </b>
-            <a :href="$baseURL + '/sites/' + cdash.build.siteid">
+            <a class="cdash-link" :href="$baseURL + '/sites/' + cdash.build.siteid">
               {{ cdash.build.site }}
             </a>
           </td>
@@ -23,7 +23,7 @@
         <tr>
           <td align="left">
             <b>Build: </b>
-            <a :href="$baseURL + '/build/' + buildid">
+            <a class="cdash-link" :href="$baseURL + '/build/' + buildid">
               {{ cdash.build.buildname }}
             </a>
           </td>
@@ -96,7 +96,7 @@
               {{ configure.configurewarnings }}
             </td>
             <td>
-              <a :click="configure.show = !configure.show">
+              <a class="cdash-link" :click="configure.show = !configure.show">
                 <span v-show="!configure.show">View</span>
                 <span v-show="configure.show">Hide</span>
               </a>
@@ -111,7 +111,7 @@
                 <tr>
                   <td align="left">
                     <b>Site: </b>
-                    <a :href="$baseURL + '/sites/' + cdash.build.siteid">
+                    <a class="cdash-link" :href="$baseURL + '/sites/' + cdash.build.siteid">
                       {{ cdash.build.site }}
                     </a>
                   </td>

--- a/resources/js/components/BuildNotes.vue
+++ b/resources/js/components/BuildNotes.vue
@@ -12,7 +12,7 @@
         <tr>
           <td align="left">
             <b>Site: </b>
-            <a :href="$baseURL + '/sites/' + cdash.build.siteid">
+            <a class="cdash-link" :href="$baseURL + '/sites/' + cdash.build.siteid">
               {{ cdash.build.site }}
             </a>
           </td>
@@ -20,7 +20,7 @@
         <tr>
           <td align="left">
             <b>Build: </b>
-            <a :href="$baseURL + '/build/' + cdash.build.buildid">
+            <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.buildid">
               {{ cdash.build.buildname }}
             </a>
           </td>

--- a/resources/js/components/BuildSummary.vue
+++ b/resources/js/components/BuildSummary.vue
@@ -9,7 +9,7 @@
     <div v-else>
       <!-- Display link to create bug tracker issue if supported. -->
       <div v-if="cdash.newissueurl">
-        <a :href="cdash.newissueurl">
+        <a class="cdash-link" :href="cdash.newissueurl">
           <b>Create {{ cdash.bugtracker }} issue for this build</b>
         </a>
         <br>
@@ -49,7 +49,7 @@
             <td style="white-space: nowrap;">
               {{ cdash.build.name }}
               <span v-if="cdash.build.note">
-                (<a :href="$baseURL + '/build/' + cdash.build.id + '/notes'">view notes</a>)
+                (<a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.id + '/notes'">view notes</a>)
               </span>
             </td>
           </tr>
@@ -148,7 +148,7 @@
               Last submission:
             </th>
             <td>
-              <a :href="$baseURL + '/build/' + cdash.build.lastsubmitbuild">
+              <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.lastsubmitbuild">
                 {{ cdash.build.lastsubmitdate }}
               </a>
             </td>
@@ -172,7 +172,7 @@
                     colspan="3"
                     class="header"
                   >
-                    <a :href="$baseURL + '/build/' + cdash.previousbuild.buildid">
+                    <a class="cdash-link" :href="$baseURL + '/build/' + cdash.previousbuild.buildid">
                       <b>Previous Build</b>
                     </a>
                   </th>
@@ -193,7 +193,7 @@
                     :class="cdash.previousbuild.nupdateerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/update'">
                         {{ cdash.previousbuild.nupdateerrors }}
                       </a>
                     </b>
@@ -203,7 +203,7 @@
                     :class="cdash.previousbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/update'">
                         {{ cdash.previousbuild.nupdatewarnings }}
                       </a>
                     </b>
@@ -219,7 +219,7 @@
                     :class="cdash.previousbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/configure'">
                         {{ cdash.previousbuild.nconfigureerrors }}
                       </a>
                     </b>
@@ -229,7 +229,7 @@
                     :class="cdash.previousbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.previousbuild.buildid + '/configure'">
                         {{ cdash.previousbuild.nconfigurewarnings }}
                       </a>
                     </b>
@@ -245,7 +245,7 @@
                     :class="cdash.previousbuild.nerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.previousbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.previousbuild.buildid">
                         {{ cdash.previousbuild.nerrors }}
                       </a>
                     </b>
@@ -255,7 +255,7 @@
                     :class="cdash.previousbuild.nwarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.previousbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.previousbuild.buildid">
                         {{ cdash.previousbuild.nwarnings }}
                       </a>
                     </b>
@@ -271,7 +271,7 @@
                     :class="cdash.previousbuild.ntestfailed > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.previousbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.previousbuild.buildid">
                         {{ cdash.previousbuild.ntestfailed }}
                       </a>
                     </b>
@@ -281,7 +281,7 @@
                     :class="cdash.previousbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.previousbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.previousbuild.buildid">
                         {{ cdash.previousbuild.ntestnotrun }}
                       </a>
                     </b>
@@ -331,7 +331,7 @@
                     :class="cdash.update.nerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.build.id + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.id + '/update'">
                         {{ cdash.update.nerrors }}
                       </a>
                     </b>
@@ -341,7 +341,7 @@
                     :class="cdash.update.nwarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.build.id + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.id + '/update'">
                         {{ cdash.update.nwarnings }}
                       </a>
                     </b>
@@ -349,7 +349,7 @@
                 </tr>
                 <tr v-if="cdash.hasconfigure">
                   <th>
-                    <a href="#Configure">
+                    <a class="cdash-link" href="#Configure">
                       <b>Configure</b>
                     </a>
                   </th>
@@ -358,7 +358,7 @@
                     :class="cdash.configure.nerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.build.id + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.id + '/configure'">
                         {{ cdash.configure.nerrors }}
                       </a>
                     </b>
@@ -368,7 +368,7 @@
                     :class="cdash.configure.nwarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.build.id + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.build.id + '/configure'">
                         {{ cdash.configure.nwarnings }}
                       </a>
                     </b>
@@ -376,7 +376,7 @@
                 </tr>
                 <tr>
                   <th>
-                    <a href="#Build">
+                    <a class="cdash-link" href="#Build">
                       <b>Build</b>
                     </a>
                   </th>
@@ -385,7 +385,7 @@
                     :class="cdash.build.nerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.build.id">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.build.id">
                         {{ cdash.build.nerrors }}
                       </a>
                     </b>
@@ -395,7 +395,7 @@
                     :class="cdash.build.nwarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.build.id">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.build.id">
                         {{ cdash.build.nwarnings }}
                       </a>
                     </b>
@@ -403,7 +403,7 @@
                 </tr>
                 <tr>
                   <th>
-                    <a href="#Test">
+                    <a class="cdash-link" href="#Test">
                       <b>Test</b>
                     </a>
                   </th>
@@ -412,7 +412,7 @@
                     :class="cdash.test.nfailed > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.build.id">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.build.id">
                         {{ cdash.test.nfailed }}
                       </a>
                     </b>
@@ -422,7 +422,7 @@
                     :class="cdash.test.nnotrun > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.build.id">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.build.id">
                         {{ cdash.test.nnotrun }}
                       </a>
                     </b>
@@ -446,7 +446,7 @@
                     colspan="3"
                     class="header"
                   >
-                    <a :href="$baseURL + '/build/' + cdash.nextbuild.buildid">
+                    <a class="cdash-link" :href="$baseURL + '/build/' + cdash.nextbuild.buildid">
                       <b>Next Build</b>
                     </a>
                   </th>
@@ -467,7 +467,7 @@
                     :class="cdash.nextbuild.nupdateerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/update'">
                         {{ cdash.nextbuild.nupdateerrors }}
                       </a>
                     </b>
@@ -477,7 +477,7 @@
                     :class="cdash.nextbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/update'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/update'">
                         {{ cdash.nextbuild.nupdatewarnings }}
                       </a>
                     </b>
@@ -493,7 +493,7 @@
                     :class="cdash.nextbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/configure'">
                         {{ cdash.nextbuild.nconfigureerrors }}
                       </a>
                     </b>
@@ -503,7 +503,7 @@
                     :class="cdash.nextbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/configure'">
+                      <a class="cdash-link" :href="$baseURL + '/build/' + cdash.nextbuild.buildid + '/configure'">
                         {{ cdash.nextbuild.nconfigurewarnings }}
                       </a>
                     </b>
@@ -519,7 +519,7 @@
                     :class="cdash.nextbuild.nerrors > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.nextbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?buildid=' + cdash.nextbuild.buildid">
                         {{ cdash.nextbuild.nerrors }}
                       </a>
                     </b>
@@ -529,7 +529,7 @@
                     :class="cdash.nextbuild.nwarnings > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.nextbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewBuildError.php?type=1&buildid=' + cdash.nextbuild.buildid">
                         {{ cdash.nextbuild.nwarnings }}
                       </a>
                     </b>
@@ -545,7 +545,7 @@
                     :class="cdash.nextbuild.ntestfailed > 0 ? 'error' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.nextbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlyfailed&buildid=' + cdash.nextbuild.buildid">
                         {{ cdash.nextbuild.ntestfailed }}
                       </a>
                     </b>
@@ -555,7 +555,7 @@
                     :class="cdash.nextbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
                   >
                     <b>
-                      <a :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.nextbuild.buildid">
+                      <a class="cdash-link" :href="$baseURL + '/viewTest.php?onlynotrun&buildid=' + cdash.nextbuild.buildid">
                         {{ cdash.nextbuild.ntestnotrun }}
                       </a>
                     </b>
@@ -632,7 +632,7 @@
               :class="{'even': index % 2 === 0, 'odd': index % 2 !== 0 }"
             >
               <td>
-                <a :href="$baseURL + '/build/' + build.id">
+                <a class="cdash-link" :href="$baseURL + '/build/' + build.id">
                   {{ build.starttime }}
                 </a>
               </td>
@@ -847,13 +847,13 @@
           v-for="from in cdash.relationships_from"
           :key="from.relatedid"
         >
-          This build {{ from.relationship }} <a :href="$baseURL + '/build/' + from.relatedid">{{ from.name }}</a>.
+          This build {{ from.relationship }} <a class="cdash-link" :href="$baseURL + '/build/' + from.relatedid">{{ from.name }}</a>.
         </div>
         <div
           v-for="to in cdash.relationships_to"
           :key="to.buildid"
         >
-          <a :href="$baseURL + '/build/' + to.buildid">{{ to.name }}</a> {{ to.relationship }} this build.
+          <a class="cdash-link" :href="$baseURL + '/build/' + to.buildid">{{ to.name }}</a> {{ to.relationship }} this build.
         </div>
       </div>
 

--- a/resources/js/components/BuildTestsPage.vue
+++ b/resources/js/components/BuildTestsPage.vue
@@ -7,7 +7,7 @@
       :execute-query-link="executeQueryLink"
       @changeFilters="filters => changedFilters = filters"
     />
-    <loading-indicator :is-loading="$apollo.loading">
+    <loading-indicator :is-loading="!build">
       <data-table
         :columns="[
           {
@@ -32,7 +32,6 @@
 
 import DataTable from './shared/DataTable.vue';
 import gql from 'graphql-tag';
-import { useQuery } from '@vue/apollo-composable';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 
@@ -64,7 +63,7 @@ export default {
       query: gql`
         query($buildid: ID, $filters: BuildTestsFiltersMultiFilterInput, $after: String) {
           build(id: $buildid) {
-            tests(filters: $filters, after: $after) {
+            tests(filters: $filters, after: $after, first: 100) {
               edges {
                 node {
                   id
@@ -88,6 +87,15 @@ export default {
           filters: this.initialFilters,
           after: '',
         };
+      },
+      result({data}) {
+        if (data && data.build.tests.pageInfo.hasNextPage) {
+          this.$apollo.queries.build.fetchMore({
+            variables: {
+              after: data.build.tests.pageInfo.endCursor,
+            },
+          });
+        }
       },
     },
   },

--- a/resources/js/components/BuildTestsPage.vue
+++ b/resources/js/components/BuildTestsPage.vue
@@ -114,10 +114,56 @@ export default {
     formattedTestRows() {
       return this.build.tests.edges?.map(edge => {
         return {
-          name: edge.node.name,
-          status: edge.node.status,
+          name: {
+            value: edge.node.name,
+            text: edge.node.name,
+            href: `${this.$baseURL}/tests/${edge.node.id}`,
+          },
+          status: {
+            // TODO: An integer value could be provided to provide better sorting in the future
+            value: edge.node.status,
+            text: this.humanReadableTestStatus(edge.node.status),
+            href: `${this.$baseURL}/tests/${edge.node.id}`,
+            classes: [this.testStatusToColorClass(edge.node.status)],
+          },
         };
       });
+    },
+  },
+
+  methods: {
+    testStatusToColorClass(status) {
+      switch (status) {
+      case 'PASSED':
+        return 'normal';
+      case 'FAILED':
+        return 'error';
+      case 'NOT_RUN':
+        return 'warning';
+      case 'TIMEOUT':
+        return 'error';
+      case 'DISABLED':
+        return '';
+      default:
+        return '';
+      }
+    },
+
+    humanReadableTestStatus(status) {
+      switch (status) {
+      case 'PASSED':
+        return 'Passed';
+      case 'FAILED':
+        return 'Failed';
+      case 'NOT_RUN':
+        return 'Not Run';
+      case 'TIMEOUT':
+        return 'Timeout';
+      case 'DISABLED':
+        return 'Disabled';
+      default:
+        return status;
+      }
     },
   },
 };

--- a/resources/js/components/BuildTestsPage.vue
+++ b/resources/js/components/BuildTestsPage.vue
@@ -52,9 +52,7 @@ export default {
 
     initialFilters: {
       type: Object,
-      default() {
-        return {};
-      },
+      required: true,
     },
   },
 
@@ -102,7 +100,7 @@ export default {
 
   data() {
     return {
-      changedFilters: [],
+      changedFilters: JSON.parse(JSON.stringify(this.initialFilters)),
     };
   },
 

--- a/resources/js/components/BuildTestsPage.vue
+++ b/resources/js/components/BuildTestsPage.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <filter-builder
+      filter-type="QueryProjectsFiltersMultiFilterInput"
+      primary-record-name="tests"
+      :initial-filters="initialFilters"
+      @changeFilters="filters => changedFilters = filters"
+    />
+    {{changedFilters}}
+  </div>
+</template>
+
+<script>
+
+import DataTable from './shared/DataTable.vue';
+import gql from 'graphql-tag';
+import { useQuery } from '@vue/apollo-composable';
+import FilterBuilder from './shared/FilterBuilder.vue';
+
+export default {
+  name: 'BuildTestsPage',
+
+  components: {
+    FilterBuilder,
+    DataTable,
+  },
+
+  props: {
+    buildId: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    return {
+      initialFilters: {any: [{ne: {name: 'abcd'}},{all: [{eq: {visibility: 'PROTECTED'}}]}]},
+      changedFilters: [],
+    };
+  },
+};
+</script>

--- a/resources/js/components/BuildUpdate.vue
+++ b/resources/js/components/BuildUpdate.vue
@@ -8,7 +8,7 @@
     </div>
     <div v-else>
       <h4 v-if="cdash.build.site">
-        Files changed on <a :href="$baseURL + '/sites/' + cdash.build.siteid">{{ cdash.build.site }}</a>
+        Files changed on <a class="cdash-link" :href="$baseURL + '/sites/' + cdash.build.siteid">{{ cdash.build.site }}</a>
         ({{ cdash.build.buildname }}) as of {{ cdash.build.buildtime }}
       </h4>
 
@@ -40,7 +40,7 @@
         </tt>
       </div>
 
-      <a @click="toggleGraph()">
+      <a class="cdash-link" @click="toggleGraph()">
         <span v-text="showGraph ? 'Hide Activity Graph' : 'Show Activity Graph'" />
       </a>
       <div v-if="graphLoading">

--- a/resources/js/components/EditProject.vue
+++ b/resources/js/components/EditProject.vue
@@ -11,13 +11,13 @@
       <br>
       <br>
       Click here to access the
-      <a :href="$baseURL + '/index.php?project=' + cdash.project.name_encoded">CDash project page</a>
+      <a class="cdash-link" :href="$baseURL + '/index.php?project=' + cdash.project.name_encoded">CDash project page</a>
       <br>
       Click here to
-      <a :href="$baseURL + '/project/' + cdash.project.Id + '/edit'">edit the project</a>
+      <a class="cdash-link" :href="$baseURL + '/project/' + cdash.project.Id + '/edit'">edit the project</a>
       <br>
       Click here to
-      <a :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">download the CTest configuration file</a>
+      <a class="cdash-link" :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">download the CTest configuration file</a>
       <br>
     </div>
     <div v-else>
@@ -59,14 +59,14 @@
               class="nav-item"
               @click="setTabByName('Info');"
             >
-              <a href="#Info" class="nav-link" :class="{ active: activeTab === 'Info' }">Information</a>
+              <a href="#Info" class="nav-link cdash-link" :class="{ active: activeTab === 'Info' }">Information</a>
             </li>
 
             <li
               class="nav-item"
               @click="setTabByName('Logo');"
             >
-              <a href="#Logo" class="nav-link" :class="{ active: activeTab === 'Logo', disabled: cdash.tabs.Logo.disabled }">Logo</a>
+              <a href="#Logo" class="nav-link cdash-link" :class="{ active: activeTab === 'Logo', disabled: cdash.tabs.Logo.disabled }">Logo</a>
             </li>
 
             <li
@@ -74,21 +74,21 @@
               class="nav-item"
               @click="setTabByName('Repos');"
             >
-              <a href="#Repos" class="nav-link" :class="{ active: activeTab === 'Repos', disabled: cdash.tabs.Repos.disabled }">Repository</a>
+              <a href="#Repos" class="nav-link cdash-link" :class="{ active: activeTab === 'Repos', disabled: cdash.tabs.Repos.disabled }">Repository</a>
             </li>
 
             <li
               class="nav-item"
               @click="setTabByName('Testing');"
             >
-              <a href="#Testing" class="nav-link" :class="{ active: activeTab === 'Testing', disabled: cdash.tabs.Testing.disabled }">Testing</a>
+              <a href="#Testing" class="nav-link cdash-link" :class="{ active: activeTab === 'Testing', disabled: cdash.tabs.Testing.disabled }">Testing</a>
             </li>
 
             <li
               class="nav-item"
               @click="setTabByName('Email');"
             >
-              <a href="#Email" class="nav-link" :class="{ active: activeTab === 'Email', disabled: cdash.tabs.Email.disabled }">Email</a>
+              <a href="#Email" class="nav-link cdash-link" :class="{ active: activeTab === 'Email', disabled: cdash.tabs.Email.disabled }">Email</a>
             </li>
 
             <li
@@ -96,14 +96,14 @@
               class="nav-item"
               @click="setTabByName('Spam');"
             >
-              <a href="#Spam" class="nav-link" :class="{ active: activeTab === 'Spam' }">Spam</a>
+              <a href="#Spam" class="nav-link cdash-link" :class="{ active: activeTab === 'Spam' }">Spam</a>
             </li>
 
             <li
               class="nav-item"
               @click="setTabByName('Misc');"
             >
-              <a href="#Misc" class="nav-link" :class="{ active: activeTab === 'Misc', disabled: cdash.tabs.Misc.disabled }">Miscellaneous</a>
+              <a href="#Misc" class="nav-link cdash-link" :class="{ active: activeTab === 'Misc', disabled: cdash.tabs.Misc.disabled }">Miscellaneous</a>
             </li>
           </ul>
 
@@ -1619,7 +1619,7 @@
                     </div>
                   </td>
                   <td>
-                    <a :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">
+                    <a class="cdash-link" :href="$baseURL + '/project/' + cdash.project.Id + '/ctest_configuration'">
                       CTestConfig.cmake
                     </a>
                     <a

--- a/resources/js/components/ManageAuthTokens.vue
+++ b/resources/js/components/ManageAuthTokens.vue
@@ -70,7 +70,7 @@
             v-if="token.scope === 'submit_only' && token.projectname !== null && token.projectname.length > 0"
             align="center"
           >
-            Submit Only (<a :href="$baseURL + '/index.php?project=' + token.projectname">{{ token.projectname }}</a>)
+            Submit Only (<a class="cdash-link" :href="$baseURL + '/index.php?project=' + token.projectname">{{ token.projectname }}</a>)
           </td>
           <td
             v-else-if="token.scope === 'submit_only'"

--- a/resources/js/components/TestDetails.vue
+++ b/resources/js/components/TestDetails.vue
@@ -124,14 +124,14 @@
             {{ file.name }}
           </th>
           <td>
-            <a :href="$baseURL + '/api/v1/testDetails.php?buildtestid=' + buildtestid+ '&fileid=' + file.fileid">
+            <a class="cdash-link" :href="$baseURL + '/api/v1/testDetails.php?buildtestid=' + buildtestid+ '&fileid=' + file.fileid">
               <img :src="$baseURL + '/img/package.png'">
             </a>
           </td>
         </tr>
         <tr v-for="link in links">
           <td>
-            <a :href="link.value">{{ link.name }}</a>
+            <a class="cdash-link" :href="link.value">{{ link.name }}</a>
           </td>
         </tr>
       </table>

--- a/resources/js/components/UserHomepage.vue
+++ b/resources/js/components/UserHomepage.vue
@@ -88,7 +88,7 @@
             class="table-heading"
           >
             <td align="center">
-              <a :href="$baseURL + '/index.php?project=' + project.name_encoded">{{ project.name }}</a>
+              <a class="cdash-link" :href="$baseURL + '/index.php?project=' + project.name_encoded">{{ project.name }}</a>
             </td>
             <td
               align="center"
@@ -209,7 +209,7 @@
               v-for="project in cdash.claimedsiteprojects"
               align="center"
             >
-              <a :href="$baseURL + '/index.php?project=' + project.name_encoded">
+              <a class="cdash-link" :href="$baseURL + '/index.php?project=' + project.name_encoded">
                 {{ project.name }}
               </a>
             </td>
@@ -219,7 +219,7 @@
             v-for="site in cdash.claimedsites"
           >
             <td align="center">
-              <a :href="$baseURL + '/editSite.php?siteid=' + site.id">
+              <a class="cdash-link" :href="$baseURL + '/editSite.php?siteid=' + site.id">
                 {{ site.name }}
               </a>
               <img
@@ -380,10 +380,10 @@
         <tbody>
           <tr v-for="project in cdash.publicprojects">
             <td align="center">
-              <a :href="$baseURL + '/index.php?project=' + project.name">{{ project.name }}</a>
+              <a class="cdash-link" :href="$baseURL + '/index.php?project=' + project.name">{{ project.name }}</a>
             </td>
             <td>
-              <a :href="$baseURL + '/subscribeProject.php?projectid=' + project.id">
+              <a class="cdash-link" :href="$baseURL + '/subscribeProject.php?projectid=' + project.id">
                 Subscribe to this project
               </a>
             </td>
@@ -578,7 +578,7 @@
           </tr>
           <tr class="trodd">
             <td id="nob">
-              <a href="project/new">Start a new project</a>
+              <a class="cdash-link" href="project/new">Start a new project</a>
             </td>
           </tr>
         </tbody>
@@ -605,73 +605,73 @@
         <template v-if="cdash.user_is_admin == 1">
           <tr>
             <td>
-              <a :href="$baseURL + '/project/new'">Create new project</a>
+              <a class="cdash-link" :href="$baseURL + '/project/new'">Create new project</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageProjectRoles.php'">Manage project roles</a>
+              <a class="cdash-link" :href="$baseURL + '/manageProjectRoles.php'">Manage project roles</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageSubProject.php'">Manage subproject</a>
+              <a class="cdash-link" :href="$baseURL + '/manageSubProject.php'">Manage subproject</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageBuildGroup.php'">Manage project groups</a>
+              <a class="cdash-link" :href="$baseURL + '/manageBuildGroup.php'">Manage project groups</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageCoverage.php'">Manage project coverage</a>
+              <a class="cdash-link" :href="$baseURL + '/manageCoverage.php'">Manage project coverage</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageBanner.php'">Manage banner message</a>
+              <a class="cdash-link" :href="$baseURL + '/manageBanner.php'">Manage banner message</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/manageUsers.php'">Manage users</a>
+              <a class="cdash-link" :href="$baseURL + '/manageUsers.php'">Manage users</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/authtokens/manage'">Manage authentication tokens</a>
+              <a class="cdash-link" :href="$baseURL + '/authtokens/manage'">Manage authentication tokens</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/upgrade.php'">Maintenance</a>
+              <a class="cdash-link" :href="$baseURL + '/upgrade.php'">Maintenance</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/sites'">Site Statistics</a>
+              <a class="cdash-link" :href="$baseURL + '/sites'">Site Statistics</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/userStatistics.php'">User Statistics</a>
+              <a class="cdash-link" :href="$baseURL + '/userStatistics.php'">User Statistics</a>
             </td>
           </tr>
           <tr>
             <td>
-              <a :href="$baseURL + '/removeBuilds.php'">Remove Builds</a>
+              <a class="cdash-link" :href="$baseURL + '/removeBuilds.php'">Remove Builds</a>
             </td>
           </tr>
           <tr v-if="cdash.show_monitor">
             <td>
-              <a :href="$baseURL + '/monitor'">Monitor / Processing Statistics</a>
+              <a class="cdash-link" :href="$baseURL + '/monitor'">Monitor / Processing Statistics</a>
             </td>
           </tr>
         </template>
         <tr>
           <td>
-            <a :href="$baseURL + '/profile'">My Profile</a>
+            <a class="cdash-link" :href="$baseURL + '/profile'">My Profile</a>
           </td>
         </tr>
       </tbody>

--- a/resources/js/components/ViewDynamicAnalysis.vue
+++ b/resources/js/components/ViewDynamicAnalysis.vue
@@ -63,7 +63,7 @@
             align="center"
           >
             <td align="left">
-              <a :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id">
+              <a class="cdash-link" :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id">
                 {{ DA.name }}
               </a>
             </td>

--- a/resources/js/components/page-header/HeaderMenu.vue
+++ b/resources/js/components/page-header/HeaderMenu.vue
@@ -2,28 +2,28 @@
   <nav id="headermenu">
     <ul id="navigation">
       <li v-if="hasProject">
-        <a :href="indexUrl">Dashboard</a>
+        <a class="cdash-link" :href="indexUrl">Dashboard</a>
         <ul>
           <li v-if="showSubProjects">
-            <a :href="subProjectsUrl">SubProjects</a>
+            <a class="cdash-link" :href="subProjectsUrl">SubProjects</a>
           </li>
           <li>
-            <a :href="overviewUrl">Overview</a>
+            <a class="cdash-link" :href="overviewUrl">Overview</a>
           </li>
           <li>
-            <a :href="buildsUrl">Builds</a>
+            <a class="cdash-link" :href="buildsUrl">Builds</a>
           </li>
           <li>
-            <a :href="testsUrl">Tests</a>
+            <a class="cdash-link" :href="testsUrl">Tests</a>
           </li>
           <li>
-            <a :href="testQueryUrl">Tests Query</a>
+            <a class="cdash-link" :href="testQueryUrl">Tests Query</a>
           </li>
           <li>
-            <a :href="statisticsUrl">Statistics</a>
+            <a class="cdash-link" :href="statisticsUrl">Statistics</a>
           </li>
           <li class="endsubmenu">
-            <a :href="sitesUrl">Sites</a>
+            <a class="cdash-link" :href="sitesUrl">Sites</a>
           </li>
         </ul>
       </li>
@@ -31,7 +31,7 @@
         v-if="showBack"
         id="Back"
       >
-        <a :href="backUrl">Up</a>
+        <a class="cdash-link" :href="backUrl">Up</a>
       </li>
       <li v-if="showCalendar">
         <a
@@ -51,22 +51,22 @@
         >Project</a>
         <ul>
           <li>
-            <a :href="homeUrl">Home</a>
+            <a class="cdash-link" :href="homeUrl">Home</a>
           </li>
           <li>
-            <a :href="docUrl">Documentation</a>
+            <a class="cdash-link" :href="docUrl">Documentation</a>
           </li>
           <li>
-            <a :href="vcsUrl">Repository</a>
+            <a class="cdash-link" :href="vcsUrl">Repository</a>
           </li>
           <li :class="{ endsubmenu: !showSubscribe }">
-            <a :href="bugUrl">Bug Tracker</a>
+            <a class="cdash-link" :href="bugUrl">Bug Tracker</a>
           </li>
           <li
             v-if="showSubscribe"
             class="endsubmenu"
           >
-            <a :href="subscribeUrl">Subscribe</a>
+            <a class="cdash-link" :href="subscribeUrl">Subscribe</a>
           </li>
         </ul>
       </li>
@@ -74,31 +74,31 @@
         v-if="showAdmin"
         id="admin"
       >
-        <a href="#">Settings</a>
+        <a class="cdash-link" href="#">Settings</a>
         <ul>
           <li>
-            <a :href="projectSettingsUrl">Project</a>
+            <a class="cdash-link" :href="projectSettingsUrl">Project</a>
           </li>
           <li>
-            <a :href="userSettingsUrl">Users</a>
+            <a class="cdash-link" :href="userSettingsUrl">Users</a>
           </li>
           <li>
-            <a :href="groupSettingsUrl">Groups</a>
+            <a class="cdash-link" :href="groupSettingsUrl">Groups</a>
           </li>
           <li>
-            <a :href="coverageSettingsUrl">Coverage</a>
+            <a class="cdash-link" :href="coverageSettingsUrl">Coverage</a>
           </li>
           <li>
-            <a :href="bannerSettingsUrl">Banner</a>
+            <a class="cdash-link" :href="bannerSettingsUrl">Banner</a>
           </li>
           <li>
-            <a :href="measurementSettingsUrl">Measurements</a>
+            <a class="cdash-link" :href="measurementSettingsUrl">Measurements</a>
           </li>
           <li>
-            <a :href="subProjectSettingsUrl">SubProjects</a>
+            <a class="cdash-link" :href="subProjectSettingsUrl">SubProjects</a>
           </li>
           <li class="endsubmenu">
-            <a :href="overviewSettingsUrl">Overview</a>
+            <a class="cdash-link" :href="overviewSettingsUrl">Overview</a>
           </li>
         </ul>
       </li>

--- a/resources/js/components/page-header/HeaderNav.vue
+++ b/resources/js/components/page-header/HeaderNav.vue
@@ -7,7 +7,7 @@
       id="header-nav-previous-btn"
       :class="previousClass"
     >
-      <a :href="previous">
+      <a class="cdash-link" :href="previous">
         <svg
           id="i-chevron-left"
           xmlns="http://www.w3.org/2000/svg"
@@ -29,13 +29,13 @@
       id="header-nav-current-btn"
       :class="currentClass"
     >
-      <a :href="current">LATEST</a>
+      <a class="cdash-link" :href="current">LATEST</a>
     </li>
     <li
       id="header-nav-next-btn"
       :class="nextClass"
     >
-      <a :href="next">
+      <a class="cdash-link" :href="next">
         NEXT
         <svg
           id="i-chevron-right"

--- a/resources/js/components/shared/DataTable.vue
+++ b/resources/js/components/shared/DataTable.vue
@@ -41,7 +41,7 @@
       >
         <td
           v-for="column in columns"
-          :class="{ shrink: !column.expand }"
+          :class="(row[column.name]?.classes ?? []).concat(column.expand ? [] : ['shrink'])"
           class="table-cell"
           data-cy="data-table-cell"
         >
@@ -139,9 +139,10 @@ export default {
      *       value: ?String  # The value to sort by (will sort by text if no value provided)
      *       text: String
      *       href: String
+     *       classes: ?[String]  # A optional list of classes to be applied to the <td> element
      *   }
      *
-     * Custom metadata objects can be use to provide props to custom templates passed via slots.
+     * Custom metadata objects can be used to provide props to custom templates passed via slots.
      *
      * A "value" key is required in the metadata object.  The associated value will be used for sorting.
      * In the case of a pure text item, the object will be sorted by text value.

--- a/resources/js/components/shared/FilterBuilder.vue
+++ b/resources/js/components/shared/FilterBuilder.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <filter-group
+      :type="filterType"
+      :primary-record-name="primaryRecordName"
+      :initial-filters="initialFilters"
+      @changeFilters="filters => $emit('changeFilters', filters)"
+    />
+  </div>
+</template>
+
+<script>
+import FilterGroup from './FilterGroup.vue';
+
+export default {
+  components: { FilterGroup },
+
+  props: {
+    /**
+     * The GraphQL input filter type.
+     *
+     * Example: QueryProjectsFiltersMultiFilterInput
+     */
+    filterType: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * A human-readable string to provide context for the plural type of record being filtered.
+     *
+     * For example: "test measurements", "builds", "tests", etc...
+     */
+    primaryRecordName: {
+      type: String,
+      required: true,
+    },
+
+    initialFilters: {
+      type: Object,
+      default() {
+        return {
+          all: [],
+        };
+      },
+    },
+  },
+};
+</script>

--- a/resources/js/components/shared/FilterBuilder.vue
+++ b/resources/js/components/shared/FilterBuilder.vue
@@ -2,9 +2,9 @@
   <div class="tw-flex tw-flex-col tw-w-full tw-gap-1">
     <div
       class="table-heading1 tw-font-bold"
-      style="font-size: 14px; padding: 3px 15px;"
+      style="font-size: 16px; padding: 6px;"
     >
-      Filters
+      <font-awesome-icon icon="fa-filter" /> Filters
     </div>
     <filter-group
       :type="filterType"

--- a/resources/js/components/shared/FilterBuilder.vue
+++ b/resources/js/components/shared/FilterBuilder.vue
@@ -1,19 +1,44 @@
 <template>
-  <div>
+  <div class="tw-flex tw-flex-col tw-w-full tw-gap-1">
+    <div
+      class="table-heading1 tw-font-bold"
+      style="font-size: 14px; padding: 3px 15px;"
+    >
+      Filters
+    </div>
     <filter-group
       :type="filterType"
       :primary-record-name="primaryRecordName"
       :initial-filters="initialFilters"
       @changeFilters="filters => $emit('changeFilters', filters)"
     />
+    <div class="tw-flex tw-flex-row tw-w-full tw-gap-1">
+      <a
+        role="button"
+        class="tw-btn tw-btn-xs"
+        :href="executeQueryLink"
+      >
+        <font-awesome-icon icon="fa-play" /> Show
+      </a>
+      <a
+        role="button"
+        class="tw-btn tw-btn-xs"
+        :href="$baseURL + '/graphql/explorer'"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <font-awesome-icon icon="fa-terminal" /> GraphQL
+      </a>
+    </div>
   </div>
 </template>
 
 <script>
 import FilterGroup from './FilterGroup.vue';
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
-  components: { FilterGroup },
+  components: { FilterGroup, FontAwesomeIcon },
 
   props: {
     /**
@@ -44,6 +69,19 @@ export default {
         };
       },
     },
+
+    /**
+     * A link provided by the parent, presumably containing information this component has provided about
+     * its current value.
+     */
+    executeQueryLink: {
+      type: URL,
+      required: true,
+    },
   },
+
+  emits: [
+    'changeFilters',
+  ],
 };
 </script>

--- a/resources/js/components/shared/FilterBuilder.vue
+++ b/resources/js/components/shared/FilterBuilder.vue
@@ -18,7 +18,7 @@
         class="tw-btn tw-btn-xs"
         :href="executeQueryLink"
       >
-        <font-awesome-icon icon="fa-play" /> Show
+        <font-awesome-icon icon="fa-magnifying-glass" /> Apply
       </a>
       <a
         role="button"
@@ -75,7 +75,7 @@ export default {
      * its current value.
      */
     executeQueryLink: {
-      type: URL,
+      type: String,
       required: true,
     },
   },

--- a/resources/js/components/shared/FilterGroup.vue
+++ b/resources/js/components/shared/FilterGroup.vue
@@ -1,0 +1,194 @@
+<template>
+  <loading-indicator :is-loading="!result">
+    <div class="flex w-full">
+      <div class="divider divider-horizontal" />
+      <div class="flex flex-col w-full gap-1">
+        <div>
+          <template v-if="primaryRecordName === ''">
+            and
+          </template>
+          <template v-else>
+            Show all {{ primaryRecordName }} where
+          </template>
+          <select
+            class="select select-xs select-bordered shrink"
+            @change="event => changeCombineType(event.target.value)"
+          >
+            <option
+              value="all"
+              :selected="currentCombineType === 'all'"
+            >
+              all
+            </option>
+            <option
+              value="any"
+              :selected="currentCombineType === 'any'"
+            >
+              any
+            </option>
+          </select> of the following are true
+        </div>
+        <div v-for="(entry, index) in filters[currentCombineType]">
+          <filter-group
+            v-if="entry !== 'deleted' && (entry.hasOwnProperty('any') || entry.hasOwnProperty('all'))"
+            :initial-filters="entry"
+            :type="type"
+            @delete="changeRow('deleted', index)"
+            @changeFilters="newEntry => changeRow(newEntry, index)"
+          />
+          <filter-row
+            v-else-if="entry !== 'deleted'"
+            :operators="result.typeInformation.inputFields.filter(f => f.type.kind !== 'LIST').map(o => o.name)"
+            :type="result.typeInformation.inputFields.filter(f => f.type.kind !== 'LIST')[0].type.name"
+            :initial-field="filterToFilterRow(entry).field"
+            :initial-operator="filterToFilterRow(entry).operator"
+            :initial-value="filterToFilterRow(entry).value"
+            @delete="changeRow('deleted', index)"
+            @changeFilters="newEntry => changeRow(newEntry, index)"
+          />
+        </div>
+        <div class="flex flex-row w-full gap-1">
+          <button
+            class="btn btn-xs"
+            @click="addFilter"
+          >
+            <font-awesome-icon icon="fa-plus" /> Add Filter
+          </button>
+          <button
+            class="btn btn-xs"
+            @click="addGroup"
+          >
+            <font-awesome-icon icon="fa-bars-staggered" /> Add Group
+          </button>
+          <button
+            class="btn btn-xs"
+            @click="$emit('delete')"
+          >
+            <font-awesome-icon icon="fa-trash" /> Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  </loading-indicator>
+</template>
+
+<script>
+import LoadingIndicator from './LoadingIndicator.vue';
+import {useQuery} from '@vue/apollo-composable';
+import gql from 'graphql-tag';
+import FilterRow from './FilterRow.vue';
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+
+export default {
+  components: { FontAwesomeIcon, FilterRow, LoadingIndicator },
+
+  props: {
+    type: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * A human-readable string to provide context for the plural type of record being filtered.
+     * This is expected to only be set for the top level of the recursive hierarchy.
+     *
+     * For example: "test measurements", "builds", "tests", etc...
+     */
+    primaryRecordName: {
+      type: String,
+      required: false,
+      default: '',
+    },
+
+    initialFilters: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const { result, error } = useQuery(gql`
+      query {
+        typeInformation: __type(name: "${props.type}") {
+          inputFields {
+            name
+            type {
+              name
+              kind
+              ofType {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    return {
+      result,
+      error,
+    };
+  },
+
+  data() {
+    return {
+      filters: JSON.parse(JSON.stringify(this.initialFilters)),
+    };
+  },
+
+  computed: {
+    currentCombineType() {
+      return this.filters.hasOwnProperty('any') ? 'any' : 'all';
+    },
+  },
+
+  methods: {
+    addGroup() {
+      this.filters[this.currentCombineType].push({
+        all: [
+          {},
+        ],
+      });
+    },
+
+    addFilter() {
+      this.filters[this.currentCombineType].push({});
+    },
+
+    filterToFilterRow(filter) {
+      if (Object.keys(filter).length > 0 && Object.keys(Object.values(filter)[0]).length > 0) {
+        return {
+          field: Object.keys(Object.values(filter)[0])[0],
+          operator: Object.keys(filter)[0],
+          value: Object.values(Object.values(filter)[0])[0],
+        };
+      }
+      else {
+        return {
+          field: null,
+          operator: null,
+          value: null,
+        };
+      }
+    },
+
+    changeCombineType(newCombineType) {
+      const originalCombinetype = this.currentCombineType;
+      this.filters[newCombineType] = this.filters[originalCombinetype];
+      delete this.filters[originalCombinetype];
+      this.emitChange();
+    },
+
+    changeRow(newRow, index) {
+      this.filters[this.currentCombineType][index] = newRow;
+      this.emitChange();
+    },
+
+    emitChange() {
+      this.$emit('changeFilters', JSON.parse(JSON.stringify({
+        [this.currentCombineType]: this.filters[this.currentCombineType].filter(r => r !== 'deleted'),
+      })));
+    },
+  },
+};
+</script>

--- a/resources/js/components/shared/FilterGroup.vue
+++ b/resources/js/components/shared/FilterGroup.vue
@@ -106,6 +106,11 @@ export default {
     },
   },
 
+  emits: [
+    'changeFilters',
+    'delete',
+  ],
+
   setup(props) {
     const { result, error } = useQuery(gql`
       query {

--- a/resources/js/components/shared/FilterGroup.vue
+++ b/resources/js/components/shared/FilterGroup.vue
@@ -1,8 +1,8 @@
 <template>
   <loading-indicator :is-loading="!result">
-    <div class="flex w-full">
-      <div class="divider divider-horizontal" />
-      <div class="flex flex-col w-full gap-1">
+    <div class="tw-flex tw-w-full">
+      <div class="tw-divider tw-divider-horizontal" />
+      <div class="tw-flex tw-flex-col tw-w-full tw-gap-1">
         <div>
           <template v-if="primaryRecordName === ''">
             and
@@ -11,7 +11,7 @@
             Show all {{ primaryRecordName }} where
           </template>
           <select
-            class="select select-xs select-bordered shrink"
+            class="tw-select tw-select-xs tw-select-bordered tw-shrink"
             @change="event => changeCombineType(event.target.value)"
           >
             <option
@@ -47,21 +47,21 @@
             @changeFilters="newEntry => changeRow(newEntry, index)"
           />
         </div>
-        <div class="flex flex-row w-full gap-1">
+        <div class="tw-flex tw-flex-row tw-w-full tw-gap-1">
           <button
-            class="btn btn-xs"
+            class="tw-btn tw-btn-xs"
             @click="addFilter"
           >
             <font-awesome-icon icon="fa-plus" /> Add Filter
           </button>
           <button
-            class="btn btn-xs"
+            class="tw-btn tw-btn-xs"
             @click="addGroup"
           >
             <font-awesome-icon icon="fa-bars-staggered" /> Add Group
           </button>
           <button
-            class="btn btn-xs"
+            class="tw-btn tw-btn-xs"
             @click="$emit('delete')"
           >
             <font-awesome-icon icon="fa-trash" /> Delete

--- a/resources/js/components/shared/FilterGroup.vue
+++ b/resources/js/components/shared/FilterGroup.vue
@@ -64,7 +64,7 @@
             class="tw-btn tw-btn-xs"
             @click="$emit('delete')"
           >
-            <font-awesome-icon icon="fa-trash" /> Delete
+            <font-awesome-icon icon="fa-trash" /> Delete Group
           </button>
         </div>
       </div>

--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -5,7 +5,7 @@
         class="tw-btn tw-btn-xs"
         @click="$emit('delete')"
       >
-        <font-awesome-icon icon="fa-trash" />
+        <font-awesome-icon icon="fa-trash" /> Delete
       </button>
       <!-- Field chooser -->
       <select

--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -1,0 +1,238 @@
+<template>
+  <loading-indicator :is-loading="!result">
+    <div class="flex flex-row w-full gap-1">
+      <button
+        class="btn btn-xs"
+        @click="$emit('delete')"
+      >
+        <font-awesome-icon icon="fa-trash" />
+      </button>
+      <!-- Field chooser -->
+      <select
+        v-model="selectedField"
+        class="select select-xs select-bordered shrink"
+      >
+        <option
+          v-for="field in result.typeInformation.inputFields"
+          :value="field.name"
+        >
+          {{ humanReadableField(field.name) }}
+        </option>
+      </select>
+      <!-- Operator chooser -->
+      <select
+        v-if="selectedField !== ''"
+        v-model="selectedOperator"
+        class="select select-xs select-bordered shrink"
+      >
+        <option
+          v-for="operator in operators"
+          :value="operator"
+        >
+          {{ humanReadableOperator(operator) }}
+        </option>
+      </select>
+      <!-- Value field -->
+      <template v-if="selectedType.kind === 'SCALAR'">
+        <input
+          v-if="selectedType.name === 'ID' || selectedType.name === 'Int' || selectedType.name === 'Float'"
+          v-model="selectedValue"
+          type="number"
+          class="input input-xs input-bordered shrink"
+        >
+        <input
+          v-else-if="selectedType.name === 'String'"
+          v-model="selectedValue"
+          type="text"
+          class="input input-xs input-bordered w-full"
+        >
+        <span v-else-if="selectedType.name === 'Boolean'">
+          <!-- TODO: Implement -->
+        </span>
+        <span v-else-if="selectedType.name === 'DateTimeTz'">
+          <!-- TODO: Implement -->
+        </span>
+        <span v-else>ERROR: Unknown type</span>
+      </template>
+      <select
+        v-else-if="selectedType.kind === 'ENUM'"
+        v-model="selectedValue"
+        class="select select-xs select-bordered shrink"
+      >
+        <option
+          v-for="option in selectedType.enumValues"
+          :value="option.name"
+        >
+          {{ option.name }}
+        </option>
+      </select>
+    </div>
+  </loading-indicator>
+</template>
+
+<script>
+import {useQuery} from '@vue/apollo-composable';
+import gql from 'graphql-tag';
+import LoadingIndicator from './LoadingIndicator.vue';
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+
+export default {
+  components: {FontAwesomeIcon, LoadingIndicator},
+
+  props: {
+    type: {
+      type: String,
+      required: true,
+    },
+
+    /**
+     * An array of GraphQL operators, as determined by API introspection.
+     * This template overrides some of these values for UI reasons.
+     *
+     * TODO: We currently assume that every field has the same operators.
+     * this could be improved in the future by intelligently populating this
+     * list based on the operators each field appears under.
+     */
+    operators: {
+      type: Array,
+      required: true,
+    },
+
+    initialField: {
+      type: String,
+      default: null,
+    },
+
+    initialOperator: {
+      type: String,
+      default: null,
+    },
+
+    initialValue: {
+      type: null,
+      default: null,
+    },
+  },
+
+  setup(props) {
+    const { result, error } = useQuery(gql`
+      query {
+        typeInformation: __type(name: "${props.type}") {
+          inputFields {
+            name
+            type {
+              name
+              kind
+              enumValues {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    return {
+      result,
+      error,
+    };
+  },
+
+  data() {
+    return {
+      // selectedType is derived from the selected field
+      selectedField: null,
+      selectedOperator: null,
+      selectedValue: null,
+    };
+  },
+
+  computed: {
+    selectedType() {
+      return this.result?.typeInformation.inputFields.filter(field => field.name === this.selectedField)[0].type;
+    },
+  },
+
+  watch: {
+    result: {
+      handler(result) {
+        // Do nothing if we haven't loaded data from the server yet
+        if (!result) {
+          return;
+        }
+
+        this.selectedField = this.initialField ?? result.typeInformation.inputFields[0].name;
+
+        this.selectedOperator = this.initialOperator ?? 'eq';
+      },
+      immediate: true,
+    },
+
+    selectedType: {
+      handler(type) {
+        if (this.selectedValue === null && this.initialValue !== null) {
+          this.selectedValue = this.initialValue;
+        }
+        else {
+          if (type.kind === 'ENUM') {
+            this.selectedValue = type.enumValues[0].name;
+          }
+          else {
+            this.selectedValue = '';
+          }
+        }
+      },
+    },
+
+    selectedField() {
+      this.emitChange();
+    },
+
+    selectedOperator() {
+      this.emitChange();
+    },
+
+    selectedValue() {
+      this.emitChange();
+    },
+  },
+
+  methods: {
+    /**
+     * Converts a GraphQL filter field operator to a more human-readable text string
+     */
+    humanReadableOperator(operator) {
+      switch (operator) {
+      case 'eq':
+        return 'equal to';
+      case 'ne':
+        return 'not equal to';
+      case 'lt':
+        return 'less than';
+      case 'gt':
+        return 'greater than';
+      default:
+        return operator;
+      }
+    },
+
+    /**
+     * Converts a GraphQL field to a human-readable equivalent
+     */
+    humanReadableField(field) {
+      return field;
+    },
+
+    /**
+     * Emits the current value of this GraphQL filter entry
+     */
+    emitChange() {
+      this.$emit('changeFilters', {
+        [this.selectedOperator]: {
+          [this.selectedField]: this.selectedValue,
+        },
+      });
+    },
+  },
+};
+</script>

--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -1,8 +1,8 @@
 <template>
   <loading-indicator :is-loading="!result">
-    <div class="flex flex-row w-full gap-1">
+    <div class="tw-flex tw-flex-row tw-w-full tw-gap-1">
       <button
-        class="btn btn-xs"
+        class="tw-btn tw-btn-xs"
         @click="$emit('delete')"
       >
         <font-awesome-icon icon="fa-trash" />
@@ -10,7 +10,7 @@
       <!-- Field chooser -->
       <select
         v-model="selectedField"
-        class="select select-xs select-bordered shrink"
+        class="tw-select tw-select-xs tw-select-bordered tw-shrink"
       >
         <option
           v-for="field in result.typeInformation.inputFields"
@@ -23,7 +23,7 @@
       <select
         v-if="selectedField !== ''"
         v-model="selectedOperator"
-        class="select select-xs select-bordered shrink"
+        class="tw-select tw-select-xs tw-select-bordered tw-shrink"
       >
         <option
           v-for="operator in operators"
@@ -38,13 +38,13 @@
           v-if="selectedType.name === 'ID' || selectedType.name === 'Int' || selectedType.name === 'Float'"
           v-model="selectedValue"
           type="number"
-          class="input input-xs input-bordered shrink"
+          class="tw-input tw-input-xs tw-input-bordered tw-shrink"
         >
         <input
           v-else-if="selectedType.name === 'String'"
           v-model="selectedValue"
           type="text"
-          class="input input-xs input-bordered w-full"
+          class="tw-input tw-input-xs tw-input-bordered tw-w-full"
         >
         <span v-else-if="selectedType.name === 'Boolean'">
           <!-- TODO: Implement -->
@@ -57,7 +57,7 @@
       <select
         v-else-if="selectedType.kind === 'ENUM'"
         v-model="selectedValue"
-        class="select select-xs select-bordered shrink"
+        class="tw-select tw-select-xs tw-select-bordered tw-shrink"
       >
         <option
           v-for="option in selectedType.enumValues"

--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -114,6 +114,11 @@ export default {
     },
   },
 
+  emits: [
+    'changeFilters',
+    'delete',
+  ],
+
   setup(props) {
     const { result, error } = useQuery(gql`
       query {

--- a/resources/js/components/shared/LoadingIndicator.vue
+++ b/resources/js/components/shared/LoadingIndicator.vue
@@ -7,6 +7,7 @@
       alt="The page is loading."
     >
   </div>
+  <!-- eslint-disable-next-line vue/no-multiple-template-root -->
   <slot v-else />
 </template>
 

--- a/resources/js/components/shared/LoadingIndicator.vue
+++ b/resources/js/components/shared/LoadingIndicator.vue
@@ -1,15 +1,13 @@
 <template>
-  <div>
-    <div v-if="isLoading">
-      <img
-        v-if="initialDelayComplete"
-        :src="$baseURL + '/img/loading.gif'"
-        class="loading-indicator"
-        alt="The page is loading."
-      >
-    </div>
-    <slot v-else />
+  <div v-if="isLoading">
+    <img
+      v-if="initialDelayComplete"
+      :src="$baseURL + '/img/loading.gif'"
+      class="loading-indicator"
+      alt="The page is loading."
+    >
   </div>
+  <slot v-else />
 </template>
 
 <script>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -60,7 +60,7 @@
 				</div>
 				<div class="col-auto text-right">
 					@if (Route::has('password.request'))
-						<a href="recoverPassword.php">Forgot your password?</a>
+						<a class="cdash-link" href="recoverPassword.php">Forgot your password?</a>
 					@endif
 				</div>
 			</div>
@@ -82,7 +82,7 @@
                 @endif
                 @foreach($socialiteCollection as $key => $config)
                     @if ($config['enable'])
-                        <a href="/auth/{{ $key }}/redirect">
+                        <a class="cdash-link" href="/auth/{{ $key }}/redirect">
                             <button>
                                 <img class="paddr" src="img/{{ $key }}_signin.png" title="Log in with your {{ $key }} account" style="height:40px"/>
                                 {{ $config['display_name']}}
@@ -92,7 +92,7 @@
                 @endforeach
                 @foreach($oauthCollection as $key => $config)
                     @if ($config['enable'])
-                        <a href="/oauth/{{ $key }}">
+                        <a class="cdash-link" href="/oauth/{{ $key }}">
                             <img class="paddr" src="img/{{ $key }}_signin.png" title="Log in with your {{ $key }} account"/>
                         </a>
                     @endif

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -17,7 +17,7 @@
                     @endif
 
                     {{ __('Before proceeding, please check your email for a verification link.') }}
-                    {{ __('If you did not receive the email') }}, <a href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
+                    {{ __('If you did not receive the email') }}, <a class="cdash-link" href="{{ route('verification.resend') }}">{{ __('click here to request another') }}</a>.
                 </div>
             </div>
         </div>

--- a/resources/views/build/files.blade.php
+++ b/resources/views/build/files.blade.php
@@ -4,7 +4,7 @@
 
 @section('main_content')
     <b>Site:</b> {{ $build->GetSite()->name }}<br />
-    <b>Build name:</b> <a href="{{ $build->GetBuildSummaryUrl() }}">{{ $build->Name }}</a><br />
+    <b>Build name:</b> <a class="cdash-link" href="{{ $build->GetBuildSummaryUrl() }}">{{ $build->Name }}</a><br />
     <b>Build start time:</b> {{ $build->StartTime }}<br />
 
     <h3>URLs or Files submitted with this build</h3>
@@ -19,7 +19,7 @@
             @foreach($urls as $url)
                 <tr>
                     <td>
-                        <a href="{{ $url['filename'] }}">{{ $url['filename'] }}</a>
+                        <a class="cdash-link" href="{{ $url['filename'] }}">{{ $url['filename'] }}</a>
                     </td>
                 </tr>
             @endforeach
@@ -39,7 +39,7 @@
             @foreach($files as $file)
                 <tr>
                     <td>
-                        <a href="{{ $file['href'] }}">
+                        <a class="cdash-link" href="{{ $file['href'] }}">
                             <img src="{{ url('/img/package.png') }}" alt="Files" border="0"/> {{ $file['filename'] }}
                         </a>
                     </td>

--- a/resources/views/build/tests.blade.php
+++ b/resources/views/build/tests.blade.php
@@ -4,5 +4,5 @@
 ])
 
 @section('main_content')
-    <build-tests-page buildid="{{ $build->Id }}"></build-tests-page>
+    <build-tests-page :build-id="{{ $build->Id }}" :initial-filters="@js($filters)"></build-tests-page>
 @endsection

--- a/resources/views/build/tests.blade.php
+++ b/resources/views/build/tests.blade.php
@@ -1,0 +1,8 @@
+@extends('cdash', [
+    'vue' => true,
+    'daisyui' => true,
+])
+
+@section('main_content')
+    <build-tests-page buildid="{{ $build->Id }}"></build-tests-page>
+@endsection

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -3,23 +3,23 @@
 
 <div id="footer" class="clearfix ng-scope">
     <div id="kitwarelogo">
-        <a href="https://www.kitware.com">
+        <a class="cdash-link" href="https://www.kitware.com">
             <img src="{{ asset('img/kitware_logo_footer.svg') }}" alt="logo" height="30">
         </a>
     </div>
 
     <div id="footerlinks" class="clearfix">
-        <a href="https://www.cdash.org" class="footerlogo">
+        <a href="https://www.cdash.org" class="footerlogo cdash-link">
             <img src="{{ asset('img/cdash_logo_full.svg?rev=2023-05-31') }}" height="30" alt="CDash logo">
         </a>
         <span id="footertext" class="pull-right">
-            CDash {{ $cdash_version }} ©&nbsp; <a href="https://www.kitware.com">Kitware</a>
-            | <a href="https://github.com/Kitware/CDash/issues" target="_blank">Report problems</a>
+            CDash {{ $cdash_version }} ©&nbsp; <a class="cdash-link" href="https://www.kitware.com">Kitware</a>
+            | <a class="cdash-link" href="https://github.com/Kitware/CDash/issues" target="_blank">Report problems</a>
 
             @if(isset($angular) && $angular === true)
-                | <a ng-href="@{{cdash.endpoint}}">View as JSON</a>
+                | <a class="cdash-link" ng-href="@{{cdash.endpoint}}">View as JSON</a>
             @elseif(isset($vue) && $vue === true)
-                | <a id="api-endpoint">View as JSON</a> {{-- Will be filled by Vue --}}
+                | <a class="cdash-link" id="api-endpoint">View as JSON</a> {{-- Will be filled by Vue --}}
             @endif
 
             @if(isset($angular) && $angular === true)

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -8,18 +8,18 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
 <div id="header">
     <div id="headertop">
         <div id="topmenu">
-            <a href="{{ url('/projects') }}">All Dashboards</a>
+            <a class="cdash-link" href="{{ url('/projects') }}">All Dashboards</a>
             @if(Auth::check())
-                <a href="{{ url('/user') }}">My CDash</a>
+                <a class="cdash-link" href="{{ url('/user') }}">My CDash</a>
             @endif
 
             <span style="float: right;">
                 @if(Auth::check())
-                    <a href="{{ url('/logout') }}">Logout</a>
+                    <a class="cdash-link" href="{{ url('/logout') }}">Logout</a>
                 @else
-                    <a href="{{ url('/login') }}">Login</a>
+                    <a class="cdash-link" href="{{ url('/login') }}">Login</a>
                     @if(!$hideRegistration)
-                      <a href="{{ route('register') }}">{{ __('Register') }}</a>
+                      <a class="cdash-link" href="{{ route('register') }}">{{ __('Register') }}</a>
                     @endif
                 @endif
             </span>
@@ -70,17 +70,17 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
                 @verbatim
                     <ul ng-if="cdash.menu.previous || cdash.menu.current || cdash.menu.next" class="projectnav_controls clearfix">
                         <li class="btnprev">
-                            <a ng-if="cdash.menu.previous"
+                            <a class="cdash-link" ng-if="cdash.menu.previous"
                                ng-href="{{::cdash.menu.previous}}{{::cdash.filterurl}}">Prev</a>
                         </li>
                         <li class="btncurr">
-                            <a ng-if="cdash.menu.current"
+                            <a class="cdash-link" ng-if="cdash.menu.current"
                                ng-href="{{::cdash.menu.current}}{{::cdash.filterurl}}">
                                 Latest
                             </a>
                         </li>
                         <li class="btnnext">
-                            <a ng-if="cdash.menu.next"
+                            <a class="cdash-link" ng-if="cdash.menu.next"
                                ng-href="{{::cdash.menu.next}}{{::cdash.filterurl}}">
                                 Next
                             </a>
@@ -97,124 +97,125 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
             <div id="headermenu" style="float: right;">
                 <ul id="navigation">
                     <li ng-if="!cdash.noproject && cdash.projectname_encoded !== undefined">
-                        <a ng-href="{{ url('/index.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
+                        <a class="cdash-link" ng-href="{{ url('/index.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
                             Dashboard
                         </a>
                         <ul>
                             <li ng-if="cdash.menu.subprojects == 1">
-                                <a ng-href="{{ url('/viewSubProjects.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
+                                <a class="cdash-link" ng-href="{{ url('/viewSubProjects.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
                                     SubProjects
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/overview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
+                                <a class="cdash-link" ng-href="{{ url('/overview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
                                     Overview
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/buildOverview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
+                                <a class="cdash-link" ng-href="{{ url('/buildOverview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
                                     Builds
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/testOverview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
+                                <a class="cdash-link" ng-href="{{ url('/testOverview.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
                                     Tests
                                 </a>
                             </li>
                             <li>
-                                <a ng-if="!cdash.parentid || cdash.parentid <= 0"
+                                <a class="cdash-link" ng-if="!cdash.parentid || cdash.parentid <= 0"
                                    ng-href="{{ url('/queryTests.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}@{{::cdash.querytestfilters}}">
                                     Tests Query
                                 </a>
-                                <a ng-if="cdash.parentid > 0"
+                                <a class="cdash-link" ng-if="cdash.parentid > 0"
                                    ng-href="{{ url('/queryTests.php') }}?project=@{{::cdash.projectname_encoded}}&parentid=@{{::cdash.parentid}}@{{::cdash.extraurl}}@{{::cdash.extrafilterurl}}">
                                     Tests Query
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/userStatistics.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
+                                <a class="cdash-link" ng-href="{{ url('/userStatistics.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}">
                                     Statistics
                                 </a>
                             </li>
                             <li class="endsubmenu">
-                                <a ng-href="{{ url('/viewMap.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
+                                <a class="cdash-link" ng-href="{{ url('/viewMap.php') }}?project=@{{::cdash.projectname_encoded}}&date=@{{::cdash.date}}@{{::cdash.extraurl}}">
                                     Sites
                                 </a>
                             </li>
                         </ul>
                     </li>
                     <li id="Back" ng-if="cdash.menu.back">
-                        <a ng-href="@{{::cdash.menu.back}}@{{::cdash.extrafilterurl}}"
+                        <a class="cdash-link"
+                           ng-href="@{{::cdash.menu.back}}@{{::cdash.extrafilterurl}}"
                            tooltip-popup-delay="1500"
                            tooltip-append-to-body="true"
                            tooltip-placement="bottom"
                            uib-tooltip="Go back up one level in the hierarchy of results">Up</a>
                     </li>
                     <li ng-if="cdash.showcalendar">
-                        <a id="cal" href="" ng-click="toggleCalendar()">Calendar</a>
+                        <a class="cdash-link" id="cal" href="" ng-click="toggleCalendar()">Calendar</a>
                         <span id="date_now" style="display:none;">@{{::cdash.date}}</span>
                     </li>
                     <li ng-if="!cdash.hidenav && cdash.projectname_encoded !== undefined">
-                        <a href="#">Project</a>
+                        <a class="cdash-link" href="#">Project</a>
                         <ul>
                             <li>
-                                <a ng-href="@{{::cdash.home}}">Home</a>
+                                <a class="cdash-link" ng-href="@{{::cdash.home}}">Home</a>
                             </li>
                             <li ng-if="cdash.documentation.replace('https://', '').replace('http://', '').trim() !== ''">
-                                <a ng-href="@{{::cdash.documentation}}">Documentation</a>
+                                <a class="cdash-link" ng-href="@{{::cdash.documentation}}">Documentation</a>
                             </li>
                             <li ng-if="cdash.vcs.replace('https://', '').replace('http://', '').trim() !== ''">
-                                <a ng-href="@{{::cdash.vcs}}">Repository</a>
+                                <a class="cdash-link" ng-href="@{{::cdash.vcs}}">Repository</a>
                             </li>
                             <li ng-if="cdash.bugtracker.replace('https://', '').replace('http://', '').trim() !== ''"
                                 ng-class="::{endsubmenu: cdash.projectrole}">
-                                <a ng-href="@{{::cdash.bugtracker}}"> Bug Tracker</a>
+                                <a class="cdash-link" ng-href="@{{::cdash.bugtracker}}"> Bug Tracker</a>
                             </li>
                             <li ng-if="!cdash.projectrole" class="endsubmenu">
-                                <a ng-href="{{ url('/subscribeProject.php') }}?projectid=@{{::cdash.projectid}}">Subscribe</a>
+                                <a class="cdash-link" ng-href="{{ url('/subscribeProject.php') }}?projectid=@{{::cdash.projectid}}">Subscribe</a>
                             </li>
                         </ul>
                     </li>
                     <li ng-if="cdash.user.admin == 1 && !cdash.noproject && cdash.projectid !== undefined" id="admin">
-                        <a href="#">Settings</a>
+                        <a class="cdash-link" href="#">Settings</a>
                         <ul>
                             <li>
-                                <a ng-href="{{ url('/project') }}/@{{::cdash.projectid}}/edit">
+                                <a class="cdash-link" ng-href="{{ url('/project') }}/@{{::cdash.projectid}}/edit">
                                     Project
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/manageProjectRoles.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageProjectRoles.php') }}?projectid=@{{::cdash.projectid}}">
                                     Users
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/manageBuildGroup.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageBuildGroup.php') }}?projectid=@{{::cdash.projectid}}">
                                     Groups
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/manageCoverage.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageCoverage.php') }}?projectid=@{{::cdash.projectid}}">
                                     Coverage
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/manageBanner.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageBanner.php') }}?projectid=@{{::cdash.projectid}}">
                                     Banner
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/project') }}/@{{::cdash.projectid}}/testmeasurements">
+                                <a class="cdash-link" ng-href="{{ url('/project') }}/@{{::cdash.projectid}}/testmeasurements">
                                     Measurements
                                 </a>
                             </li>
                             <li>
-                                <a ng-href="{{ url('/manageSubProject.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageSubProject.php') }}?projectid=@{{::cdash.projectid}}">
                                     SubProjects
                                 </a>
                             </li>
                             <li class="endsubmenu">
-                                <a ng-href="{{ url('/manageOverview.php') }}?projectid=@{{::cdash.projectid}}">
+                                <a class="cdash-link" ng-href="{{ url('/manageOverview.php') }}?projectid=@{{::cdash.projectid}}">
                                     Overview
                                 </a>
                             </li>
@@ -228,19 +229,19 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
             <div id="headermenu">
                 <ul id="navigation">
                     <li id="admin">
-                        <a href="#">Settings</a><ul>
-                            <li><a href="{{ url('/project') }}/{{ $project->Id }}/edit">Project</a></li>
-                            <li><a href="{{ url('/manageProjectRoles.php') }}?projectid={{ $project->Id }}">Users</a></li>
-                            <li><a href="{{ url('/manageBuildGroup.php') }}?projectid={{ $project->Id }}">Groups</a></li>
-                            <li><a href="{{ url('/manageCoverage.php') }}?projectid={{ $project->Id }}">Coverage</a></li>
-                            <li><a href="{{ url('/manageBanner.php') }}?projectid={{ $project->Id }}">Banner</a></li>
-                            <li><a href="{{ url('/project') }}/{{ $project->Id }}/testmeasurements">Measurements</a></li>
-                            <li><a href="{{ url('/manageSubProject.php') }}?projectid={{ $project->Id }}">SubProjects</a></li>
-                            <li class="endsubmenu"><a href="{{ url('/manageOverview.php') }}?projectid={{ $project->Id }}">Overview</a></li>
+                        <a class="cdash-link" href="#">Settings</a><ul>
+                            <li><a class="cdash-link" href="{{ url('/project') }}/{{ $project->Id }}/edit">Project</a></li>
+                            <li><a class="cdash-link" href="{{ url('/manageProjectRoles.php') }}?projectid={{ $project->Id }}">Users</a></li>
+                            <li><a class="cdash-link" href="{{ url('/manageBuildGroup.php') }}?projectid={{ $project->Id }}">Groups</a></li>
+                            <li><a class="cdash-link" href="{{ url('/manageCoverage.php') }}?projectid={{ $project->Id }}">Coverage</a></li>
+                            <li><a class="cdash-link" href="{{ url('/manageBanner.php') }}?projectid={{ $project->Id }}">Banner</a></li>
+                            <li><a class="cdash-link" href="{{ url('/project') }}/{{ $project->Id }}/testmeasurements">Measurements</a></li>
+                            <li><a class="cdash-link" href="{{ url('/manageSubProject.php') }}?projectid={{ $project->Id }}">SubProjects</a></li>
+                            <li class="endsubmenu"><a class="cdash-link" href="{{ url('/manageOverview.php') }}?projectid={{ $project->Id }}">Overview</a></li>
                         </ul>
                     </li>
                     <li id="Dashboard">
-                        <a href="{{ url('/index.php') }}?project={{ rawurlencode($project->Name) }}">Dashboard</a>
+                        <a class="cdash-link" href="{{ url('/index.php') }}?project={{ rawurlencode($project->Name) }}">Dashboard</a>
                     </li>
                 </ul>
             </div>

--- a/resources/views/site/site-statistics.blade.php
+++ b/resources/views/site/site-statistics.blade.php
@@ -15,7 +15,7 @@
                 <tr>
                     <td>
                         <b>
-                            <a href="{{ url('/sites/' . $site->siteid) }}">
+                            <a class="cdash-link" href="{{ url('/sites/' . $site->siteid) }}">
                                 {{ $site->sitename }}
                             </a>
                         </b>

--- a/resources/views/test/view-test.blade.php
+++ b/resources/views/test/view-test.blade.php
@@ -25,7 +25,7 @@
                         <b>Site Name:</b>
                     </td>
                     <td>
-                        <a ng-href="sites/{{::cdash.build.siteid}}"
+                        <a class="cdash-link" ng-href="sites/{{::cdash.build.siteid}}"
                            ng-click="cancelAjax()">{{::cdash.build.site}}</a>
                     </td>
                 </tr>
@@ -35,7 +35,7 @@
                         <b>Build Name:</b>
                     </td>
                     <td>
-                        <a ng-href="build/{{::cdash.build.buildid}}"
+                        <a class="cdash-link" ng-href="build/{{::cdash.build.buildid}}"
                            ng-click="cancelAjax()">{{::cdash.build.buildname}}</a>
                     </td>
                 </tr>
@@ -118,7 +118,7 @@
 
         <!-- Filters -->
         <div id="labelshowfilters">
-            <a id="label_showfilters" ng-click="showfilters_toggle()">
+            <a class="cdash-link" id="label_showfilters" ng-click="showfilters_toggle()">
                 <span ng-show="showfilters == 0">Show Filters</span>
                 <span ng-show="showfilters != 0">Hide Filters</span>
             </a>
@@ -232,7 +232,7 @@
 
                 <tr ng-repeat="test in pagination.filteredTests" ng-class-odd="'odd'" ng-class-even="'even'">
                     <td ng-if="::cdash.parentBuild" align="left">
-                        <a ng-href="viewTest.php?buildid={{::test.buildid}}">{{::test.subprojectname}}</a>
+                        <a class="cdash-link" ng-href="viewTest.php?buildid={{::test.buildid}}">{{::test.subprojectname}}</a>
                     </td>
 
                     <td>
@@ -240,18 +240,18 @@
                              src="img/flaggreen.gif" title="flag"/>
                         <img ng-if="::test.new == 1 && !(test.timestatus == 'Passed' && test.status == 'Passed')"
                              src="img/flag.png" title="flag"/>
-                        <a ng-href="{{::test.detailsLink}}"
+                        <a class="cdash-link" ng-href="{{::test.detailsLink}}"
                            ng-click="cancelAjax()">{{::test.name}}</a>
                     </td>
 
                     <td align="center" ng-class="::test.statusclass">
-                        <a ng-href="{{::test.detailsLink}}"
+                        <a class="cdash-link" ng-href="{{::test.detailsLink}}"
                            ng-click="cancelAjax()">{{::test.status}}</a>
                     </td>
 
                     <td ng-if="::cdash.project.showtesttime == 1"
                         align="center" ng-class="::test.timestatusclass">
-                        <a ng-href="{{::test.detailsLink}}?graph=time"
+                        <a class="cdash-link" ng-href="{{::test.detailsLink}}?graph=time"
                            ng-click="cancelAjax()">{{::test.timestatus}}</a>
                     </td>
 
@@ -278,7 +278,7 @@
                     </td>
 
                     <td align="center" ng-class="test.summaryclass">
-                        <a ng-href="{{test.summaryLink}}"
+                        <a class="cdash-link" ng-href="{{test.summaryLink}}"
                            ng-click="cancelAjax()">{{test.summary}}</a>
                     </td>
                     <td ng-repeat="measurement in ::test.measurements track by $index">
@@ -309,7 +309,7 @@
             </div>
 
             <br/>
-            <a ng-href="{{::cdash.csvlink}}">Download Table as CSV File</a>
+            <a class="cdash-link" ng-href="{{::cdash.csvlink}}">Download Table as CSV File</a>
         </div>
     @endverbatim
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,6 +77,7 @@ Route::get('/viewConfigure.php', function (Request $request) {
     return redirect("/builds/{$buildid}/configure", 301);
 });
 
+Route::get('/builds/{build_id}/tests', 'BuildController@tests');
 
 Route::get('/builds/{id}/update', 'BuildController@update');
 Route::permanentRedirect('/build/{id}/update', url('/builds/{id}/update'));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,7 @@ module.exports = {
   ],
   daisyui: {
     logs: false,
+    darkTheme: 'light',
   },
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,5 +15,6 @@ module.exports = {
     logs: false,
     darkTheme: 'light',
   },
+  prefix: 'tw-',
 };
 

--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -22,7 +22,7 @@ class BuildTypeTest extends TestCase
         parent::setUp();
 
         $this->project = $this->makePublicProject();
-        $this->project2 = $this->makePublicProject();
+        $this->project2 = $this->makePrivateProject();
     }
 
     protected function tearDown(): void

--- a/tests/cypress/e2e/view-build-error.cy.js
+++ b/tests/cypress/e2e/view-build-error.cy.js
@@ -82,7 +82,7 @@ describe('viewBuildError', () => {
     const green_text = 'Hello world!';
     cy.get('@error_snippet').eq(0).should('have.css', 'color', 'rgb(0, 187, 0)').and('contain', green_text);
 
-    const red_text = 'Visit our website: <a href="https://www.kitware.com/">Kitware</a>';
+    const red_text = 'Visit our website: <a class="cdash-link" href="https://www.kitware.com/">Kitware</a>';
     cy.get('@error_snippet').eq(1).should('have.css', 'color', 'rgb(255, 85, 85)').and('contain', red_text);
   });
 });

--- a/tests/cypress/e2e/view-build-error.cy.js
+++ b/tests/cypress/e2e/view-build-error.cy.js
@@ -82,7 +82,7 @@ describe('viewBuildError', () => {
     const green_text = 'Hello world!';
     cy.get('@error_snippet').eq(0).should('have.css', 'color', 'rgb(0, 187, 0)').and('contain', green_text);
 
-    const red_text = 'Visit our website: <a class="cdash-link" href="https://www.kitware.com/">Kitware</a>';
+    const red_text = 'Visit our website: <a href="https://www.kitware.com/">Kitware</a>';
     cy.get('@error_snippet').eq(1).should('have.css', 'color', 'rgb(255, 85, 85)').and('contain', red_text);
   });
 });


### PR DESCRIPTION
The current filters interface is written in AngularJS, and the backend for the filters interface currently suffers from a variety of performance, security, and maintainability issues.  The new GraphQL API was designed to replace the legacy JSON API, including the existing filtering logic.  This PR introduces a new filters interface which uses GraphQL introspection to automatically determine the available fields, operators, and enum values (if applicable) for a given filter type.  Since the filters interface accepts an initial set of GraphQL filters and returns modified GraphQL filters, it's completely reusable and straightforward to add to new pages.  This PR is also the first time DaisyUI has been used for a page in CDash.

To provide a basic use case for the new filters component, I created a skeleton replacement for viewTest.php which displays test names and statuses via a paginated GraphQL query.  This page should appear to load much faster than the existing viewTest.php due to the pagination.

Although this PR introduces a significant amount of new functionality, there is still much more to do, including:
- I intend to create a follow-up PR which builds upon our existing Cypress component testing infrastructure, after which thorough tests can be written for the individual components which make GraphQL queries.
- The creation of a `cdash-link` CSS class was needed in this PR to prevent conflicts between DaisyUI and existing CDash CSS code.  This work should be continued to reduce the number of conflicts between DaisyUI and CDash CSS.
- The Boolean and DateTime filter types need to be implemented in the UI.  This requires a date picker to be added, and will be done in a separate PR.
- More columns will be added to the new tests page when the associated data becomes available in the GraphQL API.

<hr>

![image](https://github.com/user-attachments/assets/f00c83b3-5ae6-486b-86a7-49d8ad15f94f)
