### PR TITLE
Add Coverage type to GraphQL API

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -221,4 +221,12 @@ class Build extends Model
     {
         return $this->hasMany(BuildMeasurement::class, 'buildid');
     }
+
+    /**
+     * @return HasMany<Coverage>
+     */
+    public function coverageResults(): HasMany
+    {
+        return $this->hasMany(Coverage::class, 'buildid');
+    }
 }

--- a/app/Models/Coverage.php
+++ b/app/Models/Coverage.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $buildid
@@ -35,4 +36,12 @@ class Coverage extends Model
         'functionstested',
         'functionsuntested',
     ];
+
+    /**
+     * @return BelongsTo<Build, self>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
 }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -219,8 +219,11 @@ set_tests_properties(/Feature/GraphQL/NoteTypeTest PROPERTIES DEPENDS /Feature/G
 add_laravel_test(/Feature/GraphQL/BuildMeasurementTypeTest)
 set_tests_properties(/Feature/GraphQL/BuildMeasurementTypeTest PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
 
+add_laravel_test(/Feature/GraphQL/CoverageTypeTest)
+set_tests_properties(/Feature/GraphQL/CoverageTypeTest PROPERTIES DEPENDS /Feature/GraphQL/BuildTypeTest)
+
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
-set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS "/Feature/GraphQL/TestTypeTest;/Feature/GraphQL/TestMeasurementTypeTest;/Feature/GraphQL/NoteTypeTest;/Feature/GraphQL/BuildMeasurementTypeTest")
+set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS "/Feature/GraphQL/TestTypeTest;/Feature/GraphQL/TestMeasurementTypeTest;/Feature/GraphQL/NoteTypeTest;/Feature/GraphQL/BuildMeasurementTypeTest;/Feature/GraphQL/CoverageTypeTest")
 
 add_laravel_test(/Feature/TestSchemaMigration)
 set_tests_properties(/Feature/TestSchemaMigration PROPERTIES DEPENDS /Feature/PurgeUnusedProjectsCommand)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -251,6 +251,10 @@ type Build {
   compilerName: String @rename(attribute: "compilername")
 
   compilerVersion: String @rename(attribute: "compilerversion")
+  
+  coverageResults(
+    filters: _ @filter(inputType: "CoverageFilterInput")
+  ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 }
 
 input BuildFilterInput {
@@ -469,4 +473,35 @@ input NoteFilterInput {
   id: ID
   name: String
   text: String
+}
+
+
+"""
+Coverage result for a particular build+file combination.
+"""
+type Coverage {
+  "Unique primary key."
+  id: ID!
+
+  linesOfCodeTested: Int! @rename(attribute: "loctested")
+
+  linesOfCodeUntested: Int! @rename(attribute: "locuntested")
+
+  branchesTested: Int! @rename(attribute: "branchestested")
+
+  branchesUntested: Int! @rename(attribute: "branchesuntested")
+
+  functionsTested: Int! @rename(attribute: "functionstested")
+
+  functionsUntested: Int! @rename(attribute: "functionsuntested")
+}
+
+input CoverageFilterInput {
+  id: ID
+  linesOfCodeTested: Int @rename(attribute: "loctested")
+  linesOfCodeUntested: Int @rename(attribute: "locuntested")
+  branchesTested: Int @rename(attribute: "branchestested")
+  branchesUntested: Int @rename(attribute: "branchesuntested")
+  functionsTested: Int @rename(attribute: "functionstested")
+  functionsUntested: Int @rename(attribute: "functionsuntested")
 }

--- a/tests/Feature/GraphQL/CoverageTypeTest.php
+++ b/tests/Feature/GraphQL/CoverageTypeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Project;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class CoverageTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        // Deleting the project will delete all corresponding builds and coverage results
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic test to ensure that each of the fields works
+     */
+    public function testBasicFieldAccess(): void
+    {
+        $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->coverageResults()->create([
+            'loctested' => 4,
+            'locuntested' => 5,
+            'branchestested' => 6,
+            'branchesuntested' => 7,
+            'functionstested' => 8,
+            'functionsuntested' => 9,
+        ]);
+
+        $this->graphQL('
+            query project($id: ID) {
+                project(id: $id) {
+                    builds {
+                        edges {
+                            node {
+                                coverageResults {
+                                    edges {
+                                        node {
+                                            linesOfCodeTested
+                                            linesOfCodeUntested
+                                            branchesTested
+                                            branchesUntested
+                                            functionsTested
+                                            functionsUntested
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $this->project->id,
+        ])->assertJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'coverageResults' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'linesOfCodeTested' => 4,
+                                                    'linesOfCodeUntested' => 5,
+                                                    'branchesTested' => 6,
+                                                    'branchesUntested' => 7,
+                                                    'functionsTested' => 8,
+                                                    'functionsUntested' => 9,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+}


### PR DESCRIPTION
This PR continues our ongoing effort to expose major components of the CDash database via the GraphQL API.  As of now, these changes are rather useless since the filename is not stored in the Coverage table.  A future PR will migrate the filename to the underlying coverage table, and add a filename field to the Coverage GraphQL type.