### PR TITLE
Update Laravel to v10.48.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "guzzlehttp/guzzle": "7.8.1",
     "http-interop/http-factory-guzzle": "1.2.0",
     "knplabs/github-api": "3.14.1",
-    "laravel/framework": "10.48.14",
+    "laravel/framework": "10.48.23",
     "laravel/legacy-factories": "1.4.0",
     "laravel/socialite": "5.15.0",
     "laravel/ui": "4.5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ece8a3d95d99d8d8d7518b8f70d094d0",
+    "content-hash": "ee42ed973905c0352b6a2e45b4cd3f83",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -2138,16 +2138,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.48.14",
+            "version": "v10.48.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "27cb4736bb7e60a5311ec73160068dfbcf98336b"
+                "reference": "625269ca4881d2b50eded2045cb930960a181d98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/27cb4736bb7e60a5311ec73160068dfbcf98336b",
-                "reference": "27cb4736bb7e60a5311ec73160068dfbcf98336b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/625269ca4881d2b50eded2045cb930960a181d98",
+                "reference": "625269ca4881d2b50eded2045cb930960a181d98",
                 "shasum": ""
             },
             "require": {
@@ -2341,7 +2341,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-06-21T10:06:42+00:00"
+            "time": "2024-11-12T15:39:10+00:00"
         },
         {
             "name": "laravel/legacy-factories",


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-gv7v-rgg6-548h.