### PR TITLE
Replace usages of deprecated `setMethods()` method

### DIFF
--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -50,13 +50,13 @@ class CDashTestCase extends TestCase
 
         $mock_stmt = $this->getMockBuilder(\PDOStatement::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'prepare', 'fetch', 'fetchAll', 'fetchColumn', 'bindParam', 'bindValue', 'rowCount', 'closeCursor'])
+            ->onlyMethods([
+                'fetch', 'fetchAll', 'fetchColumn', 'bindParam', 'bindValue', 'rowCount', 'closeCursor'])
             ->getMock();
 
         $mock_pdo = $this->getMockBuilder(Database::class)
-            ->setMethods(
-                ['getPdo', 'prepare', 'execute', 'query', 'beginTransaction', 'commit', 'rollBack', 'quote']
+            ->onlyMethods(
+                ['getPdo', 'prepare', 'execute', 'query']
             )
             ->getMock();
 
@@ -74,13 +74,6 @@ class CDashTestCase extends TestCase
             ->expects($this->any())
             ->method('query')
             ->willReturn($mock_stmt);
-
-        $mock_pdo
-            ->expects($this->any())
-            ->method('quote')
-            ->willReturnCallback(function ($arg) {
-                return "'" . $arg . "'";
-            });
 
         Database::setInstance(Database::class, $mock_pdo);
     }

--- a/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
@@ -22,10 +22,6 @@ class BuildErrorTest extends CDashTestCase
     public function setUp() : void
     {
         $container = ServiceContainer::container();
-        $this->mock_builderror = $this->getMockBuilder(BuildError::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['GetBuildErrorArguments'])
-            ->getMock();
         $this->mock_project = $this->getMockBuilder(Project::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -48,7 +44,7 @@ class BuildErrorTest extends CDashTestCase
         ];
 
         $this->mock_project->CvsUrl = 'https://github.com/FooCo/foo';
-        $marshaled = $this->mock_builderror->marshal($input_data, $this->mock_project, '12');
+        $marshaled = BuildError::marshal($input_data, $this->mock_project, '12');
 
         $expected = [
             'new' => '1',

--- a/app/cdash/tests/case/CDash/NightlyTimeTest.php
+++ b/app/cdash/tests/case/CDash/NightlyTimeTest.php
@@ -21,9 +21,9 @@ use Tests\TestCase;
 
 class NightlyTimeTest extends TestCase
 {
-    public function __construct()
+    public function setUp(): void
     {
-        parent::__construct();
+        parent::setUp();
         $this->Project = new Project();
         // Avoid the database for this test.
         $this->Project->Filled = true;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12723,16 +12723,8 @@ parameters:
 			path: app/cdash/include/Submission/CommitAuthorHandlerInterface.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/cdash/include/Test/CDashTestCase.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:any\\(\\)\\.$#"
-			count: 4
+			count: 3
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
@@ -12766,11 +12758,6 @@ parameters:
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
-			message: "#^Trying to mock an undefined method quote\\(\\) on class CDash\\\\Database\\.$#"
-			count: 1
-			path: app/cdash/include/Test/CDashTestCase.php
-
-		-
 			message: "#^Unable to resolve the template type T in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
 			count: 1
 			path: app/cdash/include/Test/CDashTestCase.php
@@ -12791,14 +12778,6 @@ parameters:
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/cdash/include/Test/CDashUseCaseTestCase.php
-
-		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:any\\(\\)\\.$#"
 			count: 5
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
@@ -12811,6 +12790,11 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, CDash\\\\ServiceContainer given\\.$#"
 			count: 1
+			path: app/cdash/include/Test/CDashUseCaseTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$class_name of method CDash\\\\Test\\\\UseCase\\\\UseCase\\:\\:getIdForClass\\(\\) expects string, class\\-string\\|object given\\.$#"
+			count: 2
 			path: app/cdash/include/Test/CDashUseCaseTestCase.php
 
 		-
@@ -18095,21 +18079,8 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildErrorFilterTest.php
 
 		-
-			message: "#^Access to an undefined property BuildErrorTest\\:\\:\\$mock_builderror\\.$#"
-			count: 2
-			path: app/cdash/tests/case/CDash/Model/BuildErrorTest.php
-
-		-
 			message: "#^Access to an undefined property BuildErrorTest\\:\\:\\$mock_project\\.$#"
 			count: 3
-			path: app/cdash/tests/case/CDash/Model/BuildErrorTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildErrorTest.php
 
 		-
@@ -32965,19 +32936,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: tests/Unit/app/ControllerNameTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: tests/Unit/app/Validators/PasswordTest.php
-
-		-
-			message: "#^Method App\\\\Validators\\\\PasswordTest\\:\\:getMockValidator\\(\\) has parameter \\$methods with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Unit/app/Validators/PasswordTest.php
 
 		-
 			message: "#^Method App\\\\Validators\\\\PasswordTest\\:\\:testComplexityFailsGivenEmptyPassword\\(\\) has no return type specified\\.$#"

--- a/tests/Unit/app/Validators/PasswordTest.php
+++ b/tests/Unit/app/Validators/PasswordTest.php
@@ -19,7 +19,7 @@ namespace App\Validators;
 use App\Validators\Password as PasswordValidator;
 use Config;
 use Illuminate\Contracts\Translation\Translator;
-use PHPUnit\Framework\MockObject\MockObject;
+use Mockery;
 use Tests\TestCase;
 use Illuminate\Validation\Validator;
 
@@ -403,24 +403,10 @@ class PasswordTest extends TestCase
         $this::assertEquals($expected, $actual);
     }
 
-    /**
-     * @param array $methods
-     * @return Validator|MockObject
-     */
-    private function getMockValidator($methods = [])
+    private function getMockValidator(): Validator
     {
-        /** @var Translator|MockObject $translator */
-        $translator = $this->getMockBuilder(Translator::class)
-            ->setMethods(['trans', 'transChoice', 'setLocale', 'getLocale'])
-            ->getMockForAbstractClass();
+        $translator = Mockery::mock(Translator::class);
         $validator = new Validator($translator, [], []);
-        /** @var Validator|MockObject $validator */
-        /*
-        $validator = $this->getMockBuilder(Validator::class)
-            ->setConstructorArgs([$translator, [], []])
-            ->setMethods(null)
-            ->getMock();
-        */
         return $validator;
     }
 }


### PR DESCRIPTION
The [upgrade](https://github.com/Kitware/CDash/pull/1866) of PHPUnit to 10 and beyond is currently blocked by our usage of PHPUnit's deprecated `setMethods()` method which was removed in PHPUnit 10.  This PR addresses all of our remaining usages of `setMethods()`, which clears the way for a PHPUnit upgrade in the near future.