### PR TITLE
Fix `testDetails.php` redirect

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -134,7 +134,7 @@ Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
     $testid = $request->query('test');
-    $buildtest = \App\Models\Test::where('buildid', $buildid)->where('testid', $testid)->first();
+    $buildtest = \App\Models\Test::where('buildid', $buildid)->where('id', $testid)->first();
     if ($buildtest !== null) {
         return redirect("/tests/{$buildtest->id}", 301);
     }


### PR DESCRIPTION
The redirect for `testDetails.php` currently throws a 500 error.  This PR resolves the error by querying the correct database column.