### PR TITLE
Ensure configureerror FK types match

### DIFF
--- a/database/migrations/2024_11_18_113619_configure_error_foreign_key.php
+++ b/database/migrations/2024_11_18_113619_configure_error_foreign_key.php
@@ -11,6 +11,11 @@ return new class extends Migration {
      */
     public function up(): void
     {
+        echo 'Converting configureerror.configureid to int' . PHP_EOL;
+        Schema::table('configureerror', function (Blueprint $table) {
+            $table->integer('configureid')->change();
+        });
+
         echo "Adding foreign key constraint configureerror(configureid)->configure(id)...";
         $num_deleted = DB::delete("DELETE FROM configureerror WHERE configureid NOT IN (SELECT id FROM configure)");
         echo $num_deleted . ' invalid rows deleted' . PHP_EOL;


### PR DESCRIPTION
CDash databases that were initialized in v2.5 or older have a type mismatch between configure.id (int) and configureerror.configureid (bigint). See #506 for more context about where this mismatch occurred.

Update the recent migration so that these types match and we can apply the foreign key successfully.