### PR TITLE
Remove unnecessary Composer hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,12 +105,6 @@
     "post-autoload-dump": [
       "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
       "@php artisan package:discover --ansi"
-    ],
-    "post-root-package-install": [
-      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-    ],
-    "post-create-project-cmd": [
-      "@php artisan key:generate --ansi"
     ]
   },
   "repositories": [


### PR DESCRIPTION
The default Laravel starter kit includes Composer hooks which make it easy to get a Laravel project set up.  These hooks are no longer useful for CDash.