### PR TITLE
Make filter names more user friendly

### DIFF
--- a/resources/js/components/shared/FilterRow.vue
+++ b/resources/js/components/shared/FilterRow.vue
@@ -225,7 +225,8 @@ export default {
      * Converts a GraphQL field to a human-readable equivalent
      */
     humanReadableField(field) {
-      return field;
+      const result = field.replace(/([A-Z])/g, ' $1');
+      return result.charAt(0).toUpperCase() + result.slice(1);
     },
 
     /**


### PR DESCRIPTION
The new GraphQL-based filters interface currently shows the raw GraphQL field name as the filter name.  This PR improves the UI by rendering the filter names in Title Case.

![image](https://github.com/user-attachments/assets/92844535-c279-42ed-bef2-372adc9c626b)
