### PR TITLE
Improve maintenance page UI

### DIFF
--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -2,8 +2,35 @@
 <html>
 <head>
     <title>CDash</title>
+    <style>
+        body {
+            font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+            margin: 0;
+        }
+
+        #content {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            text-align: center;
+            align-items: center;
+            height: 100vh;
+        }
+    </style>
 </head>
 <body>
-    CDash is being updated.  Please try again in 2 minutes.
+    <div id="content">
+        <div>
+            <img
+                src="data:image/svg+xml;charset=utf-8,{!! rawurlencode(file_get_contents(public_path('/img/cdash_logo_full.svg'))) !!}"
+                height="100"
+                alt="CDash Logo"
+            >
+        </div>
+        <div>
+            CDash is being updated.<br>
+            This page will reload automatically when CDash is back online.
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Given that some migrations may take extended periods of time for large systems, it is likely that many users will be exposed to the CDash maintenance page eventually.  This PR cleans up the maintenance page UI by centering the text, adding a CDash logo, and adding text indicating that the page will reload automatically.

| **Before**  | **After** |
|---|---|
| ![image](https://github.com/user-attachments/assets/866418f9-70a1-44cc-8739-715487637b92) | ![image](https://github.com/user-attachments/assets/8a487acc-9eda-4f22-ab9c-c6017ef86c01) |