### PR TITLE
Add foreign-key constraints to dynamic analysis tables

### DIFF
--- a/database/migrations/2024_09_23_133018_dynamic_analysis_foreign_keys.php
+++ b/database/migrations/2024_09_23_133018_dynamic_analysis_foreign_keys.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        echo "Adding foreign key constraint dynamicanalysisdefect(dynamicanalysisid)->dynamicanalysis(id)...";
+        $num_deleted = DB::delete("DELETE FROM dynamicanalysisdefect WHERE dynamicanalysisid NOT IN (SELECT id FROM dynamicanalysis)");
+        echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+        Schema::table('dynamicanalysisdefect', function (Blueprint $table) {
+            $table->foreign('dynamicanalysisid')->references('id')->on('dynamicanalysis')->cascadeOnDelete();
+            $table->index(['value']);
+            $table->index(['type']);
+            $table->unique(['dynamicanalysisid', 'value', 'type']);
+            $table->unique(['dynamicanalysisid', 'type', 'value']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dynamicanalysisdefect', function (Blueprint $table) {
+            $table->dropForeign(['dynamicanalysisid']);
+            $table->dropIndex(['value']);
+            $table->dropIndex(['type']);
+            $table->dropUnique(['dynamicanalysisid', 'value', 'type']);
+            $table->dropUnique(['dynamicanalysisid', 'type', 'value']);
+        });
+    }
+};


### PR DESCRIPTION
This PR adds a foreign-key constraint to the `dynamicanalysisdefect` table, as well as associated indexing, in support of #2093.  Dynamic analysis results are now cleaned up 100% automatically when their associated build results are removed.