### PR TITLE
Stick header to top of screen on scroll

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -320,8 +320,11 @@ a.sup {
 
 
 /** New CSS starts here */
-div#header {
-  width:100%;
+#header {
+  width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 9999;
 }
 
 #headername2 {


### PR DESCRIPTION
The current site header scrolls with the page content.  This behavior is not ideal because users who have navigated to the bottom of a long list of builds/tests/etc then have to scroll all the way to the top to access the menu options.  This PR sticks the page header to the top of the viewport on scroll, meaning that menu items will be accessible all the time.