### PR TITLE
Replace custom SQL in removeBuilds with Eloquent relationships

### DIFF
--- a/app/Models/BuildUpdate.php
+++ b/app/Models/BuildUpdate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property Carbon $starttime
+ * @property Carbon $endtime
+ * @property string $command
+ * @property string $type
+ * @property int $nfiles
+ * @property int $warnings
+ * @property string $revision
+ * @property string $priorrevision
+ * @property string $path
+ *
+ * @mixin Builder<BuildUpdate>
+ */
+class BuildUpdate extends Model
+{
+    protected $table = 'buildupdate';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'starttime',
+        'endtime',
+        'command',
+        'type',
+        'nfiles',
+        'warnings',
+        'revision',
+        'priorrevision',
+        'path',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'starttime' => 'datetime',
+        'endtime' => 'datetime',
+        'nfiles' => 'integer',
+        'warnings' => 'integer',
+    ];
+
+    /**
+     * @return BelongsToMany<Build>
+     */
+    public function builds(): BelongsToMany
+    {
+        return $this->belongsToMany(Build::class, 'build2update', 'updateid', 'buildid');
+    }
+}

--- a/app/Models/CoverageFile.php
+++ b/app/Models/CoverageFile.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * @property int $id
+ * @property string $fullpath
+ * @property string $file
+ * @property int $crc32
+ *
+ * @mixin Builder<CoverageFile>
+ */
+class CoverageFile extends Model
+{
+    protected $table = 'coveragefile';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'fullpath',
+        'file',
+        'crc32',
+    ];
+
+    protected $casts = [
+        'crc32' => 'integer',
+    ];
+
+    /**
+     * @return HasManyThrough<Build>
+     */
+    public function builds(): HasManyThrough
+    {
+        return $this->hasManyThrough(Build::class, Coverage::class, 'fileid', 'id', 'id', 'buildid');
+    }
+}

--- a/app/Models/RichBuildAlert.php
+++ b/app/Models/RichBuildAlert.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ *
+ * @property int $buildid
+ * @property int $detailsid
+ * @property string $sourcefile
+ * @property int $newstatus
+ *
+ * @mixin Builder<RichBuildAlert>
+ */
+class RichBuildAlert extends Model
+{
+    protected $table = 'buildfailure';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'detailsid',
+        'sourcefile',
+        'newstatus',
+    ];
+
+    protected $casts = [
+        'buildid' => 'integer',
+        'detailsid' => 'integer',
+        'newstatus' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Build, self>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return HasOne<RichBuildAlertDetails>
+     */
+    public function details(): HasOne
+    {
+        return $this->hasOne(RichBuildAlertDetails::class, 'id', 'detailsid');
+    }
+}

--- a/app/Models/RichBuildAlertDetails.php
+++ b/app/Models/RichBuildAlertDetails.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * @property int $id
+ * @property int $type
+ * @property string $stdoutput
+ * @property string $stderror
+ * @property string $exitcondition
+ * @property string $language
+ * @property string $targetname
+ * @property string $outputfile
+ * @property string $outputtype
+ * @property int $crc32
+ *
+ * @mixin Builder<RichBuildAlertDetails>
+ */
+class RichBuildAlertDetails extends Model
+{
+    protected $table = 'buildfailuredetails';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'type',
+        'stdoutput',
+        'stderror',
+        'exitcondition',
+        'language',
+        'targetname',
+        'outputfile',
+        'outputtype',
+        'crc32',
+    ];
+
+    protected $casts = [
+        'type' => 'integer',
+        'crc32' => 'integer',
+    ];
+
+    /**
+     * @return HasManyThrough<Build>
+     */
+    public function builds(): HasManyThrough
+    {
+        return $this->hasManyThrough(Build::class, RichBuildAlert::class, 'detailsid', 'id', 'id', 'buildid');
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3842,12 +3842,12 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:whereIn\\(\\)\\.$#"
-			count: 2
+			count: 5
 			path: app/Utils/DatabaseCleanupUtils.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:whereNotIn\\(\\)\\.$#"
-			count: 2
+			count: 5
 			path: app/Utils/DatabaseCleanupUtils.php
 
 		-


### PR DESCRIPTION
This commit introduces the use of Eloquent relationships to remove the following types of shared records:

* buildfailure
* buildfailuredetails
* coveragefile