### PR TITLE
Improve `/projects` load performance

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -76,6 +76,13 @@ type Project {
   ): [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
 
   """
+  An efficient way to get the number of builds matching a given filter.
+  """
+  buildCount(
+    filters: _ @filter(inputType: "BuildFilterInput")
+  ): Int! @count(relation: "builds")
+
+  """
   The most recent build submitted to this server.  Note: this is determined by
   submission time, not build start time.
   """

--- a/resources/js/components/AllProjects.vue
+++ b/resources/js/components/AllProjects.vue
@@ -109,15 +109,11 @@ export default {
               mostRecentBuild {
                 startTime
               }
-              builds(filters: {
+              buildCount(filters: {
                 gt: {
                   submissionTime: "${DateTime.now().minus({days: 7}).startOf('second').toISO({suppressMilliseconds: true})}"
                 }
-              }) {
-                pageInfo {
-                  total
-                }
-              }
+              })
             }
           }
           pageInfo {
@@ -150,9 +146,9 @@ export default {
   methods: {
     formatProjectResults: function (project_edges) {
       return project_edges
-        .filter((project) => this.show_all ? true : project.node.builds.pageInfo.total > 0)
+        .filter((project) => this.show_all ? true : project.node.buildCount > 0)
         .map((project) => {
-          const num_builds_in_last_week = project.node.builds.pageInfo.total;
+          const num_builds_in_last_week = project.node.buildCount;
 
           let activity_level;
           if (num_builds_in_last_week >= 70) {

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -1030,4 +1030,134 @@ class ProjectTypeTest extends TestCase
             ],
         ], true);
     }
+
+    public function testBuildCountFieldWithNoFilters(): void
+    {
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'submittime' => '2009-02-23 10:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'build2',
+            'submittime' => '2010-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'build3',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->projects['public2']->builds()->create([
+            'name' => 'build4',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->projects['private1']->builds()->create([
+            'name' => 'build5',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            buildCount
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'buildCount' => 3,
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'buildCount' => 1,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+
+    public function testBuildCountFieldWithFilters(): void
+    {
+        $this->projects['public1']->builds()->create([
+            'name' => 'build1',
+            'submittime' => '2009-02-23 10:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'build2',
+            'submittime' => '2010-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'build3',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->projects['public2']->builds()->create([
+            'name' => 'build4',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->projects['private1']->builds()->create([
+            'name' => 'build5',
+            'submittime' => '2009-02-23 11:07:03',
+            'uuid' => Str::uuid(),
+        ]);
+
+        $this->graphQL('
+            query {
+                projects {
+                    edges {
+                        node {
+                            name
+                            buildCount(filters: {
+                                gt: {
+                                    submissionTime: "2010-01-01T00:00:00+00:00"
+                                }
+                            })
+                        }
+                    }
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'projects' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'name' => $this->projects['public1']->name,
+                                'buildCount' => 1,
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'name' => $this->projects['public2']->name,
+                                'buildCount' => 0,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
 }


### PR DESCRIPTION
`/projects` currently shows a loading indicator briefly on large production instances with many builds.  This PR attempts to address the issue by adding a `buildCount` field to the Project type in the GraphQL API, which allows filtered count queries to be executed more efficiently.  I plan to add similar fields for build errors/warnings, tests, etc in the future.