### PR TITLE
Add index to builderror(buildid,type,crc32)

### DIFF
--- a/database/migrations/2024_09_18_131622_builderror_indexing.php
+++ b/database/migrations/2024_09_18_131622_builderror_indexing.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('builderror', function (Blueprint $table) {
+            $table->index(['buildid', 'type', 'crc32']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('builderror', function (Blueprint $table) {
+            $table->dropIndex(['buildid', 'type', 'crc32']);
+        });
+    }
+};


### PR DESCRIPTION
The `builderror` table currently only has indexes on individual columns.  Almost all queries search the table by `buildid` and `type` together.  Adding this index resulted in a significant reduction in processing time for submissions to a large production CDash instance.