### PR TITLE
Index individual buildfailuredetails columns

### DIFF
--- a/database/migrations/2024_09_24_230654_buildfailuredetails_indexing.php
+++ b/database/migrations/2024_09_24_230654_buildfailuredetails_indexing.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('buildfailuredetails', function (Blueprint $table) {
+            $table->index(['exitcondition']);
+            $table->index(['language']);
+            $table->index(['outputfile']);
+            $table->index(['outputtype']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('buildfailuredetails', function (Blueprint $table) {
+            $table->dropIndex(['exitcondition']);
+            $table->dropIndex(['language']);
+            $table->dropIndex(['outputfile']);
+            $table->dropIndex(['outputtype']);
+        });
+    }
+};


### PR DESCRIPTION
The `buildfailuredetails` table currently has almost no indexing, which makes query times slow if an ID is not provided.  This PR adds indexes to each of the columns, excluding the `stdoutput` and `stderror` columns which can potentially contain data which is too large to index.