### PR TITLE
Add build instrumentation API

### DIFF
--- a/app/Enums/BuildCommandType.php
+++ b/app/Enums/BuildCommandType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum BuildCommandType: string
+{
+    case COMPILE = 'COMPILE';
+    case LINK = 'LINK';
+    case CUSTOM = 'CUSTOM';
+    case CMAKE_BUILD = 'CMAKE_BUILD';
+    case CMAKE_INSTALL = 'CMAKE_INSTALL';
+    case INSTALL = 'INSTALL';
+}

--- a/app/Enums/BuildMeasurementType.php
+++ b/app/Enums/BuildMeasurementType.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace App\Enums;
-
-enum BuildMeasurementType: int
-{
-    case TARGET = 0;
-}

--- a/app/Enums/TargetType.php
+++ b/app/Enums/TargetType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * See: https://cmake.org/cmake/help/latest/prop_tgt/TYPE.html
+ *
+ * We also include an "UNKNOWN" value in case CMake adds a new type before CDash does.
+ */
+enum TargetType: string
+{
+    case UNKNOWN = 'UNKNOWN';
+    case STATIC_LIBRARY = 'STATIC_LIBRARY';
+    case MODULE_LIBRARY = 'MODULE_LIBRARY';
+    case SHARED_LIBRARY = 'SHARED_LIBRARY';
+    case OBJECT_LIBRARY = 'OBJECT_LIBRARY';
+    case INTERFACE_LIBRARY = 'INTERFACE_LIBRARY';
+    case EXECUTABLE = 'EXECUTABLE';
+}

--- a/app/GraphQL/Scalars/NonNegativeIntegerMilliseconds.php
+++ b/app/GraphQL/Scalars/NonNegativeIntegerMilliseconds.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Scalars;
+
+use GraphQL\Error\Error;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\IntValueNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\ValueNode;
+use GraphQL\Type\Definition\ScalarType;
+
+final class NonNegativeIntegerMilliseconds extends ScalarType
+{
+    protected function validate(mixed $value): bool
+    {
+        return is_numeric($value) && (int) $value >= 0;
+    }
+
+    /**
+     * Serializes an internal value to include in a response.
+     *
+     * @throws InvariantViolation
+     */
+    public function serialize(mixed $value): float
+    {
+        if (!$this->validate($value)) {
+            throw new InvariantViolation("Could not serialize {$value} as non-negative integer milliseconds.");
+        }
+
+        return $this->parseValue($value);
+    }
+
+    /**
+     * Parses an externally provided value (query variable) to use as an input.
+     *
+     * @throws InvariantViolation
+     */
+    public function parseValue(mixed $value): int
+    {
+        if (!$this->validate($value)) {
+            throw new InvariantViolation("Could not parse {$value} as non-negative integer milliseconds.");
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * Parses an externally provided literal value (hardcoded in GraphQL query) to use as an input.
+     *
+     * Should throw an exception with a client friendly message on invalid value nodes.
+     *
+     * @param ValueNode&Node $valueNode
+     * @param array<string, mixed>|null $variables
+     *
+     * @throws Error
+     */
+    public function parseLiteral(Node $valueNode, ?array $variables = null): float
+    {
+        if (!($valueNode instanceof IntValueNode)) {
+            throw new Error("Query error: Can only parse Integers, got {$valueNode->kind}.", $valueNode);
+        }
+
+        return (float) $valueNode->value;
+    }
+}

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -215,14 +215,6 @@ class Build extends Model
     }
 
     /**
-     * @return HasMany<BuildMeasurement>
-     */
-    public function measurements(): HasMany
-    {
-        return $this->hasMany(BuildMeasurement::class, 'buildid');
-    }
-
-    /**
      * @return HasMany<Coverage>
      */
     public function coverageResults(): HasMany
@@ -244,5 +236,29 @@ class Build extends Model
     public function uploadedFiles(): BelongsToMany
     {
         return $this->belongsToMany(UploadFile::class, 'build2uploadfile', 'buildid', 'fileid');
+    }
+
+    /**
+     * @return HasMany<BuildCommand>
+     */
+    public function commands(): HasMany
+    {
+        return $this->hasMany(BuildCommand::class, 'buildid');
+    }
+
+    /**
+     * @return HasMany<Target>
+     */
+    public function targets(): HasMany
+    {
+        return $this->hasMany(Target::class, 'buildid');
+    }
+
+    /**
+     * @return HasMany<self>
+     */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parentid');
     }
 }

--- a/app/Models/BuildCommand.php
+++ b/app/Models/BuildCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\BuildCommandType;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $buildid
+ * @property int $targetid
+ * @property BuildCommandType $type
+ * @property Carbon $starttime
+ * @property int $duration Command running time in ms.
+ * @property string $command
+ * @property string $workingdirectory
+ * @property string $result
+ * @property string $source
+ * @property string $language
+ * @property string $config
+ *
+ * @mixin Builder<BuildCommand>
+ */
+class BuildCommand extends Model
+{
+    protected $table = 'buildcommands';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'type',
+        'starttime',
+        'duration',
+        'command',
+        'workingdirectory',
+        'result',
+        'source',
+        'language',
+        'config',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'buildid' => 'integer',
+        'targetid' => 'integer',
+        'type' => BuildCommandType::class,
+        'starttime' => 'datetime',
+        'duration' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Build, self>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return HasMany<BuildMeasurement>
+     */
+    public function measurements(): HasMany
+    {
+        return $this->hasMany(BuildMeasurement::class, 'buildcommandid');
+    }
+
+    /**
+     * Some types of commands are associated with a target.
+     *
+     * https://cmake.org/cmake/help/git-master/manual/cmake-instrumentation.7.html#v1-snippet-file
+     *
+     * @return BelongsTo<Target, self>
+     */
+    public function target(): BelongsTo
+    {
+        return $this->belongsTo(Target::class, 'targetid');
+    }
+}

--- a/app/Models/BuildMeasurement.php
+++ b/app/Models/BuildMeasurement.php
@@ -2,17 +2,14 @@
 
 namespace App\Models;
 
-use App\Enums\BuildMeasurementType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @property int $id
- * @property int $buildid
+ * @property int $buildcommandid
  * @property string $name
- * @property string $source
- * @property BuildMeasurementType $type
+ * @property string $type
  * @property string $value
  *
  * @mixin Builder<BuildMeasurement>
@@ -25,22 +22,12 @@ class BuildMeasurement extends Model
 
     protected $fillable = [
         'name',
-        'source',
         'type',
         'value',
     ];
 
     protected $casts = [
         'id' => 'integer',
-        'buildid' => 'integer',
-        'type' => BuildMeasurementType::class,
+        'buildcommandid' => 'integer',
     ];
-
-    /**
-     * @return HasOne<Build>
-     */
-    public function build(): HasOne
-    {
-        return $this->hasOne(Build::class, 'id', 'buildid');
-    }
 }

--- a/app/Models/Target.php
+++ b/app/Models/Target.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TargetType;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $buildid
+ * @property string $name
+ * @property TargetType $type
+ *
+ * @mixin Builder<Target>
+ */
+class Target extends Model
+{
+    protected $table = 'targets';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'type',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'buildid' => 'integer',
+        'type' => TargetType::class,
+    ];
+
+    /**
+     * @return BelongsTo<Build, self>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return BelongsToMany<Label>
+     */
+    public function labels(): BelongsToMany
+    {
+        return $this->belongsToMany(Label::class, 'label2target', 'targetid', 'labelid');
+    }
+
+    /**
+     * @return HasMany<BuildCommand>
+     */
+    public function commands(): HasMany
+    {
+        return $this->hasMany(BuildCommand::class, 'targetid');
+    }
+}

--- a/app/Providers/GraphQLServiceProvider.php
+++ b/app/Providers/GraphQLServiceProvider.php
@@ -2,21 +2,19 @@
 
 namespace App\Providers;
 
-use App\Enums\BuildMeasurementType;
+use App\Enums\BuildCommandType;
 use App\Enums\ProjectRole;
-use GraphQL\Error\InvariantViolation;
+use App\Enums\TargetType;
 use GraphQL\Type\Definition\PhpEnumType;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 
 final class GraphQLServiceProvider extends ServiceProvider
 {
-    /**
-     * @throws InvariantViolation
-     */
     public function boot(TypeRegistry $typeRegistry): void
     {
-        $typeRegistry->register(new PhpEnumType(BuildMeasurementType::class));
         $typeRegistry->register(new PhpEnumType(ProjectRole::class));
+        $typeRegistry->register(new PhpEnumType(TargetType::class));
+        $typeRegistry->register(new PhpEnumType(BuildCommandType::class));
     }
 }

--- a/app/Validators/Schemas/Build.xsd
+++ b/app/Validators/Schemas/Build.xsd
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="common.xsd" />
+  <xs:element name="NamedMeasurement">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Value" type="xs:string" />
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
   <xs:element name="Site">
     <xs:complexType>
       <xs:sequence>
@@ -79,6 +88,120 @@
                         </xs:choice>
                       </xs:sequence>
                       <xs:attribute name="type" type="xs:string" use="required" />
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Targets">
+                    <xs:complexType>
+                      <xs:sequence maxOccurs="unbounded">
+                        <xs:element name="Target">
+                          <xs:complexType>
+                            <xs:all>
+                              <xs:element name="Labels" type="LabelsType" minOccurs="0"/>
+                              <xs:element name="Commands">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:choice maxOccurs="unbounded">
+                                      <xs:element name="Compile">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                          </xs:sequence>
+                                          <xs:attribute name="command" use="required"/>
+                                          <xs:attribute name="workingDir" use="required"/>
+                                          <xs:attribute name="config" use="required"/>
+                                          <xs:attribute name="duration" use="required" type="xs:integer"/>
+                                          <xs:attribute name="language" use="required"/>
+                                          <xs:attribute name="result" use="required"/>
+                                          <xs:attribute name="source" use="required"/>
+                                          <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                                        </xs:complexType>
+                                      </xs:element>
+                                      <xs:element name="Link">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                          </xs:sequence>
+                                          <xs:attribute name="command" use="required"/>
+                                          <xs:attribute name="workingDir" use="required"/>
+                                          <xs:attribute name="config" use="required"/>
+                                          <xs:attribute name="duration" use="required" type="xs:integer"/>
+                                          <xs:attribute name="language" use="required"/>
+                                          <xs:attribute name="result" use="required"/>
+                                          <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                                        </xs:complexType>
+                                      </xs:element>
+                                    </xs:choice>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:all>
+                            <xs:attribute name="name" use="required"/>
+                            <xs:attribute name="type" use="required"/>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Commands">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:choice maxOccurs="unbounded">
+                          <xs:element name="CmakeBuild">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                              </xs:sequence>
+                              <xs:attribute name="command" use="required"/>
+                              <xs:attribute name="workingDir" use="required"/>
+                              <xs:attribute name="duration" use="required" type="xs:integer"/>
+                              <xs:attribute name="result" use="required"/>
+                              <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="CmakeInstall">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                              </xs:sequence>
+                              <xs:attribute name="command" use="required"/>
+                              <xs:attribute name="workingDir" use="required"/>
+                              <xs:attribute name="duration" use="required" type="xs:integer"/>
+                              <xs:attribute name="result" use="required"/>
+                              <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="Custom">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                              </xs:sequence>
+                              <xs:attribute name="command" use="required"/>
+                              <xs:attribute name="workingDir" use="required"/>
+                              <xs:attribute name="duration" use="required" type="xs:integer"/>
+                              <xs:attribute name="result" use="required"/>
+                              <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="Install">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                              </xs:sequence>
+                              <xs:attribute name="command" use="required"/>
+                              <xs:attribute name="workingDir" use="required"/>
+                              <xs:attribute name="duration" use="required" type="xs:integer"/>
+                              <xs:attribute name="result" use="required"/>
+                              <xs:attribute name="timeStart" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:choice>
+                      </xs:sequence>
                     </xs:complexType>
                   </xs:element>
                   <xs:element name="Log" type="LogType" />

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -193,14 +193,23 @@ set_tests_properties(/Feature/GraphQL/TestMeasurementTypeTest PROPERTIES DEPENDS
 add_laravel_test(/Feature/GraphQL/NoteTypeTest)
 set_tests_properties(/Feature/GraphQL/NoteTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
-add_laravel_test(/Feature/GraphQL/BuildMeasurementTypeTest)
-set_tests_properties(/Feature/GraphQL/BuildMeasurementTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
-
 add_laravel_test(/Feature/GraphQL/CoverageTypeTest)
 set_tests_properties(/Feature/GraphQL/CoverageTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 add_laravel_test(/Feature/GraphQL/UserInvitationTypeTest)
 set_tests_properties(/Feature/GraphQL/UserInvitationTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/GraphQL/LabelTypeTest)
+set_tests_properties(/Feature/GraphQL/LabelTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/GraphQL/TargetTypeTest)
+set_tests_properties(/Feature/GraphQL/TargetTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/GraphQL/BuildCommandTypeTest)
+set_tests_properties(/Feature/GraphQL/BuildCommandTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/Submission/Instrumentation/BuildInstrumentationTest)
+set_tests_properties(/Feature/Submission/Instrumentation/BuildInstrumentationTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 add_laravel_test(/Feature/RouteAccessTest)
 set_tests_properties(/Feature/RouteAccessTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
@@ -335,9 +344,12 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/GraphQL/TestTypeTest
   /Feature/GraphQL/TestMeasurementTypeTest
   /Feature/GraphQL/NoteTypeTest
-  /Feature/GraphQL/BuildMeasurementTypeTest
   /Feature/GraphQL/CoverageTypeTest
   /Feature/GraphQL/UserInvitationTypeTest
+  /Feature/GraphQL/LabelTypeTest
+  /Feature/GraphQL/TargetTypeTest
+  /Feature/GraphQL/BuildCommandTypeTest
+  /Feature/Submission/Instrumentation/BuildInstrumentationTest
   /Feature/RouteAccessTest
   /Feature/Monitor
   /Feature/PasswordRotation

--- a/app/cdash/xml_handlers/configure_handler.php
+++ b/app/cdash/xml_handlers/configure_handler.php
@@ -131,7 +131,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                 $build->SubProjectName = $this->SubProjectName;
                 $this->Builds[$this->SubProjectName] = $build;
             }
-        } elseif ($name == 'CONFIGURE') {
+        } elseif ($this->currentPathMatches('site.configure')) {
             $this->Configure = $this->getModelFactory()->create(BuildConfigure::class);
             if (empty($this->Builds)) {
                 // No subprojects
@@ -144,7 +144,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
 
     public function endElement($parser, $name): void
     {
-        if ($name == 'CONFIGURE') {
+        if ($this->currentPathMatches('site.configure')) {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
             // Configure Duration is handled differently if this XML
@@ -262,7 +262,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
         $parent = $this->getParent();
         $element = $this->getElement();
 
-        if ($parent == 'CONFIGURE') {
+        if ($this->currentPathMatches('site.configure.*')) {
             switch ($element) {
                 case 'STARTCONFIGURETIME':
                     $this->StartTimeStamp = $data;

--- a/database/migrations/2024_11_04_202649_build_measurements.php
+++ b/database/migrations/2024_11_04_202649_build_measurements.php
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Completely re-do the table
+        if (Schema::hasTable('buildmeasurements')) {
+            Schema::table('buildmeasurements', function (Blueprint $table) {
+                $table->dropForeign(['buildid']);
+            });
+        }
+        Schema::dropIfExists('buildmeasurements');
+
+        Schema::create('targets', function (Blueprint $table) {
+            $table->id();
+            $table->integer('buildid')->nullable(false)->index();
+            $table->enum('type', [
+                'UNKNOWN',
+                'STATIC_LIBRARY',
+                'MODULE_LIBRARY',
+                'SHARED_LIBRARY',
+                'OBJECT_LIBRARY',
+                'INTERFACE_LIBRARY',
+                'EXECUTABLE',
+            ])->nullable(false);
+            $table->string('name')->nullable(false);
+            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
+        });
+
+        Schema::create('label2target', function (Blueprint $table) {
+            $table->foreignId('targetid')->nullable(false)->references('id')->on('targets')->cascadeOnDelete();
+            $table->bigInteger('labelid')->nullable(false);
+            $table->foreign('labelid')->references('id')->on('label')->cascadeOnDelete();
+            $table->unique(['targetid', 'labelid']);
+            $table->unique(['labelid', 'targetid']);
+        });
+
+        Schema::create('buildcommands', function (Blueprint $table) {
+            // Required columns for all types of commands
+            $table->id();
+            $table->integer('buildid')->nullable(false)->index();
+            $table->foreign('buildid')->references('id')->on('build')->cascadeOnDelete();
+            $table->foreignId('targetid')->nullable()->index()->references('id')->on('targets')->cascadeOnDelete();
+            $table->enum('type', [
+                'COMPILE',
+                'LINK',
+                'CUSTOM',
+                'CMAKE_BUILD',
+                'CMAKE_INSTALL',
+                'INSTALL',
+            ])->nullable(false);
+            $table->dateTimeTz('starttime')->nullable(false);
+            $table->integer('duration')->nullable(false);
+            $table->text('command')->nullable(false);
+            $table->text('workingdirectory')->nullable(false);
+            $table->text('result')->nullable(false);
+
+            // Optional columns depending on the type of command entered
+            $table->text('source')->nullable();
+            $table->string('language', 32)->nullable();
+            $table->string('config', 32)->nullable();
+        });
+
+        Schema::create('buildmeasurements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('buildcommandid')->nullable(false)->index()->references('id')->on('buildcommands')->cascadeOnDelete();
+            // 512 should be long enough for any reasonable value, while also being short enough to index if needed
+            $table->string('type', 512)->nullable(false);
+            $table->string('name', 512)->nullable(false);
+            $table->string('value', 512)->nullable(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No need to revert the changes to the buildmeasurements table because it isn't hooked up to anything yet.
+        if (Schema::hasTable('buildmeasurements')) {
+            Schema::table('buildmeasurements', function (Blueprint $table) {
+                $table->dropForeign(['buildcommandid']);
+            });
+        }
+        Schema::dropIfExists('buildmeasurements');
+
+        if (Schema::hasTable('buildcommands')) {
+            Schema::table('buildcommands', function (Blueprint $table) {
+                $table->dropForeign(['buildid']);
+                $table->dropForeign(['targetid']);
+            });
+        }
+        Schema::dropIfExists('buildcommands');
+
+        if (Schema::hasTable('label2target')) {
+            Schema::table('label2target', function (Blueprint $table) {
+                $table->dropForeign(['labelid']);
+                $table->dropForeign(['buildid']);
+            });
+        }
+        Schema::dropIfExists('label2targets');
+
+        if (Schema::hasTable('targets')) {
+            Schema::table('targets', function (Blueprint $table) {
+                $table->dropForeign(['buildid']);
+            });
+        }
+        Schema::dropIfExists('targets');
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,9 +1,11 @@
 "A datetime and timezone string in ISO 8601 format `Y-m-dTH:i:sP`, e.g. `2020-04-20T13:53:12+02:00`."
 scalar DateTimeTz @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTimeTz")
 
-# It would be better to replace this with a "Duration" scalar type in the future.
+# It would be better to replace these with a "Duration" scalar type in the future.
 "A non-negative decimal number of seconds."
 scalar NonNegativeSeconds @scalar(class: "App\\GraphQL\\Scalars\\NonNegativeSeconds")
+"A non-negative integer number of milliseconds."
+scalar NonNegativeIntegerMilliseconds @scalar(class: "App\\GraphQL\\Scalars\\NonNegativeIntegerMilliseconds")
 
 
 "Indicates what fields are available at the top level of a query operation."
@@ -345,10 +347,6 @@ type Build {
 
   notes: [Note!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
-  measurements(
-    filters: _ @filter(inputType: "BuildMeasurementFilterInput")
-  ): [BuildMeasurement!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
-
   operatingSystemName: String @rename(attribute: "osname")
 
   operatingSystemPlatform: String @rename(attribute: "osplatform")
@@ -361,6 +359,14 @@ type Build {
 
   compilerVersion: String @rename(attribute: "compilerversion")
 
+  """
+  Child builds associated wirh this parent build.  Note that CDash only supports one level of
+  subprojects, so no child builds will have children of their own.
+  """
+  children(
+    filters: _ @filter(inputType: "BuildFilterInput")
+  ): [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
+
   coverageResults(
     filters: _ @filter(inputType: "CoverageFilterInput")
   ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
@@ -368,6 +374,14 @@ type Build {
   labels(
     filters: _ @filter(inputType: "LabelFilterInput")
   ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
+  targets(
+    filters: _ @filter(inputType: "TargetFilterInput")
+  ): [Target!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
+
+  commands(
+    filters: _ @filter(inputType: "BuildCommandFilterInput")
+  ): [BuildCommand!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
 }
 
 input BuildFilterInput {
@@ -458,6 +472,53 @@ type TestMeasurement {
 }
 
 
+"""
+Represents a command run during the build step.
+
+https://cmake.org/cmake/help/git-master/manual/cmake-instrumentation.7.html#v1-snippet-file
+"""
+type BuildCommand @model(class: "App\\Models\\BuildCommand") {
+  id: ID!
+
+  type: BuildCommandType!
+
+  startTime: DateTimeTz! @rename(attribute: "starttime")
+
+  duration: NonNegativeIntegerMilliseconds!
+
+  command: String!
+
+  workingDirectory: String! @rename(attribute: "workingdirectory")
+
+  result: String!
+
+  source: String
+
+  language: String
+
+  config: String
+
+  target: Target @belongsTo
+
+  measurements(
+    filters: _ @filter(inputType: "BuildMeasurementFilterInput")
+  ): [BuildMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
+}
+
+input BuildCommandFilterInput {
+  id: ID
+  type: BuildCommandType
+  startTime: DateTimeTz @rename(attribute: "starttime")
+  duration: NonNegativeIntegerMilliseconds
+  command: String
+  workingDirectory: String @rename(attribute: "workingdirectory")
+  result: String
+  source: String
+  language: String
+  config: String
+}
+
+
 "Build Measurement."
 type BuildMeasurement {
   "Unique primary key."
@@ -465,13 +526,12 @@ type BuildMeasurement {
 
   name: String!
 
-  source: String!
-
-  type: BuildMeasurementType!
+  type: String!
 
   """
   The value for this measurement.  Even though some values may be numeric, all
-  values are returned as strings.
+  values are returned as strings.  The type of the value field is not guaranteed
+  to match the actual type of the value field.
 
   Example: "5"
   """
@@ -482,8 +542,7 @@ type BuildMeasurement {
 input BuildMeasurementFilterInput {
   id: ID
   name: String
-  source: String
-  type: BuildMeasurementType
+  type: String
   value: String
 }
 
@@ -692,4 +751,34 @@ type Label {
 input LabelFilterInput {
   id: ID
   text: String
+}
+
+
+"""
+Target.
+"""
+type Target {
+  "Unique primary key."
+  id: ID!
+
+  name: String!
+
+  """
+  https://cmake.org/cmake/help/latest/prop_tgt/TYPE.html
+  """
+  type: TargetType!
+
+  commands(
+    filters: _ @filter(inputType: "BuildCommandFilterInput")
+  ): [BuildCommand!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
+
+  labels(
+    filters: _ @filter(inputType: "LabelFilterInput")
+  ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+}
+
+input TargetFilterInput {
+  id: ID
+  name: String
+  type: TargetType
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -297,6 +297,16 @@ parameters:
 			path: app/GraphQL/Mutations/UpdateSiteDescription.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: app/GraphQL/Scalars/NonNegativeIntegerMilliseconds.php
+
+		-
+			message: "#^Part \\$value \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 2
+			path: app/GraphQL/Scalars/NonNegativeIntegerMilliseconds.php
+
+		-
 			message: "#^Cannot cast mixed to float\\.$#"
 			count: 1
 			path: app/GraphQL/Scalars/NonNegativeSeconds.php
@@ -27167,7 +27177,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 21
+			count: 18
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
@@ -27377,7 +27387,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 10
+			count: 7
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-

--- a/tests/Feature/GraphQL/BuildCommandTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandTypeTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Enums\BuildCommandType;
+use App\Models\Build;
+use App\Models\BuildCommand;
+use App\Models\Project;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class BuildCommandTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    public function testBasicFieldAccess(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var BuildCommand $command */
+        $command = $build->commands()->create([
+            'type' => BuildCommandType::CUSTOM,
+            'starttime' => Carbon::now(),
+            'duration' => 12345,
+            'command' => Str::random(10),
+            'result' => Str::random(10),
+            'source' => Str::random(10),
+            'language' => Str::random(10),
+            'config' => Str::random(10),
+            'workingdirectory' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    commands {
+                        edges {
+                            node {
+                                id
+                                type
+                                startTime
+                                duration
+                                command
+                                result
+                                source
+                                language
+                                config
+                                workingDirectory
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'commands' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $command->id,
+                                    'type' => 'CUSTOM',
+                                    'startTime' => $command->starttime->toIso8601String(),
+                                    'duration' => $command->duration,
+                                    'command' => $command->command,
+                                    'result' => $command->result,
+                                    'source' => $command->source,
+                                    'language' => $command->language,
+                                    'config' => $command->config,
+                                    'workingDirectory' => $command->workingdirectory,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public static function commandTypes(): array
+    {
+        $return_arr = [];
+        foreach (BuildCommandType::cases() as $type) {
+            $return_arr[] = [$type->name];
+        }
+
+        return $return_arr;
+    }
+
+    /**
+     * @dataProvider commandTypes
+     */
+    public function testFilterByType(string $type): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $commands = [];
+        foreach (BuildCommandType::cases() as $bc_type) {
+            $commands[] = [
+                'type' => $bc_type,
+                'starttime' => Carbon::now(),
+                'duration' => 12345,
+                'command' => Str::random(10),
+                'result' => Str::random(10),
+                'workingdirectory' => Str::uuid()->toString(),
+            ];
+        }
+        $build->commands()->createMany($commands);
+
+        $this->graphQL('
+            query build($id: ID, $type: BuildCommandType) {
+                build(id: $id) {
+                    commands(
+                        filters: {
+                            eq: {
+                                type: $type
+                            }
+                        }
+                    ){
+                        edges {
+                            node {
+                                type
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+            'type' => $type,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'commands' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'type' => $type,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testFilterByDuration(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $build->commands()->createMany([
+            [
+                'type' => BuildCommandType::CUSTOM,
+                'starttime' => Carbon::now(),
+                'duration' => 1234,
+                'command' => Str::random(10),
+                'result' => Str::random(10),
+                'workingdirectory' => Str::uuid()->toString(),
+            ],
+            [
+                'type' => BuildCommandType::CUSTOM,
+                'starttime' => Carbon::now(),
+                'duration' => 2345,
+                'command' => Str::random(10),
+                'result' => Str::random(10),
+                'workingdirectory' => Str::uuid()->toString(),
+            ],
+            [
+                'type' => BuildCommandType::CUSTOM,
+                'starttime' => Carbon::now(),
+                'duration' => 3456,
+                'command' => Str::random(10),
+                'result' => Str::random(10),
+                'workingdirectory' => Str::uuid()->toString(),
+            ],
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    commands(
+                        filters: {
+                            eq: {
+                                duration: 2345
+                            }
+                        }
+                    ){
+                        edges {
+                            node {
+                                duration
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'commands' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'duration' => 2345,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/BuildMeasurementTypeTest.php
+++ b/tests/Feature/GraphQL/BuildMeasurementTypeTest.php
@@ -2,11 +2,8 @@
 
 namespace Tests\Feature\GraphQL;
 
-use App\Enums\BuildMeasurementType;
 use App\Models\Build;
-use App\Models\BuildMeasurement;
 use App\Models\Project;
-use Illuminate\Support\Str;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -17,149 +14,19 @@ class BuildMeasurementTypeTest extends TestCase
     use CreatesProjects;
 
     private Project $project;
-    private Project $project2;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->project = $this->makePublicProject();
-        $this->project2 = $this->makePrivateProject();
     }
 
     protected function tearDown(): void
     {
         // Deleting the project will delete all corresponding builds and build measurements
         $this->project->delete();
-        $this->project2->delete();
 
         parent::tearDown();
-    }
-
-    /**
-     * A basic test to ensure that each of the fields works
-     */
-    public function testBasicFieldAccess(): void
-    {
-        /** @var Build $build */
-        $build = $this->project->builds()->create([
-            'name' => Str::uuid()->toString(),
-            'uuid' => Str::uuid()->toString(),
-        ]);
-
-        /** @var BuildMeasurement $measurement */
-        $measurement = $build->measurements()->create([
-            'name' => Str::uuid()->toString(),
-            'source' => Str::uuid()->toString(),
-            'type' => BuildMeasurementType::TARGET,
-            'value' => 5,
-        ]);
-
-        $this->graphQL('
-            query($id: ID) {
-                build(id: $id) {
-                    measurements {
-                        edges {
-                            node {
-                                id
-                                name
-                                source
-                                type
-                                value
-                            }
-                        }
-                    }
-                }
-            }
-        ', [
-            'id' => $build->id,
-        ])->assertJson([
-            'data' => [
-                'build' => [
-                    'measurements' => [
-                        'edges' => [
-                            [
-                                'node' => [
-                                    'id' => (string) $measurement->id,
-                                    'name' => $measurement->name,
-                                    'source' => $measurement->source,
-                                    'type' => 'TARGET',
-                                    'value' => '5',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ], true);
-    }
-
-    public function testMeasurementFiltering(): void
-    {
-        /** @var Build $build */
-        $build = $this->project->builds()->create([
-            'name' => Str::uuid()->toString(),
-            'uuid' => Str::uuid()->toString(),
-        ]);
-
-        $build->measurements()->create([
-            'name' => Str::uuid()->toString(),
-            'source' => Str::uuid()->toString(),
-            'type' => BuildMeasurementType::TARGET,
-            'value' => 4,
-        ]);
-
-        $build->measurements()->create([
-            'name' => Str::uuid()->toString(),
-            'source' => Str::uuid()->toString(),
-            'type' => BuildMeasurementType::TARGET,
-            'value' => 5,
-        ]);
-
-        $build->measurements()->create([
-            'name' => Str::uuid()->toString(),
-            'source' => Str::uuid()->toString(),
-            'type' => BuildMeasurementType::TARGET,
-            'value' => 6,
-        ]);
-
-        $this->graphQL('
-            query($id: ID) {
-                build(id: $id) {
-                    measurements(filters: {
-                        gt: {
-                            value: "4"
-                        }
-                    }) {
-                        edges {
-                            node {
-                                value
-                            }
-                        }
-                    }
-                }
-            }
-        ', [
-            'id' => $build->id,
-        ])->assertJson([
-            'data' => [
-                'build' => [
-                    'measurements' => [
-                        'edges' => [
-                            [
-                                'node' => [
-                                    'value' => '6',
-                                ],
-                            ],
-                            [
-                                'node' => [
-                                    'value' => '5',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ], true);
     }
 }

--- a/tests/Feature/GraphQL/LabelTypeTest.php
+++ b/tests/Feature/GraphQL/LabelTypeTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Enums\TargetType;
+use App\Models\Label;
+use App\Models\Project;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class LabelTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+
+    /**
+     * @var array<Label>
+     */
+    private array $labels = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        foreach ($this->labels as $label) {
+            $label->delete();
+        }
+        $this->labels = [];
+
+        parent::tearDown();
+    }
+
+    public function testBuildRelationship(): void
+    {
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->labels['label1'] = $build->labels()->create([
+            'text' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    labels {
+                        edges {
+                            node {
+                                id
+                                text
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'labels' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $this->labels['label1']->id,
+                                    'text' => $this->labels['label1']->text,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testLabelFilters(): void
+    {
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->labels['label1'] = $build->labels()->create([
+            'text' => 'text1',
+        ]);
+
+        $this->labels['label2'] = $build->labels()->create([
+            'text' => 'text2',
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    labels(
+                        filters: {
+                            eq: {
+                                text: "text1"
+                            }
+                        }
+                    ){
+                        edges {
+                            node {
+                                id
+                                text
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'labels' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $this->labels['label1']->id,
+                                    'text' => $this->labels['label1']->text,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testTargetRelationship(): void
+    {
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $target = $build->targets()->create([
+            'name' => Str::uuid()->toString(),
+            'type' => TargetType::UNKNOWN,
+        ]);
+
+        $this->labels['label1'] = $target->labels()->create([
+            'text' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    targets {
+                        edges {
+                            node {
+                                labels {
+                                    edges {
+                                        node {
+                                            text
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'targets' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'labels' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'text' => $this->labels['label1']->text,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/TargetTypeTest.php
+++ b/tests/Feature/GraphQL/TargetTypeTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Enums\BuildCommandType;
+use App\Enums\TargetType;
+use App\Models\Build;
+use App\Models\BuildCommand;
+use App\Models\Project;
+use App\Models\Target;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class TargetTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    public function testTypeEnumValues(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        // Create one target of each type
+        $targets = [];
+        foreach (TargetType::cases() as $target_type) {
+            $targets[] = [
+                'name' => Str::uuid()->toString(),
+                'type' => $target_type,
+            ];
+        }
+        $build->targets()->createMany($targets);
+
+        $target_node_list = [];
+        foreach ($targets as $target) {
+            $target_node_list[] = [
+                'node' => [
+                    'name' => $target['name'],
+                    'type' => $target['type']->name,
+                ],
+            ];
+        }
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    targets {
+                        edges {
+                            node {
+                                name
+                                type
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'targets' => [
+                        'edges' => $target_node_list,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testFilterByName(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $build->targets()->createMany([
+            [
+                'name' => 'name1',
+                'type' => TargetType::UNKNOWN,
+            ],
+            [
+                'name' => 'name2',
+                'type' => TargetType::UNKNOWN,
+            ],
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    targets(
+                        filters: {
+                            eq: {
+                                name: "name2"
+                            }
+                        }
+                    ){
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'targets' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'name2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public static function targetTypes(): array
+    {
+        $return_arr = [];
+        foreach (TargetType::cases() as $type) {
+            $return_arr[] = [$type->name];
+        }
+
+        return $return_arr;
+    }
+
+    /**
+     * @dataProvider targetTypes
+     */
+    public function testFilterByType(string $type): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        // Create one target of each type
+        $targets = [];
+        foreach (TargetType::cases() as $target_type) {
+            $targets[] = [
+                'name' => Str::uuid()->toString(),
+                'type' => $target_type,
+            ];
+        }
+        $build->targets()->createMany($targets);
+
+        $this->graphQL('
+            query build($id: ID, $type: TargetType) {
+                build(id: $id) {
+                    targets(
+                        filters: {
+                            eq: {
+                                type: $type
+                            }
+                        }
+                    ){
+                        edges {
+                            node {
+                                type
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+            'type' => $type,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'targets' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'type' => $type,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testBuildCommandRelationship(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Target $target */
+        $target = $build->targets()->create([
+            'name' => 'name1',
+            'type' => TargetType::UNKNOWN,
+        ]);
+
+        /** @var BuildCommand $command */
+        $command = $build->commands()->create([
+            'type' => BuildCommandType::CUSTOM,
+            'starttime' => Carbon::now(),
+            'duration' => 0,
+            'command' => '',
+            'result' => '',
+            'workingdirectory' => Str::uuid()->toString(),
+        ]);
+
+        $target->commands()->save($command);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    targets {
+                        edges {
+                            node {
+                                commands {
+                                    edges {
+                                        node {
+                                            id
+                                            type
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    commands {
+                        edges {
+                            node {
+                                id
+                                type
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'targets' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'commands' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'id' => (string) $command->id,
+                                                    'type' => 'CUSTOM',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'commands' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $command->id,
+                                    'type' => 'CUSTOM',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
+++ b/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Tests\Feature\Submission\Instrumentation;
+
+use App\Models\Project;
+use Exception;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSubmissions;
+
+class BuildInstrumentationTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSubmissions;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        // The trait doesn't initialize the default buildgroups for us, so we do it manually
+        $legacy_project = new \CDash\Model\Project();
+        $legacy_project->Id = $this->project->id;
+        $legacy_project->InitialSetup();
+
+        $this->project->refresh();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic submission which tests all of the core parts of the instrumentation functionality
+     */
+    public function testValidSubmission(): void
+    {
+        $this->submitFiles($this->project->name, [
+            base_path('tests/Feature/Submission/Instrumentation/data/Build.xml'),
+        ]);
+
+        $expected_result_json = file_get_contents(base_path('tests/Feature/Submission/Instrumentation/data/result.json'));
+        if ($expected_result_json === false) {
+            throw new Exception('Failed to read result JSON.');
+        }
+        $expected_result_json = json_decode($expected_result_json, true);
+
+        // Make PHPStan happy
+        if (!is_array($expected_result_json)) {
+            throw new Exception('Result JSON is not an associative array.');
+        }
+
+        $this->graphQL('
+            query project($id: ID) {
+                project(id: $id) {
+                    builds {
+                        edges {
+                            node {
+                                name
+                                targets {
+                                    edges {
+                                        node {
+                                            name
+                                            type
+                                            commands {
+                                                edges {
+                                                    node {
+                                                        type
+                                                        startTime
+                                                        duration
+                                                        command
+                                                        result
+                                                        source
+                                                        language
+                                                        config
+                                                        target {
+                                                            name
+                                                            type
+                                                        }
+                                                        measurements {
+                                                            edges {
+                                                                node {
+                                                                    name
+                                                                    type
+                                                                    value
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            labels {
+                                                edges {
+                                                    node {
+                                                        text
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                commands {
+                                    edges {
+                                        node {
+                                            type
+                                            startTime
+                                            duration
+                                            command
+                                            result
+                                            source
+                                            language
+                                            config
+                                            target {
+                                                name
+                                                type
+                                            }
+                                            measurements {
+                                                edges {
+                                                    node {
+                                                        name
+                                                        type
+                                                        value
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                children {
+                                    edges {
+                                        node {
+                                            name
+                                            targets {
+                                                edges {
+                                                    node {
+                                                        name
+                                                        type
+                                                        commands {
+                                                            edges {
+                                                                node {
+                                                                    type
+                                                                    startTime
+                                                                    duration
+                                                                    command
+                                                                    result
+                                                                    source
+                                                                    language
+                                                                    config
+                                                                    target {
+                                                                        name
+                                                                        type
+                                                                    }
+                                                                    measurements {
+                                                                        edges {
+                                                                            node {
+                                                                                name
+                                                                                type
+                                                                                value
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                        labels {
+                                                            edges {
+                                                                node {
+                                                                    text
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            commands {
+                                                edges {
+                                                    node {
+                                                        type
+                                                        startTime
+                                                        duration
+                                                        command
+                                                        result
+                                                        source
+                                                        language
+                                                        config
+                                                        target {
+                                                            name
+                                                            type
+                                                        }
+                                                        measurements {
+                                                            edges {
+                                                                node {
+                                                                    name
+                                                                    type
+                                                                    value
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $this->project->id,
+        ])->assertJson($expected_result_json, true);
+    }
+}

--- a/tests/Feature/Submission/Instrumentation/data/Build.xml
+++ b/tests/Feature/Submission/Instrumentation/data/Build.xml
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_instrument"
+	BuildStamp="20250328-1619-Experimental"
+	Name="test-site"
+	Generator="ctest-4.0.xyz"
+	CompilerName=""
+	CompilerVersion=""
+	OSName="macOS"
+	Hostname="test"
+	OSRelease="1.2.3"
+	OSVersion="ABC"
+	OSPlatform="arm64"
+	Is64Bits="1"
+	VendorString="Apple"
+	VendorID="Apple"
+	FamilyID="0"
+	ModelID="0"
+	ModelName="Apple M3 Max"
+	ProcessorCacheSize="131072"
+	NumberOfLogicalCPU="14"
+	NumberOfPhysicalCPU="14"
+	TotalVirtualMemory="0"
+	TotalPhysicalMemory="98304"
+	LogicalProcessorsPerPhysical="14"
+	ProcessorClockFrequency="0"
+	>
+	<Subproject name="MakeTable">
+		<Label>MakeTable</Label>
+	</Subproject>
+	<Subproject name="MathFunctions">
+		<Label>MathFunctions</Label>
+	</Subproject>
+	<Subproject name="Tutorial">
+		<Label>Tutorial</Label>
+	</Subproject>
+	<Build>
+		<StartDateTime>Mar 28 12:19 EDT</StartDateTime>
+		<StartBuildTime>1743178749</StartBuildTime>
+		<BuildCommand>/my/path/projects/CMake_bin/bin/cmake --build . --config "Release" --target "install"</BuildCommand>
+		<Failure type="Warning">
+			<!-- Meta-information about the build action -->
+			<Action>
+				<TargetName>MakeTable</TargetName>
+				<Language>C++</Language>
+				<SourceFile>MathFunctions/MakeTable.cxx</SourceFile>
+				<OutputFile>MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o</OutputFile>
+				<OutputType>object file</OutputType>
+			</Action>
+			<!-- Details of command -->
+			<Command>
+				<WorkingDirectory>/my/path/projects/tmp_for_cdash/bin_instrument</WorkingDirectory>
+				<Argument>/usr/bin/c++</Argument>
+				<Argument>-std=gnu++11</Argument>
+				<Argument>-arch</Argument>
+				<Argument>arm64</Argument>
+				<Argument>-Wall</Argument>
+				<Argument>-Wextra</Argument>
+				<Argument>-Wshadow</Argument>
+				<Argument>-Wformat=2</Argument>
+				<Argument>-Wunused</Argument>
+				<Argument>-MD</Argument>
+				<Argument>-MT</Argument>
+				<Argument>MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o</Argument>
+				<Argument>-MF</Argument>
+				<Argument>MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o.d</Argument>
+				<Argument>-o</Argument>
+				<Argument>MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o</Argument>
+				<Argument>-c</Argument>
+				<Argument>/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx</Argument>
+			</Command>
+			<!-- Result of command -->
+			<Result>
+				<StdOut/>
+				<StdErr>[CTest: warning matched] /my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx:15:9: warning: comparison of integers of different signs: 'unsigned int' and 'int' [-Wsign-compare]
+   15 |   if (j &lt; -1) {
+      |       ~ ^ ~~
+[CTest: warning matched] 1 warning generated.</StdErr>
+				<ExitCondition>0</ExitCondition>
+			</Result>
+			<!-- Interested parties -->
+			<Labels>
+				<Label>Label4</Label>
+				<Label>MakeTable</Label>
+			</Labels>
+		</Failure>
+		<Targets>
+			<Target name="Tutorial" type="EXECUTABLE">
+				<Labels>
+					<Label>Tutorial</Label>
+					<Label>Label1</Label>
+					<Label>Label2</Label>
+				</Labels>
+				<Commands>
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="70" language="C++" result="0" timeStart="1743178751667" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51395712.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51400464.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="365" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx" timeStart="1743178750573" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51398064.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51406128.0</Value>
+						</NamedMeasurement>
+					</Compile>
+				</Commands>
+			</Target>
+			<Target name="MakeTable" type="EXECUTABLE">
+				<Labels>
+					<Label>MakeTable</Label>
+					<Label>Label4</Label>
+				</Labels>
+				<Commands>
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="76" language="C++" result="0" timeStart="1743178750216" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51399056.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51405264.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="340" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx" timeStart="1743178749799" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51401328.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51365504.0</Value>
+						</NamedMeasurement>
+					</Compile>
+				</Commands>
+			</Target>
+			<Target name="MathFunctions" type="SHARED_LIBRARY">
+				<Labels>
+					<Label>MathFunctions</Label>
+					<Label>Label3</Label>
+				</Labels>
+				<Commands>
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="67" language="C++" result="0" timeStart="1743178751470" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51400864.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51400288.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="99" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx" timeStart="1743178750573" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51428640.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51405616.0</Value>
+						</NamedMeasurement>
+					</Compile>
+				</Commands>
+			</Target>
+			<Target name="SqrtLibrary" type="STATIC_LIBRARY">
+				<Labels>
+					<Label>MathFunctions</Label>
+					<Label>Label3</Label>
+				</Labels>
+				<Commands>
+					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="" duration="64" language="C++" result="0" timeStart="1743178751022" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51401440.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51401152.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Link command="&quot;/usr/bin/ranlib&quot; (truncated)" config="" duration="24" language="C++" result="0" timeStart="1743178751245" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51400672.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51400576.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Link command="&quot;/usr/bin/ar&quot; (truncated)" config="" duration="29" language="C++" result="0" timeStart="1743178751153" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51400704.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51400912.0</Value>
+						</NamedMeasurement>
+					</Link>
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="365" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx" timeStart="1743178750574" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51397360.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.74755859375</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51405904.0</Value>
+						</NamedMeasurement>
+					</Compile>
+					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="" duration="60" language="C++" result="0" timeStart="1743178751337" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>51407712.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>4.84765625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>51400720.0</Value>
+						</NamedMeasurement>
+					</Link>
+				</Commands>
+			</Target>
+		</Targets>
+		<Commands>
+			<Custom command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="195" result="0" timeStart="1743178751806" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>51396352.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>51395488.0</Value>
+				</NamedMeasurement>
+			</Custom>
+			<Custom command="&quot;/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable&quot; (truncated)" duration="135" result="0" timeStart="1743178750362" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument/MathFunctions">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>4.74755859375</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>51402880.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>4.74755859375</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>51398928.0</Value>
+				</NamedMeasurement>
+			</Custom>
+			<Install command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="126" result="0" timeStart="1743178752075" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>51397248.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>51395936.0</Value>
+				</NamedMeasurement>
+			</Install>
+			<CmakeInstall command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="122" result="0" timeStart="1743178751867" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>51400928.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>51398320.0</Value>
+				</NamedMeasurement>
+			</CmakeInstall>
+			<CmakeBuild command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="2488" result="0" timeStart="1743178749725" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>4.84765625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>51391872.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>4.74755859375</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>51340336.0</Value>
+				</NamedMeasurement>
+			</CmakeBuild>
+		</Commands>
+		<Log Encoding="base64" Compression="bin/gzip"/>
+		<EndDateTime>Mar 28 12:19 EDT</EndDateTime>
+		<EndBuildTime>1743178752</EndBuildTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Build>
+</Site>

--- a/tests/Feature/Submission/Instrumentation/data/result.json
+++ b/tests/Feature/Submission/Instrumentation/data/result.json
@@ -1,0 +1,1447 @@
+{
+  "data": {
+    "project": {
+      "builds": {
+        "edges": [
+          {
+            "node": {
+              "name": "test_instrument",
+              "targets": {
+                "edges": []
+              },
+              "commands": {
+                "edges": [
+                  {
+                    "node": {
+                      "type": "CUSTOM",
+                      "startTime": "2025-03-28T16:19:11+00:00",
+                      "duration": 195,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51396352.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51395488.0"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "CUSTOM",
+                      "startTime": "2025-03-28T16:19:10+00:00",
+                      "duration": 135,
+                      "command": "\"/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.74755859375"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51402880.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.74755859375"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51398928.0"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "INSTALL",
+                      "startTime": "2025-03-28T16:19:12+00:00",
+                      "duration": 126,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51397248.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51395936.0"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "CMAKE_INSTALL",
+                      "startTime": "2025-03-28T16:19:11+00:00",
+                      "duration": 122,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51400928.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51398320.0"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "CMAKE_BUILD",
+                      "startTime": "2025-03-28T16:19:09+00:00",
+                      "duration": 2488,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.84765625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51391872.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "4.74755859375"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "51340336.0"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              "children": {
+                "edges": [
+                  {
+                    "node": {
+                      "name": "test_instrument",
+                      "targets": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "MakeTable",
+                              "type": "EXECUTABLE",
+                              "commands": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:10+00:00",
+                                      "duration": 76,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "MakeTable",
+                                        "type": "EXECUTABLE"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51399056.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51405264.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "COMPILE",
+                                      "startTime": "2025-03-28T16:19:09+00:00",
+                                      "duration": 340,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx",
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "MakeTable",
+                                        "type": "EXECUTABLE"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51401328.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51365504.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "labels": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "text": "Label4"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "text": "MakeTable"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "commands": {
+                        "edges": [
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:10+00:00",
+                              "duration": 76,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "MakeTable",
+                                "type": "EXECUTABLE"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51399056.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51405264.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "COMPILE",
+                              "startTime": "2025-03-28T16:19:09+00:00",
+                              "duration": 340,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx",
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "MakeTable",
+                                "type": "EXECUTABLE"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51401328.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51365504.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "name": "test_instrument",
+                      "targets": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "MathFunctions",
+                              "type": "SHARED_LIBRARY",
+                              "commands": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 67,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "MathFunctions",
+                                        "type": "SHARED_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400864.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400288.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "COMPILE",
+                                      "startTime": "2025-03-28T16:19:10+00:00",
+                                      "duration": 99,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx",
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "MathFunctions",
+                                        "type": "SHARED_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51428640.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51405616.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "labels": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "text": "Label3"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "text": "MathFunctions"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "SqrtLibrary",
+                              "type": "STATIC_LIBRARY",
+                              "commands": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 64,
+                                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51401440.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51401152.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 24,
+                                      "command": "\"/usr/bin/ranlib\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400672.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400576.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 29,
+                                      "command": "\"/usr/bin/ar\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400704.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400912.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "COMPILE",
+                                      "startTime": "2025-03-28T16:19:10+00:00",
+                                      "duration": 365,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx",
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51397360.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51405904.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 60,
+                                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51407712.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400720.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "labels": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "text": "Label3"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "text": "MathFunctions"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "commands": {
+                        "edges": [
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 67,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "MathFunctions",
+                                "type": "SHARED_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400864.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400288.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "COMPILE",
+                              "startTime": "2025-03-28T16:19:10+00:00",
+                              "duration": 99,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx",
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "MathFunctions",
+                                "type": "SHARED_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51428640.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51405616.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 64,
+                              "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51401440.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51401152.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 24,
+                              "command": "\"/usr/bin/ranlib\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400672.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400576.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 29,
+                              "command": "\"/usr/bin/ar\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400704.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400912.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "COMPILE",
+                              "startTime": "2025-03-28T16:19:10+00:00",
+                              "duration": 365,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx",
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51397360.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51405904.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 60,
+                              "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51407712.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400720.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "name": "test_instrument",
+                      "targets": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "Tutorial",
+                              "type": "EXECUTABLE",
+                              "commands": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "duration": 70,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "Tutorial",
+                                        "type": "EXECUTABLE"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51395712.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51400464.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "COMPILE",
+                                      "startTime": "2025-03-28T16:19:10+00:00",
+                                      "duration": 365,
+                                      "command": "\"/usr/bin/c++\" (truncated)",
+                                      "result": "0",
+                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx",
+                                      "language": "C++",
+                                      "config": "",
+                                      "target": {
+                                        "name": "Tutorial",
+                                        "type": "EXECUTABLE"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.84765625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51398064.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "4.74755859375"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "51406128.0"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "labels": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "text": "Label2"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "text": "Label1"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "text": "Tutorial"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "commands": {
+                        "edges": [
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "duration": 70,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "Tutorial",
+                                "type": "EXECUTABLE"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51395712.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51400464.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "COMPILE",
+                              "startTime": "2025-03-28T16:19:10+00:00",
+                              "duration": 365,
+                              "command": "\"/usr/bin/c++\" (truncated)",
+                              "result": "0",
+                              "source": "/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx",
+                              "language": "C++",
+                              "config": "",
+                              "target": {
+                                "name": "Tutorial",
+                                "type": "EXECUTABLE"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.84765625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51398064.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "4.74755859375"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "51406128.0"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR replaces the initial build instrumentation work in #2460 with a more complete version based on a working CMake/CTest [implementation](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9791).  See #2395 for the full feature request.

I plan to make a follow-up PR to add support for configure measurements once a handful of blocking database schema changes are completed.  Future PRs will also implement various UIs to display the data collected here.