### PR TITLE
Email all site maintainers

### DIFF
--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -402,25 +402,14 @@ final class ManageProjectRolesController extends AbstractProjectController
      */
     private static function find_site_maintainers(int $projectid): array
     {
+        // Get all the users with the 'Site maintainer' role for this project.
+        $project = \App\Models\Project::findOrFail($projectid);
+        $userids = $project->siteMaintainers()->pluck('userid')->toArray();
+
+        // Next, get the users maintaining specific sites that have received
+        // submissions in the past 48 hours.
         $db = Database::getInstance();
-
-        // Get the registered user first
-        $site2user = $db->executePrepared('
-                     SELECT site2user.userid
-                     FROM site2user, user2project
-                     WHERE
-                         site2user.userid=user2project.userid
-                         AND user2project.projectid=?
-                     ', [$projectid]);
-
-        $userids = [];
-        foreach ($site2user as $site2user_array) {
-            $userids[] = intval($site2user_array['userid']);
-        }
-
-        // Then we list all the users that have been submitting in the past 48 hours
         $submittime_UTCDate = gmdate(FMT_DATETIME, time() - 3600 * 48);
-
         $site2project = $db->executePrepared('
                             SELECT DISTINCT userid
                             FROM site2user

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1367,7 +1367,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 6
+			count: 5
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1407,7 +1407,12 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 6
+			count: 5
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
+			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-


### PR DESCRIPTION
This commit relaxes the constraints used when decided who should receive an email to when a project admin uses the "Email all site maintainers" form.

We will now email all users with the "Site maintainer" role, even if they are not currently marked as maintaining any specific site.