### PR TITLE
Delete unused uploads directory

### DIFF
--- a/public/upload/.gitignore
+++ b/public/upload/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Uploaded files have been stored in the storage directory for some time now, and there is no longer a need to keep the previous uploads directory around.