### PR TITLE
Remove `laravel/legacy-factories` dependency

### DIFF
--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -311,7 +311,7 @@ class KWWebTestCase extends WebTestCase
             $fields['password'] = password_hash($fields['password'], PASSWORD_DEFAULT);
         }
 
-        $user = factory(User::class)->create($fields);
+        $user = User::create($fields);
         return $user;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "http-interop/http-factory-guzzle": "1.2.0",
     "knplabs/github-api": "3.16.0",
     "laravel/framework": "10.48.23",
-    "laravel/legacy-factories": "1.4.0",
     "laravel/socialite": "5.16.1",
     "laravel/ui": "4.6.0",
     "lcobucci/jwt": "5.4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed9a56e6e2ffff462d5947b39ed9de9e",
+    "content-hash": "409734b5fa6dd2794fd9a3a84bf84102",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -2347,62 +2347,6 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2024-11-12T15:39:10+00:00"
-        },
-        {
-            "name": "laravel/legacy-factories",
-            "version": "v1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/legacy-factories.git",
-                "reference": "6cb79f668fc36b8b396ada1da3ba45867889c30f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/legacy-factories/zipball/6cb79f668fc36b8b396ada1da3ba45867889c30f",
-                "reference": "6cb79f668fc36b8b396ada1da3ba45867889c30f",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/macroable": "^8.0|^9.0|^10.0|^11.0",
-                "php": "^7.3|^8.0",
-                "symfony/finder": "^3.4|^4.0|^5.0|^6.0|^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                },
-                "laravel": {
-                    "providers": [
-                        "Illuminate\\Database\\Eloquent\\LegacyFactoryServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "helpers.php"
-                ],
-                "psr-4": {
-                    "Illuminate\\Database\\Eloquent\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Taylor Otwell",
-                    "email": "taylor@laravel.com"
-                }
-            ],
-            "description": "The legacy version of the Laravel Eloquent factories.",
-            "homepage": "http://laravel.com",
-            "support": {
-                "issues": "https://github.com/laravel/framework/issues",
-                "source": "https://github.com/laravel/framework"
-            },
-            "time": "2024-01-15T13:55:14+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
[`laravel/legacy-factories`](https://github.com/laravel/legacy-factories) provides support for the legacy Laravel `factory()` method which was removed in Laravel 8.x.  This PR refactors the last remaining usage of this legacy method and removes the dependency.