### PR TITLE
Fix emailing multiple site maintainers

### DIFF
--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -77,18 +77,15 @@ final class ManageProjectRolesController extends AbstractProjectController
             if (strlen($emailMaintainers) < 50) {
                 $xml .= '<error>The email should be more than 50 characters.</error>';
             } else {
+                $email_to = [];
                 $maintainerids = self::find_site_maintainers(intval($projectid));
-                $email = '';
                 foreach ($maintainerids as $maintainerid) {
-                    if (strlen($email) > 0) {
-                        $email .= ', ';
-                    }
-                    $email .= User::findOrFail((int) $maintainerid)->email;
+                    $email_to[] = User::findOrFail((int) $maintainerid)->email;
                 }
 
                 $projectname = get_project_name($projectid);
-                if ($email != '') {
-                    if (cdashmail("$email", 'CDash - ' . $projectname . ' : To Site Maintainers', "$emailMaintainers")) {
+                if (count($email_to) !== 0) {
+                    if (cdashmail($email_to, 'CDash - ' . $projectname . ' : To Site Maintainers', "$emailMaintainers")) {
                         $xml .= '<warning>Email sent to site maintainers.</warning>';
                     } else {
                         $xml .= '<error>Cannot send email to site maintainers.</error>';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1417,7 +1417,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 5
+			count: 4
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-


### PR DESCRIPTION
Prior to this commit, attempting to email multiple site maintainers from the manageProjectRoles.php page would result in the following error:

```
Email "user1@example.com, user2@example.com" does not comply with addr-spec of RFC 2822.
```

Fixes #2450
Follow-up to #2505