### PR TITLE
Fix project role field in standard API response

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -427,7 +427,7 @@ final class CoverageController extends AbstractBuildController
             // Is the user administrator of the project
 
             $project = \App\Models\Project::find((int) $projectid);
-            $role = $project !== null ? $project->users()->withPivot('role')->find((int) ($user->id ?? -1))->role ?? 0 : -1;
+            $role = $project !== null ? $project->users()->withPivot('role')->find((int) ($user->id ?? -1))->pivot->role ?? 0 : -1;
 
             $xml .= add_XML_value('projectrole', $role);
 

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -1037,7 +1037,7 @@ function get_dashboard_JSON($projectname, $date, &$response)
     $userid = Auth::id();
     if ($userid) {
         $project = \App\Models\Project::findOrFail((int) $project->Id);
-        $response['projectrole'] = $project->users()->withPivot('role')->find((int) $userid)->role ?? 0;
+        $response['projectrole'] = $project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? 0;
         if ($response['projectrole'] > Project::SITE_MAINTAINER) {
             $response['user']['admin'] = 1;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -839,7 +839,7 @@ parameters:
 			path: app/Http/Controllers/CDash.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$role\\.$#"
+			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$pivot\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -12466,7 +12466,7 @@ parameters:
 			path: app/cdash/include/cdashmail.php
 
 		-
-			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$role\\.$#"
+			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$pivot\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 


### PR DESCRIPTION
#2396 inadvertently used the incorrect syntax to access values from a pivot table, which led to users being unable to perform admin actions on AngularJS pages.