### PR TITLE
Allow production sites to operate over HTTP

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,11 +36,6 @@ class AppServiceProvider extends ServiceProvider
             Schema::defaultStringLength(191);
         }
 
-        // Serve content over https in production mode.
-        if (config('app.env') === 'production') {
-            URL::forceScheme('https');
-        }
-
         URL::forceRootUrl(Config::get('app.url'));
 
         Model::preventSilentlyDiscardingAttributes(!$this->app->isProduction());


### PR DESCRIPTION
CDash currently requires all production sites to operate over HTTPS, even if the `APP_URL` has a HTTP prefix.  There is no technical reason why this requirement is necessary at this point, and some users may desire to forgo setting up certificates for a small internal instance, such as #2457.  This PR removes this requirement and fully respects the `APP_URL` as configured.