### PR TITLE
Expose Labels via GraphQL API

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -229,4 +229,12 @@ class Build extends Model
     {
         return $this->hasMany(Coverage::class, 'buildid');
     }
+
+    /**
+     * @return BelongsToMany<Label>
+     */
+    public function labels(): BelongsToMany
+    {
+        return $this->belongsToMany(Label::class, 'label2build', 'buildid', 'labelid');
+    }
 }

--- a/app/Models/Label.php
+++ b/app/Models/Label.php
@@ -4,9 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
+ * Note: Use caution when creating relationships on this model.  Labels can be shared between
+ * projects and relationships could allow malicious actors to access resources they should
+ * not have access to via those relationships if not set up properly.  In the future, it would
+ * be good to have labels be unique on a per-project basis instead of being shared between projects.
+ *
  * @property int $id
  * @property string $text
  *
@@ -26,12 +30,4 @@ class Label extends Model
     protected $casts = [
         'id' => 'integer',
     ];
-
-    /**
-     * @return BelongsToMany<Test>
-     */
-    public function tests(): BelongsToMany
-    {
-        return $this->belongsToMany(Test::class, 'label2test', 'labelid', 'testid');
-    }
 }

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -109,6 +109,8 @@ class Test extends Model
 
     /**
      * Add a label to this buildtest.
+     *
+     * @deprecated 10/26/2024  The legacy Label class is deprecated.  Use the labels() Eloquent relationship instead.
      **/
     public function addLabel(Label $label): void
     {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -296,6 +296,10 @@ type Test {
   appear first when using paginated queries.
   """
   testMeasurements: [TestMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
+  labels(
+    filters: _ @filter(inputType: "LabelFilterInput")
+  ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 }
 
 enum TestStatus {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -251,10 +251,14 @@ type Build {
   compilerName: String @rename(attribute: "compilername")
 
   compilerVersion: String @rename(attribute: "compilerversion")
-  
+
   coverageResults(
     filters: _ @filter(inputType: "CoverageFilterInput")
   ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
+  labels(
+    filters: _ @filter(inputType: "LabelFilterInput")
+  ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 }
 
 input BuildFilterInput {
@@ -504,4 +508,20 @@ input CoverageFilterInput {
   branchesUntested: Int @rename(attribute: "branchesuntested")
   functionsTested: Int @rename(attribute: "functionstested")
   functionsUntested: Int @rename(attribute: "functionsuntested")
+}
+
+
+"""
+Label.
+"""
+type Label {
+  "Unique primary key."
+  id: ID!
+
+  text: String!
+}
+
+input LabelFilterInput {
+  id: ID
+  text: String
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2894,14 +2894,6 @@ parameters:
 			path: app/Models/SubProject.php
 
 		-
-			message: """
-				#^Access to deprecated property \\$labels of class App\\\\Models\\\\Test\\:
-				08/24/2024  This member variable is deprecated\\.  Use the labels\\(\\) Eloquent relationship instead\\.$#
-			"""
-			count: 3
-			path: app/Models/Test.php
-
-		-
 			message: "#^Method App\\\\Models\\\\Test\\:\\:getLabels\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/Models/Test.php
@@ -4519,6 +4511,14 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Test\\:\\:\\$measurements\\.$#"
+			count: 1
+			path: app/Utils/TestCreator.php
+
+		-
+			message: """
+				#^Call to deprecated method addLabel\\(\\) of class App\\\\Models\\\\Test\\:
+				10/26/2024  The legacy Label class is deprecated\\.  Use the labels\\(\\) Eloquent relationship instead\\.$#
+			"""
 			count: 1
 			path: app/Utils/TestCreator.php
 
@@ -16174,6 +16174,14 @@ parameters:
 		-
 			message: "#^Access to property \\$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 2
+			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
+
+		-
+			message: """
+				#^Call to deprecated method addLabel\\(\\) of class App\\\\Models\\\\Test\\:
+				10/26/2024  The legacy Label class is deprecated\\.  Use the labels\\(\\) Eloquent relationship instead\\.$#
+			"""
+			count: 6
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
 		-


### PR DESCRIPTION
This PR continues our ongoing effort to expose major parts of the CDash database schema via GraphQL by adding a new `Label` type, as well as label relationships for the `Build` and `Test` types.