### PR TITLE
Build arm64 images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         name: Build ${{matrix.base-image}} production image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: false
           target: cdash
           build-args: |
@@ -84,6 +85,7 @@ jobs:
         name: Build ${{matrix.base-image}} worker image
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: false
           target: cdash-worker
           build-args: |


### PR DESCRIPTION
The "Publish Images" job [recently](https://github.com/Kitware/CDash/actions/runs/12956371942) started failing due to an issue with arm64/amd64 cross-compilation.  This was not caught by the regular "Build Images" CI job because it does not build for both arm64 and amd64.