### PR TITLE
Add GraphQL "contains" filter

### DIFF
--- a/app/GraphQL/Directives/FilterDirective.php
+++ b/app/GraphQL/Directives/FilterDirective.php
@@ -114,6 +114,22 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
                     break;
                 }
             }
+
+            // The "contains" filter requires special treatment
+            if (array_key_exists('contains', $filter)) {
+                $key = array_key_first($filter['contains']);
+                $value = $filter['contains'][$key];
+
+                $query = "POSITION(? IN {$table}.{$key}) > 0";
+
+                if ($context === 'and') {
+                    $builder->whereRaw($query, [$value]);
+                } elseif ($context === 'or') {
+                    $builder->orWhereRaw($query, [$value]);
+                } else {
+                    throw new \InvalidArgumentException('$context must be "and" or "or"');
+                }
+            }
         }
     }
 
@@ -137,6 +153,8 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
                     gt: {$filterName}
                     "Find nodes where the provided field is less than the provided value."
                     lt: {$filterName}
+                    "Find nodes where the provided field contains the provided value."
+                    contains: {$filterName}
                 }
             GRAPHQL
         );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -172,6 +172,11 @@ parameters:
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:orWhereRaw\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:where\\(\\)\\.$#"
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
@@ -179,6 +184,11 @@ parameters:
 		-
 			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:whereNested\\(\\)\\.$#"
 			count: 2
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\|Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation\\|Illuminate\\\\Database\\\\Query\\\\Builder\\:\\:whereRaw\\(\\)\\.$#"
+			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -148,6 +148,55 @@ class FilterTest extends TestCase
         ]);
     }
 
+    public function testContainsOperator(): void
+    {
+        $this->constructNameFilterQuery('
+            contains: {
+                name: "2"
+            }
+        ', [
+            'public2',
+            'private2',
+        ]);
+
+        $this->constructNameFilterQuery('
+            contains: {
+                name: "vate"
+            }
+        ', [
+            'private1',
+            'private2',
+        ]);
+
+        $this->constructNameFilterQuery('
+            contains: {
+                name: ""
+            }
+        ', []);
+    }
+
+    public function testMultipleContainsClauses(): void
+    {
+        $this->constructNameFilterQuery('
+            any: [
+                {
+                    contains: {
+                        name: "2"
+                    }
+                },
+                {
+                    contains: {
+                        name: "3"
+                    }
+                }
+            ]
+        ', [
+            'public2',
+            'public3',
+            'private2',
+        ]);
+    }
+
     public function testAllOperatorWithMultipleEqualOperators(): void
     {
         $this->constructNameFilterQuery('


### PR DESCRIPTION
This PR adds a basic "contains" filter to the GraphQL API.  Users should note that indexing is not helpful for queries using this filter, potentially leading to slowness for some queries.