### PR TITLE
Update usages of deprecated utf8_encode() function

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -106,7 +106,7 @@ function generate_XSLT($xml, string $pageName, bool $return_html = false): strin
 function XMLStrFormat(string $str): string
 {
     if (mb_detect_encoding($str, 'UTF-8', true) === false) {
-        $str = utf8_encode($str);
+        $str = mb_convert_encoding($str, 'UTF-8');
     }
     $str = str_replace('&', '&amp;', $str);
     $str = str_replace('<', '&lt;', $str);
@@ -1137,7 +1137,7 @@ function cast_data_for_JSON($value)
         if (function_exists('mb_detect_encoding') &&
             mb_detect_encoding($value, 'UTF-8', true) === false
         ) {
-            $value = utf8_encode($value);
+            $value = mb_convert_encoding($value, 'UTF-8');
         }
     }
     return $value;


### PR DESCRIPTION
The `utf8_encode()` function is [deprecated](https://www.php.net/manual/en/function.utf8-encode.php).  PHPStan is currently failing for many of our monthly dependency updates because various dependencies got rid of a PHP 7.2 [polyfill](https://github.com/symfony/polyfill-php72) dependency.  This PR updates our two usages of `utf8_encode()` to use `mb_convert_encoding()` instead, which will address the PHPStan failures in some of our dependencies.