### PR TITLE
Move angular_view function to AbstractController

### DIFF
--- a/app/Http/Controllers/AbstractController.php
+++ b/app/Http/Controllers/AbstractController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 abstract class AbstractController extends BaseController
@@ -27,6 +28,32 @@ abstract class AbstractController extends BaseController
         }
 
         return $result;
+    }
+
+    protected function angular_view(string $view): View
+    {
+        // A hack to ensure that redirects work properly after being redirected to the login page
+        session(['url.intended' => url()->full()]);
+
+        $controller_name = '';
+        $path = request()->path() === '/' ? 'index.php' : request()->path();
+        $file = pathinfo(substr($path, strrpos($path, '/')), PATHINFO_FILENAME);
+
+        // Special case: viewBuildGroup.php shares a controller with index.php.
+        if ($file === 'viewBuildGroup') {
+            $file = 'index';
+        }
+        $controller_path = config('cdash.file.path.js.controllers');
+        $controller = "{$controller_path}/{$file}.js";
+        if (is_readable($controller)) {
+            $controller_name = Str::studly($file) . 'Controller';
+        }
+
+        return $this->view('cdash')
+            ->with('xsl_content', file_get_contents(base_path("public/build/views/$view.html")))
+            ->with('xsl', true)
+            ->with('angular', true)
+            ->with('angular_controller', $controller_name);
     }
 
     public static function getCDashVersion(): string

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -502,9 +502,9 @@ final class AdminController extends AbstractController
             ->with('xsl_content', generate_XSLT($xml, base_path() . '/app/cdash/public/upgrade', true));
     }
 
-    public function userStatistics(): \Illuminate\Http\Response
+    public function userStatistics(): View
     {
-        return response()->angular_view('userStatistics');
+        return $this->angular_view('userStatistics');
     }
 
     /** Delete unused rows */

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1006,19 +1006,19 @@ final class BuildController extends AbstractBuildController
         return response()->json(cast_data_for_JSON($response));
     }
 
-    public function manageBuildGroup(): Response
+    public function manageBuildGroup(): View
     {
-        return response()->angular_view('manageBuildGroup');
+        return $this->angular_view('manageBuildGroup');
     }
 
-    public function viewBuildError(): Response
+    public function viewBuildError(): View
     {
-        return response()->angular_view('viewBuildError');
+        return $this->angular_view('viewBuildError');
     }
 
-    public function viewBuildGroup(): Response
+    public function viewBuildGroup(): View
     {
-        return response()->angular_view('index');
+        return $this->angular_view('index');
     }
 
     /**

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -25,14 +25,14 @@ require_once 'include/filterdataFunctions.php';
 
 final class CoverageController extends AbstractBuildController
 {
-    public function compareCoverage(): Response|RedirectResponse
+    public function compareCoverage(): View|RedirectResponse
     {
         // If the project name is not set we display the table of projects.
         if (!isset($_GET['project'])) {
             return redirect('projects');
         }
 
-        return response()->angular_view('compareCoverage');
+        return $this->angular_view('compareCoverage');
     }
 
     /**

--- a/app/Http/Controllers/DynamicAnalysisController.php
+++ b/app/Http/Controllers/DynamicAnalysisController.php
@@ -5,7 +5,6 @@ use App\Utils\PageTimer;
 use App\Utils\TestingDay;
 use CDash\Model\DynamicAnalysis;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
@@ -17,9 +16,9 @@ final class DynamicAnalysisController extends AbstractBuildController
         return $this->view('dynamicanalysis.dynamic-analysis');
     }
 
-    public function viewDynamicAnalysisFile(): Response
+    public function viewDynamicAnalysisFile(): View
     {
-        return response()->angular_view('viewDynamicAnalysisFile');
+        return $this->angular_view('viewDynamicAnalysisFile');
     }
 
     public function apiViewDynamicAnalysis(): JsonResponse

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -2,11 +2,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Response;
+use Illuminate\View\View;
 
 final class IndexController extends AbstractController
 {
-    public function showIndexPage(): Response|RedirectResponse
+    public function showIndexPage(): View|RedirectResponse
     {
         if (!isset($_GET['project'])) {
             $default_project = config('cdash.default_project');
@@ -14,6 +14,6 @@ final class IndexController extends AbstractController
             return redirect($url);
         }
 
-        return response()->angular_view('index');
+        return $this->angular_view('index');
     }
 }

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -11,12 +11,13 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Request;
+use Illuminate\View\View;
 
 final class ProjectOverviewController extends AbstractProjectController
 {
-    public function overview(): Response
+    public function overview(): View
     {
-        return response()->angular_view('overview');
+        return $this->angular_view('overview');
     }
 
     public function apiOverview(): JsonResponse
@@ -750,9 +751,9 @@ final class ProjectOverviewController extends AbstractProjectController
         return json_encode($chart_data);
     }
 
-    public function manageOverview(): Response
+    public function manageOverview(): View
     {
-        return response()->angular_view('manageOverview');
+        return $this->angular_view('manageOverview');
     }
 
     public function apiManageOverview(): JsonResponse

--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -8,7 +8,6 @@ use App\Utils\PageTimer;
 use CDash\Model\SubProject;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -17,14 +16,14 @@ use Illuminate\View\View;
 
 final class SubProjectController extends AbstractProjectController
 {
-    public function viewSubProjects(): Response
+    public function viewSubProjects(): View
     {
-        return response()->angular_view('viewSubProjects');
+        return $this->angular_view('viewSubProjects');
     }
 
-    public function manageSubProject(): Response
+    public function manageSubProject(): View
     {
-        return response()->angular_view('manageSubProject');
+        return $this->angular_view('manageSubProject');
     }
 
 

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -124,9 +124,9 @@ final class TestController extends AbstractProjectController
             ->with('tarray', $tarray);
     }
 
-    public function queryTests(): Response
+    public function queryTests(): View
     {
-        return response()->angular_view('queryTests');
+        return $this->angular_view('queryTests');
     }
 
     public function apiQueryTests(): JsonResponse
@@ -141,9 +141,9 @@ final class TestController extends AbstractProjectController
         return response()->json(cast_data_for_JSON($controller->getResponse()));
     }
 
-    public function testOverview(): Response
+    public function testOverview(): View
     {
-        return response()->angular_view('testOverview');
+        return $this->angular_view('testOverview');
     }
 
     public function apiTestOverview(): JsonResponse
@@ -159,9 +159,9 @@ final class TestController extends AbstractProjectController
         return response()->json(cast_data_for_JSON($controller->getResponse()));
     }
 
-    public function testSummary(): Response
+    public function testSummary(): View
     {
-        return response()->angular_view('testSummary');
+        return $this->angular_view('testSummary');
     }
 
     public function apiTestSummary(): JsonResponse|StreamedResponse

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,12 +12,10 @@ define('FMT_DATETIMEDISPLAY', 'M d, Y - H:i T');  // date and time standard
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 
 require_once 'include/common.php';
 require_once 'include/pdo.php';
@@ -42,33 +40,6 @@ class AppServiceProvider extends ServiceProvider
         if (config('app.env') === 'production') {
             URL::forceScheme('https');
         }
-
-        // This allows us to do response()->angular_view(<view_name>).
-        Response::macro('angular_view', function (string $view_name) {
-            // A hack to ensure that redirects work properly after being redirected to the login page
-            session(['url.intended' => url()->full()]);
-
-            $controller_name = '';
-            $path = request()->path() === '/' ? 'index.php' : request()->path();
-            $file = pathinfo(substr($path, strrpos($path, '/')), PATHINFO_FILENAME);
-
-            // Special case: viewBuildGroup.php shares a controller with index.php.
-            if ($file === 'viewBuildGroup') {
-                $file = 'index';
-            }
-            $controller_path = config('cdash.file.path.js.controllers');
-            $controller = "{$controller_path}/{$file}.js";
-            if (is_readable($controller)) {
-                $controller_name = Str::studly($file) . 'Controller';
-            }
-
-            return response()->view('cdash', [
-                'xsl_content' => file_get_contents(base_path("public/build/views/$view_name.html")),
-                'xsl' => true,
-                'angular' => true,
-                'angular_controller' => $controller_name,
-            ]);
-        });
 
         URL::forceRootUrl(Config::get('app.url'));
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -198,7 +198,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\UrlGenerator\\:\\:full\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: app/Http/Controllers/AbstractController.php
 
 		-
@@ -208,6 +208,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractController.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\|false given\\.$#"
 			count: 1
 			path: app/Http/Controllers/AbstractController.php
 
@@ -307,11 +312,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: app/Http/Controllers/AdminController.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
 
@@ -585,11 +585,6 @@ parameters:
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Comment\\>\\:\\:with\\(\\)\\.$#"
 			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 3
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -991,11 +986,6 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 1
-			path: app/Http/Controllers/CoverageController.php
-
-		-
 			message: "#^Foreach overwrites \\$userid with its value variable\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
@@ -1296,11 +1286,6 @@ parameters:
 			path: app/Http/Controllers/DynamicAnalysisController.php
 
 		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 1
-			path: app/Http/Controllers/DynamicAnalysisController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\EditProjectController\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Http/Controllers/EditProjectController.php
@@ -1329,11 +1314,6 @@ parameters:
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: app/Http/Controllers/FilterController.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 1
-			path: app/Http/Controllers/IndexController.php
 
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, mixed given\\.$#"
@@ -1741,11 +1721,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: app/Http/Controllers/ProjectOverviewController.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
 			count: 2
 			path: app/Http/Controllers/ProjectOverviewController.php
 
@@ -2317,11 +2292,6 @@ parameters:
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubProjectController.php
@@ -2421,11 +2391,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
-			path: app/Http/Controllers/TestController.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\ResponseFactory\\:\\:angular_view\\(\\)\\.$#"
-			count: 3
 			path: app/Http/Controllers/TestController.php
 
 		-
@@ -3033,16 +2998,6 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Foundation\\\\Application\\:\\:isProduction\\(\\)\\.$#"
-			count: 1
-			path: app/Providers/AppServiceProvider.php
-
-		-
-			message: "#^Dynamic call to static method Illuminate\\\\Routing\\\\UrlGenerator\\:\\:full\\(\\)\\.$#"
-			count: 1
-			path: app/Providers/AppServiceProvider.php
-
-		-
-			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\|false given\\.$#"
 			count: 1
 			path: app/Providers/AppServiceProvider.php
 


### PR DESCRIPTION
The `angular_view()` method was previously dynamically attached to the `response()` facade by Laravel.  This PR moves it to the AbstractController class.  This change has two main benefits:

1. PHPStan is able to understand the method better
2. Any project or build information is now passed into the view automatically by building off of the existing `view()` method.