### PR TITLE
Set default scope for pre-3.2 auth tokens

### DIFF
--- a/database/migrations/2025_01_28_154916_authtoken_default_scope.php
+++ b/database/migrations/2025_01_28_154916_authtoken_default_scope.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('authtoken', function (Blueprint $table) {
+            $table->string('scope')->default('full_access')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('authtoken', function (Blueprint $table) {
+            $table->string('scope')->default(null)->change();
+        });
+    }
+};


### PR DESCRIPTION
Fixes https://github.com/Kitware/CDash/issues/2678 by defaulting all pre-3.2 tokens to be full access tokens.