### PR TITLE
docker container dependency condition updated

### DIFF
--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -25,7 +25,7 @@ services:
         condition: any
     depends_on:
       cdash:
-        condition: service_healthy
+        condition: service_started
     volumes:
       - type: volume
         source: storage


### PR DESCRIPTION
The health check of the cdash docker container has been removed in #2334 
When using the docker compose files the cdash_worker will not start with the error 

`container for service "cdash" has no healthcheck configured`

The dependency is changed to `service_started` to fix this