### PR TITLE
Install OPcache PHP extension in Docker by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && \
         pdo_mysql \
         pdo_pgsql \
         xsl \
+        opcache \
         && \
     wget -q -O checksum https://composer.github.io/installer.sha384sum && \
     wget -q -O composer-setup.php https://getcomposer.org/installer && \
@@ -171,7 +172,8 @@ RUN dnf install -y \
       php-ldap \
       php-mbstring \
       php-mysqlnd \
-      php-pdo
+      php-pdo \
+      php-opcache
 
 RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \
       dnf install -y \


### PR DESCRIPTION
PHP's OPcache extension is recommended for most PHP systems, but is not currently installed in our official Docker images.  This PR installs OPcache in each of our Docker images.  In a blank development environment, the overhead cost per request was observed to be 70% less with OPcache installed.  This is particularly important for pages powered by our new GraphQL API, because this overhead cost is incurred for each pagination request.  In my human testing, pages felt considerably faster as I clicked around on the site.

Apache Bench results for an empty development environment:
<details>
<summary>Without OPcache:</summary>

```
$ ab -n 1000 http://localhost:8080/projects
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        Apache/2.4.62
Server Hostname:        localhost
Server Port:            8080

Document Path:          /projects
Document Length:        354 bytes

Concurrency Level:      1
Time taken for tests:   85.755 seconds
Complete requests:      1000
Failed requests:        0
Non-2xx responses:      1000
Total transferred:      1208000 bytes
HTML transferred:       354000 bytes
Requests per second:    11.66 [#/sec] (mean)
Time per request:       85.755 [ms] (mean)
Time per request:       85.755 [ms] (mean, across all concurrent requests)
Transfer rate:          13.76 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       1
Processing:    75   85   3.9     86     111
Waiting:       75   85   3.9     85     110
Total:         75   86   3.9     86     111

Percentage of the requests served within a certain time (ms)
  50%     86
  66%     87
  75%     87
  80%     87
  90%     88
  95%     92
  98%     98
  99%    101
 100%    111 (longest request)
```

</details>
<details>
<summary>With OPcache:</summary>

```
$ ab -n 1000 http://localhost:8080/projects
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        Apache/2.4.62
Server Hostname:        localhost
Server Port:            8080

Document Path:          /projects
Document Length:        354 bytes

Concurrency Level:      1
Time taken for tests:   27.062 seconds
Complete requests:      1000
Failed requests:        0
Non-2xx responses:      1000
Total transferred:      1208000 bytes
HTML transferred:       354000 bytes
Requests per second:    36.95 [#/sec] (mean)
Time per request:       27.062 [ms] (mean)
Time per request:       27.062 [ms] (mean, across all concurrent requests)
Transfer rate:          43.59 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       1
Processing:    23   27   3.2     27     101
Waiting:       22   26   3.2     26     100
Total:         23   27   3.2     27     101

Percentage of the requests served within a certain time (ms)
  50%     27
  66%     27
  75%     27
  80%     28
  90%     28
  95%     28
  98%     31
  99%     33
 100%    101 (longest request)
```

</details>