### PR TITLE
Add "claim site" functionality to site overview page

### DIFF
--- a/app/GraphQL/Mutations/AbstractMutation.php
+++ b/app/GraphQL/Mutations/AbstractMutation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use Exception;
+
+abstract class AbstractMutation
+{
+    public ?string $message = null;
+
+    /**
+     * @param array<string,mixed> $args
+     */
+    final public function __invoke(null $_, array $args): self
+    {
+        try {
+            $this->mutate($args);
+        } catch (Exception $e) {
+            report($e);
+            $this->message = $e->getMessage();
+        }
+
+        return $this;
+    }
+
+    /**
+     * TODO: It would be good to strengthen the type safety of the $args array eventually.
+     *
+     * @param array<string,mixed> $args
+     */
+    abstract protected function mutate(array $args): void;
+}

--- a/app/GraphQL/Mutations/ClaimSite.php
+++ b/app/GraphQL/Mutations/ClaimSite.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Site;
+use App\Models\User;
+
+final class ClaimSite extends AbstractMutation
+{
+    public ?Site $site = null;
+    public ?User $user = null;
+
+    /** @param array{
+     *     siteId: int
+     * } $args
+     */
+    protected function mutate(array $args): void
+    {
+        /** @var ?User $user */
+        $user = auth()->user();
+
+        if ($user === null) {
+            abort(401, 'Authentication required to claim sites.');
+        }
+
+        $site = Site::find((int) $args['siteId']);
+
+        if ($site === null) {
+            abort(404, 'Requested site not found.');
+        }
+
+        $site->maintainers()->syncWithoutDetaching($user);
+
+        $this->site = $site;
+        $this->user = $user;
+    }
+}

--- a/app/GraphQL/Mutations/UnclaimSite.php
+++ b/app/GraphQL/Mutations/UnclaimSite.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Site;
+use App\Models\User;
+
+final class UnclaimSite extends AbstractMutation
+{
+    public ?Site $site = null;
+    public ?User $user = null;
+
+    /** @param array{
+     *     siteId: int
+     * } $args
+     */
+    protected function mutate(array $args): void
+    {
+        /** @var ?User $user */
+        $user = auth()->user();
+
+        if ($user === null) {
+            abort(401, 'Authentication required to unclaim sites.');
+        }
+
+        $site = Site::find((int) $args['siteId']);
+
+        if ($site === null) {
+            abort(404, 'Requested site not found.');
+        }
+
+        $site->maintainers()->detach($user);
+
+        $this->site = $site;
+        $this->user = $user;
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -200,7 +200,6 @@ set_tests_properties(/Feature/Monitor PROPERTIES DEPENDS /CDash/XmlHandler/Updat
 add_laravel_test(/Feature/PasswordRotation)
 set_tests_properties(/Feature/PasswordRotation PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
-# Technically this test doesn't have to run serially.  It just needs to have exclusive access to the .env
 add_laravel_test(/Browser/Pages/SitesIdPageTest)
 set_tests_properties(/Browser/Pages/SitesIdPageTest PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Browser/Pages/SitesIdPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -43,6 +43,18 @@ type Query {
 type Mutation {
   "Create a new project."
   createProject(input: CreateProjectInput! @spread): Project @create @canModel(ability: "create")
+
+  "Subscribe the current user to the specified site."
+  claimSite(input: ClaimSiteInput! @spread): ClaimSiteMutationPayload! @field(resolver: "ClaimSite")
+
+  "Unsubscribe the current user from the specified site."
+  unclaimSite(input: UnclaimSiteInput! @spread): UnclaimSiteMutationPayload! @field(resolver: "UnclaimSite")
+}
+
+
+interface MutationPayloadInterface {
+  "Optional error message."
+  message: String
 }
 
 
@@ -65,6 +77,15 @@ type User {
 
   "Whether or not the user is a global administrator."
   admin: Boolean!
+}
+
+input UserFilterInput {
+  id: ID
+  firstname: String
+  lastname: String
+  email: String
+  institution: String
+  admin: Boolean
 }
 
 
@@ -433,7 +454,9 @@ type Site {
   mostRecentInformation: SiteInformation @hasOne
 
   "The users who have signed up to maintain this site."
-  maintainers: [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
+  maintainers(
+    filters: _ @filter(inputType: "UserFilterInput")
+  ): [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 }
 
 input SiteFilterInput {
@@ -442,6 +465,36 @@ input SiteFilterInput {
   ip: String
   latitude: Float
   longitude: Float
+}
+
+input ClaimSiteInput {
+  siteId: ID!
+}
+
+type ClaimSiteMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+
+  "Site being claimed."
+  site: Site
+
+  "The user claiming the requested site."
+  user: User
+}
+
+type UnclaimSiteMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+
+  "Site being unclaimed."
+  site: Site
+
+  "The user being detached from the requested site."
+  user: User
+}
+
+input UnclaimSiteInput {
+  siteId: ID!
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -242,6 +242,26 @@ parameters:
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Contracts\\\\Auth\\\\Guard\\:\\:user\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Mutations/ClaimSite.php
+
+		-
+			message: "#^Parameter \\#1 \\$args \\(array\\{siteId\\: int\\}\\) of method App\\\\GraphQL\\\\Mutations\\\\ClaimSite\\:\\:mutate\\(\\) should be contravariant with parameter \\$args \\(array\\<string, mixed\\>\\) of method App\\\\GraphQL\\\\Mutations\\\\AbstractMutation\\:\\:mutate\\(\\)$#"
+			count: 1
+			path: app/GraphQL/Mutations/ClaimSite.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Contracts\\\\Auth\\\\Guard\\:\\:user\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Mutations/UnclaimSite.php
+
+		-
+			message: "#^Parameter \\#1 \\$args \\(array\\{siteId\\: int\\}\\) of method App\\\\GraphQL\\\\Mutations\\\\UnclaimSite\\:\\:mutate\\(\\) should be contravariant with parameter \\$args \\(array\\<string, mixed\\>\\) of method App\\\\GraphQL\\\\Mutations\\\\AbstractMutation\\:\\:mutate\\(\\)$#"
+			count: 1
+			path: app/GraphQL/Mutations/UnclaimSite.php
+
+		-
 			message: "#^Cannot cast mixed to float\\.$#"
 			count: 1
 			path: app/GraphQL/Scalars/NonNegativeSeconds.php
@@ -31902,6 +31922,11 @@ parameters:
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
 			count: 3
+			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
+			count: 8
 			path: tests/Feature/GraphQL/SiteTypeTest.php
 
 		-

--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -111,6 +111,7 @@ const apolloClient = new ApolloClient({
       },
       Site: {
         information: relayStylePagination(),
+        maintainers: relayStylePagination(),
       },
     },
   }),

--- a/resources/views/site/view-site.blade.php
+++ b/resources/views/site/view-site.blade.php
@@ -4,5 +4,5 @@
 ])
 
 @section('main_content')
-    <sites-id-page :site-id="{{ $site->id }}"></sites-id-page>
+    <sites-id-page :site-id="{{ $site->id }}" :user-id="@js(auth()->user()?->id)"></sites-id-page>
 @endsection


### PR DESCRIPTION
As discussed in #2659, the "claim site" feature is currently broken.  This PR supersedes the previous functionality by adding a "claim site" button to the site overview page.  I intend to make a separate PR to add similar buttons to the project sites page.  In addition, I plan to remove `editSite.php` and move the remaining functionality to the site overview page in a separate upcoming PR.  That PR will also remove the broken claim site logic.

![image](https://github.com/user-attachments/assets/f214bef4-0851-4c7d-a870-4fac6f6a2d00)



Closes #2659.