### PR TITLE
Run worker containers with unlimited memory

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -38,7 +38,7 @@ if [ "$1" = "start-website" ] ; then
 
 # If the start-worker argument was provided, start a worker process instead
 elif [ "$1" = "start-worker" ] ; then
-  php artisan queue:work
+  php -d memory_limit=-1 artisan queue:work
 
 # Otherwise, throw an error...
 else


### PR DESCRIPTION
Override the memory_limit from php.ini (currently hardcoded to 512M) for worker containers.

The reasoning here is that the `php artisan queue:work` command is running by itself in the container, so it should be allowed to consume as much memory as necessary.

Memory requests/limits should be specified at the Kubernetes or docker compose level instead.