### PR TITLE
Remove last traces of google analytics tracker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,10 +38,6 @@ DB_PASSWORD=secret
 # daily updates are triggered (e.g. cron).
 #DAILY_UPDATES=true
 
-# Google Universal Analytics Tracking ID to use by default
-# https://support.google.com/analytics/answer/7372977
-#DEFAULT_GOOGLE_ANALYTICS=
-
 # Should users be taken directly to a certain project when they arrive
 # via index.php?
 #DEFAULT_PROJECT=

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -199,7 +199,6 @@ final class CoverageController extends AbstractBuildController
             'cvsurl' => 'unknown',
             'bugtrackerurl' => 'unknown',
             'documentationurl' => 'unknown',
-            'googletracker' => 'unknonw',
             'name' => $projectname,
             'nightlytime' => '00:00:00',
         ];
@@ -223,7 +222,6 @@ final class CoverageController extends AbstractBuildController
   <startdate>' . date('l, F d Y H:i:s', $currentstarttime) . '</startdate>
   <svn>' . make_cdash_url(htmlentities($project_array['cvsurl'])) . '</svn>
   <bugtracker>' . make_cdash_url(htmlentities($project_array['bugtrackerurl'])) . '</bugtracker>
-  <googletracker>' . htmlentities($project_array['googletracker']) . '</googletracker>
   <documentation>' . make_cdash_url(htmlentities($project_array['documentationurl'])) . '</documentation>
   <projectid>' . $projectid . '</projectid>
   <projectname>' . $project_array['name'] . '</projectname>

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -25,7 +25,6 @@ use Illuminate\Support\Facades\Auth;
  * @property int $coveragethreshold
  * @property string $testingdataurl
  * @property string $nightlytime
- * @property string $googletracker
  * @property int $emaillowcoverage
  * @property int $emailtesttimingchanged
  * @property int $emailbrokensubmission
@@ -73,7 +72,6 @@ class Project extends Model
         'coveragethreshold',
         'testingdataurl',
         'nightlytime',
-        'googletracker',
         'emaillowcoverage',
         'emailtesttimingchanged',
         'emailbrokensubmission',

--- a/app/cdash/app/Controller/Api/ViewProjects.php
+++ b/app/cdash/app/Controller/Api/ViewProjects.php
@@ -57,7 +57,6 @@ class ViewProjects extends \CDash\Controller\Api
 
         $response['title'] = 'Projects';
         $response['subtitle'] = 'Projects';
-        $response['googletracker'] = config('cdash.default_google_analytics');
 
         $response['showoldtoggle'] = true;
         $this->activeProjectDays = (int) config('cdash.active_project_days');

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -63,7 +63,6 @@ class Project
     public $NightlyTime;
     public $NightlyDateTime;
     public $NightlyTimezone;
-    public $GoogleTracker;
     public $EmailLowCoverage;
     public $EmailTestTimingChanged;
     public $EmailBrokenSubmission;
@@ -266,7 +265,6 @@ class Project
             'coveragethreshold' => (int) $this->CoverageThreshold,
             'testingdataurl' => $this->TestingDataUrl ?? '',
             'nightlytime' => $this->NightlyTime ?? '',
-            'googletracker' => $this->GoogleTracker ?? '',
             'emaillowcoverage' => (int) $this->EmailLowCoverage,
             'emailtesttimingchanged' => (int) $this->EmailTestTimingChanged,
             'emailbrokensubmission' => (int) $this->EmailBrokenSubmission,
@@ -355,7 +353,6 @@ class Project
             $this->CoverageThreshold = $project->coveragethreshold;
             $this->TestingDataUrl = $project->testingdataurl;
             $this->SetNightlyTime($project->nightlytime);
-            $this->GoogleTracker = $project->googletracker;
             $this->EmailLowCoverage = $project->emaillowcoverage;
             $this->EmailTestTimingChanged = $project->emailtesttimingchanged;
             $this->EmailBrokenSubmission = $project->emailbrokensubmission;

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -688,7 +688,6 @@ function get_dashboard_JSON($projectname, $date, &$response)
     $project_array['bugtrackerurl'] = $project->Id ? $project->BugTrackerUrl : 'unknown';
     $project_array['documentationurl'] = $project->Id ? $project->DocumentationUrl : 'unknown';
     $project_array['homeurl'] = $project->Id ? $project->HomeUrl : 'unknown';
-    $project_array['googletracker'] = $project->Id ? $project->GoogleTracker : 'unknown';
     $project_array['name'] = $projectname;
     $project_array['nightlytime'] =  $project->Id ? $project->NightlyTime : '00:00:00';
 
@@ -704,7 +703,6 @@ function get_dashboard_JSON($projectname, $date, &$response)
     $response['currentdate'] = TestingDay::get($project, gmdate(FMT_DATETIME));
     $response['vcs'] = make_cdash_url(htmlentities($project_array['cvsurl']));
     $response['bugtracker'] = make_cdash_url(htmlentities($project_array['bugtrackerurl']));
-    $response['googletracker'] = htmlentities($project_array['googletracker']);
     $response['documentation'] = make_cdash_url(htmlentities($project_array['documentationurl']));
     $response['projectid'] = $project->Id;
     $response['projectname'] = $project_array['name'];

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -51,7 +51,6 @@ return [
     'curl_localhost_prefix' => env('CURL_LOCALHOST_PREFIX', ''),
     'daily_updates' => env('DAILY_UPDATES', true),
     'default_git_dir' => env('DEFAULT_GIT_DIRECTORY', '/cdash/_build'),
-    'default_google_analytics' => env('DEFAULT_GOOGLE_ANALYTICS', ''),
     'default_project' => env('DEFAULT_PROJECT', null),
     'delete_old_subprojects' => env('DELETE_OLD_SUBPROJECTS', true),
     'google_map_api_key' => env('GOOGLE_MAP_API_KEY', null),

--- a/database/migrations/2024_11_22_160106_drop_googletracker_column.php
+++ b/database/migrations/2024_11_22_160106_drop_googletracker_column.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project', function (Blueprint $table) {
+            $table->dropColumn('googletracker');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project', function (Blueprint $table) {
+            $table->string('googletracker', 50)->nullable();
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1497,7 +1497,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlentities expects string, mixed given\\.$#"
-			count: 5
+			count: 4
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -10891,11 +10891,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$Filled has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$GoogleTracker has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 

--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -1706,44 +1706,6 @@
                     <td />
                     <td>
                       <div align="right">
-                        <strong>Google Analytics Tracker:</strong>
-                      </div>
-                    </td>
-                    <td>
-                      <input
-                        id="googleTracker"
-                        v-model="cdash.project.GoogleTracker"
-                        name="googleTracker"
-                        type="text"
-                        size="30"
-                        @change="cdash.changesmade = true"
-                        @focus="showHelp('google_help')"
-                      >
-                      <a
-                        href="http://www.cdash.org/Wiki/CDash:Administration#Creating_a_project"
-                        target="blank"
-                      >
-                        <img
-                          :src="$baseURL + '/img/help.gif'"
-                          border="0"
-                          @mouseover="showHelp('google_help')"
-                        >
-                      </a>
-                      <span
-                        id="google_help"
-                        class="help_content"
-                      >
-                        <b>Google Analytics Tracker</b>
-                        <br>
-                        CDash supports visitor tracking through Google analytics.
-                        See “Adding Google Analytics” for more information.
-                      </span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td />
-                    <td>
-                      <div align="right">
                         <strong>Show site IP addresses:</strong>
                       </div>
                     </td>


### PR DESCRIPTION
CDash historically supported tracking users via a Google Analytics tracking link.  That functionality has been removed for some time now.  This PR removes the last few traces of that functionality.