### PR TITLE
Add details and time columns to new tests page

### DIFF
--- a/app/GraphQL/Scalars/NonNegativeSeconds.php
+++ b/app/GraphQL/Scalars/NonNegativeSeconds.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace App\GraphQL\Scalars;
+
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\FloatValueNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Type\Definition\ScalarType;
+
+final class NonNegativeSeconds extends ScalarType
+{
+    protected function validate(mixed $value): bool
+    {
+        return is_numeric($value) && (float) $value >= 0;
+    }
+
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @throws InvariantViolation
+     */
+    public function serialize(mixed $value): float
+    {
+        if (!$this->validate($value)) {
+            throw new InvariantViolation("Could not serialize {$value} as non-negative seconds.");
+        }
+
+        return $this->parseValue($value);
+    }
+
+    /**
+     * Parses an externally provided value (query variable) to use as an input.
+     *
+     * @throws InvariantViolation
+     */
+    public function parseValue(mixed $value): float
+    {
+        if (!$this->validate($value)) {
+            throw new InvariantViolation("Could not parse {$value} as non-negative seconds.");
+        }
+
+        return (float) $value;
+    }
+
+    /**
+     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input.
+     *
+     * Should throw an exception with a client friendly message on invalid value nodes.
+     *
+     * @param \GraphQL\Language\AST\ValueNode&\GraphQL\Language\AST\Node $valueNode
+     * @param array<string, mixed>|null $variables
+     * @throws Error
+     */
+    public function parseLiteral(Node $valueNode, ?array $variables = null): float
+    {
+        if (!($valueNode instanceof FloatValueNode)) {
+            throw new Error("Query error: Can only parse Floats, got {$valueNode->kind}.", $valueNode);
+        }
+
+        return (float) $valueNode->value;
+    }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,10 @@
 "A datetime and timezone string in ISO 8601 format `Y-m-dTH:i:sP`, e.g. `2020-04-20T13:53:12+02:00`."
 scalar DateTimeTz @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTimeTz")
 
+# It would be better to replace this with a "Duration" scalar type in the future.
+"A non-negative decimal number of seconds."
+scalar NonNegativeSeconds @scalar(class: "App\\GraphQL\\Scalars\\NonNegativeSeconds")
+
 
 "Indicates what fields are available at the top level of a query operation."
 type Query {
@@ -253,6 +257,10 @@ type Test {
 
   status: TestStatus!
 
+  runningTime: NonNegativeSeconds! @rename(attribute: "time")
+
+  details: String!
+
   """
   Test measurements for this test, sorted in descending order so newer results
   appear first when using paginated queries.
@@ -276,6 +284,8 @@ input TestFilterInput {
   id: ID
   name: String @rename(attribute: "testname")
   status: TestStatus
+  runningTime: NonNegativeSeconds @rename(attribute: "time")
+  details: String
 }
 
 

--- a/resources/js/components/BuildTestsPage.vue
+++ b/resources/js/components/BuildTestsPage.vue
@@ -16,6 +16,14 @@
             expand: true,
           },
           {
+            name: 'time',
+            displayName: 'Time',
+          },
+          {
+            name: 'details',
+            displayName: 'Details',
+          },
+          {
             name: 'status',
             displayName: 'Status',
           },
@@ -67,6 +75,8 @@ export default {
                   id
                   name
                   status
+                  details
+                  runningTime
                 }
               }
               pageInfo {
@@ -117,6 +127,11 @@ export default {
             text: edge.node.name,
             href: `${this.$baseURL}/tests/${edge.node.id}`,
           },
+          time: {
+            value: edge.node.runningTime,
+            text: `${edge.node.runningTime}s`,
+          },
+          details: edge.node.details,
           status: {
             // TODO: An integer value could be provided to provide better sorting in the future
             value: edge.node.status,

--- a/resources/js/components/shared/DataTable.vue
+++ b/resources/js/components/shared/DataTable.vue
@@ -60,7 +60,11 @@
             >
               {{ row[column.name].text }}
             </a>
-            <!-- If this is a text value, just display it. -->
+            <!-- If there's a text attribute, display only the text. -->
+            <template v-else-if="Object.hasOwn(row[column.name], 'text')">
+              {{ row[column.name].text }}
+            </template>
+            <!-- If this is a pure text value, just display it. -->
             <template v-else>
               {{ row[column.name] }}
             </template>

--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -35,21 +35,21 @@
       <!-- Value field -->
       <template v-if="selectedType.kind === 'SCALAR'">
         <input
-          v-if="selectedType.name === 'ID' || selectedType.name === 'Int' || selectedType.name === 'Float'"
+          v-if="typeCategory(selectedType.name) === 'NUMBER'"
           v-model="selectedValue"
           type="number"
           class="tw-input tw-input-xs tw-input-bordered tw-shrink"
         >
         <input
-          v-else-if="selectedType.name === 'String'"
+          v-else-if="typeCategory(selectedType.name) === 'STRING'"
           v-model="selectedValue"
           type="text"
           class="tw-input tw-input-xs tw-input-bordered tw-w-full"
         >
-        <span v-else-if="selectedType.name === 'Boolean'">
+        <span v-else-if="typeCategory(selectedType.name) === 'BOOLEAN'">
           <!-- TODO: Implement -->
         </span>
-        <span v-else-if="selectedType.name === 'DateTimeTz'">
+        <span v-else-if="typeCategory(selectedType.name) === 'DATE'">
           <!-- TODO: Implement -->
         </span>
         <span v-else>ERROR: Unknown type</span>
@@ -237,6 +237,32 @@ export default {
           [this.selectedField]: this.selectedValue,
         },
       });
+    },
+
+    /**
+     * Accepts a GraphQL type and returns the type of field to display
+     *
+     * Valid return values: STRING, NUMBER, DATE, BOOLEAN
+     */
+    typeCategory(typename) {
+      switch (typename) {
+      case 'ID':
+        return 'NUMBER';
+      case 'Integer':
+        return 'NUMBER';
+      case 'Float':
+        return 'NUMBER';
+      case 'NonNegativeSeconds':
+        return 'NUMBER';
+      case 'String':
+        return 'STRING';
+      case 'DateTimeTz':
+        return 'DATE';
+      case 'Boolean':
+        return 'BOOLEAN';
+      default:
+        return 'UNKNOWN';
+      }
     },
   },
 };

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -56,6 +56,8 @@ class TestTypeTest extends TestCase
         ])->tests()->create([
             'testname' => 'test1',
             'status' => 'failed',
+            'details' => 'details text',
+            'time' => 1.2,
             'outputid' => $this->test_output->id,
         ]);
 
@@ -71,6 +73,8 @@ class TestTypeTest extends TestCase
                                         node {
                                             name
                                             status
+                                            details
+                                            runningTime
                                         }
                                     }
                                 }
@@ -95,6 +99,8 @@ class TestTypeTest extends TestCase
                                                 'node' => [
                                                     'name' => 'test1',
                                                     'status' => 'FAILED',
+                                                    'details' => 'details text',
+                                                    'runningTime' => 1.2,
                                                 ],
                                             ],
                                         ],

--- a/tests/cypress/component/data-table.cy.js
+++ b/tests/cypress/component/data-table.cy.js
@@ -125,6 +125,35 @@ describe('Data table component tests', () => {
     cy.get('@table-row-2').eq(1).should('contain', 'Data value 5');
   });
 
+  it('Handles text with value without link', () => {
+    cy.mount(DataTable, {
+      props: {
+        columns: [
+          {
+            displayName: 'Test',
+            name: 'test',
+          },
+        ],
+        rows: [
+          {
+            test: {
+              text: 'text1',
+              value: 'value1',
+            },
+          },
+        ],
+        sortable: false,
+      },
+    });
+
+    cy.get('[data-cy="data-table"]')
+      .find('[data-cy="data-table-row"]')
+      .first()
+      .find('[data-cy="data-table-cell"]')
+      .first()
+      .should('have.text', 'text1');
+  });
+
   it('Handles links', () => {
     cy.mount(DataTable, {
       props: {


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2439 introduced a new tests page which will eventually supersede `viewTest.php`.  This PR adds the time and details columns displayed on viewTest.php to the new tests page.  As part of this work, test details and running time are now available via the GraphQL API.

![image](https://github.com/user-attachments/assets/581cf4f6-c1c3-4470-84e4-eb3f35c007be)
