### PR TITLE
Update Laravel to v10.48.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "guzzlehttp/guzzle": "7.9.2",
     "http-interop/http-factory-guzzle": "1.2.0",
     "knplabs/github-api": "3.15.0",
-    "laravel/framework": "10.48.14",
+    "laravel/framework": "10.48.23",
     "laravel/legacy-factories": "1.4.0",
     "laravel/socialite": "5.16.0",
     "laravel/ui": "4.5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96d8848c6885b904f26594c03542cfe1",
+    "content-hash": "64bfed8460e9adfc126d46f490ae14f3",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -2145,16 +2145,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.48.14",
+            "version": "v10.48.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "27cb4736bb7e60a5311ec73160068dfbcf98336b"
+                "reference": "625269ca4881d2b50eded2045cb930960a181d98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/27cb4736bb7e60a5311ec73160068dfbcf98336b",
-                "reference": "27cb4736bb7e60a5311ec73160068dfbcf98336b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/625269ca4881d2b50eded2045cb930960a181d98",
+                "reference": "625269ca4881d2b50eded2045cb930960a181d98",
                 "shasum": ""
             },
             "require": {
@@ -2348,7 +2348,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-06-21T10:06:42+00:00"
+            "time": "2024-11-12T15:39:10+00:00"
         },
         {
             "name": "laravel/legacy-factories",


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-gv7v-rgg6-548h.