### PR TITLE
Remove `dailyupdatefile` table

### DIFF
--- a/app/Console/Commands/CleanDatabase.php
+++ b/app/Console/Commands/CleanDatabase.php
@@ -37,7 +37,6 @@ class CleanDatabase extends Command
         DatabaseCleanupUtils::deleteUnusedRows('buildfailuredetails', 'id', 'buildfailure', 'detailsid');
         DatabaseCleanupUtils::deleteUnusedRows('configure', 'id', 'build2configure', 'configureid');
         DatabaseCleanupUtils::deleteUnusedRows('coveragefile', 'id', 'coverage', 'fileid');
-        DatabaseCleanupUtils::deleteUnusedRows('dailyupdatefile', 'dailyupdateid', 'dailyupdate');
         DatabaseCleanupUtils::deleteUnusedRows('note', 'id', 'build2note', 'noteid');
         DatabaseCleanupUtils::deleteUnusedRows('testoutput', 'id', 'build2test', 'outputid');
         DatabaseCleanupUtils::deleteUnusedRows('uploadfile', 'id', 'build2uploadfile', 'fileid');

--- a/app/Http/Controllers/ManageProjectRolesController.php
+++ b/app/Http/Controllers/ManageProjectRolesController.php
@@ -329,56 +329,6 @@ final class ManageProjectRolesController extends AbstractProjectController
 
                 $xml .= '</user>';
             }
-
-            if (is_array($project_array)) {
-                // Check if a user is committing without being registered to CDash or with email disabled
-                $date = date(FMT_DATETIME, strtotime(date(FMT_DATETIME) . ' -30 days'));
-                $query = $db->executePrepared('
-                             SELECT DISTINCT
-                                 author,
-                                 emailtype,
-                                 u.email
-                             FROM
-                                 dailyupdate,
-                                 dailyupdatefile
-                             LEFT JOIN user2repository ON (
-                                 dailyupdatefile.author=user2repository.credential
-                                 AND (
-                                     user2repository.projectid=0
-                                     OR user2repository.projectid=?
-                                 )
-                             )
-                             LEFT JOIN user2project ON (
-                                 user2repository.userid= user2project.userid
-                                 AND user2project.projectid=?
-                             )
-                             LEFT JOIN users AS u ON (
-                                 user2project.userid=u.id
-                             )
-                             WHERE
-                                 dailyupdatefile.dailyupdateid=dailyupdate.id
-                                 AND dailyupdate.projectid=?
-                                 AND dailyupdatefile.checkindate>?
-                                 AND (
-                                     emailtype=0
-                                     OR emailtype IS NULL
-                                 )
-                         ', [
-                    intval($project_array['id']),
-                    intval($project_array['id']),
-                    intval($project_array['id']),
-                    $date,
-                ]);
-
-                add_last_sql_error('ManageProjectRole');
-                foreach ($query as $query_array) {
-                    $xml .= '<baduser>';
-                    $xml .= add_XML_value('author', $query_array['author']);
-                    $xml .= add_XML_value('emailtype', $query_array['emailtype']);
-                    $xml .= add_XML_value('email', $query_array['email']);
-                    $xml .= '</baduser>';
-                }
-            }
         }
 
         if ((bool) config('require_full_email_when_adding_user')) {

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -202,13 +202,6 @@ class Project
         DB::delete('DELETE FROM labelemail WHERE projectid=?', [intval($this->Id)]);
         DB::delete('DELETE FROM project2repositories WHERE projectid=?', [intval($this->Id)]);
 
-        $dailyupdate = DB::select('SELECT id FROM dailyupdate WHERE projectid=?', [intval($this->Id)]);
-        $dailyupdate_ids = [];
-        foreach ($dailyupdate as $dailyupdate_array) {
-            $dailyupdate_ids[] = (int) $dailyupdate_array->id;
-        }
-        DB::table('dailyupdatefile')->whereIn('dailyupdateid', $dailyupdate_ids)->delete();
-
         DB::delete('DELETE FROM dailyupdate WHERE projectid=?', [intval($this->Id)]);
         DB::delete('DELETE FROM build_filters WHERE projectid=?', [intval($this->Id)]);
 

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -982,44 +982,11 @@ function addDailyChanges(int $projectid): void
 
         // Insert the commits
         foreach ($commits as $commit) {
-            $filename = $commit['directory'] . '/' . $commit['filename'];
-            $checkindate = $commit['time'];
             $author = addslashes($commit['author']);
-            $email = '';
-            if (isset($commit['email'])) {
-                $email = addslashes($commit['email']);
-            }
-            $log = addslashes($commit['comment']);
-            $revision = $commit['revision'];
-            $priorrevision = $commit['priorrevision'];
 
             if (!in_array(stripslashes($author), $cvsauthors)) {
                 $cvsauthors[] = stripslashes($author);
             }
-
-            $db->executePreparedSingleRow('
-                INSERT INTO dailyupdatefile (
-                    dailyupdateid,
-                    filename,
-                    checkindate,
-                    author,
-                    email,
-                    log,
-                    revision,
-                    priorrevision
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ', [
-                $updateid,
-                $filename,
-                $checkindate,
-                $author,
-                $email,
-                $log,
-                $revision,
-                $priorrevision,
-            ]);
-            add_last_sql_error('addDailyChanges', $projectid);
         }
 
         // If the project has the option to send an email to the author

--- a/app/cdash/public/manageProjectRoles.xsl
+++ b/app/cdash/public/manageProjectRoles.xsl
@@ -115,24 +115,6 @@
 
           <table width="800"  border="0">
             <tr>
-            <td><div align="right"></div></td>
-            <td>
-            <span style="color: #ff0000;">
-              <xsl:for-each select="cdash/baduser">
-              <xsl:choose>
-                <xsl:when test="emailtype=0">
-                * <b><xsl:value-of select="author"/></b> (<xsl:value-of select="email"/>) doesn't want to receive emails but has been submitting in the past month.
-                </xsl:when>
-                <xsl:otherwise>
-                * <b><xsl:value-of select="author"/></b> is not registered for this project but has been submitting in the past month.
-                </xsl:otherwise>
-              </xsl:choose>
-              <br/>
-              </xsl:for-each>
-              </span>
-            </td>
-            </tr>
-            <tr>
              <td><div align="right"></div></td>
              <td>
              <table width="850">

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -414,16 +414,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
             'status' => 0,
             'revision' => 'DEADBEEF',
         ]);
-        DB::table('dailyupdatefile')->insert([
-            'dailyupdateid' => $dailyupdate_id,
-            'filename' => 'test_removebuilds.php',
-            'checkindate' => $time,
-            'author' => 'CDash',
-            'email' => 'admin@cdash.org',
-            'log' => 'test_removebuilds.php',
-            'revision' => 'DEADBEEF',
-            'priorrevision' => '00000000',
-        ]);
         $image_id = DB::table('image')->insertGetId([
             'img' => 'asdf',
             'extension' => 'png',
@@ -455,7 +445,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('configure', 'id', '=', $configure_id, 0, $extra_msg);
         $this->verify('coveragefile', 'id', '=', $coveragefile_id, 0, $extra_msg);
         $this->verify('dailyupdate', 'id', '=', $dailyupdate_id, 0, $extra_msg);
-        $this->verify('dailyupdatefile', 'dailyupdateid', '=', $dailyupdate_id, 0, $extra_msg);
         $this->verify('image', 'id', '=', $image_id, 0, $extra_msg);
         $this->verify('note', 'id', '=', $note_id, 0, $extra_msg);
         $this->verify('testoutput', 'id', '=', $testoutput_id, 0, $extra_msg);

--- a/database/migrations/2025_02_06_220212_drop_dailyupdatefile_table.php
+++ b/database/migrations/2025_02_06_220212_drop_dailyupdatefile_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::dropIfExists('dailyupdatefile');
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('dailyupdatefile')) {
+            Schema::create('dailyupdatefile', function (Blueprint $table) {
+                $table->integer('dailyupdateid')->default(0)->index();
+                $table->string('filename')->default('');
+                $table->timestamp('checkindate')->default(DB::raw('CURRENT_TIMESTAMP'));
+                $table->string('author')->default('')->index();
+                $table->string('email')->default('');
+                $table->text('log');
+                $table->string('revision', 60)->default('0');
+                $table->string('priorrevision', 60)->default('0');
+            });
+        }
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1737,7 +1737,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 5
+			count: 4
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1750,7 +1750,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1774,7 +1774,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 4
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1904,21 +1904,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 4
+			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: "#^Parameter \\#2 \\$timestamp of function date expects int\\|null, int\\|false given\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: "#^Variable \\$project_array might not be defined\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
@@ -14037,7 +14027,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -14061,7 +14051,7 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 8
+			count: 7
 			path: app/cdash/include/dailyupdates.php
 
 		-


### PR DESCRIPTION
The `dailyupdatefile` table is currently only used to display a list of users who have committed to the project recently but don't have a CDash account.  As we rethink what it means for CDash to be integrated with version control systems, it seems unlikely that we will want CDash to be responsible for interacting with version control systems directly, instead relying upon CTest to include the necessary information in the Update step.