### PR TITLE
Add mock email server to development environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -15,3 +15,7 @@ QUEUE_CONNECTION=sync
 
 # Disable the slow page warning messages when testing
 SLOW_PAGE_TIME=1000000
+
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -28,6 +28,14 @@ services:
       LDAP_PASSWORDS: password1,password2
       LDAP_PORT_NUMBER: 389
 
+  # Development mail server available at http://localhost:8025
+  mailpit:
+    image: axllent/mailpit
+    container_name: mailpit
+    ports:
+      - 8025:8025
+      - 1025:1025
+
   # Used for live browser testing
   selenium:
     image: selenium/standalone-chromium


### PR DESCRIPTION
Email testing is currently difficult in the CDash development environment, with developers having to set up their own local email servers for testing purposes.  This PR adds a [mailpit](https://mailpit.axllent.org) container to the Docker development environment so developers can inspect the emails sent by a local CDash server at http://localhost:8025.