### PR TITLE
Remove obsolete user credentials feature

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -634,29 +634,7 @@ final class BuildController extends AbstractBuildController
             $file['filename'] = $update_file->Filename;
             $file['author'] = $update_file->Author;
             $file['status'] = $update_file->Status;
-
-            // Only display email if the user is logged in.
-            if (Auth::check()) {
-                if ($update_file->Email == '') {
-                    // Try to find author email from repository credentials.
-                    $stmt = $db->prepare('
-                SELECT email FROM user WHERE id IN (
-                  SELECT up.userid FROM user2project AS up, user2repository AS ur
-                   WHERE ur.userid=up.userid
-                   AND up.projectid=:projectid
-                   AND ur.credential=:author
-                   AND (ur.projectid=0 OR ur.projectid=:projectid) )
-                   LIMIT 1');
-                    $stmt->bindParam(':projectid', $this->project->Id);
-                    $stmt->bindParam(':author', $file['author']);
-                    $db->execute($stmt);
-                    $file['email'] = $stmt ? $stmt->fetchColumn() : '';
-                } else {
-                    $file['email'] = $update_file->Email;
-                }
-            } else {
-                $file['email'] = '';
-            }
+            $file['email'] = '';
 
             $file['log'] = $update_file->Log;
             $file['revision'] = $update_file->Revision;

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -435,36 +435,6 @@ final class UserController extends AbstractController
             $error_msg = 'Password has expired';
         }
 
-        // Update the credentials
-        if (isset($_POST['updatecredentials'])) {
-            $credentials = $_POST['credentials'] ?? [];
-            $UserProject = new UserProject();
-            $UserProject->ProjectId = 0;
-            $UserProject->UserId = $userid;
-            $credentials[] = $user->Email;
-            $UserProject->UpdateCredentials($credentials);
-        }
-
-        // List the credentials
-        $credentials_query = DB::select('
-            SELECT credential
-            FROM user2repository
-            WHERE
-                userid = ?
-              AND projectid = 0
-        ', [(int) $userid]);
-
-        $credentials = [];
-
-        foreach ($credentials_query as $credential) {
-            if ($credential->credential === $user->Email) {
-                // Move the email credential (which cannot be changed) to the top of the array
-                array_unshift($credentials, $credential->credential);
-            } else {
-                $credentials[] = $credential->credential;
-            }
-        }
-
         if (($_GET['reason'] ?? '') === 'expired') {
             $error_msg = 'Your password has expired. Please set a new one.';
         }
@@ -472,8 +442,7 @@ final class UserController extends AbstractController
         return $this->view('auth.profile')
             ->with('user', $user)
             ->with('error', $error_msg)
-            ->with('message', $other_msg)
-            ->with('credentials', $credentials);
+            ->with('message', $other_msg);
     }
 
     public function recoverPassword(): View

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -1524,23 +1524,8 @@ class Build
         // Find user by email address.
         $user = User::firstWhere('email', $email);
         if ($user === null) {
-            // Find user by author name.
-            $stmt = $this->PDO->prepare(
-                'SELECT up.userid FROM user2project AS up
-                JOIN user2repository AS ur ON (ur.userid=up.userid)
-                WHERE up.projectid=:projectid
-                AND (ur.credential=:author OR ur.credential=:email)
-                AND (ur.projectid=0 OR ur.projectid=:projectid)');
-            $stmt->bindParam(':projectid', $this->ProjectId);
-            $stmt->bindParam(':author', $author);
-            $stmt->bindParam(':email', $email);
-            pdo_execute($stmt);
-            $row = $stmt->fetch();
-            if (!$row) {
-                // Unable to find user, return early.
-                return;
-            }
-            $userid = $row['userid'];
+            // Unable to find user, return early.
+            return;
         } else {
             $userid = $user->id;
         }
@@ -2700,19 +2685,7 @@ class Build
      */
     public function AuthoredBy(SubscriberInterface $subscriber): bool
     {
-        $authoredBy = false;
-        $authors = $this->GetCommitAuthors();
-        $credentials = $subscriber->getUserCredentials();
-        $credentials[] = $subscriber->getAddress();
-
-        foreach (array_unique($credentials) as $credential) {
-            if (in_array($credential, $authors)) {
-                $authoredBy = true;
-                break;
-            }
-        }
-
-        return $authoredBy;
+        return in_array($subscriber->getAddress(), $this->GetCommitAuthors());
     }
 
     /**

--- a/app/cdash/app/Model/Subscriber.php
+++ b/app/cdash/app/Model/Subscriber.php
@@ -151,9 +151,4 @@ class Subscriber implements SubscriberInterface
     {
         return $this->user->Id;
     }
-
-    public function getUserCredentials()
-    {
-        return $this->user->GetRepositoryCredentials();
-    }
 }

--- a/app/cdash/app/Model/SubscriberInterface.php
+++ b/app/cdash/app/Model/SubscriberInterface.php
@@ -58,9 +58,4 @@ interface SubscriberInterface
      * @return NotificationPreferencesInterface
      */
     public function getNotificationPreferences();
-
-    /**
-     * @return array
-     */
-    public function getUserCredentials();
 }

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -34,7 +34,6 @@ class User
     public $Admin;
     private $Filled;
     private $PDO;
-    private $Credentials;
     private $LabelCollection;
 
     public function __construct()
@@ -48,7 +47,6 @@ class User
         $this->Admin = 0;
         $this->Filled = false;
         $this->PDO = Database::getInstance();
-        $this->Credentials = null;
         $this->LabelCollection = collect();
     }
 
@@ -202,29 +200,6 @@ class User
                 ])->delete();
             }
         }
-    }
-
-    /**
-     * Returns the current User's repository credentials. (There may be multiple credentials
-     * for multiple repositories).
-     *
-     * @return array|bool|null
-     */
-    public function GetRepositoryCredentials()
-    {
-        if (is_null($this->Credentials)) {
-            if (!$this->Id) {
-                return false;
-            }
-
-            $sql = 'SELECT credential FROM user2repository WHERE userid = :id';
-            $stmt = $this->PDO->prepare($sql);
-            $stmt->bindParam(':id', $this->Id);
-            if ($this->PDO->execute($stmt)) {
-                $this->Credentials = $stmt->fetchAll(PDO::FETCH_COLUMN);
-            }
-        }
-        return $this->Credentials;
     }
 
     /**

--- a/app/cdash/public/manageProjectRoles.xsl
+++ b/app/cdash/public/manageProjectRoles.xsl
@@ -122,7 +122,6 @@
                 <td><center><b>User</b></center></td>
                 <td><center><b>Email</b></center></td>
                 <td><center><b>Role</b></center></td>
-                <td><center><b>Repository Credentials<br/>(cred1;cred2;)</b></center></td>
                 <td><center><b>Notifications</b></center></td>
                 <td><center><b>Action</b></center></td>
                </tr>
@@ -143,11 +142,6 @@
                  <option value="1"><xsl:if test="role=1"><xsl:attribute name="selected"></xsl:attribute></xsl:if>Site maintainer</option>
                  <option value="2"><xsl:if test="role=2"><xsl:attribute name="selected"></xsl:attribute></xsl:if>Project Administrator</option>
                 </select>
-                </td>
-               <td>
-                 <input name="credentials" type="text">
-                  <xsl:attribute name="value"><xsl:for-each select="repositorycredential"><xsl:value-of select="."/>;</xsl:for-each></xsl:attribute>
-                 </input>
                 </td>
                 <td>
                 <select name="emailtype">
@@ -238,14 +232,6 @@
               </td>
               </tr>
               <tr>
-              <td><div align="right">Repository credential:</div></td>
-              <td>
-              <input name="registeruserrepositorycredential" type="text" id="registeruserrepositorycredential" size="40"/>
-              * email address is automatically added as a credential
-              </td>
-              </tr>
-              <tr>
-              <td></td>
               <td>
               <input type="submit" name="registerUser" value="Register User"/>
               </td>

--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -50,8 +50,6 @@
           <li>
             <a class="cdash-link" href="#fragment-1"><span>Select your role in this project</span></a></li>
           <li>
-            <a class="cdash-link" href="#fragment-2"><span>Repository Credential</span></a></li>
-          <li>
             <a class="cdash-link" href="#fragment-3"><span>Email Notifications</span></a></li>
           <li>
             <a class="cdash-link" href="#fragment-4"><span>Email Category</span></a></li>
@@ -106,56 +104,6 @@
           </tr>
           </xsl:if>
            <tr>
-            <td></td>
-            <td bgcolor="#FFFFFF"></td>
-          </tr>
-        </table>
-    </div>
-    <div id="fragment-2" class="tab_content" >
-      <div class="tab_help"></div>
-        <table width="800">
-         <tr>
-            <td></td>
-            <td>Your repository credentials are used to match your repository id with cdash and send you alerts.<br/>
-            To change your global credentials go to "My Profile".
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td>Global Credentials:
-             <xsl:for-each select="/cdash/global_credential">
-               '<xsl:value-of select="."/>'
-             </xsl:for-each>
-            </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td>Credential #1: <input onchange="saveChanges();" type="text" name="credentials[0]" size="30">
-             <xsl:attribute name="value">
-               <xsl:value-of select="cdash/credential_0"/>
-             </xsl:attribute>
-             </input>
-             </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td>Credential #2: <input onchange="saveChanges();" type="text" name="credentials[1]" size="30">
-             <xsl:attribute name="value">
-               <xsl:value-of select="cdash/credential_1"/>
-             </xsl:attribute>
-             </input>
-             </td>
-          </tr>
-          <tr>
-            <td></td>
-            <td>Credential #3: <input onchange="saveChanges();" type="text" name="credentials[2]" size="30">
-             <xsl:attribute name="value">
-               <xsl:value-of select="cdash/credential_2"/>
-             </xsl:attribute>
-             </input>
-             </td>
-          </tr>
-          <tr>
             <td></td>
             <td bgcolor="#FFFFFF"></td>
           </tr>

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -4,7 +4,6 @@ use App\Enums\TestDiffType;
 use App\Models\Site;
 use App\Models\TestDiff;
 use App\Models\User;
-use CDash\Database;
 use Illuminate\Support\Facades\DB;
 
 require_once dirname(__FILE__) . '/cdash_test_case.php';
@@ -131,24 +130,6 @@ class EmailTestCase extends KWWebTestCase
         if ($this->assertLogContains($expected, 13)) {
             $this->pass('Passed');
         }
-
-        // Also check that viewUpdate shows email address for logged in users.
-        $db = Database::getInstance();
-        $stmt = $db->prepare("
-                SELECT build.id FROM build
-                JOIN project ON (build.projectid = project.id)
-                JOIN build2update ON (build.id = build2update.buildid)
-                WHERE build.name = 'Win32-MSVC2009' AND
-                      project.name = 'EmailProjectExample'");
-        $db->execute($stmt);
-        $buildid = $stmt->fetchColumn();
-        $this->login();
-        $this->get($this->url . "/api/v1/viewUpdate.php?buildid=$buildid");
-        $content = $this->getBrowser()->getContent();
-        $jsonobj = json_decode($content, true);
-        $expected = 'user1@kw';
-        $actual = $jsonobj['updategroups'][0]['directories'][0]['files'][0]['email'];
-        $this->assertEqual($expected, $actual);
     }
 
     public function testSubmissionEmailTest()

--- a/app/cdash/tests/test_manageprojectroles.php
+++ b/app/cdash/tests/test_manageprojectroles.php
@@ -32,9 +32,6 @@ class ManageProjectRolesTestCase extends KWWebTestCase
         if (!$this->setFieldByName('registeruserlastname', 'User')) {
             $this->fail('Set user last name returned false');
         }
-        if (!$this->setFieldByName('registeruserrepositorycredential', 'simpleuser')) {
-            $this->fail('Set user repository credential returned false');
-        }
         $this->clickSubmitByName('registerUser');
         if (!str_contains($this->getBrowser()->getContentAsText(), $email)) {
             $this->fail("'{$email}' not found when expected");
@@ -48,9 +45,6 @@ class ManageProjectRolesTestCase extends KWWebTestCase
         // Verify that they are no longer associated with this project.
         if (DB::table('user2project')->where('userid', $user->id)->where('projectid', $this->projectid)->exists()) {
             $this->fail('user2project row still exists after deletion');
-        }
-        if (DB::table('user2repository')->where('userid', $user->id)->where('projectid', $this->projectid)->exists()) {
-            $this->fail('user2repository row still exists after deletion');
         }
     }
 

--- a/database/migrations/2025_02_12_204506_drop_user2repository_table.php
+++ b/database/migrations/2025_02_12_204506_drop_user2repository_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('user2repository')) {
+            Schema::table('user2repository', function (Blueprint $table) {
+                $table->dropForeign(['projectid']);
+                $table->dropForeign(['userid']);
+                $table->drop();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // No way to reverse the deletion of credentials
+        if (!Schema::hasTable('user2repository')) {
+            Schema::create('user2repository', function (Blueprint $table) {
+                $table->integer('userid')->index();
+                $table->string('credential', 255)->index();
+                $table->integer('projectid')->default(0)->index();
+                $table->foreign('userid')->references('id')->on('users')->cascadeOnDelete();
+                $table->foreign('projectid')->references('id')->on('project')->cascadeOnDelete();
+            });
+        }
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -605,23 +605,7 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: """
 				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: """
-				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
@@ -665,11 +649,6 @@ parameters:
 		-
 			message: "#^Cannot access property \\$name on App\\\\Models\\\\Site\\|null\\.$#"
 			count: 4
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Cannot call method bindParam\\(\\) on PDOStatement\\|false\\.$#"
-			count: 2
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -719,7 +698,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 4
+			count: 3
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -783,11 +762,6 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PDOStatement\\|false given\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
 			message: "#^Only numeric types are allowed in \\*, \\(int\\|false\\) given on the left side\\.$#"
 			count: 2
 			path: app/Http/Controllers/BuildController.php
@@ -840,11 +814,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$stmt of function pdo_execute expects PDOStatement, \\(PDOStatement\\|false\\) given\\.$#"
 			count: 4
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
-			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -1747,7 +1716,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 4
+			count: 3
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1760,7 +1729,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 2
+			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1784,17 +1753,12 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 4
+			count: 3
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
 			message: "#^Cannot access offset 'tmp_name' on mixed\\.$#"
 			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: "#^Cannot access offset int\\<0, max\\> on mixed\\.$#"
-			count: 5
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1848,11 +1812,6 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:register_user\\(\\) has parameter \\$repositoryCredential with no type specified\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\ManageProjectRolesController\\:\\:viewPage\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
@@ -1864,7 +1823,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 6
+			count: 5
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
@@ -1908,17 +1867,7 @@ parameters:
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: app/Http/Controllers/ManageProjectRolesController.php
-
-		-
-			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/ManageProjectRolesController.php
 
@@ -2588,11 +2537,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
 
@@ -2601,7 +2545,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 5
+			count: 4
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -2635,11 +2579,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$array of function array_diff expects array, array\\<int\\>\\|false given\\.$#"
 			count: 1
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
-			message: "#^Parameter \\#1 \\$credentials of method CDash\\\\Model\\\\UserProject\\:\\:UpdateCredentials\\(\\) expects array, mixed given\\.$#"
-			count: 2
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -2802,11 +2741,6 @@ parameters:
 			path: app/Http/Controllers/UserController.php
 
 		-
-			message: "#^Cannot access an offset on mixed\\.$#"
-			count: 1
-			path: app/Http/Controllers/UserController.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 2
 			path: app/Http/Controllers/UserController.php
@@ -2898,11 +2832,6 @@ parameters:
 
 		-
 			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
-			count: 1
-			path: app/Http/Controllers/UserController.php
-
-		-
-			message: "#^Parameter \\#1 \\$credentials of method CDash\\\\Model\\\\UserProject\\:\\:UpdateCredentials\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: app/Http/Controllers/UserController.php
 
@@ -7221,7 +7150,7 @@ parameters:
 				#^Call to deprecated function pdo_execute\\(\\)\\:
 				v2\\.5\\.0 01/22/2018$#
 			"""
-			count: 28
+			count: 27
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -10838,16 +10767,6 @@ parameters:
 			path: app/cdash/app/Model/Subscriber.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getUserCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Subscriber.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getUserCredentials\\(\\) should return array but returns array\\|bool\\|null\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Subscriber.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\Subscriber\\:\\:getUserId\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
@@ -10896,11 +10815,6 @@ parameters:
 			message: "#^Return type \\(CDash\\\\Model\\\\Collection\\) of method CDash\\\\Model\\\\Subscriber\\:\\:getLabels\\(\\) should be compatible with return type \\(array\\<string\\>\\) of method CDash\\\\Model\\\\SubscriberInterface\\:\\:getLabels\\(\\)$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\SubscriberInterface\\:\\:getUserCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/SubscriberInterface.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\SubscriberInterface\\:\\:setAddress\\(\\) has no return type specified\\.$#"
@@ -11030,22 +10944,12 @@ parameters:
 			path: app/cdash/app/Model/User.php
 
 		-
-			message: "#^Method CDash\\\\Model\\\\User\\:\\:GetRepositoryCredentials\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
 			message: "#^Method CDash\\\\Model\\\\User\\:\\:Save\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
 		-
 			message: "#^Property CDash\\\\Model\\\\User\\:\\:\\$Admin has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/User.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\User\\:\\:\\$Credentials has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/User.php
 
@@ -11099,7 +11003,7 @@ parameters:
 				#^Call to deprecated function add_last_sql_error\\(\\)\\:
 				04/22/2023$#
 			"""
-			count: 5
+			count: 2
 			path: app/cdash/app/Model/UserProject.php
 
 		-
@@ -11115,7 +11019,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/UserProject.php
 
 		-
@@ -11123,7 +11027,7 @@ parameters:
 				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 3
+			count: 1
 			path: app/cdash/app/Model/UserProject.php
 
 		-
@@ -11136,26 +11040,11 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'c' on array\\|false\\|null\\.$#"
-			count: 2
-			path: app/cdash/app/Model/UserProject.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: app/cdash/app/Model/UserProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\UserProject\\:\\:AddCredential\\(\\) has parameter \\$credential with no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/UserProject.php
 
 		-
 			message: "#^Method CDash\\\\Model\\\\UserProject\\:\\:GetProjects\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/cdash/app/Model/UserProject.php
-
-		-
-			message: "#^Method CDash\\\\Model\\\\UserProject\\:\\:UpdateCredentials\\(\\) has parameter \\$credentials with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/app/Model/UserProject.php
 
@@ -11186,11 +11075,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\UserProject\\:\\:\\$ProjectId has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/UserProject.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\UserProject\\:\\:\\$RepositoryCredential has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/UserProject.php
 
@@ -13835,7 +13719,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 6
+			count: 5
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -13864,7 +13748,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 9
+			count: 8
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -13925,7 +13809,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
+			count: 4
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -14064,11 +13948,6 @@ parameters:
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: "#^Function sendEmailUnregisteredUsers\\(\\) has parameter \\$cvsauthors with no type specified\\.$#"
-			count: 1
-			path: app/cdash/include/dailyupdates.php
-
-		-
 			message: "#^Implicit array creation is not allowed \\- variable \\$commit might not exist\\.$#"
 			count: 3
 			path: app/cdash/include/dailyupdates.php
@@ -14085,7 +13964,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 15
+			count: 14
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -22609,24 +22488,8 @@ parameters:
 			path: app/cdash/tests/test_dynamicanalysissummary.php
 
 		-
-			message: """
-				#^Call to deprecated method execute\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
 			message: "#^Call to deprecated method pass\\(\\) of class SimpleTestCase\\.$#"
 			count: 5
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: """
-				#^Call to deprecated method prepare\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -22635,31 +22498,6 @@ parameters:
 				12/09/2024  Use \\\\Test\\\\Traits\\\\CreatesSubmissions instead$#
 			"""
 			count: 10
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot access offset 'directories' on mixed\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot access offset 'email' on mixed\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot access offset 'files' on mixed\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot access offset 'updategroups' on mixed\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 3
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -22695,11 +22533,6 @@ parameters:
 		-
 			message: "#^Cannot access property \\$type on mixed\\.$#"
 			count: 4
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Cannot call method fetchColumn\\(\\) on PDOStatement\\|false\\.$#"
-			count: 1
 			path: app/cdash/tests/test_email.php
 
 		-
@@ -22744,11 +22577,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
-			count: 1
-			path: app/cdash/tests/test_email.php
-
-		-
-			message: "#^Parameter \\#1 \\$stmt of method CDash\\\\Database\\:\\:execute\\(\\) expects PDOStatement, PDOStatement\\|false given\\.$#"
 			count: 1
 			path: app/cdash/tests/test_email.php
 
@@ -24347,7 +24175,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$id on App\\\\Models\\\\User\\|null\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_manageprojectroles.php
 
 		-

--- a/resources/js/angular/views/partials/build.html
+++ b/resources/js/angular/views/partials/build.html
@@ -224,7 +224,6 @@
                 build.update.errors == 1 ? 'error': (
                 build.update.warning == 1 ? 'warning' : 'normal'))">
   <div ng-if="::build.hasupdate">
-    <img ng-if="::build.userupdates > 0" src="img/yellowled.png" height="10px" alt="star" title="I checked in some code for this build!"/>
     <a class="cdash-link" ng-href="build/{{::build.id}}/update">
       {{::build.update.files}}
     </a>

--- a/resources/views/admin/ajax-find-user-project.blade.php
+++ b/resources/views/admin/ajax-find-user-project.blade.php
@@ -13,7 +13,6 @@
                             <option value="1">Site maintainer</option>
                             <option value="2">Project administrator</option>
                         </select>
-                        Repository credential: <input name="repositoryCredential" type="text" size="20"/>
                         <input name="adduser" type="submit" value="add user">
                     </form>
                 </font>

--- a/resources/views/auth/profile.blade.php
+++ b/resources/views/auth/profile.blade.php
@@ -18,9 +18,6 @@
     <form method="post" action="" id="password_form">
         @csrf
     </form>
-    <form method="post" action="" id="credentials_form">
-        @csrf
-    </form>
 
     <table border="0" cellpadding="4" cellspacing="0" width="100%" class="tabb striped">
         <thead>
@@ -157,73 +154,6 @@
                 </td>
             </tr>
 
-            {{-- Credentials Form --}}
-            <tr>
-                <td width="20%" height="2">
-                    <div align="right">Repository Credential #1</div>
-                </td>
-                <td width="80%" height="2">
-                    @if(count($credentials) === 0)
-                        Not found (you should really add it)
-                    @else
-                        {{ $credentials[0] }}
-                    @endif
-                </td>
-            </tr>
-            <tr>
-                <td width="20%" height="2">
-                    <div align="right">Repository Credential #2</div>
-                </td>
-                <td width="80%" height="2">
-                    <input
-                        class="textbox"
-                        type="text"
-                        name="credentials[1]"
-                        value="{{ $credentials[1] ?? '' }}"
-                        form="credentials_form"
-                    >
-                </td>
-            </tr>
-            <tr>
-                <td width="20%" height="2">
-                    <div align="right">Repository Credential #3</div>
-                </td>
-                <td width="80%" height="2">
-                    <input
-                        class="textbox"
-                        type="text"
-                        name="credentials[2]"
-                        value="{{ $credentials[2] ?? '' }}"
-                        form="credentials_form"
-                    >
-                </td>
-            </tr>
-            <tr>
-                <td width="20%" height="2">
-                    <div align="right">Repository Credential #4</div>
-                </td>
-                <td width="80%" height="2">
-                    <input
-                        class="textbox"
-                        type="text"
-                        name="credentials[3]"
-                        value="{{ $credentials[3] ?? '' }}"
-                        form="credentials_form"
-                    >
-                </td>
-            </tr>
-            <tr>
-                <td width="20%"></td>
-                <td width="80%">
-                    <input
-                        type="submit"
-                        value="Update Credentials"
-                        name="updatecredentials"
-                        class="textbox"
-                        form="credentials_form"
-                    >
-                </td>
-            </tr>
             {{-- Other Misc Info --}}
             <tr>
                 <td width="20%" height="2">


### PR DESCRIPTION
User credentials are no longer used for anything but matching email addresses to themselves through convoluted code paths.  This PR removes all references to user credentials in the UI and deletes the underlying `user2repository` table.