### PR TITLE
Add foreign-key constraint to configureerror table

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -484,7 +484,6 @@ function remove_build($buildid)
     if (count($configureids) > 0) {
         $configureids_prepare_array = $db->createPreparedArray(count($configureids));
         DB::delete("DELETE FROM configure WHERE id IN $configureids_prepare_array", $configureids);
-        DB::delete("DELETE FROM configureerror WHERE configureid IN $configureids_prepare_array", $configureids);
     }
 
     // coverage files are kept unless they are shared

--- a/database/migrations/2024_11_18_113619_configure_error_foreign_key.php
+++ b/database/migrations/2024_11_18_113619_configure_error_foreign_key.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        echo "Adding foreign key constraint configureerror(configureid)->configure(id)...";
+        $num_deleted = DB::delete("DELETE FROM configureerror WHERE configureid NOT IN (SELECT id FROM configure)");
+        echo $num_deleted . ' invalid rows deleted' . PHP_EOL;
+        Schema::table('configureerror', function (Blueprint $table) {
+            $table->foreign('configureid')->references('id')->on('configure')->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('configureerror', function (Blueprint $table) {
+            $table->dropForeign(['configureid']);
+        });
+    }
+};


### PR DESCRIPTION
This PR adds a foreign-key constraint to the `configureerror` table in support of #2093.