### PR TITLE
Use Laravel relationships to remove configure and note rows

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3841,6 +3841,16 @@ parameters:
 			path: app/Utils/DatabaseCleanupUtils.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:whereIn\\(\\)\\.$#"
+			count: 2
+			path: app/Utils/DatabaseCleanupUtils.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:whereNotIn\\(\\)\\.$#"
+			count: 2
+			path: app/Utils/DatabaseCleanupUtils.php
+
+		-
 			message: "#^Method App\\\\Utils\\\\DatabaseCleanupUtils\\:\\:deleteRowsChunked\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/Utils/DatabaseCleanupUtils.php


### PR DESCRIPTION
Replace custom SQL with Laravel relationships to identify configure and note rows that are only being used by builds that are about to be deleted.