### PR TITLE
Restrict build GraphQL test to only the projects it creates

### DIFF
--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -470,8 +470,12 @@ class BuildTypeTest extends TestCase
         }
 
         $this->graphQL('
-            query($buildname: String) {
-                projects {
+            query($projectid: ID, $buildname: String) {
+                projects(filters: {
+                    eq: {
+                        id: $projectid
+                    }
+                }) {
                     edges {
                         node {
                             name
@@ -491,6 +495,7 @@ class BuildTypeTest extends TestCase
                 }
             }
         ', [
+            'projectid' => $this->project->id,
             'buildname' => $builds[2]->name,
         ])->assertJson([
             'data' => [


### PR DESCRIPTION
#2664 allowed CTest to have more flexibility regarding the ordering of tests.  That exposed an issue with the `BuildTypeTest` which relied upon more than just data it created.  This PR resolves the issue by restricting the test to use only the data it creates.