### PR TITLE
Add missing ->change() call to testmeasurement migration

### DIFF
--- a/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
+++ b/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
@@ -13,7 +13,8 @@ return new class extends Migration {
     {
         Schema::table('testmeasurement', function (Blueprint $table) {
             $table->unsignedInteger('testid')
-                ->nullable(); // Temporarily make the column nullable
+                ->nullable() // Temporarily make the column nullable
+                ->change();
         });
 
         DB::insert('


### PR DESCRIPTION
#2336 failed to include a call to `->change()` in the migration, which resulted in MySQL instances failing to upgrade due to a type incompatibility issue when adding the foreign key constraint.  It is unclear to me why this was not caught by our CI, and does not affect newly created instances.  I plan to investigate the root cause further and create a testing scheme to prevent this from happening in the future.

Fixes https://github.com/Kitware/CDash/issues/2448.