### PR TITLE
Account for non-xml submission objects

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -142,7 +142,7 @@ final class SubmissionController extends AbstractProjectController
         } catch (BadSubmissionException $e) {
             $xml_info['xml_handler'] = '';
             $message = "Could not determine submission file type for: '{$stored_filename}'";
-            Log::warning($message . PHP_EOL);
+            Log::warning($message);
             if ((bool) config('cdash.validate_xml_submissions') === true) {
                 abort(400, $message);
             }

--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -136,17 +136,28 @@ final class SubmissionController extends AbstractProjectController
 
         // Figure out what type of XML file this is.
         $stored_filename = 'inbox/' . $filename;
-        $xml_info = SubmissionUtils::get_xml_type(fopen(Storage::path($stored_filename), 'r'), $stored_filename);
-
-        // If validation is enabled and if this file has a corresponding schema, validate it
-        $validation_errors = $xml_info['xml_handler']::validate(storage_path('app/' . $stored_filename));
-        if (count($validation_errors) > 0) {
-            $error_string = implode(PHP_EOL, $validation_errors);
-
-            // We always log validation failures, but we only send messages back to the client if configured to do so
-            Log::warning("Submission validation failed for file '$filename':" . PHP_EOL);
+        $xml_info = [];
+        try {
+            $xml_info = SubmissionUtils::get_xml_type(fopen(Storage::path($stored_filename), 'r'), $stored_filename);
+        } catch (BadSubmissionException $e) {
+            $xml_info['xml_handler'] = '';
+            $message = "Could not determine submission file type for: '{$stored_filename}'";
+            Log::warning($message . PHP_EOL);
             if ((bool) config('cdash.validate_xml_submissions') === true) {
-                abort(400, "XML validation failed: rejected file $filename:" . PHP_EOL . $error_string);
+                abort(400, $message);
+            }
+        }
+        if ($xml_info['xml_handler'] !== '') {
+            // If validation is enabled and if this file has a corresponding schema, validate it
+            $validation_errors = $xml_info['xml_handler']::validate(storage_path('app/' . $stored_filename));
+            if (count($validation_errors) > 0) {
+                $error_string = implode(PHP_EOL, $validation_errors);
+
+                // We always log validation failures, but we only send messages back to the client if configured to do so
+                Log::warning("Submission validation failed for file '$filename':" . PHP_EOL);
+                if ((bool) config('cdash.validate_xml_submissions') === true) {
+                    abort(400, "XML validation failed: rejected file $filename:" . PHP_EOL . $error_string);
+                }
             }
         }
 

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -4,7 +4,6 @@ namespace App\Jobs;
 
 use AbstractSubmissionHandler;
 use ActionableBuildInterface;
-use App\Exceptions\BadSubmissionException;
 use App\Models\SuccessfulJob;
 use App\Utils\UnparsedSubmissionProcessor;
 use BuildPropertiesJSONHandler;
@@ -133,8 +132,6 @@ class ProcessSubmission implements ShouldQueue
      * Execute the job.
      *
      * @return void
-     *
-     * @throws BadSubmissionException
      */
     public function handle()
     {
@@ -199,7 +196,6 @@ class ProcessSubmission implements ShouldQueue
      * This method could be running on a worker that is either remote or local, so it accepts
      * a file handle or a filename that it can query the CDash API for.
      *
-     * @throws BadSubmissionException
      **/
     private function doSubmit($filename, $projectid, $buildid = null, $expected_md5 = ''): AbstractSubmissionHandler|UnparsedSubmissionProcessor|false
     {

--- a/app/cdash/include/ctestparser.php
+++ b/app/cdash/include/ctestparser.php
@@ -192,7 +192,7 @@ function ctest_parse($filehandle, string $filename, $projectid, $expected_md5 = 
         $xml_info['xml_handler'] = null;
         $xml_info['xml_type'] = '';
         $message = "Could not determine submission file type for: '{$filename}'";
-        Log::warning($message . PHP_EOL);
+        Log::warning($message);
         if ((bool) config('cdash.validate_xml_submissions') === true) {
             abort(400, $message);
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14003,21 +14003,6 @@ parameters:
 			path: app/cdash/include/ctestparser.php
 
 		-
-			message: "#^Parameter \\#1 \\$stream of function feof expects resource, mixed given\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparser.php
-
-		-
-			message: "#^Parameter \\#1 \\$stream of function fread expects resource, mixed given\\.$#"
-			count: 2
-			path: app/cdash/include/ctestparser.php
-
-		-
-			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, mixed given\\.$#"
-			count: 1
-			path: app/cdash/include/ctestparser.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of function xml_parse expects string, string\\|false given\\.$#"
 			count: 2
 			path: app/cdash/include/ctestparser.php


### PR DESCRIPTION
When given a non-xml submission file, catch the exception of the bad submission and only reject the submission of the Validate setting is enabled.

Fixes: #2662