### PR TITLE
Start creating new permissions for registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,13 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 # Whether or not a Project administrator can register a user
 # PROJECT_ADMIN_REGISTRATION_FORM_ENABLED=true
 
+# The minimum permission level able to register a user.
+# Leaving this value blank will disable registration forms, unless a value can be
+# generated from USER_REGISTRATION_FORM_ENABLED and PROJECT_ADMIN_REGISTRATION_FORM_ENABLED
+
+# Options: PUBLIC, PROJECT_ADMIN, ADMIN, DISABLED
+# USER_REGISTRATION_ACCESS_LEVEL_REQUIRED=PUBLIC
+
 # Require all new projects to use authenticated submissions.
 # Instance administrators can override this, and this setting has no effect on
 # existing projects.

--- a/app/Enums/RegistrationPermissionsLevel.php
+++ b/app/Enums/RegistrationPermissionsLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum RegistrationPermissionsLevel: int
+{
+    case PUBLIC = 0;
+    case PROJECT_ADMIN = 1;
+    case ADMIN = 2;
+    case DISABLED = 3;
+}

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Models\Project as EloquentProject;
@@ -384,7 +386,7 @@ final class ManageProjectRolesController extends AbstractProjectController
         if ((bool) config('require_full_email_when_adding_user')) {
             $xml .= add_XML_value('fullemail', '1');
         }
-        if ((config('auth.project_admin_registration_form_enabled') === true) || $current_user->admin) {
+        if ($current_user->can('create', [User::class, EloquentProject::find($projectid)])) {
             $xml .= add_XML_value('canRegister', '1');
         }
         $xml .= '</cdash>';
@@ -426,7 +428,7 @@ final class ManageProjectRolesController extends AbstractProjectController
 
     private function register_user($projectid, $email, $firstName, $lastName, $repositoryCredential)
     {
-        if (config('auth.project_admin_registration_form_enabled') === false) {
+        if (Gate::authorize('create', [User::class, EloquentProject::findOrFail($projectid)])->denied()) {
             return '<error>Users cannot be registered via this form at the current time.</error>';
         }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\RegistrationPermissionsLevel;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+class UserPolicy
+{
+    protected function AttemptValueBuild(): int
+    {
+        return (bool) env('USER_REGISTRATION_FORM_ENABLED', true) ? RegistrationPermissionsLevel::PUBLIC->value : ((bool) env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true) ? RegistrationPermissionsLevel::PROJECT_ADMIN->value : RegistrationPermissionsLevel::ADMIN->value);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        $user_permission_level = Project::whereRelation('administrators', 'users.id', request()->user()?->id)->exists() ? 1 : 0;
+        $user_permission_level = $user->admin ? 2 : $user_permission_level;
+        $registration_permission_level_required = match (Str::upper(config('auth.user_registration_access_level_required'))) {
+            'PUBLIC' => RegistrationPermissionsLevel::PUBLIC->value,
+            'PROJECT_ADMIN' => RegistrationPermissionsLevel::PROJECT_ADMIN->value,
+            'ADMIN' => RegistrationPermissionsLevel::ADMIN->value,
+            'DISABLED' => RegistrationPermissionsLevel::DISABLED->value,
+            default => $this->AttemptValueBuild(),
+        };
+
+        // Fail if the caller is requesting a value that the setting disallows
+        return $user_permission_level >= $registration_permission_level_required;
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -214,6 +214,11 @@ add_laravel_test(/Browser/Pages/ProjectSitesPageTest)
 set_tests_properties(/Browser/Pages/ProjectSitesPageTest PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Browser/Pages/ProjectSitesPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+# Technically this test doesn't have to run serially.  It just needs to have exclusive access to the .env
+add_laravel_test(/Browser/Pages/RegistrationTest)
+set_tests_properties(/Browser/Pages/RegistrationTest PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(/Browser/Pages/RegistrationTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)
 set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Feature/PurgeUnusedProjectsCommand PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)

--- a/config/auth.php
+++ b/config/auth.php
@@ -6,10 +6,9 @@ use App\Models\User;
 return [
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),
-    // Whether or not "normal" username+password authentication is enabled
-    'user_registration_form_enabled' => env('USER_REGISTRATION_FORM_ENABLED', true),
-    // Whether or not a Project administrator can register a user
-    'project_admin_registration_form_enabled' => env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true),
+    // Which level of permissions can register a user
+    // supported: PUBLIC,PROJECT_ADMIN,ADMIN,""
+    'user_registration_access_level_required' => env('USER_REGISTRATION_ACCESS_LEVEL_REQUIRED', (bool) env('USER_REGISTRATION_FORM_ENABLED', true) ? 'PUBLIC' : ((bool) env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true) ? 'PROJECT_ADMIN' : 'ADMIN')),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3740,6 +3740,16 @@ parameters:
 			path: app/Policies/ProjectPolicy.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\Project\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/Policies/UserPolicy.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of static method Illuminate\\\\Support\\\\Str\\:\\:upper\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: app/Policies/UserPolicy.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Foundation\\\\Application\\:\\:isProduction\\(\\)\\.$#"
 			count: 1
 			path: app/Providers/AppServiceProvider.php

--- a/resources/views/admin/manage-users.blade.php
+++ b/resources/views/admin/manage-users.blade.php
@@ -40,93 +40,95 @@
                     >
                 </td>
             </tr>
-            <tr>
-                <td></td>
-                <td>
-                    <div name="newuser" id="newuser"></div>
-                </td>
-            </tr>
-            <tr>
-                <td></td>
-                <td  bgcolor="#DDDDDD">
-                    <strong>Add new user</strong>
-                </td>
-            </tr>
-            <tr class="treven">
-                <td width="20%" height="2" class="nob">
-                    <div align="right"> First Name: </div>
-                </td>
-                <td  width="80%" height="2" class="nob">
-                    <input class="textbox" name="fname" size="20"/>
-                </td>
-            </tr>
-            <tr class="trodd">
-                <td width="20%" height="2" class="nob">
-                    <div align="right"> Last Name: </div>
-                </td>
-                <td  width="80%" height="2" class="nob">
-                    <input class="textbox" name="lname" size="20"/>
-                </td>
-            </tr>
-            <tr class="treven">
-                <td width="20%" height="2" class="nob">
-                    <div align="right"> Email: </div>
-                </td>
-                <td  width="80%" height="2" class="nob">
-                    <input class="textbox"  name="email" size="20"/>
-                </td>
-            </tr>
-            <tr class="trodd">
-                <td width="20%" height="2" class="nob">
-                    <div align="right">Password: </div>
-                </td>
-                <td width="80%" height="2" class="nob">
-                    <input
-                        class="textbox"
-                        type="password"
-                        id="passwd"
-                        name="passwd"
-                        size="20"
-                    >
-                    <input
-                        type="button"
-                        value="Generate Password"
-                        onclick="javascript:generatePassword();"
-                        name="generatepassword"
-                        class="textbox"
-                    >
-                    <span id="clearpasswd"></span>
-                </td>
-            </tr>
-            <tr class="treven">
-                <td width="20%" height="2" class="nob">
-                    <div align="right">Confirm Password: </div>
-                </td>
-                <td width="80%" height="2" class="nob">
-                    <input
-                        class="textbox"
-                        type="password"
-                        id="passwd2"
-                        name="passwd2"
-                        size="20"
-                    >
-                </td>
-            </tr>
-            <tr class="trodd">
-                <td width="20%" height="2" class="nob">
-                    <div align="right"> Institution: </div>
-                </td>
-                <td  width="80%" height="2" class="nob">
-                    <input class="textbox" name="institution" size="20">
-                </td>
-            </tr>
-            <tr>
-                <td width="20%" class="nob"></td>
-                <td width="80%" class="nob">
-                    <input type="submit" value="Add user >>" name="adduser" class="textbox"/>
-                    (password will be displayed in clear text upon addition)
-                </td>
-            </tr>
+            @can("create", App\Models\User::class)
+                <tr>
+                    <td></td>
+                    <td>
+                        <div name="newuser" id="newuser"></div>
+                    </td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td  bgcolor="#DDDDDD">
+                        <strong>Add new user</strong>
+                    </td>
+                </tr>
+                <tr class="treven">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right"> First Name: </div>
+                    </td>
+                    <td  width="80%" height="2" class="nob">
+                        <input class="textbox" name="fname" size="20"/>
+                    </td>
+                </tr>
+                <tr class="trodd">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right"> Last Name: </div>
+                    </td>
+                    <td  width="80%" height="2" class="nob">
+                        <input class="textbox" name="lname" size="20"/>
+                    </td>
+                </tr>
+                <tr class="treven">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right"> Email: </div>
+                    </td>
+                    <td  width="80%" height="2" class="nob">
+                        <input class="textbox"  name="email" size="20"/>
+                    </td>
+                </tr>
+                <tr class="trodd">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right">Password: </div>
+                    </td>
+                    <td width="80%" height="2" class="nob">
+                        <input
+                            class="textbox"
+                            type="password"
+                            id="passwd"
+                            name="passwd"
+                            size="20"
+                        >
+                        <input
+                            type="button"
+                            value="Generate Password"
+                            onclick="javascript:generatePassword();"
+                            name="generatepassword"
+                            class="textbox"
+                        >
+                        <span id="clearpasswd"></span>
+                    </td>
+                </tr>
+                <tr class="treven">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right">Confirm Password: </div>
+                    </td>
+                    <td width="80%" height="2" class="nob">
+                        <input
+                            class="textbox"
+                            type="password"
+                            id="passwd2"
+                            name="passwd2"
+                            size="20"
+                        >
+                    </td>
+                </tr>
+                <tr class="trodd">
+                    <td width="20%" height="2" class="nob">
+                        <div align="right"> Institution: </div>
+                    </td>
+                    <td  width="80%" height="2" class="nob">
+                        <input class="textbox" name="institution" size="20">
+                    </td>
+                </tr>
+                <tr>
+                    <td width="20%" class="nob"></td>
+                    <td width="80%" class="nob">
+                        <input type="submit" value="Add user >>" name="adduser" class="textbox"/>
+                        (password will be displayed in clear text upon addition)
+                    </td>
+                </tr>
+            @endcan
         </table>
     </form>
 

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -2,9 +2,10 @@
     if (isset($project)) {
         $logoid = $project->ImageId;
     }
-$hideRegistration = config('auth.user_registration_form_enabled') === false;
-@endphp
 
+    use Illuminate\Support\Str;
+    $canRegister = Str::upper(config('auth.user_registration_access_level_required')) === "PUBLIC";
+@endphp
 <div id="header">
     <div id="headertop">
         <div id="topmenu">
@@ -18,7 +19,7 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
                     <a class="cdash-link" href="{{ url('/logout') }}">Logout</a>
                 @else
                     <a class="cdash-link" href="{{ url('/login') }}">Login</a>
-                    @if(!$hideRegistration)
+                    @if($canRegister)
                       <a class="cdash-link" href="{{ route('register') }}">{{ __('Register') }}</a>
                     @endif
                 @endif

--- a/tests/Browser/Pages/RegistrationTest.php
+++ b/tests/Browser/Pages/RegistrationTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\BrowserTestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class RegistrationTest extends BrowserTestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+
+    /**
+     * @var array<Project>
+     */
+    private array $projects = [];
+    private string|bool $original = '';
+    private string $path = '../../../../.env';
+
+    /**
+     * Stolen from https://laracasts.com/discuss/channels/testing/how-to-change-env-variable-config-in-dusk-test
+     *
+     * @param array<string,string> $variables
+     */
+    protected function override(array $variables = []): void
+    {
+        if (file_exists($this->path)) {
+            // The environment variables to prepend
+            $prepend = '';
+
+            // Convert all new parameters to expected format
+            foreach ($variables as $key => $value) {
+                $prepend .= $key . '=' . $value . PHP_EOL;
+            }
+
+            // Grab original .env file contents
+            $this->original = file_get_contents($this->path);
+            // Write all to .env file for dusk test
+            file_put_contents($this->path, $prepend . $this->original);
+        }
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        foreach ($this->projects as $project) {
+            $project->delete();
+        }
+        $this->projects = [];
+
+        // Reset the .env file
+        file_put_contents($this->path, $this->original);
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<int,array<int,bool|string>>
+     */
+    public static function PublicRegistrationChecks(): array
+    {
+        return [
+            ['PUBLIC', true],
+            ['PROJECT_ADMIN', false],
+            ['ADMIN', false],
+            ['DISABLED', false],
+        ];
+    }
+
+    /**
+     * @dataProvider PublicRegistrationChecks
+     */
+    public function testPublicRegistrationForm(string $envVariableValue, bool $shouldFind): void
+    {
+        $this->override(['USER_REGISTRATION_ACCESS_LEVEL_REQUIRED' => $envVariableValue]);
+        $this->browse(function (Browser $browser) use ($shouldFind) {
+            $browser->refresh()->visit('/projects}')
+                ->whenAvailable('#topmenu', function (Browser $browser) use ($shouldFind) {
+                    $shouldFind ? $browser->assertSee('Register') : $browser->assertDontSee('Register');
+                });
+        });
+    }
+
+    /**
+     * @return array<int,array<int,bool|string>>
+     */
+    public static function ProjectManagerChecksAsAdministrator(): array
+    {
+        return [
+            ['PUBLIC', true],
+            ['PROJECT_ADMIN', true],
+            ['ADMIN', true],
+            ['DISABLED', false],
+        ];
+    }
+
+    public function visitProjectManageUsersForm(string $envVariableValue, bool $shouldFind, User $user): void
+    {
+        $this->override(['USER_REGISTRATION_ACCESS_LEVEL_REQUIRED' => $envVariableValue]);
+        $this->browse(function (Browser $browser) use ($shouldFind, $user) {
+            $browser->loginAs((string) $user->id)
+                ->visit("/manageProjectRoles.php?projectid={$this->projects['public1']->id}")
+                ->refresh()
+                ->whenAvailable(' #wizard', function (Browser $browser) use ($shouldFind) {
+                    $shouldFind ? $browser->assertPresent('#fragment-3') : $browser->assertNotPresent('#fragment-3');
+                });
+        });
+    }
+
+    /**
+     * @dataProvider ProjectManagerChecksAsAdministrator
+     */
+    public function testProjectManageUsersFormAsSiteAdministrator(string $envVariableValue, bool $shouldFind): void
+    {
+        $user = $this->makeAdminUser();
+        $this->projects['public1'] = $this->makePublicProject();
+        $this->projects['public1']->description = Str::uuid()->toString();
+        $this->projects['public1']->save();
+
+        $this->visitProjectManageUsersForm($envVariableValue, $shouldFind, $user);
+    }
+
+    /**
+     * @return array<int,array<int,bool|string>>
+     */
+    public static function ProjectManagerChecksAsProjectAdministrator()
+    {
+        return [
+            ['PUBLIC', true],
+            ['PROJECT_ADMIN', true],
+            ['ADMIN', false],
+            ['DISABLED', false],
+        ];
+    }
+
+    /**
+     * @dataProvider ProjectManagerChecksAsProjectAdministrator
+     */
+    public function testProjectManageUsersFormAsProjectAdminstrator(string $envVariableValue, bool $shouldFind): void
+    {
+        $user = $this->makeNormalUser();
+        $this->projects['public1'] = $this->makePublicProject();
+        $this->projects['public1']->description = Str::uuid()->toString();
+        $this->projects['public1']->save();
+        // Add the user to project as admin.
+
+        $this->projects['public1']->users()->attach($user->id, ['role' => Project::PROJECT_ADMIN]);
+        $this->visitProjectManageUsersForm($envVariableValue, $shouldFind, $user);
+    }
+
+    /**
+     * @return array<int,array<int,bool|string>>
+     */
+    public static function ManageUsersChecks(): array
+    {
+        return [
+            ['PUBLIC', true],
+            ['PROJECT_ADMIN', true],
+            ['ADMIN', true],
+            ['DISABLED', false],
+        ];
+    }
+
+    public function visitManageUsersForm(string $envVariableValue, bool $shouldFind, User $user): void
+    {
+        $this->override(['USER_REGISTRATION_ACCESS_LEVEL_REQUIRED' => $envVariableValue]);
+        $this->browse(function (Browser $browser) use ($shouldFind, $user) {
+            $browser->loginAs((string) $user->id)
+                ->visit('/manageUsers.php')
+                ->refresh()
+                ->whenAvailable('', function (Browser $browser) use ($shouldFind) {
+                    $shouldFind ? $browser->assertSee('Add new user') : $browser->assertDontSee('Add new user');
+                });
+        });
+    }
+
+    /**
+     * @dataProvider ProjectManagerChecksAsAdministrator
+     */
+    public function testManageUsersForm(string $envVariableValue, bool $shouldFind): void
+    {
+        $user = $this->makeAdminUser();
+        $this->visitManageUsersForm($envVariableValue, $shouldFind, $user);
+    }
+}


### PR DESCRIPTION
Introduce a new setting that determines what registration forms are shown as the pages are accessed:

PUBLIC (or not set) : All registration forms are available and non-users can register an account
PROJECTADMIN: The public form is hidden and users must be added via the "Manage project users" or "Manage users" by someone with Project Administrator priviliges or highter.

ADMIN: Only the Site administrators may register a new account via the two available forms.

DISABLED: All registration forms are disabled and registration must occur through a different means (via OAuth/LDAP).