### PR TITLE
Force URL to start with HTTPS if APP_URL starts with https://

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,6 +38,12 @@ class AppServiceProvider extends ServiceProvider
 
         URL::forceRootUrl(Config::get('app.url'));
 
+        // Work around k8s and proxy issues where Laravel automatically changes the protocol to HTTP
+        // if the incoming request is HTTP.
+        if (str_starts_with(config('app.url'), 'https://')) {
+            URL::forceScheme('https');
+        }
+
         Model::preventSilentlyDiscardingAttributes(!$this->app->isProduction());
     }
 


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2458 removed a line which was believed to have no effect.  After deploying a recent version of CDash to a production system based on Kubernetes, it was discovered that Laravel automatically changes the protocol to `http://` if the incoming request is a HTTP request, even if the `APP_URL` starts with `https://`.  This PR addresses the issue by forcing Laravel to respect the protocol specified by the `APP_URL` environment variable.