### PR TITLE
Bump PHPStan rules to level 9

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,8 +17,28 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
+			message: "#^Cannot access offset 'autoremovemaxbuilds' on mixed\\.$#"
+			count: 2
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Cannot access offset 'autoremovetimeframe' on mixed\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 3
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 2
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 3
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
@@ -42,9 +62,24 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
+			message: "#^Parameter \\#1 \\$projectid of static method App\\\\Utils\\\\DatabaseCleanupUtils\\:\\:removeFirstBuilds\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 2
 			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Parameter \\#2 \\$days of static method App\\\\Utils\\\\DatabaseCleanupUtils\\:\\:removeFirstBuilds\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: app/Console/Commands/AutoRemoveBuilds.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: app/Console/Commands/CheckKey.php
 
 		-
 			message: "#^Method App\\\\Console\\\\Commands\\\\QueueSubmissions\\:\\:handle\\(\\) should return mixed but return statement is missing\\.$#"
@@ -142,6 +177,11 @@ parameters:
 			path: app/Console/Commands/UpdateDependencies.php
 
 		-
+			message: "#^Part \\$xml_type \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Console/Commands/ValidateXml.php
+
+		-
 			message: "#^Parameter \\#1 \\$path of function app_path expects string, bool\\|string given\\.$#"
 			count: 1
 			path: app/Console/Kernel.php
@@ -167,6 +207,16 @@ parameters:
 			path: app/Exceptions/Handler.php
 
 		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 2
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			message: "#^Method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:applyFilters\\(\\) has parameter \\$builder with generic class Illuminate\\\\Database\\\\Eloquent\\\\Builder but does not specify its types\\: TModelClass$#"
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
@@ -175,6 +225,31 @@ parameters:
 			message: "#^Method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:applyFilters\\(\\) has parameter \\$builder with generic class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\Relation but does not specify its types\\: TRelatedModel$#"
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_key_first expects array, mixed given\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 4
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Parameter \\#2 \\$filterName of method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:createMultiFilterInput\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			message: "#^Cannot cast mixed to float\\.$#"
+			count: 1
+			path: app/GraphQL/Scalars/NonNegativeSeconds.php
+
+		-
+			message: "#^Part \\$value \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/GraphQL/Scalars/NonNegativeSeconds.php
 
 		-
 			message: "#^Class App\\\\Http\\\\Controllers\\\\AbstractBuildController has an uninitialized property \\$build\\. Give it default value or assign it in the constructor\\.$#"
@@ -198,6 +273,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AbstractController.php
+
+		-
+			message: "#^Part \\$controller_path \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Http/Controllers/AbstractController.php
 
@@ -291,6 +371,11 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: app/Http/Controllers/AdminController.php
@@ -366,6 +451,11 @@ parameters:
 			path: app/Http/Controllers/AdminController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 8
+			path: app/Http/Controllers/AdminController.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, \\(int\\|false\\) given\\.$#"
 			count: 3
 			path: app/Http/Controllers/AdminController.php
@@ -391,7 +481,17 @@ parameters:
 			path: app/Http/Controllers/Auth/LoginController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\LoginController\\:\\:redirectTo\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/LoginController.php
+
+		-
 			message: "#^Cannot access property \\$password on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: "#^Cannot call method hasVerifiedEmail\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
 
@@ -411,6 +511,11 @@ parameters:
 			path: app/Http/Controllers/Auth/RegisterController.php
 
 		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:register\\(\\) should return Illuminate\\\\Http\\\\RedirectResponse\\|Illuminate\\\\Http\\\\Response but returns mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\Auth\\\\RegisterController\\:\\:validator\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
@@ -422,6 +527,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$user of method Illuminate\\\\Contracts\\\\Auth\\\\StatefulGuard\\:\\:login\\(\\) expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/Auth/RegisterController.php
+
+		-
+			message: "#^Part \\$password_min \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Http/Controllers/Auth/RegisterController.php
 
@@ -441,7 +551,22 @@ parameters:
 			path: app/Http/Controllers/AuthTokenController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AuthTokenController.php
+
+		-
 			message: "#^Parameter \\#2 \\$expected_user_id of static method App\\\\Utils\\\\AuthTokenUtil\\:\\:deleteToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AuthTokenController.php
+
+		-
+			message: "#^Parameter \\#3 \\$scope of static method App\\\\Utils\\\\AuthTokenUtil\\:\\:generateToken\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/AuthTokenController.php
+
+		-
+			message: "#^Parameter \\#4 \\$description of static method App\\\\Utils\\\\AuthTokenUtil\\:\\:generateToken\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/AuthTokenController.php
 
@@ -498,6 +623,36 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			message: "#^Cannot access an offset on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access offset 'stderror' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access offset 'stdoutput' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access offset 'subprojectid' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot access property \\$BuildId on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 2
 			path: app/Http/Controllers/BuildController.php
@@ -505,6 +660,11 @@ parameters:
 		-
 			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot call method GetUpdateForBuild\\(\\) on mixed\\.$#"
+			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -520,6 +680,16 @@ parameters:
 		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 3
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Cannot use \\+\\+ on mixed\\.$#"
+			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -653,6 +823,21 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function substr_count expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$project_name of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectByName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
 			count: 4
 			path: app/Http/Controllers/BuildController.php
@@ -668,6 +853,11 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, \\(array\\<int, string\\>\\|string\\) given\\.$#"
 			count: 2
 			path: app/Http/Controllers/BuildController.php
@@ -675,6 +865,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
 			count: 4
+			path: app/Http/Controllers/BuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 9
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -713,6 +908,11 @@ parameters:
 			path: app/Http/Controllers/BuildNoteController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildNoteController.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -729,6 +929,36 @@ parameters:
 			path: app/Http/Controllers/BuildPropertiesController.php
 
 		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot access offset 'descr' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot access offset 'properties' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot access offset int\\|string on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 3
 			path: app/Http/Controllers/BuildPropertiesController.php
@@ -740,6 +970,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildPropertiesController.php
 
@@ -759,7 +994,22 @@ parameters:
 			path: app/Http/Controllers/BuildPropertiesController.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
 			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, float\\|int\\|string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$project_name of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectByName\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildPropertiesController.php
 
@@ -771,6 +1021,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$stmt of method App\\\\Http\\\\Controllers\\\\BuildPropertiesController\\:\\:gather_defects\\(\\) expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
 			count: 2
+			path: app/Http/Controllers/BuildPropertiesController.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
+			count: 1
 			path: app/Http/Controllers/BuildPropertiesController.php
 
 		-
@@ -829,13 +1084,28 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 7
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Binary operation \"\\+\" between \\(array\\|float\\|int\\) and 10 results in an error\\.$#"
 			count: 2
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'build' and mixed results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and \\(array\\|float\\|int\\) results in an error\\.$#"
 			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 2
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -886,13 +1156,68 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 10
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'key' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Cannot access offset 'loctested' on array\\|false\\|null\\.$#"
 			count: 4
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Cannot access offset 'loctested' on mixed\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'loctesteddiff' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Cannot access offset 'locuntested' on array\\|false\\|null\\.$#"
 			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'locuntested' on mixed\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'locuntesteddiff' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'percentage' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot access offset 'subprojectgroup' on mixed\\.$#"
+			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -916,8 +1241,23 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Cannot call method GetId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot call method GetName\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 13
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -1136,6 +1476,16 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Parameter \\#1 \\$coverage of static method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:apiCompareCoverage_create_subproject\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, int\\|string given\\.$#"
 			count: 2
 			path: app/Http/Controllers/CoverageController.php
@@ -1146,7 +1496,42 @@ parameters:
 			path: app/Http/Controllers/CoverageController.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function htmlentities expects string, mixed given\\.$#"
+			count: 5
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 6
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/CoverageController.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 13
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#2 \\$build_array of static method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:apiCompareCoverage_get_build_label\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#2 \\$file_path of method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:setFilePriority\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -1162,6 +1547,21 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Parameter \\#3 \\$coverage of static method App\\\\Http\\\\Controllers\\\\CoverageController\\:\\:apiCompareCoverage_populate_subproject\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
+			count: 4
+			path: app/Http/Controllers/CoverageController.php
+
+		-
+			message: "#^Part \\$num_labels \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Http/Controllers/CoverageController.php
 
@@ -1206,8 +1606,18 @@ parameters:
 			path: app/Http/Controllers/EditProjectController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 3
+			path: app/Http/Controllers/ExpectedBuildController.php
+
+		-
 			message: "#^Only numeric types are allowed in \\-, \\(int\\|false\\) given on the right side\\.$#"
 			count: 1
+			path: app/Http/Controllers/ExpectedBuildController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 3
 			path: app/Http/Controllers/ExpectedBuildController.php
 
 		-
@@ -1221,9 +1631,29 @@ parameters:
 			path: app/Http/Controllers/FilterController.php
 
 		-
+			message: "#^Parameter \\#1 \\$page_id of static method App\\\\Http\\\\Controllers\\\\FilterController\\:\\:getFiltersForPage\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/FilterController.php
+
+		-
+			message: "#^Parameter \\#1 \\$page_id of static method App\\\\Http\\\\Controllers\\\\FilterController\\:\\:isDatePage\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/FilterController.php
+
+		-
 			message: "#^Only booleans are allowed in a ternary operator condition, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/IndexController.php
+
+		-
+			message: "#^Part \\$default_project \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/IndexController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 3
+			path: app/Http/Controllers/ManageBannerController.php
 
 		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageBannerController\\:\\:manageBanner\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
@@ -1233,6 +1663,21 @@ parameters:
 		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 2
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
 		-
@@ -1258,6 +1703,11 @@ parameters:
 		-
 			message: "#^Cannot call method save\\(\\) on App\\\\Models\\\\Measurement\\|null\\.$#"
 			count: 1
+			path: app/Http/Controllers/ManageMeasurementsController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 4
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
 		-
@@ -1301,6 +1751,11 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Binary operation \"\\.\" between '%%' and mixed results in an error\\.$#"
+			count: 3
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: """
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
@@ -1338,6 +1793,21 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 5
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Cannot access offset 'tmp_name' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
+			count: 5
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 4
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1416,6 +1886,11 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
 			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -1437,6 +1912,21 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function urlencode expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 4
+			path: app/Http/Controllers/ManageProjectRolesController.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
@@ -1471,7 +1961,52 @@ parameters:
 			path: app/Http/Controllers/ManageUsersController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageUsersController\\:\\:showPage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Parameter \\#1 \\$password of function password_hash expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Part \\$email \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Part \\$passwd \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$email \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$firstname \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$institution \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ManageUsersController.php
+
+		-
+			message: "#^Property App\\\\Models\\\\User\\:\\:\\$lastname \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageUsersController.php
 
@@ -1527,6 +2062,11 @@ parameters:
 			path: app/Http/Controllers/MapController.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/MapController.php
+
+		-
 			message: "#^Parameter \\#2 \\$minute of function gmmktime expects int\\|null, string given\\.$#"
 			count: 2
 			path: app/Http/Controllers/MapController.php
@@ -1572,12 +2112,27 @@ parameters:
 			path: app/Http/Controllers/MapController.php
 
 		-
+			message: "#^Binary operation \"\\-\" between int\\<1, max\\> and mixed results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/MonitorController.php
+
+		-
 			message: "#^Cannot access property \\$truncated_time on stdClass\\|null\\.$#"
 			count: 8
 			path: app/Http/Controllers/MonitorController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/MonitorController.php
+
+		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\OAuthController\\:\\:callback\\(\\) never returns Illuminate\\\\Routing\\\\Redirector so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/Http/Controllers/OAuthController.php
+
+		-
+			message: "#^Parameter \\#1 \\$to of function redirect expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/OAuthController.php
 
@@ -1600,8 +2155,18 @@ parameters:
 			path: app/Http/Controllers/ProjectController.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/ProjectController.php
+
+		-
 			message: "#^Access to an undefined property object\\:\\:\\$numdefects\\.$#"
 			count: 2
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
@@ -1627,6 +2192,21 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
@@ -1920,6 +2500,26 @@ parameters:
 			path: app/Http/Controllers/ProjectOverviewController.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 3
+			path: app/Http/Controllers/ProjectOverviewController.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 2
 			path: app/Http/Controllers/ProjectOverviewController.php
@@ -1937,6 +2537,11 @@ parameters:
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -1976,6 +2581,11 @@ parameters:
 		-
 			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
 			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 4
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2039,8 +2649,23 @@ parameters:
 			path: app/Http/Controllers/SiteController.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SiteController.php
+
+		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|false given\\.$#"
 			count: 2
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 4
+			path: app/Http/Controllers/SiteController.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
 			path: app/Http/Controllers/SiteController.php
 
 		-
@@ -2207,8 +2832,23 @@ parameters:
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
 			count: 2
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Parameter \\#1 \\$time of static method Carbon\\\\Carbon\\:\\:parse\\(\\) expects DateTimeInterface\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubProjectController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
@@ -2235,6 +2875,31 @@ parameters:
 			path: app/Http/Controllers/SubmissionController.php
 
 		-
+			message: "#^Parameter \\#1 \\$projectname of static method CDash\\\\Model\\\\Project\\:\\:validateProjectName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function decrypt expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
+			message: "#^Part \\$projectname \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 4
+			path: app/Http/Controllers/SubmissionController.php
+
+		-
 			message: "#^Argument of an invalid type array\\<int\\>\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
@@ -2242,6 +2907,11 @@ parameters:
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 2
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -2286,9 +2956,44 @@ parameters:
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
+			message: "#^Parameter \\#1 \\$credentials of method CDash\\\\Model\\\\UserProject\\:\\:UpdateCredentials\\(\\) expects array, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Parameter \\#1 \\$labels of method CDash\\\\Model\\\\LabelEmail\\:\\:UpdateLabels\\(\\) expects array\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 13
+			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
+
+		-
+			message: "#^Binary operation \"\\+\" between mixed and 86400 results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Binary operation \"\\-\" between mixed and 604800 results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Binary operation \"\\-\\=\" between mixed and 86400 results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Binary operation \"\\.\" between mixed and '&export\\=csv' results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
 
 		-
 			message: """
@@ -2301,6 +3006,26 @@ parameters:
 		-
 			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
 			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot access property \\$buildid on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot access property \\$name on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot access property \\$value on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
 			path: app/Http/Controllers/TestController.php
 
 		-
@@ -2319,6 +3044,21 @@ parameters:
 			path: app/Http/Controllers/TestController.php
 
 		-
+			message: "#^Parameter \\#1 \\$project_name of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectByName\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 3
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 1
 			path: app/Http/Controllers/TestController.php
@@ -2327,6 +3067,16 @@ parameters:
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 2
 			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/TestController.php
+
+		-
+			message: "#^Parameter \\#1 \\$project_name of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectByName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/TimelineController.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Models\\\\Site\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Site\\>\\:\\:\\$id\\.$#"
@@ -2349,6 +3099,11 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Binary operation \"\\.\" between mixed and ' UTC' results in an error\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -2365,6 +3120,46 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Cannot access an offset on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'projectid' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'redirect' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'starttime' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 3
 			path: app/Http/Controllers/UserController.php
@@ -2372,6 +3167,11 @@ parameters:
 		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 4
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
 			path: app/Http/Controllers/UserController.php
 
 		-
@@ -2420,8 +3220,43 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Parameter \\#1 \\$credentials of method CDash\\\\Model\\\\UserProject\\:\\:UpdateCredentials\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$password of function password_hash expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$password of function password_verify expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
 			count: 4
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
 			path: app/Http/Controllers/UserController.php
 
 		-
@@ -2435,6 +3270,26 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
+			message: "#^Part \\$complexity_count \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Part \\$email \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Part \\$minimum_complexity \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/Http/Controllers/UserController.php
+
+		-
+			message: "#^Part \\$minimum_length \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserController.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between mixed~'subscribedtoproject' and 'subscribedtoproject' will always evaluate to false\\.$#"
 			count: 1
 			path: app/Http/Controllers/UserController.php
@@ -2443,6 +3298,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, array\\|string given\\.$#"
 			count: 2
 			path: app/Http/Controllers/UserNoteController.php
+
+		-
+			message: "#^Binary operation \"\\+\\=\" between \\(array\\|float\\|int\\) and mixed results in an error\\.$#"
+			count: 8
+			path: app/Http/Controllers/UserStatisticsController.php
 
 		-
 			message: """
@@ -2458,6 +3318,51 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfailederrors' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfailedtests' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfailedwarnings' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfixederrors' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfixedtests' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'nfixedwarnings' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'totalbuilds' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'totalupdatedfiles' on mixed\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Cannot access offset 'userid' on mixed\\.$#"
+			count: 2
 			path: app/Http/Controllers/UserStatisticsController.php
 
 		-
@@ -2481,7 +3386,22 @@ parameters:
 			path: app/Http/Controllers/UserStatisticsController.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$project_name of method App\\\\Http\\\\Controllers\\\\AbstractProjectController\\:\\:setProjectByName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
+			count: 1
+			path: app/Http/Controllers/UserStatisticsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/UserStatisticsController.php
 
@@ -2574,6 +3494,16 @@ parameters:
 			path: app/Http/Middleware/EncryptCookies.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/Http/Middleware/PasswordExpired.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/Http/Middleware/Timer.php
+
+		-
 			message: "#^PHPDoc type array of property App\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except is not the same as PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Foundation\\\\Http\\\\Middleware\\\\TrimStrings\\:\\:\\$except\\.$#"
 			count: 1
 			path: app/Http/Middleware/TrimStrings.php
@@ -2610,6 +3540,11 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$backupFileName\\.$#"
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
@@ -2729,6 +3664,11 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
+			message: "#^Parameter \\#1 \\$num of function pow expects float\\|int, mixed given\\.$#"
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
 			message: "#^Parameter \\#1 \\$value of method Carbon\\\\Carbon\\:\\:addSeconds\\(\\) expects int, \\(float\\|int\\) given\\.$#"
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
@@ -2752,6 +3692,21 @@ parameters:
 			message: "#^Property App\\\\Jobs\\\\ProcessSubmission\\:\\:\\$projectid has no type specified\\.$#"
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Property App\\\\Jobs\\\\ProcessSubmission\\:\\:\\$timeout \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of method Carbon\\\\Carbon\\:\\:subHours\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: app/Jobs/PruneJobs.php
+
+		-
+			message: "#^Part \\$lifetime \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/Jobs/PruneJobs.php
 
 		-
 			message: "#^Parameter \\#1 \\$filters of static method LdapRecord\\\\Query\\\\Builder\\:\\:rawFilter\\(\\) expects array\\|string, string\\|true given\\.$#"
@@ -2819,6 +3774,11 @@ parameters:
 			path: app/Models/Site.php
 
 		-
+			message: "#^Property App\\\\Models\\\\Site\\:\\:\\$ip \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/Models/Site.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\SubProject\\>\\:\\:orWhere\\(\\)\\.$#"
 			count: 1
 			path: app/Models/SubProject.php
@@ -2830,6 +3790,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Models\\\\Test\\:\\:getLabels\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/Models/Test.php
+
+		-
+			message: "#^Part \\$host_base \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Models/Test.php
 
@@ -2904,6 +3869,16 @@ parameters:
 			path: app/Providers/AppServiceProvider.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function str_starts_with expects string, mixed given\\.$#"
+			count: 1
+			path: app/Providers/AppServiceProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$root of static method Illuminate\\\\Support\\\\Facades\\\\URL\\:\\:forceRootUrl\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/Providers/AppServiceProvider.php
+
+		-
 			message: "#^PHPDoc type array of property App\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies is not the same as PHPDoc type array\\<class\\-string, class\\-string\\> of overridden property Illuminate\\\\Foundation\\\\Support\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies\\.$#"
 			count: 1
 			path: app/Providers/AuthServiceProvider.php
@@ -2934,6 +3909,21 @@ parameters:
 			path: app/Providers/ViewServiceProvider.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/Rules/ProjectVisibilityAllowed.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of static method Illuminate\\\\Support\\\\Str\\:\\:upper\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Rules/ProjectVisibilityAllowed.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/Utils/AuthTokenUtil.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\AuthToken\\>\\:\\:leftJoin\\(\\)\\.$#"
 			count: 3
 			path: app/Utils/AuthTokenUtil.php
@@ -2944,7 +3934,17 @@ parameters:
 			path: app/Utils/AuthTokenUtil.php
 
 		-
+			message: "#^Method App\\\\Utils\\\\AuthTokenUtil\\:\\:getUserIdFromRequest\\(\\) should return int\\|null but returns mixed\\.$#"
+			count: 1
+			path: app/Utils/AuthTokenUtil.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, float\\|int given\\.$#"
+			count: 1
+			path: app/Utils/AuthTokenUtil.php
+
+		-
+			message: "#^Part \\$duration \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Utils/AuthTokenUtil.php
 
@@ -3061,6 +4061,26 @@ parameters:
 		-
 			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\|null\\.$#"
 			count: 1
+			path: app/Utils/RepositoryUtils.php
+
+		-
+			message: "#^Cannot access offset 'email' on mixed\\.$#"
+			count: 1
+			path: app/Utils/RepositoryUtils.php
+
+		-
+			message: "#^Cannot access property \\$CvsViewerType on mixed\\.$#"
+			count: 2
+			path: app/Utils/RepositoryUtils.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 2
+			path: app/Utils/RepositoryUtils.php
+
+		-
+			message: "#^Cannot call method Fill\\(\\) on mixed\\.$#"
+			count: 2
 			path: app/Utils/RepositoryUtils.php
 
 		-
@@ -4334,6 +5354,16 @@ parameters:
 			path: app/Utils/RepositoryUtils.php
 
 		-
+			message: "#^Binary operation \"\\+\\=\" between mixed and 1 results in an error\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Binary operation \"\\+\\=\" between mixed and mixed results in an error\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -4352,6 +5382,26 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Cannot access offset 'detailsid' on mixed\\.$#"
+			count: 2
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Cannot access offset 'difference_negative' on mixed\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Cannot access offset 'difference_positive' on mixed\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 3
 			path: app/Utils/SubmissionUtils.php
 
 		-
@@ -4432,6 +5482,21 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
 			count: 9
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function feof expects resource, mixed given\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fread expects resource, mixed given\\.$#"
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, mixed given\\.$#"
+			count: 1
 			path: app/Utils/SubmissionUtils.php
 
 		-
@@ -4608,6 +5673,76 @@ parameters:
 			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
+			message: "#^Cannot access offset 'backupfilename' on mixed\\.$#"
+			count: 2
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 2
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'buildstamp' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'endtime' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'generator' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'inboxdatafilename' on mixed\\.$#"
+			count: 2
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'md5' on mixed\\.$#"
+			count: 2
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'projectname' on mixed\\.$#"
+			count: 3
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'sitename' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'starttime' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'subprojectname' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'token' on mixed\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 2
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/Utils/UnparsedSubmissionProcessor.php
@@ -4653,7 +5788,22 @@ parameters:
 			path: app/Utils/UnparsedSubmissionProcessor.php
 
 		-
+			message: "#^Parameter \\#1 \\$projectname of static method CDash\\\\Model\\\\Project\\:\\:validateProjectName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 12
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, \\(array\\<int, string\\>\\|string\\) given\\.$#"
+			count: 1
+			path: app/Utils/UnparsedSubmissionProcessor.php
+
+		-
+			message: "#^Part \\$build_metadata\\['projectname'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/Utils/UnparsedSubmissionProcessor.php
 
@@ -4799,6 +5949,11 @@ parameters:
 
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			count: 1
+			path: app/Validators/Password.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
 			count: 1
 			path: app/Validators/Password.php
 
@@ -5069,6 +6224,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Index.php
+
+		-
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, \\(array\\<int, string\\>\\|string\\|null\\) given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
@@ -5204,12 +6364,22 @@ parameters:
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/QueryTests.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
@@ -5439,6 +6609,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
 		-
+			message: "#^Binary operation \"\\.\" between '\\?graph\\=' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestDetails.php
@@ -5495,6 +6670,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Controller\\\\Api\\\\TestDetails\\:\\:utf8_for_xml\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestDetails.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
@@ -5579,6 +6759,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/TestOverview.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/TestOverview.php
+
+		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/TestOverview.php
@@ -5589,11 +6774,46 @@ parameters:
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
 			count: 3
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot access offset 'pageId' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot call method Exists\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot call method GetType\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot call method SetName\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Cannot call method SetProjectId\\(\\) on mixed\\.$#"
+			count: 1
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
@@ -5672,8 +6892,23 @@ parameters:
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlentities expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, \\(int\\|false\\) given\\.$#"
 			count: 2
+			path: app/cdash/app/Controller/Api/Timeline.php
+
+		-
+			message: "#^Part \\$type\\['name'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
@@ -5698,6 +6933,46 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property CDash\\\\Controller\\\\Api\\\\ViewProjects\\:\\:\\$pageTimer\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$c on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$description on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$id on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$name on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$projectid on mixed\\.$#"
+			count: 3
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$submittime on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot access property \\$viewsubprojectslink on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewProjects.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewProjects.php
 
@@ -5752,6 +7027,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:measurements\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
@@ -5772,6 +7052,11 @@ parameters:
 		-
 			message: "#^Cannot access property \\$projectid on object\\|null\\.$#"
 			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
@@ -6015,6 +7300,11 @@ parameters:
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
 			message: "#^Parameter \\#2 \\$timestamp of function gmdate expects int\\|null, \\(float\\|int\\) given\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
@@ -6043,6 +7333,71 @@ parameters:
 			message: "#^Variable \\$next_buildid might not be defined\\.$#"
 			count: 1
 			path: app/cdash/app/Controller/Api/ViewTest.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'file\\://' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'author' on mixed\\.$#"
+			count: 3
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'commit' on mixed\\.$#"
+			count: 7
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'committer' on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'date' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'email' on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'filename' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'message' on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 'sha' on mixed\\.$#"
+			count: 3
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
 			message: "#^Comparison operation \"\\>\" between 0 and 0 is always false\\.$#"
@@ -6085,12 +7440,52 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_column expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_reverse expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$issuer of method Lcobucci\\\\JWT\\\\Builder\\:\\:issuedBy\\(\\) expects non\\-empty\\-string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, \\(array\\<int, string\\>\\|string\\) given\\.$#"
 			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
 			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$apiClient has no type specified\\.$#"
+			count: 1
+			path: app/cdash/app/Lib/Repository/GitHub.php
+
+		-
+			message: "#^Property CDash\\\\Lib\\\\Repository\\\\GitHub\\:\\:\\$baseUrl \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
@@ -6398,6 +7793,11 @@ parameters:
 
 		-
 			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNotRunTests\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Build.php
+
+		-
+			message: "#^Method CDash\\\\Model\\\\Build\\:\\:GetNumberOfTestsByField\\(\\) should return int but returns mixed\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Build.php
 
@@ -6751,6 +8151,11 @@ parameters:
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
 			message: """
 				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -6764,6 +8169,11 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/app/Model/BuildEmail.php
+
+		-
+			message: "#^Cannot call method Save\\(\\) on mixed\\.$#"
+			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
@@ -8296,6 +9706,16 @@ parameters:
 			path: app/cdash/app/Model/CoverageSummary.php
 
 		-
+			message: "#^Cannot access property \\$loctested on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: "#^Cannot access property \\$locuntested on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 11
 			path: app/cdash/app/Model/CoverageSummary.php
@@ -8738,6 +10158,21 @@ parameters:
 			path: app/cdash/app/Model/Image.php
 
 		-
+			message: "#^Cannot access offset 'checksum' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Cannot access offset 'extension' on mixed\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Cannot access offset 'img' on mixed\\.$#"
+			count: 2
+			path: app/cdash/app/Model/Image.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 11
 			path: app/cdash/app/Model/Image.php
@@ -8779,6 +10214,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$stream of function fread expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Image.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function stream_get_contents expects resource, mixed given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Image.php
 
@@ -9091,6 +10531,11 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
+			message: "#^Binary operation \"\\.\" between mixed and 'UTC' results in an error\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
 			message: "#^Call to an undefined method App\\\\Models\\\\Project\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\Models\\\\Project\\>\\:\\:fill\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -9138,6 +10583,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
@@ -9299,6 +10749,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$handle of function curl_setopt expects CurlHandle, \\(CurlHandle\\|false\\) given\\.$#"
 			count: 6
+			path: app/cdash/app/Model/Project.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#"
+			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -9878,6 +11333,16 @@ parameters:
 			path: app/cdash/app/Model/Subscriber.php
 
 		-
+			message: "#^Parameter \\#1 \\$build of method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:addBuild\\(\\) expects CDash\\\\Model\\\\Build, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
+			message: "#^Parameter \\#1 \\$build of method CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\:\\:subscribesToBuild\\(\\) expects CDash\\\\Model\\\\Build, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
 			message: "#^Property CDash\\\\Model\\\\Subscriber\\:\\:\\$topics \\(CDash\\\\Messaging\\\\Topic\\\\TopicCollection\\) does not accept CDash\\\\Messaging\\\\Topic\\\\TopicCollection\\|null\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
@@ -9969,6 +11434,11 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
+			count: 1
+			path: app/cdash/app/Model/User.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
@@ -10321,6 +11791,11 @@ parameters:
 			path: app/cdash/include/CDash/Database.php
 
 		-
+			message: "#^Method CDash\\\\Database\\:\\:executePreparedSingleRow\\(\\) should return array\\|false\\|null but returns mixed\\.$#"
+			count: 1
+			path: app/cdash/include/CDash/Database.php
+
+		-
 			message: "#^Method CDash\\\\Database\\:\\:prepare\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/include/CDash/Database.php
@@ -10411,7 +11886,22 @@ parameters:
 			path: app/cdash/include/Collection/BuildCollection.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/BuildEmailCollection.php
+
+		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/BuildEmailCollection.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Collection/BuildEmailCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_push expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/Collection/BuildEmailCollection.php
 
@@ -10469,6 +11959,11 @@ parameters:
 			message: "#^Method CDash\\\\Messaging\\\\FactoryInterface\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/FactoryInterface.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/Email/EmailBuilder.php
 
 		-
 			message: "#^Method CDash\\\\Messaging\\\\Notification\\\\Email\\\\EmailBuilder\\:\\:setBuildEmailCollection\\(\\) has no return type specified\\.$#"
@@ -10551,6 +12046,26 @@ parameters:
 			path: app/cdash/include/Messaging/Notification/Email/Mail.php
 
 		-
+			message: "#^Part \\$smtp_host \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/include/Messaging/Notification/Email/Mail.php
+
+		-
+			message: "#^Part \\$smtp_port \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/include/Messaging/Notification/Email/Mail.php
+
+		-
+			message: "#^Part \\$smtp_pswd \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/Email/Mail.php
+
+		-
+			message: "#^Part \\$smtp_user \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/Email/Mail.php
+
+		-
 			message: "#^Property CDash\\\\Messaging\\\\Notification\\\\Email\\\\Mail\\:\\:\\$defaultSender has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Notification/Email/Mail.php
@@ -10601,12 +12116,27 @@ parameters:
 			path: app/cdash/include/Messaging/Notification/Mailer.php
 
 		-
+			message: "#^Parameter \\#1 \\$notification of method CDash\\\\Messaging\\\\Notification\\\\Mailer\\:\\:sendNotification\\(\\) expects CDash\\\\Messaging\\\\Notification\\\\NotificationInterface, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/Mailer.php
+
+		-
 			message: "#^Method CDash\\\\Messaging\\\\Notification\\\\NotificationCollection\\:\\:add\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Notification/NotificationCollection.php
 
 		-
+			message: "#^Cannot call method getTopicTemplates\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/NotificationDirector.php
+
+		-
 			message: "#^Only booleans are allowed in an if condition, CDash\\\\Messaging\\\\Notification\\\\NotificationInterface\\|null given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Notification/NotificationDirector.php
+
+		-
+			message: "#^Parameter \\#1 \\$subscription of method CDash\\\\Messaging\\\\Notification\\\\NotificationBuilderInterface\\:\\:createNotification\\(\\) expects CDash\\\\Messaging\\\\Subscription\\\\SubscriptionInterface, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Notification/NotificationDirector.php
 
@@ -10814,6 +12344,41 @@ parameters:
 			message: "#^Only booleans are allowed in a negated boolean, CDash\\\\Messaging\\\\Subscription\\\\SubscriptionFactory given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Subscription/CommitAuthorSubscriptionBuilder.php
+
+		-
+			message: "#^Cannot call method getBuildCollection\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getFixed\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getLabels\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getTemplate\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getTopicCount\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getTopicDescription\\(\\) on mixed\\.$#"
+			count: 2
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
+
+		-
+			message: "#^Cannot call method getTopicName\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Subscription/Subscription.php
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
@@ -11036,6 +12601,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/ConfigureTopic.php
 
 		-
+			message: "#^Parameter \\#1 \\$object_or_class of function is_a expects object, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/ConfigureTopic.php
+
+		-
 			message: "#^Property CDash\\\\Messaging\\\\Topic\\\\ConfigureTopic\\:\\:\\$collection has no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/ConfigureTopic.php
@@ -11051,12 +12621,22 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/DynamicAnalysisTopic.php
 
 		-
+			message: "#^Cannot access property \\$Status on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/DynamicAnalysisTopic.php
+
+		-
 			message: "#^Method CDash\\\\Messaging\\\\Topic\\\\DynamicAnalysisTopic\\:\\:itemHasTopicSubject\\(\\) has parameter \\$item with no type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/DynamicAnalysisTopic.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, CDash\\\\Collection\\\\DynamicAnalysisCollection given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/DynamicAnalysisTopic.php
+
+		-
+			message: "#^Parameter \\#1 \\$analysis of method CDash\\\\Collection\\\\DynamicAnalysisCollection\\:\\:add\\(\\) expects CDash\\\\Model\\\\DynamicAnalysis, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/DynamicAnalysisTopic.php
 
@@ -11229,6 +12809,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
 		-
+			message: "#^Cannot access property \\$Text on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
+
+		-
 			message: "#^Iterating over an object of an unknown class CDash\\\\Model\\\\TestCollection\\.$#"
 			count: 3
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
@@ -11319,6 +12904,11 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/TestFailureTopic.php
 
 		-
+			message: "#^Cannot call method has\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/Topic.php
+
+		-
 			message: "#^Method CDash\\\\Messaging\\\\Topic\\\\Topic\\:\\:getFixed\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/Topic.php
@@ -11389,7 +12979,32 @@ parameters:
 			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
 
 		-
+			message: "#^Parameter \\#1 \\$object_or_class of function is_a expects object, mixed given\\.$#"
+			count: 3
+			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
+
+		-
+			message: "#^Parameter \\#1 \\$topic of class CDash\\\\Messaging\\\\Topic\\\\AuthoredTopic constructor expects CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\|null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
+
+		-
+			message: "#^Parameter \\#1 \\$topic of class CDash\\\\Messaging\\\\Topic\\\\BuildGroupSummaryTopic constructor expects CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\|null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
+
+		-
+			message: "#^Parameter \\#1 \\$topic of class CDash\\\\Messaging\\\\Topic\\\\EmailSentTopic constructor expects CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\|null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
+
+		-
 			message: "#^Parameter \\#1 \\$topic of class CDash\\\\Messaging\\\\Topic\\\\FixedTopic constructor expects CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\|null, CDash\\\\Messaging\\\\Topic\\\\Fixable given\\.$#"
+			count: 1
+			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
+
+		-
+			message: "#^Parameter \\#1 \\$topic of class CDash\\\\Messaging\\\\Topic\\\\GroupMembershipTopic constructor expects CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\|null, mixed given\\.$#"
 			count: 1
 			path: app/cdash/include/Messaging/Topic/TopicDecorator.php
 
@@ -12118,6 +13733,16 @@ parameters:
 			path: app/cdash/include/api_common.php
 
 		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 2
+			path: app/cdash/include/api_common.php
+
+		-
+			message: "#^Cannot call method Exists\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/api_common.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/include/api_common.php
@@ -12164,6 +13789,11 @@ parameters:
 
 		-
 			message: "#^Function get_param\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/api_common.php
+
+		-
+			message: "#^Function get_project_from_request\\(\\) should return CDash\\\\Model\\\\Project but returns mixed\\.$#"
 			count: 1
 			path: app/cdash/include/api_common.php
 
@@ -12231,6 +13861,16 @@ parameters:
 			path: app/cdash/include/cdashmail.php
 
 		-
+			message: "#^Parameter \\#1 \\$address of method Illuminate\\\\Mail\\\\Message\\:\\:from\\(\\) expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/cdashmail.php
+
+		-
+			message: "#^Parameter \\#1 \\$address of method Illuminate\\\\Mail\\\\Message\\:\\:replyTo\\(\\) expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/cdashmail.php
+
+		-
 			message: "#^Access to an undefined property App\\\\Models\\\\User\\:\\:\\$pivot\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -12294,7 +13934,42 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Cannot access offset 'filename' on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access offset 'filesize' on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access offset 'sha1sum' on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access offset 'text' on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot access property \\$Name on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method GetIdByName\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -12310,6 +13985,31 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method getBasename\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method getPathname\\(\\) on mixed\\.$#"
+			count: 2
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method isDir\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method isFile\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Cannot call method isLink\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -12420,6 +14120,11 @@ parameters:
 
 		-
 			message: "#^Function generate_XSLT\\(\\) has parameter \\$xml with no type specified\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			message: "#^Function generate_XSLT\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -12749,6 +14454,11 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			message: "#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#"
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
 			message: "#^Parameter \\#2 \\$baseTimestamp of function strtotime expects int\\|null, int\\|false given\\.$#"
 			count: 1
 			path: app/cdash/include/common.php
@@ -12794,8 +14504,18 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'An XML submission…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
 			message: "#^Binary operation \"\\.\" between \\(list\\<string\\>\\|string\\|null\\) and '_' results in an error\\.$#"
 			count: 2
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Binary operation \"\\.\" between mixed and '\\.xml' results in an error\\.$#"
+			count: 1
 			path: app/cdash/include/ctestparser.php
 
 		-
@@ -12948,6 +14668,21 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
+			message: "#^Parameter \\#1 \\$stream of function feof expects resource, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fread expects resource, mixed given\\.$#"
+			count: 2
+			path: app/cdash/include/ctestparser.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/ctestparser.php
+
+		-
 			message: "#^Parameter \\#2 \\$data of function xml_parse expects string, string\\|false given\\.$#"
 			count: 2
 			path: app/cdash/include/ctestparser.php
@@ -12975,6 +14710,11 @@ parameters:
 		-
 			message: "#^Backtick operator is not allowed\\. Use shell_exec\\(\\) instead\\.$#"
 			count: 10
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Binary operation \"\\*\" between mixed and 3600 results in an error\\.$#"
+			count: 1
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -13037,6 +14777,11 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'cvsviewertype' on array\\|false\\|null\\.$#"
+			count: 1
+			path: app/cdash/include/dailyupdates.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
@@ -13410,6 +15155,11 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
@@ -13808,8 +15558,23 @@ parameters:
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function htmlentities expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false\\|null given\\.$#"
 			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function parse_url expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 5
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
@@ -13898,6 +15663,16 @@ parameters:
 			path: app/cdash/include/pdo.php
 
 		-
+			message: "#^Function pdo_fetch_array\\(\\) should return array\\|false\\|null but returns mixed\\.$#"
+			count: 1
+			path: app/cdash/include/pdo.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of method PDO\\:\\:quote\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/include/pdo.php
+
+		-
 			message: "#^Access to an undefined property UpdateHandler\\:\\:\\$BuildId\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
@@ -13973,6 +15748,11 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'testnotrunnegative' on array\\{builderrorspositive\\: int, builderrorsnegative\\: int, buildwarningspositive\\: int, buildwarningsnegative\\: int, configureerrors\\: int, configurewarnings\\: int, testpassedpositive\\: int, testpassednegative\\: int, \\.\\.\\.\\}\\|false\\.$#"
+			count: 1
+			path: app/cdash/include/sendemail.php
+
+		-
+			message: "#^Cannot call method build\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/include/sendemail.php
 
@@ -14070,6 +15850,16 @@ parameters:
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
 		-
+			message: "#^Cannot access offset 'head_sha' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
 			message: "#^Function handle_error\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
@@ -14095,6 +15885,21 @@ parameters:
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
 		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Parameter \\#3 \\$key of function hash_hmac expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/GitHub/webhook.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -14116,6 +15921,81 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'autoremovetimeframe' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'buildgroupid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'buildtype' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'emailcommitters' on mixed\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 9
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'includesubprojectto…' on mixed\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'match' on mixed\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'parentgroupid' on mixed\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'site' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot access offset 'summaryemail' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 9
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
@@ -14169,6 +16049,26 @@ parameters:
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 4
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/buildgroup.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
 			message: "#^Binary operation \"/\" between \\(array\\|float\\|int\\) and \\(array\\|float\\|int\\) results in an error\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/computeClassifier.php
@@ -14184,6 +16084,11 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Cannot access offset 'properties' on mixed\\.$#"
+			count: 3
 			path: app/cdash/public/api/v1/computeClassifier.php
 
 		-
@@ -14262,6 +16167,31 @@ parameters:
 			path: app/cdash/public/api/v1/computeClassifier.php
 
 		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_map expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/computeClassifier.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/deleteSubmissionFile.php
@@ -14272,7 +16202,42 @@ parameters:
 			path: app/cdash/public/api/v1/deleteSubmissionFile.php
 
 		-
+			message: "#^Parameter \\#1 \\$from of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:move\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:exists\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$paths of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:delete\\(\\) expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function decrypt expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#2 \\$to of static method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:move\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/deleteSubmissionFile.php
+
+		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/getSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/getSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function decrypt expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/getSubmissionFile.php
 
@@ -14355,6 +16320,11 @@ parameters:
 			path: app/cdash/public/api/v1/index.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/index.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 3
 			path: app/cdash/public/api/v1/index.php
@@ -14410,6 +16380,11 @@ parameters:
 			path: app/cdash/public/api/v1/index.php
 
 		-
+			message: "#^Part \\$buildgroup \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/index.php
+
+		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 3
 			path: app/cdash/public/api/v1/manageBuildGroup.php
@@ -14460,6 +16435,16 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
 			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
 			count: 3
 			path: app/cdash/public/api/v1/manageBuildGroup.php
@@ -14495,7 +16480,112 @@ parameters:
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/manageBuildGroup.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Binary operation \"\\*\" between mixed and 1024 results in an error\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Call to function is_array\\(\\) with string\\|false will always evaluate to false\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'AuthenticateSubmiss…' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'CvsUrl' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'Id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'Name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'Public' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'branch' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'ipaddress' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'password' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'repositories' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'sitename' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'size' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'tmp_name' on mixed\\.$#"
+			count: 2
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'url' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot access offset 'username' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
 
@@ -14635,12 +16725,42 @@ parameters:
 			path: app/cdash/public/api/v1/project.php
 
 		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
 
 		-
+			message: "#^Parameter \\#1 \\$projectname of static method CDash\\\\Model\\\\Project\\:\\:validateProjectName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/project.php
+
+		-
+			message: "#^Part \\$Name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/project.php
 
@@ -14670,9 +16790,29 @@ parameters:
 			path: app/cdash/public/api/v1/requeueSubmissionFile.php
 
 		-
+			message: "#^Parameter \\#1 \\$num of function pow expects float\\|int, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/requeueSubmissionFile.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function decrypt expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/requeueSubmissionFile.php
+
+		-
 			message: "#^Parameter \\#1 \\$value of method Carbon\\\\Carbon\\:\\:addSeconds\\(\\) expects int, \\(float\\|int\\) given\\.$#"
 			count: 1
 			path: app/cdash/public/api/v1/requeueSubmissionFile.php
+
+		-
+			message: "#^Part \\$filename \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: app/cdash/public/api/v1/requeueSubmissionFile.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
 
 		-
 			message: """
@@ -14687,6 +16827,21 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 2
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 2
 			path: app/cdash/public/api/v1/subproject.php
 
@@ -14736,8 +16891,28 @@ parameters:
 			path: app/cdash/public/api/v1/subproject.php
 
 		-
+			message: "#^Parameter \\#1 \\$groupName of method CDash\\\\Model\\\\SubProject\\:\\:SetGroup\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method CDash\\\\Model\\\\SubProjectGroup\\:\\:SetName\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 3
+			path: app/cdash/public/api/v1/subproject.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
+			count: 8
 			path: app/cdash/public/api/v1/subproject.php
 
 		-
@@ -14774,6 +16949,11 @@ parameters:
 			message: "#^Method BuildUseCaseTest\\:\\:testUseCaseCreateBuilderReturnsInstanceOfBuildUseCase\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/BuildUseCaseTest.php
+
+		-
+			message: "#^Cannot call method GetBuildConfigure\\(\\) on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/case/CDash/ConfigUseCaseTest.php
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\)\\.$#"
@@ -14853,6 +17033,11 @@ parameters:
 
 		-
 			message: "#^Call to method expects\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/DatabaseTest.php
+
+		-
+			message: "#^Cannot access offset 'CDash\\\\\\\\Database' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/DatabaseTest.php
 
@@ -14953,6 +17138,11 @@ parameters:
 
 		-
 			message: "#^Method GitHubTest\\:\\:testDisablePullRequestComments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+
+		-
+			message: "#^Property GitHubTest\\:\\:\\$baseUrl \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
 
@@ -16623,6 +18813,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
 
 		-
+			message: "#^Cannot access property \\$Build on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
 			count: 8
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
@@ -16754,6 +18949,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$submission of class CDash\\\\Messaging\\\\Subscription\\\\UserSubscriptionBuilder constructor expects ActionableBuildInterface, AbstractXmlHandler given\\.$#"
+			count: 1
+			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+
+		-
+			message: "#^Part \\$notification \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
 
@@ -17008,6 +19208,11 @@ parameters:
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-
+			message: "#^Cannot call method GetTestCollection\\(\\) on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
+
+		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -17180,6 +19385,11 @@ parameters:
 		-
 			message: "#^PHPDoc tag @var with type Illuminate\\\\Support\\\\Collection is not subtype of type CDash\\\\Model\\\\TestCollection\\.$#"
 			count: 4
+			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
+			count: 1
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-
@@ -17842,6 +20052,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Binary operation \"\\.\" between mixed and '/'\\|'\\\\\\\\' results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Call to an undefined method Psr\\\\Log\\\\LoggerInterface\\:\\:getHandlers\\(\\)\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -17856,6 +20071,36 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'Id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'database' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'host' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'password' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'project' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Cannot access offset 'username' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -18385,6 +20630,11 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Parameter \\#1 \\$search of function str_replace expects array\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Parameter \\#1 \\$socket of class SimpleHttpResponse constructor expects SimpleSocket, object given\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -18400,7 +20650,22 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urldecode expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
 			message: "#^Parameter \\#1 \\$url \\(SimpleUrl\\) of method CDashControllerBrowser\\:\\:fetch\\(\\) should be contravariant with parameter \\$url \\(mixed\\) of method SimpleBrowser\\:\\:fetch\\(\\)$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of function fwrite expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -18431,6 +20696,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#7 \\$content of static method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:create\\(\\) expects resource\\|string\\|null, string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/kwtest/kw_web_tester.php
+
+		-
+			message: "#^Part \\$db_type \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
@@ -18613,6 +20883,11 @@ parameters:
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
 		-
+			message: "#^Cannot access offset 'errors' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_actualtrilinossubmission.php
+
+		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_actualtrilinossubmission.php
@@ -18663,7 +20938,47 @@ parameters:
 			path: app/cdash/tests/test_actualtrilinossubmission.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_actualtrilinossubmission.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatecoverage.php
 
@@ -18718,7 +21033,82 @@ parameters:
 			path: app/cdash/tests/test_aggregatecoverage.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Part \\$name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatecoverage.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 5
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Unexpected build\\: ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'coveragegroups' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'key' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
 
@@ -18818,6 +21208,31 @@ parameters:
 			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 5
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Part \\$groupname \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
+			message: "#^Part \\$name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
+
+		-
 			message: "#^Property AggregateSubProjectCoverageTestCase\\:\\:\\$DataDir has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_aggregatesubprojectcoverage.php
@@ -18881,6 +21296,31 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Cannot access offset 'hash' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Cannot access offset 'raw_token' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Cannot access offset 'title' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Cannot access offset 'token' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Cannot call method clear\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
 
@@ -19006,6 +21446,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool\\|string given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_authtoken.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_authtoken.php
 
@@ -19167,6 +21612,11 @@ parameters:
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'Expected error at…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
@@ -19180,6 +21630,46 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'details' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'errors' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'logline' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'output' on mixed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 11
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 'time' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_bazeljson.php
 
 		-
@@ -19278,9 +21768,34 @@ parameters:
 			path: app/cdash/tests/test_bazeljson.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 16
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Part \\$jsonobj\\['test'\\]\\['time'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_bazeljson.php
+
+		-
 			message: "#^Property BazelJSONTestCase\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_bazeljson.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
 
 		-
 			message: """
@@ -19288,6 +21803,21 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_branchcoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_branchcoverage.php
 
 		-
@@ -19397,6 +21927,11 @@ parameters:
 			path: app/cdash/tests/test_buildconfigure.php
 
 		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildconfigure.php
+
+		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildconfigure.php
@@ -19453,6 +21988,56 @@ parameters:
 			path: app/cdash/tests/test_builddetails.php
 
 		-
+			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$error on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$errors on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$numFailed on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$numNotRun on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$numPassed on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$numSubprojects on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$numTimeFailed on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$parentBuild on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Cannot access property \\$tests on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_builddetails.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_builddetails.php
@@ -19505,6 +22090,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
 			count: 2
+			path: app/cdash/tests/test_builddetails.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
 			path: app/cdash/tests/test_builddetails.php
 
 		-
@@ -19736,11 +22326,56 @@ parameters:
 			path: app/cdash/tests/test_buildoverview.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Binary operation \"\\.\" between mixed and '/submit\\.php' results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
 			message: """
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
 			count: 10
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'accuracy' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'classifier' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'defects' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'success' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Cannot access offset 'testfailed' on mixed\\.$#"
+			count: 1
 			path: app/cdash/tests/test_buildproperties.php
 
 		-
@@ -19849,6 +22484,26 @@ parameters:
 			path: app/cdash/tests/test_buildproperties.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Part \\$build\\-\\>Id \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Part \\$classifier \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildproperties.php
+
+		-
 			message: "#^Property BuildPropertiesTestCase\\:\\:\\$Builds has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildproperties.php
@@ -19885,6 +22540,46 @@ parameters:
 			path: app/cdash/tests/test_buildrelationship.php
 
 		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access offset 'relatedid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access offset 'relationship' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access offset 'relationships_from' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access offset 'relationships_to' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access property \\$error on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Cannot access property \\$relationship on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
 			message: "#^Foreach overwrites \\$payload with its value variable\\.$#"
 			count: 1
 			path: app/cdash/tests/test_buildrelationship.php
@@ -19892,6 +22587,11 @@ parameters:
 		-
 			message: "#^Method BuildRelationshipTestCase\\:\\:testBuildRelationships\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_buildrelationship.php
+
+		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			count: 10
 			path: app/cdash/tests/test_buildrelationship.php
 
 		-
@@ -19996,8 +22696,53 @@ parameters:
 			path: app/cdash/tests/test_committerinfo.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'files' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'revisiondiff' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'revisionurl' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Cannot access offset 'update' on mixed\\.$#"
+			count: 3
 			path: app/cdash/tests/test_compressedtest.php
 
 		-
@@ -20023,6 +22768,21 @@ parameters:
 		-
 			message: "#^Method CompressedTestCase\\:\\:testSubmissionCompressedTest\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_compressedtest.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
 			path: app/cdash/tests/test_compressedtest.php
 
 		-
@@ -20098,6 +22858,31 @@ parameters:
 			path: app/cdash/tests/test_consistenttestingday.php
 
 		-
+			message: "#^Cannot access offset 'buildName' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 11
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
 			message: "#^Cannot call method fetchAll\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_consistenttestingday.php
@@ -20108,14 +22893,54 @@ parameters:
 			path: app/cdash/tests/test_consistenttestingday.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 4
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
+			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 7
 			path: app/cdash/tests/test_consistenttestingday.php
 
 		-
 			message: "#^Property ConsistentTestingDayTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_consistenttestingday.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Cannot access offset 'aaData' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Cannot access offset 0\\|1\\|2\\|3\\|4\\|5\\|6\\|7\\|8\\|9\\|10\\|11\\|12\\|13\\|14\\|15\\|16\\|17\\|18\\|19\\|20\\|21\\|22\\|23\\|24 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_coveragedirectories.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -20128,10 +22953,40 @@ parameters:
 			path: app/cdash/tests/test_coveragedirectories.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_coveragedirectories.php
+
+		-
 			message: """
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot access property \\$error on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot access property \\$project on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Cannot access property \\$user on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_createprojectpermissions.php
 
@@ -20151,6 +23006,16 @@ parameters:
 			path: app/cdash/tests/test_createprojectpermissions.php
 
 		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
+			count: 15
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
+			message: "#^Part \\$userid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: app/cdash/tests/test_createprojectpermissions.php
+
+		-
 			message: "#^Property CreateProjectPermissionsTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_createprojectpermissions.php
@@ -20161,7 +23026,62 @@ parameters:
 			path: app/cdash/tests/test_createpublicdashboard.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'coveragegroups' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'loctested' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'locuntested' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
@@ -20276,6 +23196,31 @@ parameters:
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Part \\$group_name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
+			message: "#^Part \\$parentid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_crosssubprojectcoverage.php
+
+		-
 			message: "#^Property CoverageAcrossSubProjectsTestCase\\:\\:\\$DataDir has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_crosssubprojectcoverage.php
@@ -20299,6 +23244,11 @@ parameters:
 			path: app/cdash/tests/test_csvexport.php
 
 		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_csvexport.php
+
+		-
 			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_csvexport.php
@@ -20314,7 +23264,17 @@ parameters:
 			path: app/cdash/tests/test_csvexport.php
 
 		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_csvexport.php
+
+		-
 			message: "#^Access to an undefined property object\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/cdash/tests/test_deferredsubmissions.php
+
+		-
+			message: "#^Cannot access offset 'raw_token' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_deferredsubmissions.php
 
@@ -20459,10 +23419,40 @@ parameters:
 			path: app/cdash/tests/test_deletesubproject.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Cannot access offset 'details' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Cannot access offset 'numFailed' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Cannot access offset 'numNotRun' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_disabledtests.php
 
@@ -20479,6 +23469,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
 			count: 2
+			path: app/cdash/tests/test_disabledtests.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
 			path: app/cdash/tests/test_disabledtests.php
 
 		-
@@ -20666,13 +23661,63 @@ parameters:
 			path: app/cdash/tests/test_email.php
 
 		-
+			message: "#^Cannot access offset 'directories' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access offset 'email' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access offset 'files' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access offset 'updategroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$buildid on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$difference_negative on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$difference_positive on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_email.php
+
+		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 2
 			path: app/cdash/tests/test_email.php
 
 		-
+			message: "#^Cannot access property \\$id on mixed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_email.php
+
+		-
 			message: "#^Cannot access property \\$id on object\\|null\\.$#"
 			count: 1
+			path: app/cdash/tests/test_email.php
+
+		-
+			message: "#^Cannot access property \\$type on mixed\\.$#"
+			count: 4
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -20746,7 +23791,197 @@ parameters:
 			path: app/cdash/tests/test_enable_async.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected \\(32 labels…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected \\(4 labels\\)…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 1 test…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 10 tests…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 15 build…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 1…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 21…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 270 tests…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 281 build…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 3 build…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 32…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 33 tests…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 4…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 5 build…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 7 tests…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 88 tests…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected ThreadPool…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected build…' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected configure…' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected proc time…' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected test…' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'compilation' on mixed\\.$#"
+			count: 18
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'configure' on mixed\\.$#"
+			count: 12
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'fail' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'notrun' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'pass' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'procTimeFull' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'site' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 14
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'time' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'timefull' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'warning' on mixed\\.$#"
 			count: 4
 			path: app/cdash/tests/test_excludesubprojects.php
 
@@ -20786,9 +24021,19 @@ parameters:
 			path: app/cdash/tests/test_excludesubprojects.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 7
+			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
 			message: "#^Variable \\$build might not be defined\\.$#"
 			count: 48
 			path: app/cdash/tests/test_excludesubprojects.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
 
 		-
 			message: """
@@ -20796,6 +24041,31 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Cannot access offset 'expectedandmissing' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Cannot access offset 'lastSubmission' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_expectedandmissing.php
 
 		-
@@ -20829,9 +24099,29 @@ parameters:
 			path: app/cdash/tests/test_expectedandmissing.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
 			message: "#^Property ExpectedAndMissingTestCase\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_expectedandmissing.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expiredbuildrules.php
 
 		-
 			message: """
@@ -20846,6 +24136,16 @@ parameters:
 				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_expiredbuildrules.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_expiredbuildrules.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_expiredbuildrules.php
 
@@ -20880,12 +24180,57 @@ parameters:
 			path: app/cdash/tests/test_expiredbuildrules.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'Expected name to be…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected type to be…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected value to…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_externallinksfromtests.php
 
 		-
+			message: "#^Cannot access offset 'measurements' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
 			message: "#^Method ExternalLinksFromTestsTestCase\\:\\:testExternalLinksFromTests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_externallinksfromtests.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_externallinksfromtests.php
 
@@ -20898,6 +24243,41 @@ parameters:
 			message: "#^Parameter \\#1 \\$mystring of method KWWebTestCase\\:\\:findString\\(\\) expects string, string\\|false given\\.$#"
 			count: 2
 			path: app/cdash/tests/test_extracttar.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 'filters' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 'multiplebuildshyper…' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 'site' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -20936,6 +24316,26 @@ parameters:
 
 		-
 			message: "#^Method FilterBlocksTestCase\\:\\:verifyTwoHutBuilds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filterblocks.php
+
+		-
+			message: "#^Part \\$sitename \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_filterblocks.php
 
@@ -21000,6 +24400,26 @@ parameters:
 			path: app/cdash/tests/test_filtertestlabels.php
 
 		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
+			message: "#^Cannot access offset 'numtestfail' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
+			message: "#^Cannot access offset 'numtestnotrun' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
+			message: "#^Cannot access offset 'numtestpass' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 7
 			path: app/cdash/tests/test_filtertestlabels.php
@@ -21010,8 +24430,38 @@ parameters:
 			path: app/cdash/tests/test_filtertestlabels.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_filtertestlabels.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Cannot access offset 'hascompilationdata' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Cannot access offset 'hasconfiguredata' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Cannot access offset 'hastestdata' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Cannot access offset 'hasupdatedata' on mixed\\.$#"
+			count: 4
 			path: app/cdash/tests/test_hidecolumns.php
 
 		-
@@ -21031,6 +24481,11 @@ parameters:
 
 		-
 			message: "#^Method HideColumnsTestCase\\:\\:testHideColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_hidecolumns.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_hidecolumns.php
 
@@ -21068,6 +24523,16 @@ parameters:
 			path: app/cdash/tests/test_imagecomparison.php
 
 		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_imagecomparison.php
+
+		-
+			message: "#^Cannot access offset 'imgid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_imagecomparison.php
+
+		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_imagecomparison.php
@@ -21078,9 +24543,34 @@ parameters:
 			path: app/cdash/tests/test_imagecomparison.php
 
 		-
+			message: "#^Part \\$imgid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_imagecomparison.php
+
+		-
 			message: "#^Property ImageComparisonTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_imagecomparison.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -21123,6 +24613,26 @@ parameters:
 			path: app/cdash/tests/test_indexfilters.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Part \\$buildname \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexfilters.php
+
+		-
 			message: "#^Property IndexFiltersTestCase\\:\\:\\$EmailUrl has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_indexfilters.php
@@ -21131,6 +24641,31 @@ parameters:
 			message: "#^Property IndexFiltersTestCase\\:\\:\\$InsightUrl has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_indexfilters.php
+
+		-
+			message: "#^Cannot access offset 'banners' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 8
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'next' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'previous' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_indexnextprevious.php
 
 		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\Site\\|null\\.$#"
@@ -21143,12 +24678,32 @@ parameters:
 			path: app/cdash/tests/test_indexnextprevious.php
 
 		-
+			message: "#^Parameter \\#1 \\$result of method WebTestCase\\:\\:assertFalse\\(\\) expects bool, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_indexnextprevious.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_install.php
 
 		-
+			message: "#^Cannot access offset 'database' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_install.php
+
+		-
 			message: "#^Method InstallTestCase\\:\\:testInstall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_install.php
+
+		-
+			message: "#^Part \\$db_type \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_install.php
+
+		-
+			message: "#^Property InstallTestCase\\:\\:\\$databaseName \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_install.php
 
@@ -21169,12 +24724,27 @@ parameters:
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
+			message: "#^Cannot access offset 'newissueurl' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_issuecreation.php
+
+		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
 			count: 1
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
 			message: "#^Method IssueCreationTestCase\\:\\:testIssueCreation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_issuecreation.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of method WebTestCase\\:\\:assertFalse\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_issuecreation.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urlencode expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_issuecreation.php
 
@@ -21194,6 +24764,31 @@ parameters:
 			path: app/cdash/tests/test_issuecreation.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_javajsoncoverage.php
@@ -21202,6 +24797,36 @@ parameters:
 			message: "#^Method JavaJSONCoverageTestCase\\:\\:testJavaJSONCoverage\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_javajsoncoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_jscovercoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_jscovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_jscovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_jscovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_jscovercoverage.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -21214,6 +24839,11 @@ parameters:
 			path: app/cdash/tests/test_jscovercoverage.php
 
 		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_jscovercoverage.php
+
+		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -21222,7 +24852,32 @@ parameters:
 			path: app/cdash/tests/test_junithandler.php
 
 		-
+			message: "#^Cannot access offset 'numFailed' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_junithandler.php
+
+		-
+			message: "#^Cannot access offset 'numNotRun' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_junithandler.php
+
+		-
+			message: "#^Cannot access offset 'numPassed' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_junithandler.php
+
+		-
+			message: "#^Cannot access offset 'totaltime' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_junithandler.php
+
+		-
 			message: "#^Method JUnitHandlerTestCase\\:\\:testJUnitHandler\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_junithandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_junithandler.php
 
@@ -21300,6 +24955,11 @@ parameters:
 			path: app/cdash/tests/test_limitedbuilds.php
 
 		-
+			message: "#^Cannot access property \\$log on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_longbuildname.php
+
+		-
 			message: "#^Method LongBuildNameTestCase\\:\\:testLongBuildName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_longbuildname.php
@@ -21330,11 +24990,136 @@ parameters:
 			path: app/cdash/tests/test_lotsofsubprojects.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 5
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'columncount' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'columnnames' on mixed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'columns' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'csvlink' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'extrameasurements' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'hasprocessors' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'measurements' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'nprocs' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'procTime' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'procTimeFull' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'proctime' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'testname' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 'y' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 13
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_managemeasurements.php
 
 		-
@@ -21414,6 +25199,36 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 6
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Part \\$label \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Part \\$measurement_id \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: app/cdash/tests/test_managemeasurements.php
+
+		-
+			message: "#^Part \\$selected_test_name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_managemeasurements.php
 
@@ -21498,9 +25313,29 @@ parameters:
 			path: app/cdash/tests/test_manageusers.php
 
 		-
+			message: "#^Cannot access offset 'configures' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_misassignedconfigure.php
+
+		-
 			message: "#^Class MisassignedConfigureTestCase has an uninitialized property \\$project\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/tests/test_misassignedconfigure.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_misassignedconfigure.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multicoverage.php
 
 		-
 			message: """
@@ -21520,6 +25355,21 @@ parameters:
 
 		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_multicoverage.php
 
@@ -21559,9 +25409,34 @@ parameters:
 			path: app/cdash/tests/test_multicoverage.php
 
 		-
+			message: "#^Part \\$this\\-\\>BuildId \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multicoverage.php
+
+		-
 			message: "#^Property MultiCoverageTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multicoverage.php
+
+		-
+			message: "#^Cannot access offset 'labels' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
 
 		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\Test\\|null\\.$#"
@@ -21579,9 +25454,19 @@ parameters:
 			path: app/cdash/tests/test_multiplelabelsfortests.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
 			message: "#^Property MultipleLabelsForTestsTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplelabelsfortests.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
 			message: """
@@ -21599,6 +25484,181 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'back' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'buildduration' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'configureduration' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'defectcount' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'defects' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'defecttypes' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'dynamicanalyses' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 11
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 10
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'loctested' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'locuntested' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'nbuilderror'\\|'nbuildpass'\\|'nbuildwarning'\\|'nconfigureerror'\\|'nconfigurepass'\\|'nconfigurewarning'\\|'ntestfail'\\|'ntestnotrun'\\|'ntestpass' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numbuilderror' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numbuildwarning' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numchildren' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numconfigureerror' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numconfigurewarning' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numtestfail' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numtestnotrun' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'numtestpass' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'parenthasnotes' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'percentage' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'project' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'subprojects' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'testduration' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'updateduration' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 'uploadfilecount' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 12
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -21624,6 +25684,11 @@ parameters:
 		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Cannot use array destructuring on mixed\\.$#"
+			count: 1
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -21732,7 +25797,177 @@ parameters:
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 7
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, int\\|string\\|false\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 8
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$build\\['id'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$build\\['label'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 7
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$build\\['position'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$build_array\\['id'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$build_duration \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$child_buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$configure_duration \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$defect_type \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$defectcount \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$jsonobj\\['buildduration'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$jsonobj\\['configureduration'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$jsonobj\\['testduration'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$jsonobj\\['updateduration'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$label \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$loctested \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$locuntested \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$num_children \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 4
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$num_defects \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$num_uploaded_files \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numbuilderror \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numbuildwarning \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numconfigureerror \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numconfigurewarning \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numtestfail \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numtestnotrun \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$numtestpass \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$parentid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 6
+			path: app/cdash/tests/test_multiplesubprojects.php
+
+		-
+			message: "#^Part \\$percent \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_multiplesubprojects.php
 
@@ -21807,11 +26042,46 @@ parameters:
 			path: app/cdash/tests/test_nobackup.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Cannot access offset 'builderrors' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Cannot access offset 'loctested' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_nobackup.php
 
 		-
@@ -21835,6 +26105,11 @@ parameters:
 			path: app/cdash/tests/test_nobackup.php
 
 		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_nobackup.php
+
+		-
 			message: "#^Property NoBackupTestCase\\:\\:\\$ConfigFile has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_nobackup.php
@@ -21845,8 +26120,23 @@ parameters:
 			path: app/cdash/tests/test_nobackup.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_notesapi.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_notesapi.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_notesapi.php
+
+		-
+			message: "#^Cannot access offset 'notes' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_notesapi.php
 
 		-
@@ -21856,6 +26146,16 @@ parameters:
 
 		-
 			message: "#^Method NotesAPICase\\:\\:testNotesAPI\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_notesapi.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_notesapi.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_notesapi.php
 
@@ -21870,7 +26170,57 @@ parameters:
 			path: app/cdash/tests/test_notesparsererrormessages.php
 
 		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'files' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'priorrevision' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'revision' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 'update' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
 			message: "#^Method NumericUpdateTestCase\\:\\:testNumericUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_numericupdate.php
 
@@ -21878,6 +26228,31 @@ parameters:
 			message: "#^Property NumericUpdateTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_numericupdate.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'POST returned ' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'description' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_opencovercoverage.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -21900,9 +26275,44 @@ parameters:
 			path: app/cdash/tests/test_opencovercoverage.php
 
 		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
 			message: "#^Property OpenCoverCoverageTestCase\\:\\:\\$buildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_opencovercoverage.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Cannot access offset 'output' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Cannot access offset 'preformatted…' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_outputcolor.php
 
 		-
 			message: "#^Method OutputColorTestCase\\:\\:getIdForTest\\(\\) has no return type specified\\.$#"
@@ -21916,6 +26326,16 @@ parameters:
 
 		-
 			message: "#^Method OutputColorTestCase\\:\\:testOutputColor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_outputcolor.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_outputcolor.php
 
@@ -22061,6 +26481,56 @@ parameters:
 			path: app/cdash/tests/test_projectmodel.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'aaData' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'coverages' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
 			message: "#^Method ProjectWebPageTestCase\\:\\:testAccessToWebPageProjectTest\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_projectwebpage.php
@@ -22141,7 +26611,37 @@ parameters:
 			path: app/cdash/tests/test_projectwebpage.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Part \\$buildid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_projectwebpage.php
+
+		-
+			message: "#^Part \\$siteid \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_projectwebpage.php
 
@@ -22191,6 +26691,31 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access offset 'dynamics' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access offset 'match' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access offset 'rules' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access offset 'siteid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_putdynamicbuilds.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 4
 			path: app/cdash/tests/test_putdynamicbuilds.php
 
 		-
@@ -22249,6 +26774,51 @@ parameters:
 			path: app/cdash/tests/test_putdynamicbuilds.php
 
 		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'filterontestoutput' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'group' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'labels' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'matchingoutput' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'next' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'previous' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_querytests.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 3
 			path: app/cdash/tests/test_querytests.php
@@ -22259,7 +26829,42 @@ parameters:
 			path: app/cdash/tests/test_querytests.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of method WebTestCase\\:\\:assertTrue\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Part \\$next_url \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Part \\$previous_url \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytests.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytestsfilterlabels.php
+
+		-
 			message: "#^Method QueryTestsFilterLabelsTestCase\\:\\:testQueryTestsFilterLabels\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_querytestsfilterlabels.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_querytestsfilterlabels.php
 
@@ -22269,8 +26874,18 @@ parameters:
 			path: app/cdash/tests/test_querytestsfilterlabels.php
 
 		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_querytestsrevisionfilter.php
+
+		-
 			message: "#^Method QueryTestsFilterLabelsTestCase\\:\\:testQueryTestsFilterLabels\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_querytestsrevisionfilter.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 3
 			path: app/cdash/tests/test_querytestsrevisionfilter.php
 
 		-
@@ -22279,12 +26894,47 @@ parameters:
 			path: app/cdash/tests/test_recoverpassword.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Cannot access offset 'measurements' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Cannot access offset 'output' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_redundanttests.php
 
 		-
 			message: "#^Method RedundantTestsTestCase\\:\\:testRedundantTests\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_redundanttests.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_redundanttests.php
 
@@ -22470,7 +27120,27 @@ parameters:
 			path: app/cdash/tests/test_replacebuild.php
 
 		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_revisionfilteracrossdates.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_revisionfilteracrossdates.php
+
+		-
 			message: "#^Method RevisionFilterIgnoresDateTestCase\\:\\:testRevisionFilterIgnoresDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_revisionfilteracrossdates.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_revisionfilteracrossdates.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_revisionfilteracrossdates.php
 
@@ -22754,12 +27424,152 @@ parameters:
 			path: app/cdash/tests/test_subprojectemail.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected …' and mixed results in an error\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 4
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
 		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 8
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'compilation' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'current' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'daysWithErrors' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'failingDate' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'hasErrors' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'hasFailingTests' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 15
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'next' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'nextbuild' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'nnotrundiffn' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'npassdiffp' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'nwarningdiffp' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'previous' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'previousbuild' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
 			message: "#^Method SubProjectNextPreviousTestCase\\:\\:testSubProjectNextPrevious\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 15
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectnextprevious.php
+
+		-
+			message: "#^Part \\$label \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectnextprevious.php
 
@@ -22780,12 +27590,47 @@ parameters:
 			path: app/cdash/tests/test_subprojectorder.php
 
 		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Cannot access offset 'position' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectorder.php
 
 		-
 			message: "#^Method SubProjectOrderTestCase\\:\\:testSubProjectOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojectorder.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_subprojectorder.php
 
@@ -22800,6 +27645,81 @@ parameters:
 			path: app/cdash/tests/test_subprojectorder.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'fail' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'notrun' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'numFailed' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'numNotRun' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'numPassed' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'pass' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'subprojectname' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 6
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'testfilters' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_subprojecttestfilters.php
@@ -22807,6 +27727,31 @@ parameters:
 		-
 			message: "#^Method SubProjectTestFiltersTestCase\\:\\:testSubProjectTestFilters\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Part \\$build\\['id'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Part \\$test\\['subprojectname'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_subprojecttestfilters.php
+
+		-
+			message: "#^Part \\$testfilters \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
 			path: app/cdash/tests/test_subprojecttestfilters.php
 
 		-
@@ -22849,6 +27794,26 @@ parameters:
 			path: app/cdash/tests/test_testgraphpermissions.php
 
 		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Cannot access offset 'projectid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Cannot access offset 'testname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
 			message: "#^Cannot call method execute\\(\\) on PDOStatement\\|false\\.$#"
 			count: 3
 			path: app/cdash/tests/test_testgraphpermissions.php
@@ -22864,6 +27829,16 @@ parameters:
 			path: app/cdash/tests/test_testgraphpermissions.php
 
 		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Part \\$testname \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 4
+			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
 			message: "#^Property TestGraphPermissionsTestCase\\:\\:\\$build has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testgraphpermissions.php
@@ -22872,6 +27847,101 @@ parameters:
 			message: "#^Property TestGraphPermissionsTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testgraphpermissions.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'buildtestid' on mixed\\.$#"
+			count: 5
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'current' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 17
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'history' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 4
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 9
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'next' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'previous' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 'y' on mixed\\.$#"
+			count: 10
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 14
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 15
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 2 on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 3 on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Cannot access offset 4 on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -22924,6 +27994,41 @@ parameters:
 			path: app/cdash/tests/test_testhistory.php
 
 		-
+			message: "#^Parameter \\#1 \\$result of method WebTestCase\\:\\:assertFalse\\(\\) expects bool, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Part \\$history \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Part \\$sporadic_ids\\[0\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Part \\$sporadic_ids\\[1\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 3
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Part \\$sporadic_ids\\[2\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 5
+			path: app/cdash/tests/test_testhistory.php
+
+		-
+			message: "#^Part \\$test\\['name'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_testhistory.php
+
+		-
 			message: "#^Property TestHistoryTestCase\\:\\:\\$project has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testhistory.php
@@ -22957,6 +28062,16 @@ parameters:
 			path: app/cdash/tests/test_testoverview.php
 
 		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_testoverview.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 7
+			path: app/cdash/tests/test_testoverview.php
+
+		-
 			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
 			count: 1
 			path: app/cdash/tests/test_testoverview.php
@@ -22972,6 +28087,16 @@ parameters:
 			path: app/cdash/tests/test_testoverview.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 6
+			path: app/cdash/tests/test_testoverview.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/test_timeline.php
+
+		-
 			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null results in an error\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timeline.php
@@ -22981,6 +28106,31 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Cannot access offset 'expected' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeline.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timeline.php
 
@@ -23070,8 +28220,28 @@ parameters:
 			path: app/cdash/tests/test_timeline.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 2
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
+			message: "#^Cannot access offset 'numMissing' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timeoutsandmissingtests.php
+
+		-
+			message: "#^Cannot access offset 'tests' on mixed\\.$#"
+			count: 1
 			path: app/cdash/tests/test_timeoutsandmissingtests.php
 
 		-
@@ -23117,6 +28287,21 @@ parameters:
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
+			count: 1
+			path: app/cdash/tests/test_timestatus.php
+
+		-
+			message: "#^Cannot access offset 'current' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timestatus.php
+
+		-
+			message: "#^Cannot access offset 'menu' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timestatus.php
+
+		-
+			message: "#^Cannot access offset 'previous' on mixed\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timestatus.php
 
@@ -23186,13 +28371,63 @@ parameters:
 			path: app/cdash/tests/test_timestatus.php
 
 		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_timestatus.php
+
+		-
 			message: "#^Property TimeStatusTestCase\\:\\:\\$PDO has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_timestatus.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected configure…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected test…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'configure' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'site' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Cannot access offset 'timefull' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_timesummary.php
 
 		-
@@ -23201,9 +28436,54 @@ parameters:
 			path: app/cdash/tests/test_timesummary.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_timesummary.php
+
+		-
 			message: "#^Variable \\$build might not be defined\\.$#"
 			count: 4
 			path: app/cdash/tests/test_timesummary.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 'errors' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 'output' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 'stderror' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 'stderror'\\|'stdoutput' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 'test' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -23222,6 +28502,11 @@ parameters:
 
 		-
 			message: "#^Method TruncateOutputTestCase\\:\\:testTruncateOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_truncateoutput.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_truncateoutput.php
 
@@ -23355,6 +28640,11 @@ parameters:
 			path: app/cdash/tests/test_updateappend.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
 			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -23365,6 +28655,26 @@ parameters:
 		-
 			message: "#^Call to method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:save\\(\\) with incorrect case\\: Save$#"
 			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Cannot access offset 'failed_errors'\\|'failed_tests'\\|'failed_warnings'\\|'fixed_errors'\\|'fixed_tests'\\|'fixed_warnings'\\|'totalupdatedfiles' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Cannot access offset 'users' on mixed\\.$#"
+			count: 2
 			path: app/cdash/tests/test_updateonlyuserstats.php
 
 		-
@@ -23389,6 +28699,26 @@ parameters:
 
 		-
 			message: "#^Method UpdateOnlyUserStatsTestCase\\:\\:testUpdateOnlyUserStats\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Part \\$found \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: app/cdash/tests/test_updateonlyuserstats.php
+
+		-
+			message: "#^Part \\$name \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/tests/test_updateonlyuserstats.php
 
@@ -23453,6 +28783,26 @@ parameters:
 			path: app/cdash/tests/test_upgrade.php
 
 		-
+			message: "#^Binary operation \"\\.\" between 'Expected…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 2
 			path: app/cdash/tests/test_uploadfile.php
@@ -23473,6 +28823,11 @@ parameters:
 			path: app/cdash/tests/test_uploadfile.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/test_uploadfile.php
+
+		-
 			message: "#^Property UploadFileTestCase\\:\\:\\$BuildId has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uploadfile.php
@@ -23486,6 +28841,21 @@ parameters:
 			message: "#^Property UploadFileTestCase\\:\\:\\$Sha1Sum has no type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_uploadfile.php
+
+		-
+			message: "#^Cannot access property \\$error on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_usernotes.php
+
+		-
+			message: "#^Cannot access property \\$note on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_usernotes.php
+
+		-
+			message: "#^Cannot access property \\$requirelogin on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_usernotes.php
 
 		-
 			message: "#^Method UserStatisticsTestCase\\:\\:testUserStatistics\\(\\) has no return type specified\\.$#"
@@ -23529,6 +28899,16 @@ parameters:
 			path: app/cdash/tests/test_viewdynamicanalysisfile.php
 
 		-
+			message: "#^Cannot access offset 'buildid' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewdynamicanalysisfile.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_viewdynamicanalysisfile.php
+
+		-
 			message: "#^Cannot call method fetch\\(\\) on PDOStatement\\|false\\.$#"
 			count: 3
 			path: app/cdash/tests/test_viewdynamicanalysisfile.php
@@ -23540,6 +28920,11 @@ parameters:
 
 		-
 			message: "#^Method ViewDynamicAnalysisFileTestCase\\:\\:testViewDynamicAnalysisFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewdynamicanalysisfile.php
+
+		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewdynamicanalysisfile.php
 
@@ -23559,9 +28944,49 @@ parameters:
 			path: app/cdash/tests/test_viewmap.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected NA for…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Binary operation \"\\.\" between literal\\-string&non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Cannot access offset 'nbuilderror'\\|'nbuildpass'\\|'nbuildwarning'\\|'nconfigureerror'\\|'nconfigurepass'\\|'nconfigurewarning'\\|'ntestfail'\\|'ntestnotrun'\\|'ntestpass'\\|'starttime' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Cannot access offset 'starttime' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Cannot access offset 'subprojects' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
 			message: "#^Method ViewSubProjectsTestCase\\:\\:testViewSubProjects\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewsubprojects.php
+
+		-
+			message: "#^Cannot access offset 'projects' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/test_viewsubprojectslinkoption.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
@@ -23592,6 +29017,66 @@ parameters:
 			message: "#^Property ViewSubProjectsLinkOptionTestCase\\:\\:\\$project is unused\\.$#"
 			count: 1
 			path: app/cdash/tests/test_viewsubprojectslinkoption.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected 36…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Expected hut11…' and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Binary operation \"\\.\" between non\\-falsy\\-string and mixed results in an error\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'buildgroups' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'buildname' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'builds' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'numchildren' on mixed\\.$#"
+			count: 2
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset 'site' on mixed\\.$#"
+			count: 3
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
@@ -23659,6 +29144,16 @@ parameters:
 			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_pop expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			count: 1
+			path: app/cdash/tests/trilinos_submission_test.php
+
+		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/trilinos_submission_test.php
@@ -23670,6 +29165,11 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$details\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Binary operation \"\\.\\=\" between 'bazel ' and mixed results in an error\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
@@ -23700,6 +29200,76 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 2
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'command' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 9
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'label' on mixed\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'path' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'pattern' on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'progress' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'started' on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'status' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'stdout' on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'testResult' on mixed\\.$#"
+			count: 5
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 'testSummary' on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Cannot access offset int\\<min, \\-1\\>\\|int\\<1, max\\>\\|non\\-falsy\\-string on mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
@@ -23759,6 +29329,11 @@ parameters:
 
 		-
 			message: "#^Method BazelJSONHandler\\:\\:CreateNewTest\\(\\) has parameter \\$test_time with no type specified\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Method BazelJSONHandler\\:\\:GetSubProjectForPath\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
@@ -23863,13 +29438,43 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$filepath of static method BazelJSONHandler\\:\\:GetSubProjectForPath\\(\\) expects string, mixed given\\.$#"
+			count: 3
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
 			count: 3
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 9
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$needle of function str_contains expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BazelJSON_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
@@ -24001,6 +29606,16 @@ parameters:
 			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
 
 		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+
+		-
+			message: "#^Cannot call method FillFromId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+
+		-
 			message: "#^Method BuildPropertiesJSONHandler\\:\\:Parse\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
@@ -24021,6 +29636,16 @@ parameters:
 			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
 
 		-
+			message: "#^Property AbstractSubmissionHandler\\:\\:\\$Build \\(CDash\\\\Model\\\\Build\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+
+		-
+			message: "#^Property CDash\\\\Model\\\\BuildProperties\\:\\:\\$Properties \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
+
+		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
@@ -24030,6 +29655,21 @@ parameters:
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
 			"""
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Cannot call method getFilename\\(\\) on mixed\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Cannot call method getPath\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Cannot call method isFile\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
@@ -24139,6 +29779,11 @@ parameters:
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
 			message: "#^Parameter \\#2 \\$offset of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
@@ -24150,6 +29795,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/GcovTar_handler.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
@@ -24214,6 +29864,11 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
 			message: """
 				#^Call to deprecated function add_log\\(\\)\\:
 				04/04/2023  Use \\\\Illuminate\\\\Support\\\\Facades\\\\Log for logging instead$#
@@ -24223,6 +29878,11 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Cannot call method getFilename\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
@@ -24272,7 +29932,22 @@ parameters:
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
 
@@ -24280,6 +29955,11 @@ parameters:
 			message: "#^Property JSCoverTarHandler\\:\\:\\$CoverageSummaries has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/JSCoverTar_handler.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
 			message: """
@@ -24292,6 +29972,11 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Cannot call method getFilename\\(\\) on mixed\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
@@ -24352,6 +30037,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
 
 		-
@@ -24419,6 +30109,16 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Cannot call method getFilename\\(\\) on mixed\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
+			message: "#^Cannot call method getPath\\(\\) on mixed\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
 
@@ -24578,6 +30278,11 @@ parameters:
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
 
 		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
+
+		-
 			message: "#^Parameter \\#2 \\$data of function xml_parse expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
@@ -24644,6 +30349,16 @@ parameters:
 			message: "#^Property SubProjectDirectoriesHandler\\:\\:\\$SubProjectOrder has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/abstract_xml_handler.php
+
+		-
+			message: "#^Cannot call method Fill\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/abstract_xml_handler.php
 
 		-
 			message: "#^Class AbstractXmlHandler has an uninitialized property \\$Project\\. Give it default value or assign it in the constructor\\.$#"
@@ -24741,6 +30456,11 @@ parameters:
 			path: app/cdash/xml_handlers/abstract_xml_handler.php
 
 		-
+			message: "#^Property AbstractXmlHandler\\:\\:\\$Project \\(CDash\\\\Model\\\\Project\\) does not accept mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/abstract_xml_handler.php
+
+		-
 			message: "#^Property AbstractXmlHandler\\:\\:\\$SubProjectName has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_xml_handler.php
@@ -24749,6 +30469,11 @@ parameters:
 			message: "#^Property AbstractXmlHandler\\:\\:\\$projectid has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_xml_handler.php
+
+		-
+			message: "#^Binary operation \"/\" between mixed and 2 results in an error\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:AddLabel\\(\\)\\.$#"
@@ -24766,6 +30491,76 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
+			message: "#^Cannot access property \\$CompilerName on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$CompilerVersion on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$Generator on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$Name on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSName on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSPlatform on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSRelease on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSVersion on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$SiteId on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot access property \\$Type on mixed\\.$#"
+			count: 5
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot call method SetId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot call method SetPullRequest\\(\\) on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot call method SetStamp\\(\\) on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Cannot call method SetText\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
 			message: "#^Class BuildHandler has an uninitialized property \\$BuildInformation\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
@@ -24778,6 +30573,11 @@ parameters:
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 29
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Method BuildHandler\\:\\:GetBuildGroup\\(\\) should return CDash\\\\Model\\\\BuildGroup but returns mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
@@ -24862,6 +30662,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, \\(float\\|int\\) given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
+			message: "#^Part \\$threshold \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
 
@@ -25526,6 +31331,141 @@ parameters:
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
+			message: "#^Cannot access property \\$BuildId on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Checker on mixed\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$CompilerName on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$CompilerVersion on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Empty on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$EndTime on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Generator on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 4
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$InsertErrors on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Name on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSName on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSPlatform on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSRelease on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$OSVersion on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$ProjectId on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$SiteId on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$StartTime on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Status on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$SubmitTime on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot access property \\$Type on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method GetIdFromName\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method Insert\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method RemoveIfDone\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method SetId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method SetStamp\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method SetSubProject\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Cannot call method UpdateBuild\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
 			message: "#^Class DynamicAnalysisHandler has an uninitialized property \\$BuildInformation\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -25543,6 +31483,11 @@ parameters:
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 22
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Method DynamicAnalysisHandler\\:\\:GetBuildGroup\\(\\) should return CDash\\\\Model\\\\BuildGroup but returns mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
@@ -25616,6 +31561,11 @@ parameters:
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$build of static method App\\\\Utils\\\\SubmissionUtils\\:\\:add_build\\(\\) expects CDash\\\\Model\\\\Build, mixed given\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
 			message: "#^Property DynamicAnalysisHandler\\:\\:\\$BuildInformation type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -25628,6 +31578,11 @@ parameters:
 		-
 			message: "#^Property DynamicAnalysisHandler\\:\\:\\$Checker has no type specified\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
+			message: "#^Property DynamicAnalysisHandler\\:\\:\\$DynamicAnalysis \\(CDash\\\\Model\\\\DynamicAnalysis\\) does not accept mixed\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
@@ -25944,6 +31899,46 @@ parameters:
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
+			message: "#^Cannot access property \\$Data on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot access property \\$Extension on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot access property \\$Id on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot access property \\$Name on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot access property \\$name on mixed\\.$#"
+			count: 2
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot access property \\$type on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot call method SetId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Cannot call method UpdateTestDuration\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
 			message: "#^Class TestingHandler has an uninitialized property \\$BuildInformation\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
@@ -25956,6 +31951,11 @@ parameters:
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 34
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Method TestingHandler\\:\\:GetBuildGroup\\(\\) should return CDash\\\\Model\\\\BuildGroup but returns mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
@@ -26031,6 +32031,11 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\|false given on the right side\\.$#"
 			count: 3
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
+			message: "#^Property AbstractXmlHandler\\:\\:\\$Project \\(CDash\\\\Model\\\\Project\\) does not accept mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
@@ -26274,6 +32279,26 @@ parameters:
 			path: app/cdash/xml_handlers/update_handler.php
 
 		-
+			message: "#^Cannot access property \\$Append on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Cannot access property \\$Generator on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Cannot access property \\$Status on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Cannot call method SetId\\(\\) on mixed\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/xml_handlers/update_handler.php
@@ -26286,6 +32311,11 @@ parameters:
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 23
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Method UpdateHandler\\:\\:GetBuildGroup\\(\\) should return CDash\\\\Model\\\\BuildGroup but returns mixed\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/update_handler.php
 
 		-
@@ -26336,6 +32366,11 @@ parameters:
 		-
 			message: "#^Method UpdateHandler\\:\\:text\\(\\) has parameter \\$parser with no type specified\\.$#"
 			count: 1
+			path: app/cdash/xml_handlers/update_handler.php
+
+		-
+			message: "#^Property AbstractSubmissionHandler\\:\\:\\$Build \\(CDash\\\\Model\\\\Build\\) does not accept mixed\\.$#"
+			count: 2
 			path: app/cdash/xml_handlers/update_handler.php
 
 		-
@@ -26504,6 +32539,11 @@ parameters:
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
+			message: "#^Parameter \\#1 \\$basePath of class Illuminate\\\\Foundation\\\\Application constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: bootstrap/app.php
+
+		-
 			message: "#^Parameter \\#1 \\$title of static method Illuminate\\\\Support\\\\Str\\:\\:slug\\(\\) expects string, bool\\|string given\\.$#"
 			count: 1
 			path: config/cache.php
@@ -26654,6 +32694,21 @@ parameters:
 			path: database/migrations/2020_01_10_120602_drop_cdash_at_home.php
 
 		-
+			message: "#^Binary operation \"\\+\" between mixed and 4999 results in an error\\.$#"
+			count: 1
+			path: database/migrations/2020_02_17_112005_reformat_test_data.php
+
+		-
+			message: "#^Binary operation \"\\+\\=\" between mixed and 5000 results in an error\\.$#"
+			count: 1
+			path: database/migrations/2020_02_17_112005_reformat_test_data.php
+
+		-
+			message: "#^Binary operation \"\\-\" between mixed and mixed results in an error\\.$#"
+			count: 1
+			path: database/migrations/2020_02_17_112005_reformat_test_data.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 3
 			path: database/migrations/2020_02_17_112005_reformat_test_data.php
@@ -26679,9 +32734,89 @@ parameters:
 			path: database/migrations/2020_02_17_112005_reformat_test_data.php
 
 		-
+			message: "#^Part \\$start \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: database/migrations/2020_02_17_112005_reformat_test_data.php
+
+		-
+			message: "#^Cannot access property \\$id on mixed\\.$#"
+			count: 1
+			path: database/migrations/2021_09_23_124054_add_measurement_order.php
+
+		-
+			message: "#^Cannot access property \\$projectid on mixed\\.$#"
+			count: 1
+			path: database/migrations/2021_09_23_124054_add_measurement_order.php
+
+		-
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, \\(array\\<int, string\\>\\|string\\|null\\) given\\.$#"
 			count: 1
 			path: database/migrations/2023_04_16_204249_project_name_regex.php
+
+		-
+			message: "#^Cannot call method getBaseName\\(\\) on mixed\\.$#"
+			count: 1
+			path: database/migrations/2023_11_13_190025_move_uploaded_files_to_storage.php
+
+		-
+			message: "#^Cannot call method getRealPath\\(\\) on mixed\\.$#"
+			count: 1
+			path: database/migrations/2023_11_13_190025_move_uploaded_files_to_storage.php
+
+		-
+			message: "#^Binary operation \"\\+\" between mixed and 4999 results in an error\\.$#"
+			count: 1
+			path: database/migrations/2024_04_17_183212_remove_test_table.php
+
+		-
+			message: "#^Binary operation \"\\+\\=\" between mixed and 5000 results in an error\\.$#"
+			count: 1
+			path: database/migrations/2024_04_17_183212_remove_test_table.php
+
+		-
+			message: "#^Binary operation \"\\-\" between mixed and mixed results in an error\\.$#"
+			count: 1
+			path: database/migrations/2024_04_17_183212_remove_test_table.php
+
+		-
+			message: "#^Part \\$start \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: database/migrations/2024_04_17_183212_remove_test_table.php
+
+		-
+			message: "#^Cannot access offset 'Id' on mixed\\.$#"
+			count: 1
+			path: database/seeds/DatabaseSeeder.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: database/seeds/DatabaseSeeder.php
+
+		-
+			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:getAuthEndpoint\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: resources/providers/PingIdentity/Provider.php
+
+		-
+			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:getInstanceUri\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: resources/providers/PingIdentity/Provider.php
+
+		-
+			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:getTokenEndpoint\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: resources/providers/PingIdentity/Provider.php
+
+		-
+			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:getUserByToken\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: resources/providers/PingIdentity/Provider.php
+
+		-
+			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:getUserEndpoint\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: resources/providers/PingIdentity/Provider.php
 
 		-
 			message: "#^Method SocialiteProviders\\\\PingIdentity\\\\Provider\\:\\:mapUserToObject\\(\\) has parameter \\$user with no value type specified in iterable type array\\.$#"
@@ -26715,6 +32850,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function urldecode expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: server.php
+
+		-
+			message: "#^Parameter \\#1 \\$url of function parse_url expects string, mixed given\\.$#"
 			count: 1
 			path: server.php
 
@@ -26800,9 +32940,59 @@ parameters:
 			path: tests/Feature/GraphQL/ProjectTypeTest.php
 
 		-
+			message: "#^Binary operation \"\\.\" between mixed and '_' results in an error\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'edges' on mixed\\.$#"
+			count: 3
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'information' on mixed\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'node' on mixed\\.$#"
+			count: 3
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'projects' on mixed\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'sites' on mixed\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 'timestamp' on mixed\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 3
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$time of static method Carbon\\\\Carbon\\:\\:parse\\(\\) expects DateTimeInterface\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SuccessfulJob\\>\\:\\:count\\(\\)\\.$#"
 			count: 4
 			path: tests/Feature/Jobs/PruneJobsTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 48
+			path: tests/Feature/LdapIntegration.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
@@ -26838,6 +33028,46 @@ parameters:
 			message: "#^Parameter \\#1 \\$user of method Illuminate\\\\Foundation\\\\Testing\\\\TestCase\\:\\:assertAuthenticatedAs\\(\\) expects Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable, App\\\\Models\\\\User\\|null given\\.$#"
 			count: 3
 			path: tests/Feature/LoginAndRegistration.php
+
+		-
+			message: "#^Cannot access offset 'color' on mixed\\.$#"
+			count: 6
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 3
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 'name' on mixed\\.$#"
+			count: 2
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 'time_chart_data' on mixed\\.$#"
+			count: 2
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 'values' on mixed\\.$#"
+			count: 2
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 5
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Cannot access offset 1 on mixed\\.$#"
+			count: 7
+			path: tests/Feature/Monitor.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function end expects array\\|object, mixed given\\.$#"
+			count: 2
+			path: tests/Feature/Monitor.php
 
 		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
@@ -26916,6 +33146,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: tests/Unit/app/ControllerNameTest.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#"
+			count: 1
+			path: tests/Unit/app/ControllerNameTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: tests/Unit/app/ControllerNameTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,6 +43,7 @@ parameters:
     checkUninitializedProperties: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
     checkBenevolentUnionTypes: true
+    reportAnyTypeWideningInVarTag: true
 
     level: 9
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,7 +44,7 @@ parameters:
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
     checkBenevolentUnionTypes: true
 
-    level: 8
+    level: 9
 
 includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon


### PR DESCRIPTION
After using PHPStan for a while, our type coverage is now far more complete and most of the worst issues have been fixed.  The codebase is now in a state where many of the errors reported by PHPStan level 9 are useful, instead of being a nuisance.  If this proves to be incorrect after a few weeks or months of testing, we can reduce our rule level back down to level 8.