### PR TITLE
Change migration batching approach to avoid problematic syntax on MySQL

### DIFF
--- a/database/migrations/2024_10_13_160937_buildinformation_to_build_table.php
+++ b/database/migrations/2024_10_13_160937_buildinformation_to_build_table.php
@@ -34,30 +34,18 @@ return new class extends Migration {
                 WHERE build.id = buildinformation.buildid
             ');
         } else {
-            // MySQL is a bit more finicky about large transactions, so update in batches of 100
-            $rows_changed = 1;
-            while ($rows_changed > 0) {
-                $rows_changed = DB::update('
-                    UPDATE build, buildinformation
-                    SET
-                        build.osname = buildinformation.osname,
-                        build.osplatform = buildinformation.osplatform,
-                        build.osrelease = buildinformation.osrelease,
-                        build.osversion = buildinformation.osversion,
-                        build.compilername = buildinformation.compilername,
-                        build.compilerversion = buildinformation.compilerversion
-                    WHERE build.id = buildinformation.buildid
-                    LIMIT 100
-                ');
-
-                // Delete the rows we just moved over
-                DB::delete('
-                    DELETE FROM buildinformation
-                    WHERE buildid IN (
-                        SELECT id FROM build
-                    )
-                ');
-            }
+            DB::update('
+                UPDATE build, buildinformation
+                SET
+                    build.osname = buildinformation.osname,
+                    build.osplatform = buildinformation.osplatform,
+                    build.osrelease = buildinformation.osrelease,
+                    build.osversion = buildinformation.osversion,
+                    build.compilername = buildinformation.compilername,
+                    build.compilerversion = buildinformation.compilerversion
+                WHERE
+                    build.id = buildinformation.buildid
+            ');
         }
 
         Schema::dropIfExists('buildinformation');


### PR DESCRIPTION
Users have reported compatibility issues with the recent batched update approach used in several migrations, including #2496.  MySQL 8.3 does not support LIMIT clauses on multi-table update statements.

This PR changes the batching approach used for the two migrations affected by these issues to avoid the problematic syntax.