### PR TITLE
Await API load before attempting to render dynamic analysis

### DIFF
--- a/resources/js/components/ViewDynamicAnalysis.vue
+++ b/resources/js/components/ViewDynamicAnalysis.vue
@@ -3,103 +3,107 @@
     <p>{{ cdash.error }}</p>
   </section>
   <section v-else>
-    <h3>Dynamic analysis started on {{ cdash.build.buildtime }}</h3>
+    <loading-indicator :is-loading="loading">
+      <h3>Dynamic analysis started on {{ cdash.build.buildtime }}</h3>
 
-    <table border="0">
-      <tr>
-        <td align="right">
-          <b>Site Name:</b>
-        </td>
-        <td>{{ cdash.build.site }}</td>
-      </tr>
-      <tr>
-        <td align="right">
-          <b>Build Name:</b>
-        </td>
-        <td>{{ cdash.build.buildname }}</td>
-      </tr>
-    </table>
-
-    <div class="buildgroup">
-      <table
-        cellspacing="0"
-        class="tabb striped"
-        width="100%"
-      >
-        <thead>
-          <tr class="table-heading1">
-            <td
-              class="center-text botl"
-              colspan="100"
-            >
-              Dynamic Analysis
-            </td>
-          </tr>
-          <tr class="table-heading">
-            <th class="column-header">
-              Name
-            </th>
-            <th class="column-header">
-              Status
-            </th>
-            <th
-              v-for="defecttype in cdash.defecttypes"
-              class="column-header"
-            >
-              {{ defecttype.type }}
-            </th>
-            <th
-              v-if="cdash.displaylabels"
-              class="column-header"
-            >
-              Labels
-            </th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr
-            v-for="DA in cdash.dynamicanalyses"
-            align="center"
-          >
-            <td align="left">
-              <a
-                class="cdash-link"
-                :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id"
-              >
-                {{ DA.name }}
-              </a>
-            </td>
-
-            <td :class="DA.status === 'Passed' ? 'normal' : 'error'">
-              {{ DA.status }}
-            </td>
-
-            <!-- Show how many defects of each type were found for this test -->
-            <td
-              v-for="numdefects in DA.defects"
-              :class="{warning: numdefects > 0}"
-            >
-              <span v-if="numdefects > 0">
-                {{ numdefects }}
-              </span>
-            </td>
-
-            <!-- Labels -->
-            <td v-if="cdash.displaylabels">
-              {{ DA.labels }}
-            </td>
-          </tr>
-        </tbody>
+      <table border="0">
+        <tr>
+          <td align="right">
+            <b>Site Name:</b>
+          </td>
+          <td>{{ cdash.build.site }}</td>
+        </tr>
+        <tr>
+          <td align="right">
+            <b>Build Name:</b>
+          </td>
+          <td>{{ cdash.build.buildname }}</td>
+        </tr>
       </table>
-    </div>
+
+      <div class="buildgroup">
+        <table
+          cellspacing="0"
+          class="tabb striped"
+          width="100%"
+        >
+          <thead>
+            <tr class="table-heading1">
+              <td
+                class="center-text botl"
+                colspan="100"
+              >
+                Dynamic Analysis
+              </td>
+            </tr>
+            <tr class="table-heading">
+              <th class="column-header">
+                Name
+              </th>
+              <th class="column-header">
+                Status
+              </th>
+              <th
+                v-for="defecttype in cdash.defecttypes"
+                class="column-header"
+              >
+                {{ defecttype.type }}
+              </th>
+              <th
+                v-if="cdash.displaylabels"
+                class="column-header"
+              >
+                Labels
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr
+              v-for="DA in cdash.dynamicanalyses"
+              align="center"
+            >
+              <td align="left">
+                <a
+                  class="cdash-link"
+                  :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id"
+                >
+                  {{ DA.name }}
+                </a>
+              </td>
+
+              <td :class="DA.status === 'Passed' ? 'normal' : 'error'">
+                {{ DA.status }}
+              </td>
+
+              <!-- Show how many defects of each type were found for this test -->
+              <td
+                v-for="numdefects in DA.defects"
+                :class="{warning: numdefects > 0}"
+              >
+                <span v-if="numdefects > 0">
+                  {{ numdefects }}
+                </span>
+              </td>
+
+              <!-- Labels -->
+              <td v-if="cdash.displaylabels">
+                {{ DA.labels }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </loading-indicator>
   </section>
 </template>
 
 <script>
 import ApiLoader from './shared/ApiLoader';
+import LoadingIndicator from './shared/LoadingIndicator.vue';
 export default {
   name: 'ViewDynamicAnalysis',
+  components: {LoadingIndicator},
 
   props: {
     buildid: {

--- a/resources/views/dynamicanalysis/dynamic-analysis.blade.php
+++ b/resources/views/dynamicanalysis/dynamic-analysis.blade.php
@@ -4,5 +4,5 @@
 ])
 
 @section('main_content')
-    <view-dynamic-analysis buildid="{{ $build->Id }}"></view-dynamic-analysis>
+    <view-dynamic-analysis :buildid="{{ $build->Id }}"></view-dynamic-analysis>
 @endsection


### PR DESCRIPTION
The dynamic analysis results page (`/builds/<id>/dynamic_analysis`) currently fails to load in some cases because the page renders before the API has returned data.  This PR wraps the page body in the loading indicator component to prevent Vue from attempting to render the content before the API returns.