### PR TITLE
Fix "Manage project coverage" from /user

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -76,7 +76,7 @@ final class CoverageController extends AbstractBuildController
         /** @var User $User */
         $User = Auth::user();
         $Project->Id = $projectid;
-        if (!Gate::allows('edit-project', $Project)) {
+        if ($projectid > 0 && !Gate::allows('edit-project', $Project)) {
             return $this->view('cdash')
                 ->with('xsl', true)
                 ->with('xsl_content', "You don't have the permissions to access this page");


### PR DESCRIPTION
Prior to this commit, clicking on the "Manage project coverage" from the /user page for an admin would result in

  You don't have the permissions to access this page

With this change, the user is now presented with a drop-down menu where they can select a project to manage.