### PR TITLE
Change build2test id column type to bigint

### DIFF
--- a/database/migrations/2024_07_01_130230_build2test_id_column.php
+++ b/database/migrations/2024_07_01_130230_build2test_id_column.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (config('database.default') !== 'pgsql') {
+            // We might have to drop these foreign key constraints if users have already run the newer migrations
+            $testmeasurement_foreign_dropped = false;
+            try {
+                Schema::table('testmeasurement', function (Blueprint $table) {
+                    $table->dropForeign(['testid']);
+                });
+                echo 'Dropped testmeasurement(testid) foreign key constraint';
+                $testmeasurement_foreign_dropped = true;
+            } catch (\Illuminate\Database\QueryException) {
+                echo 'testmeasurement(testid) foreign key constraint does not exist.  No changes needed.';
+            }
+
+            $label2test_foreign_dropped = false;
+            try {
+                Schema::table('label2test', function (Blueprint $table) {
+                    $table->dropForeign(['testid']);
+                });
+                echo 'Dropped label2test(testid) foreign key constraint';
+                $label2test_foreign_dropped = true;
+            } catch (\Illuminate\Database\QueryException) {
+                echo 'label2test(testid) foreign key constraint does not exist.  No changes needed.';
+            }
+        }
+
+
+        Schema::table('build2test', function (Blueprint $table) {
+            // Convert to bigint type
+            $table->id()->change();
+        });
+
+        if (config('database.default') !== 'pgsql') {
+            // Restore the dropped foreign key constraints if needed
+            if ($testmeasurement_foreign_dropped) {
+                Schema::table('testmeasurement', function (Blueprint $table) {
+                    $table->foreignId('testid')->change();
+                    $table->foreign('testid')->references('id')->on('build2test')->cascadeOnDelete();
+                });
+            }
+            if ($label2test_foreign_dropped) {
+                Schema::table('label2test', function (Blueprint $table) {
+                    $table->foreignId('testid')->change();
+                    $table->foreign('testid')->references('id')->on('build2test')->cascadeOnDelete();
+                });
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No down migration because we don't know which type the column was before the migration
+    }
+};

--- a/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
+++ b/database/migrations/2024_07_09_025240_find_test_measurements_by_testid.php
@@ -12,7 +12,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('testmeasurement', function (Blueprint $table) {
-            $table->unsignedInteger('testid')
+            $table->foreignId('testid')
                 ->nullable(); // Temporarily make the column nullable
         });
 
@@ -45,7 +45,7 @@ return new class extends Migration {
         ');
 
         Schema::table('testmeasurement', function (Blueprint $table) {
-            $table->unsignedInteger('testid')
+            $table->foreignId('testid')
                 ->nullable(false) // Add a not-null constraint
                 ->index()
                 ->change();
@@ -60,7 +60,7 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table('testmeasurement', function (Blueprint $table) {
-            $table->unsignedInteger('testid')
+            $table->foreignId('testid')
                 ->nullable()
                 ->change();
 

--- a/database/migrations/2024_08_24_160326_label2test_relationship_refactor.php
+++ b/database/migrations/2024_08_24_160326_label2test_relationship_refactor.php
@@ -14,7 +14,7 @@ return new class extends Migration {
         Schema::table('label2test', function (Blueprint $table) {
             $table->dropPrimary();
             $table->dropUnique(['outputid', 'buildid', 'labelid']);
-            $table->unsignedInteger('testid')
+            $table->foreignId('testid')
                 ->nullable();
         });
 
@@ -45,7 +45,7 @@ return new class extends Migration {
         Schema::table('label2test', function (Blueprint $table) {
             $table->dropForeign(['buildid']);
             $table->dropColumn(['buildid', 'outputid']);
-            $table->unsignedInteger('testid')
+            $table->foreignId('testid')
                 ->nullable(false)
                 ->change();
             $table->foreign('testid')


### PR DESCRIPTION
Users have reported issues migrating to post-3.5 commits on master, such as in #2448, due to an inconsistency between database schemas between CDash 2 and 3.  This PR resolves the issue by changing the type of the `build2test` `id` column to an unsigned bigint, in accordance with Laravel tradition.  This also avoids potential overflow concerns.  I plan to make a series of future PRs to change the rest of the ID columns to unsigned bigints.