### PR TITLE
Remove outdated install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ If you'd like to install CDash in a [Docker](https://www.docker.com) container, 
 Before installing CDash, you will need:
 
 - A web server: [Apache](https://httpd.apache.org) or [NGINX](https://www.nginx.com)
-- A database: [MySQL v5.x+](https://www.mysql.com) or [PostgreSQL v9.2+](https://www.postgresql.org)
+- A database: [MySQL v8.x+](https://www.mysql.com) or [PostgreSQL v9.2+](https://www.postgresql.org)
 - [PHP 8.x](https://www.php.net)
 - [Composer v2.x](https://getcomposer.org) (to install PHP dependencies)
 - [npm v8](https://www.npmjs.com/) (to install Javascript dependencies)
@@ -75,47 +75,9 @@ chmod -R g+rw /path/to/CDash
 Perform the follow steps when you initially install CDash and upon each subsequent upgrade.
 
 ```bash
-# Install PHP and JavaScript dependencies
-cd /path/to/CDash
-composer install --no-dev --prefer-dist
-npm install
+bash ./install.sh
 ```
 
 ## Configure CDash and generate build files
 
 The next step is to configure your CDash installation. See [the configuration guide](config.md) for more details.
-
-Once you're happy with your config settings, run `npm` to generate CDash's frontend.
-
-```bash
-# Generate build files
-npm run production
-```
-
-##### Migrating settings from `config.local.php`
-If you're upgrading from CDash v3.0 or earlier you can use the following command to migrate
-your settings from `config.local.php` into the `.env` file used by Laravel.
-
-```bash
-cd /path/to/CDash
-php artisan config:migrate
-```
-
-## Finish CDash installation
-
-Open up your new CDash instance in a web browser. You should be automatically
-redirected to `/install`. Fill out the installation form to create the
-database tables and the initial admin user.
-
-Once that is complete you can create a project and start submitting builds to it.
-
-## Database upgrade
-
-Run the following command whenever you upgrade an existing CDash installation to a new version.
-
-```bash
-cd /path/to/CDash
-php artisan migrate
-```
-
-This will ensure that your database schema is up-to-date.


### PR DESCRIPTION
Most of the install steps in `install.md` are no longer necessary since `install.sh` runs all of them.  Additionally, the `/install` route was removed entirely in #2279, in favor of using environment variables exclusively.

Closes #2464