### PR TITLE
Make buildgroup description column nullable

### DIFF
--- a/app/Models/BuildGroup.php
+++ b/app/Models/BuildGroup.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon $starttime
  * @property Carbon $endtime
  * @property int $autoremovetimeframe
- * @property string $description
+ * @property ?string $description
  * @property int $summaryemail
  * @property int $includesubprojectotal // Should this be a boolean?
  * @property int $emailcommitters // Should this be a boolean?

--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -151,7 +151,7 @@ class BuildGroup
     }
 
     /** Get/Set the description */
-    public function GetDescription(): string|false
+    public function GetDescription(): string|false|null
     {
         if (!isset($this->eloquent_model->id)) {
             Log::error('BuildGroup GetDescription(): Id not set');

--- a/database/migrations/2025_02_07_140349_nullable_buildgroup_description.php
+++ b/database/migrations/2025_02_07_140349_nullable_buildgroup_description.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('buildgroup', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        // Nothing to do here.  We don't want to roll back any systems which were inconsistent in the first place.
+    }
+};


### PR DESCRIPTION
The `buildgroup` table's `description` column is not-null for systems created since the switch to Laravel, but this column may be nullable for older systems.  Given that the description is not a mandatory field, it makes sense to make this field nullable for all systems.  For older systems, nothing will change.  For newer systems, the buildgroup description will now be nullable.