### PR TITLE
Send email notifications for expiring auth tokens

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Jobs\NotifyExpiringAuthTokens;
 use App\Jobs\PruneAuthTokens;
 use App\Jobs\PruneJobs;
 use Illuminate\Console\Scheduling\Schedule;
@@ -30,6 +31,10 @@ class Kernel extends ConsoleKernel
 
         $schedule->job(new PruneAuthTokens())
             ->hourly()
+            ->withoutOverlapping();
+
+        $schedule->job(new NotifyExpiringAuthTokens())
+            ->daily()
             ->withoutOverlapping();
 
         if (env('CDASH_AUTHENTICATION_PROVIDER') === 'ldap') {

--- a/app/Mail/AuthTokenExpired.php
+++ b/app/Mail/AuthTokenExpired.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\AuthToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Note: This Mailable serializes inputs, meaning that AuthToken objects stored within the object
+ * are still available for use, even though they may be deleted before the email actually gets sent.
+ */
+class AuthTokenExpired extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public AuthToken $authToken,
+    ) {
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[CDash] Authentication Token Expired',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'email.auth-token-expired',
+        );
+    }
+}

--- a/app/Mail/AuthTokenExpiring.php
+++ b/app/Mail/AuthTokenExpiring.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\AuthToken;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AuthTokenExpiring extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public AuthToken $authToken,
+    ) {
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[CDash] Authentication Token Expires Soon',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'email.auth-token-expiring',
+        );
+    }
+}

--- a/app/Models/AuthToken.php
+++ b/app/Models/AuthToken.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 
 /**
@@ -60,5 +61,13 @@ class AuthToken extends Model
     public function scopeExpired(Builder $query): void
     {
         $query->where('expires', '<', Carbon::now());
+    }
+
+    /**
+     * @return HasOne<User>
+     */
+    public function user(): HasOne
+    {
+        return $this->hasOne(User::class, 'id', 'userid');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -99,6 +99,14 @@ class User extends Authenticatable implements MustVerifyEmail, LdapAuthenticatab
     }
 
     /**
+     * @return HasMany<AuthToken>
+     */
+    public function authTokens(): HasMany
+    {
+        return $this->hasMany(AuthToken::class, 'userid');
+    }
+
+    /**
      * Passthrough to call legacy User model method.
      **/
     public function __call($method, $parameters)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -223,8 +223,8 @@ set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS /CDa
 add_laravel_test(/Feature/Jobs/PruneJobsTest)
 set_tests_properties(/Feature/Jobs/PruneJobsTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
-# This could theoretically conflict with another test using expired auth tokens
 add_laravel_test(/Feature/Jobs/PruneAuthTokensTest)
+set_tests_properties(/Feature/Jobs/PruneAuthTokensTest PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Feature/Jobs/PruneAuthTokensTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 add_laravel_test(/Feature/UserCommand)
@@ -263,6 +263,16 @@ set_tests_properties(/CDash/Messaging/Topic/TopicDecorator PROPERTIES DEPENDS /C
 add_laravel_test(/Feature/RemoteWorkers)
 set_tests_properties(/Feature/RemoteWorkers PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/Jobs/NotifyExpiringAuthTokensTest)
+set_tests_properties(/Feature/Jobs/NotifyExpiringAuthTokensTest PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(/Feature/Jobs/NotifyExpiringAuthTokensTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/Mail/AuthTokenExpiringTest)
+set_tests_properties(/Feature/Mail/AuthTokenExpiringTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/Mail/AuthTokenExpiredTest)
+set_tests_properties(/Feature/Mail/AuthTokenExpiredTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 cdash_install()
@@ -298,6 +308,9 @@ set_property(TEST install_3 PROPERTY DEPENDS
   /CDash/Messaging/Topic/TestFailureTopic
   /CDash/Messaging/Topic/TopicDecorator
   /Feature/RemoteWorkers
+  /Feature/Jobs/NotifyExpiringAuthTokensTest
+  /Feature/Mail/AuthTokenExpiringTest
+  /Feature/Mail/AuthTokenExpiredTest
 )
 
 

--- a/resources/views/email/auth-token-expired.blade.php
+++ b/resources/views/email/auth-token-expired.blade.php
@@ -1,0 +1,7 @@
+An authentication token associated with your account has expired:
+
+  * {{ $authToken->description ?? 'No Description' }}
+
+Visit {{ url('/user') }} to manage your authentication tokens.
+
+-CDash

--- a/resources/views/email/auth-token-expiring.blade.php
+++ b/resources/views/email/auth-token-expiring.blade.php
@@ -1,0 +1,7 @@
+An authentication token associated with your account will expire on {{ $authToken->expires->toDateString() }}:
+
+  * {{ $authToken->description ?? 'No Description' }}
+
+Visit {{ url('/user') }} to manage your authentication tokens.
+
+-CDash

--- a/tests/Feature/Jobs/NotifyExpiringAuthTokensTest.php
+++ b/tests/Feature/Jobs/NotifyExpiringAuthTokensTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\NotifyExpiringAuthTokens;
+use App\Mail\AuthTokenExpiring;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class NotifyExpiringAuthTokensTest extends TestCase
+{
+    use CreatesUsers;
+    use DatabaseTruncation;
+
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->makeNormalUser();
+    }
+
+    public function tearDown(): void
+    {
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testValidAuthTokenNotNotified(): void
+    {
+        Mail::fake();
+
+        $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now()->addDays(8),
+            'scope' => 'test',
+        ]);
+
+        NotifyExpiringAuthTokens::dispatch();
+        Mail::assertNothingQueued();
+    }
+
+    public function testAuthTokenExpiringInSixDaysNotified(): void
+    {
+        Mail::fake();
+
+        $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now()->addDays(6),
+            'scope' => 'test',
+        ]);
+
+        NotifyExpiringAuthTokens::dispatch();
+        Mail::assertQueuedCount(1);
+        Mail::assertQueued(AuthTokenExpiring::class);
+    }
+
+    public function testAuthTokenExpiringInLessThanOneDayNotified(): void
+    {
+        Mail::fake();
+
+        $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now()->addHour(),
+            'scope' => 'test',
+        ]);
+
+        NotifyExpiringAuthTokens::dispatch();
+        Mail::assertQueuedCount(1);
+        Mail::assertQueued(AuthTokenExpiring::class);
+    }
+}

--- a/tests/Feature/Mail/AuthTokenExpiredTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiredTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Mail\AuthTokenExpired;
+use App\Models\AuthToken;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class AuthTokenExpiredTest extends TestCase
+{
+    use CreatesUsers;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->makeNormalUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testMailableContainsLink(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+        ]);
+
+        $mailable = new AuthTokenExpired($authtoken);
+
+        $mailable->assertSeeInHtml('http://localhost:8080/user');
+    }
+
+    public function testMailableNoDescription(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+        ]);
+
+        $mailable = new AuthTokenExpired($authtoken);
+
+        $mailable->assertSeeInHtml('* No Description');
+    }
+
+    public function testMailableShowsDescription(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+            'description' => Str::uuid()->toString(),
+        ]);
+
+        $mailable = new AuthTokenExpired($authtoken);
+
+        $mailable->assertSeeInHtml('* ' . $authtoken->description);
+    }
+}

--- a/tests/Feature/Mail/AuthTokenExpiringTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiringTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Mail\AuthTokenExpiring;
+use App\Models\AuthToken;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class AuthTokenExpiringTest extends TestCase
+{
+    use CreatesUsers;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->makeNormalUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testMailableContainsExpirationDate(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::create(2025, 3, 14),
+            'scope' => 'test',
+        ]);
+
+        $mailable = new AuthTokenExpiring($authtoken);
+
+        $mailable->assertSeeInHtml('2025-03-14');
+    }
+
+    public function testMailableContainsLink(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+        ]);
+
+        $mailable = new AuthTokenExpiring($authtoken);
+
+        $mailable->assertSeeInHtml('http://localhost:8080/user');
+    }
+
+    public function testMailableNoDescription(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+        ]);
+
+        $mailable = new AuthTokenExpiring($authtoken);
+
+        $mailable->assertSeeInHtml('* No Description');
+    }
+
+    public function testMailableShowsDescription(): void
+    {
+        /**
+         * @var AuthToken $authtoken
+         */
+        $authtoken = $this->user->authTokens()->create([
+            'hash' => Str::uuid()->toString(),
+            'expires' => Carbon::now(),
+            'scope' => 'test',
+            'description' => Str::uuid()->toString(),
+        ]);
+
+        $mailable = new AuthTokenExpiring($authtoken);
+
+        $mailable->assertSeeInHtml('* ' . $authtoken->description);
+    }
+}


### PR DESCRIPTION
Authentication tokens currently expire silently, leading users to discover that they need to be updated once things start failing.  This PR improves the feature by sending email notifications to the token owner each day for the 7 days preceding a token's expiration date.