### PR TITLE
Remove legacy logs directory

### DIFF
--- a/app/cdash/log/README
+++ b/app/cdash/log/README
@@ -1,1 +1,0 @@
-Logs now live in ../../../storage/logs/


### PR DESCRIPTION
It has been a while since the legacy logs directory was last used, so this PR cleans up the last remaining traces of it.