### PR TITLE
Fix blank lat/long GraphQL Site fields

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -399,9 +399,9 @@ type Site {
   "IP address."
   ip: String!
 
-  latitude: Float!
+  latitude: String!
 
-  longitude: Float!
+  longitude: String!
 
   "Every edit of this site's information."
   information: [SiteInformation!]! @hasMany(type: CONNECTION) @orderBy(column: "timestamp")


### PR DESCRIPTION
Fixes #2502.  The type for the latitude and longitude fields is a string in the database but a float in the API, which causes failures when empty strings are present.  This PR converts the API type to a string to resolve the issue.  In the future, it may be worth creating a custom scalar type for lat/long information.