### PR TITLE
Demote "No note text for..." log message to debug level

### DIFF
--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -124,7 +124,7 @@ class NoteHandler extends AbstractXmlHandler
             } elseif (!$this->NoteCreator->name) {
                 \Log::error("Note missing name for build #{$this->Build->Id}");
             } elseif (!$this->NoteCreator->text) {
-                \Log::info("No note text for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
+                \Log::debug("No note text for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
             } elseif ($this->Timestamp === 0) {
                 \Log::error("No note time for '{$this->NoteCreator->name}' on build #{$this->Build->Id}");
             } else {


### PR DESCRIPTION
Notes with no text are currently logged at the `info` level, which clutters the logs with unnecessary messages.  This PR demotes that message to the lowest level (`debug`).