### PR TITLE
Add formatting rules for PHPUnit tests

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,9 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
     ->exclude('app/cdash/config')
     ->exclude('bootstrap/cache')
     ->exclude('node_modules')
@@ -10,22 +13,19 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('resources')
     ->exclude('public')
     ->notPath('app/cdash/tests/config.test.local.php')
-    ->in(__DIR__)
-;
+    ->in(__DIR__);
 
-$config = new PhpCsFixer\Config();
+$config = new Config();
 return $config->setRules([
-        '@PSR12' => true,
-        '@PHP82Migration' => true,
-        '@Symfony' => true,
-        'yoda_style' => false,
-        'blank_line_before_statement' => false,
-        'phpdoc_summary' => false,
-        'concat_space' => ['spacing' => 'one'],
-        'increment_style' => ['style' => 'post'],
-        'fully_qualified_strict_types' => ['import_symbols' => true],
-        'global_namespace_import' => ['import_classes' => true, 'import_constants' => null, 'import_functions' => null],
-        'phpdoc_align' => ['align' => 'left'],
-    ])
-    ->setFinder($finder)
-;
+    '@PSR12' => true,
+    '@PHP82Migration' => true,
+    '@Symfony' => true,
+    'yoda_style' => false,
+    'blank_line_before_statement' => false,
+    'phpdoc_summary' => false,
+    'concat_space' => ['spacing' => 'one'],
+    'increment_style' => ['style' => 'post'],
+    'fully_qualified_strict_types' => ['import_symbols' => true],
+    'global_namespace_import' => ['import_classes' => true, 'import_constants' => null, 'import_functions' => null],
+    'phpdoc_align' => ['align' => 'left'],
+])->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,7 @@ $config = new Config();
 return $config->setRules([
     '@PSR12' => true,
     '@PHP82Migration' => true,
+    '@PHPUnit100Migration:risky' => true,
     '@Symfony' => true,
     'yoda_style' => false,
     'blank_line_before_statement' => false,

--- a/app/cdash/include/Test/BuildDiffForTesting.php
+++ b/app/cdash/include/Test/BuildDiffForTesting.php
@@ -18,7 +18,7 @@
 namespace CDash\Test;
 
 use CDash\Model\Build;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 trait BuildDiffForTesting
 {

--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -19,7 +19,7 @@ use CDash\Database;
 use CDash\Model\Build;
 use CDash\ServiceContainer;
 use PDOStatement;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 require_once 'include/common.php';

--- a/app/cdash/tests/kwtest/simpletest/shell_tester.php
+++ b/app/cdash/tests/kwtest/simpletest/shell_tester.php
@@ -286,7 +286,7 @@ class ShellTestCase extends SimpleTestCase
     public function assertFileExists($path, $message = '%s')
     {
         $message = sprintf($message, "File [$path] should exist");
-        return $this->assertTrue(file_exists($path), $message);
+        return $this->assertFileExists($path, $message);
     }
 
     /**
@@ -300,7 +300,7 @@ class ShellTestCase extends SimpleTestCase
     public function assertFileNotExists($path, $message = '%s')
     {
         $message = sprintf($message, "File [$path] should not exist");
-        return $this->assertFalse(file_exists($path), $message);
+        return $this->assertFileDoesNotExist($path, $message);
     }
 
     /**

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -68,7 +68,7 @@ class BuildDetailsTestCase extends KWWebTestCase
                 $response = json_decode($this->get(
                     $this->url . '/api/v1/viewBuildError.php?buildid=' . $build['id']));
 
-                $this->assertTrue(is_array($response->errors));
+                $this->assertIsArray($response->errors);
             }
         }
     }

--- a/app/cdash/tests/test_extracttar.php
+++ b/app/cdash/tests/test_extracttar.php
@@ -12,7 +12,7 @@ class ExtractTarTestCase extends KWWebTestCase
         $result = extract_tar(dirname(__FILE__) . '/../config/config.php', 'foo');
 
         $this->assertFalse($result);
-        $this->assertTrue(is_readable($this->logfilename));
+        $this->assertIsReadable($this->logfilename);
 
         $logfileContents = file_get_contents($this->logfilename);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,7 @@ endfunction()
 
 add_test(
   NAME php_style_check
-  COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix --dry-run
+  COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 

--- a/tests/Feature/PasswordRotation.php
+++ b/tests/Feature/PasswordRotation.php
@@ -112,7 +112,7 @@ class PasswordRotation extends TestCase
         $password_rows = DB::table('password')
             ->where('userid', $this->user->id)
             ->get();
-        $this::assertEquals(2, count($password_rows));
+        $this::assertCount(2, $password_rows);
         $this->assertDatabaseMissing('password', ['password' => $password_hash]);
 
         // Verify that we can set our password back to the original one


### PR DESCRIPTION
This PR continues our ongoing effort to modernize the codebase by applying automatic code formatter rules to our PHPUnit tests.