### PR TITLE
Overhaul footer layout and add GraphQL Explorer link

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -1213,50 +1213,20 @@ background-color: #adcae6
   background-color: #e8e8e8;
   border-top: solid 1px #BBBBBB;
   margin-top:25px;
-  padding:15px 30px 23px;
+  padding: 15px;
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
 }
 
-#footer a:hover{
+#footer .footer-link {
+  text-decoration: none;
+  color: initial;
+}
+
+#footer .footer-link:hover {
   text-decoration: underline;
-}
-
-#footer #kitwarelogo {
-  float: left;
-  height:26px;
-  margin-top:5px;
-}
-
-#footer #kitwarelogo a {
-  text-decoration: none;
-}
-
-#footer #kitwarelogo img {
-  height:100%;
-  width:auto;
-}
-
-#footerlinks {
-  float: right;
-  height: 32px;
-}
-
-#footerlinks a {
-  text-decoration: none;
-}
-
-#footerlinks .footerlogo {
-  margin-right:8px;
-}
-
-#footerlinks .footerlogo img {
-  height:100%;
-  width:auto;
-}
-
-#footerlinks #footertext,
-#footerlinks #footertext a {
-  font-size: 12px;
-  color: #4A4A4A;
 }
 
 /* flot legend display */

--- a/public/js/services/renderTimer.js
+++ b/public/js/services/renderTimer.js
@@ -19,7 +19,7 @@ CDash.factory('renderTimer', ["$timeout", function ($timeout) {
     $timeout(function() {
       var renderTime = +((new Date() - start) / 1000);
       var generationTimeStr = (renderTime + cdash.generationtime).toFixed(2);
-      generationTimeStr += `s (${cdash.generationtime}s)`;
+      generationTimeStr += ` (${cdash.generationtime}s)`;
       controllerScope.cdash.generationtime = generationTimeStr;
     }, 0, true, controllerScope, cdash);
   };

--- a/resources/js/components/shared/ApiLoader.js
+++ b/resources/js/components/shared/ApiLoader.js
@@ -39,11 +39,14 @@ export default {
         if (document.getElementById('api-endpoint')) {
           document.getElementById('api-endpoint')?.setAttribute('href', vm.cdash.endpoint);
         }
+        if (document.getElementById('api-endpoint-container')) {
+          document.getElementById('api-endpoint-container').style.display = 'inline';
+        }
         if (document.getElementById('generation-time')) {
           document.getElementById('generation-time').textContent = vm.cdash.generationtime;
         }
         if (document.getElementById('testing-day') && vm.cdash.nightlytime !== undefined) {
-          document.getElementById('testing-day').textContent = `Current Testing Day ${vm.cdash.currentdate} | Started at ${vm.cdash.nightlytime}`;
+          document.getElementById('testing-day').textContent = `| Testing day ${vm.cdash.currentdate} started at ${vm.cdash.nightlytime}`;
         }
 
         // Let other components know that data has been loaded from the API.

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,52 +1,45 @@
 {{-- Fill the space between the content and the footer to push the footer to the bottom of the page --}}
 <div style="flex:1;"></div>
 
-<div id="footer" class="clearfix ng-scope">
-    <div id="kitwarelogo">
-        <a class="cdash-link" href="https://www.kitware.com">
-            <img src="{{ asset('img/kitware_logo_footer.svg') }}" alt="logo" height="30">
+<div id="footer" class="ng-scope">
+    <div>
+        <a href="https://www.kitware.com">
+            <img src="{{ asset('img/kitware_logo_footer.svg') }}" alt="logo" height="30" style="height: 30px;">
         </a>
     </div>
-
-    <div id="footerlinks" class="clearfix">
-        <a href="https://www.cdash.org" class="footerlogo cdash-link">
-            <img src="{{ asset('img/cdash_logo_full.svg?rev=2023-05-31') }}" height="30" alt="CDash logo">
+    <div class="footer-element" style="text-align: right;">
+        <a href="https://www.cdash.org">
+            <img src="{{ asset('img/cdash_logo_full.svg?rev=2023-05-31') }}" height="30" alt="CDash logo" style="height: 30px; display: inherit;">
         </a>
-        <span id="footertext" class="pull-right">
-            CDash {{ $cdash_version }} ©&nbsp; <a class="cdash-link" href="https://www.kitware.com">Kitware</a>
-            | <a class="cdash-link" href="https://github.com/Kitware/CDash/issues" target="_blank">Report problems</a>
-
+        <span>
+            {{ $cdash_version }}
+        </span>
+        |
+        <a class="footer-link" href="https://github.com/Kitware/CDash/issues" target="_blank">Report&nbsp;Problems</a>
+        @if(isset($angular) && $angular === true)
+            | <a class="footer-link" ng-href="@{{cdash.endpoint}}">View&nbsp;as&nbsp;JSON</a> {{-- All AngularJS pages have a JSON link --}}
+        @elseif(isset($vue) && $vue === true)
+            <span id="api-endpoint-container" style="display: none;"> {{-- Will be displayed by Vue (if applicable) --}}
+                | <a class="footer-link" id="api-endpoint">View as JSON</a>
+            </span>
+        @endif
+        |
+        <a href="{{ url('/graphql/explorer') }}" class="footer-link">
+            GraphQL&nbsp;Explorer
+        </a>
+        @if(isset($angular) && $angular === true)
+            <span ng-if="::cdash.currentdate">
+                | Testing day @{{ ::cdash.currentdate }} started at @{{ ::cdash.nightlytime }}
+            </span>
+        @elseif(isset($vue) && $vue === true)
+            <span id="testing-day"></span> {{-- Will be filled by Vue --}}
+        @endif
+        |
+        <span id="generation-time"> {{-- Content gets overwritten by Vue deliberately on some legacy pages --}}
             @if(isset($angular) && $angular === true)
-                | <a class="cdash-link" ng-href="@{{cdash.endpoint}}">View as JSON</a>
-            @elseif(isset($vue) && $vue === true)
-                | <a class="cdash-link" id="api-endpoint">View as JSON</a> {{-- Will be filled by Vue --}}
-            @endif
-
-            @if(isset($angular) && $angular === true)
-                <span ng-if="::cdash.generationtime"
-                      tooltip-popup-delay="1500"
-                      tooltip-append-to-body="true"
-                      uib-tooltip="Total (Backend API)"
-                >
-                    | @{{cdash.generationtime}}
-                </span>
-            @elseif(isset($vue) && $vue === true)
-                | <span id="generation-time"></span> {{-- Will be filled by Vue --}}
+                @{{cdash.generationtime}}
             @else
-                <span>
-                    | {{ round(microtime(true) - LARAVEL_START, 2) }}s
-                </span>
-            @endif
-
-            @if(isset($angular) && $angular === true)
-                <span ng-if="::cdash.currentdate">
-                    <br>
-                    Current Testing Day @{{ ::cdash.currentdate }}
-                    | Started at @{{ ::cdash.nightlytime }}
-                </span>
-            @elseif(isset($vue) && $vue === true)
-                <br>
-                <span id="testing-day"></span> {{-- Will be filled by Vue --}}
+                {{ round(microtime(true) - LARAVEL_START, 2) }}s
             @endif
         </span>
     </div>


### PR DESCRIPTION
The footer currently has a number of formatting issues on various page styles due to our inconsistent use of styling and web frameworks.  This PR aims to clean up some of the inconsistencies.  Additionally, this PR adds a new "GraphQL Explorer" footer link and removes the "View as JSON" link on pages which do not have a JSON API to display.

![image](https://github.com/user-attachments/assets/cc38ee7c-ddb8-4548-b544-e18e06de620b)
