### PR TITLE
Fix project sites page pagination

### DIFF
--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -96,6 +96,11 @@ const apolloClient = new ApolloClient({
           projects: relayStylePagination(),
         },
       },
+      Project: {
+        fields: {
+          sites: relayStylePagination(),
+        },
+      },
       Build: {
         fields: {
           tests: relayStylePagination(),


### PR DESCRIPTION
While writing end-to-end tests for the project sites page overhauled in #2583 as a proof-of-concept for the upcoming addition of Laravel Dusk, I discovered that the project sites page does not paginate correctly.  This PR fixes the issue.