### PR TITLE
Fix buggy site information deduplication behavior

### DIFF
--- a/app/Http/Submission/Traits/UpdatesSiteInformation.php
+++ b/app/Http/Submission/Traits/UpdatesSiteInformation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Submission\Traits;
+
+use App\Models\Site;
+use App\Models\SiteInformation;
+
+trait UpdatesSiteInformation
+{
+    /**
+     * Saves a new site information record if $newInformation is different from the most recent
+     * information recorded for the site.
+     */
+    protected function updateSiteInfoIfChanged(Site $site, SiteInformation $newInformation): void
+    {
+        if ($site->information()->count() === 0) {
+            // No existing information, so save whatever we're given, regardless of whether it's all null.
+            $site->information()->save($newInformation);
+            return;
+        }
+
+        $all_attributes_null = true;
+        foreach ($newInformation->getFillable() as $attribute) {
+            $all_attributes_null = $all_attributes_null && $newInformation->getAttribute($attribute) === null;
+        }
+
+        if ($all_attributes_null) {
+            // Don't save information which is all null unless this is the first information we've received.
+            return;
+        }
+
+        foreach ($newInformation->getFillable() as $attribute) {
+            if ($site->mostRecentInformation?->getAttribute($attribute) !== $newInformation->getAttribute($attribute)) {
+                // Something changed, so we can go ahead and save the new information.
+                $site->information()->save($newInformation);
+                return;
+            }
+        }
+    }
+}

--- a/app/Models/SiteInformation.php
+++ b/app/Models/SiteInformation.php
@@ -33,7 +33,6 @@ class SiteInformation extends Model
     public $timestamps = false;
 
     protected $fillable = [
-        'timestamp',
         'processoris64bits',
         'processorvendor',
         'processorvendorid',

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -278,6 +278,9 @@ set_tests_properties(/Feature/Mail/AuthTokenExpiredTest PROPERTIES DEPENDS /CDas
 add_laravel_test(/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest)
 set_tests_properties(/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/Traits/UpdatesSiteInformationTest)
+set_tests_properties(/Feature/Traits/UpdatesSiteInformationTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 cdash_install()
@@ -317,6 +320,7 @@ set_property(TEST install_3 PROPERTY DEPENDS
   /Feature/Mail/AuthTokenExpiringTest
   /Feature/Mail/AuthTokenExpiredTest
   /Feature/GraphQL/Mutations/UpdateSiteDescriptionTest
+  /Feature/Traits/UpdatesSiteInformationTest
 )
 
 

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -103,7 +103,7 @@ class TestUseCaseTest extends CDashUseCaseTestCase
         $builds = $handler->GetBuildCollection();
         /** @var Build $build */
         $build = $builds->current();
-        $information = $build->GetSite()->mostRecentInformation;
+        $information = $build->GetSite()?->refresh()->mostRecentInformation;
 
         $this->assertEquals($siteInformation['Description'], $information?->description);
         $this->assertEquals($siteInformation['Is64Bits'], $information?->processoris64bits);

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -15,6 +15,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
@@ -38,6 +39,7 @@ use CDash\Submission\CommitAuthorHandlerTrait;
 class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {
     use CommitAuthorHandlerTrait;
+    use UpdatesSiteInformation;
 
     private $StartTimeStamp;
     private $EndTimeStamp;
@@ -124,7 +126,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                 $this->BuildName = '(empty)';
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name == 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/cdash/xml_handlers/configure_handler.php
+++ b/app/cdash/xml_handlers/configure_handler.php
@@ -15,6 +15,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
@@ -33,6 +34,8 @@ use CDash\Model\SubscriberInterface;
 
 class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInterface
 {
+    use UpdatesSiteInformation;
+
     private $StartTimeStamp;
     private $EndTimeStamp;
     private $Builds;
@@ -117,7 +120,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                 $this->BuildName = '(empty)';
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name == 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/cdash/xml_handlers/coverage_handler.php
+++ b/app/cdash/xml_handlers/coverage_handler.php
@@ -15,6 +15,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
@@ -28,6 +29,8 @@ use CDash\Model\SubProject;
 
 class CoverageHandler extends AbstractXmlHandler
 {
+    use UpdatesSiteInformation;
+
     private $StartTimeStamp;
     private $EndTimeStamp;
 
@@ -83,7 +86,7 @@ class CoverageHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/cdash/xml_handlers/coverage_junit_handler.php
+++ b/app/cdash/xml_handlers/coverage_junit_handler.php
@@ -15,10 +15,10 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
-use CDash\Model\Build;
 use CDash\Model\Coverage;
 use CDash\Model\CoverageFile;
 use CDash\Model\CoverageSummary;
@@ -27,6 +27,8 @@ use CDash\Model\Project;
 
 class CoverageJUnitHandler extends AbstractXmlHandler
 {
+    use UpdatesSiteInformation;
+
     private $StartTimeStamp;
     private $EndTimeStamp;
 
@@ -79,7 +81,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/cdash/xml_handlers/dynamic_analysis_handler.php
+++ b/app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -15,6 +15,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
@@ -35,6 +36,8 @@ use CDash\Model\SubscriberInterface;
 
 class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBuildInterface
 {
+    use UpdatesSiteInformation;
+
     private $StartTimeStamp;
     private $EndTimeStamp;
     private $Checker;
@@ -112,7 +115,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
             if (empty($this->BuildName)) {
                 $this->BuildName = '(empty)';
             }
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name == 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -15,15 +15,17 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\NoteCreator;
 use App\Utils\SubmissionUtils;
-use CDash\Model\Build;
 use CDash\Model\Project;
 
 class NoteHandler extends AbstractXmlHandler
 {
+    use UpdatesSiteInformation;
+
     private $AdjustStartTime;
     private $NoteCreator;
     protected static ?string $schema_file = '/app/Validators/Schemas/Notes.xsd';
@@ -73,7 +75,7 @@ class NoteHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/cdash/xml_handlers/testing_handler.php
+++ b/app/cdash/xml_handlers/testing_handler.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\TestMeasurement;
@@ -25,6 +26,7 @@ use CDash\Submission\CommitAuthorHandlerTrait;
 class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {
     use CommitAuthorHandlerTrait;
+    use UpdatesSiteInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/Test.xsd';
     private $StartTimeStamp;
@@ -126,7 +128,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
             if (empty($this->BuildName)) {
                 $this->BuildName = '(empty)';
             }
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name == 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/cdash/xml_handlers/testing_j_unit_handler.php
+++ b/app/cdash/xml_handlers/testing_j_unit_handler.php
@@ -15,15 +15,17 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
 use App\Utils\TestCreator;
-use CDash\Model\Build;
 use CDash\Model\Project;
 
 class TestingJUnitHandler extends AbstractXmlHandler
 {
+    use UpdatesSiteInformation;
+
     private $StartTimeStamp;
     private $EndTimeStamp;
     // Should we update the end time of the build?
@@ -100,7 +102,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -15,10 +15,10 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Utils\SubmissionUtils;
-use CDash\Model\Build;
 use CDash\Model\Label;
 use CDash\Model\Project;
 use CDash\Model\UploadFile;
@@ -43,6 +43,8 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
  */
 class UploadHandler extends AbstractXmlHandler
 {
+    use UpdatesSiteInformation;
+
     private $UploadFile;
     private $TmpFilename;
     private $Base64TmpFileWriteHandle;
@@ -108,7 +110,7 @@ class UploadHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->Site->mostRecentInformation()->save($siteInformation);
+            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18081,11 +18081,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-
-			message: "#^Cannot access property \\$mostRecentInformation on App\\\\Models\\\\Site\\|null\\.$#"
-			count: 1
-			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
-
-		-
 			message: "#^Cannot call method GetTestCollection\\(\\) on mixed\\.$#"
 			count: 4
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -29490,6 +29485,11 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/build_handler.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 29
 			path: app/cdash/xml_handlers/build_handler.php
@@ -29695,6 +29695,11 @@ parameters:
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/configure_handler.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 13
 			path: app/cdash/xml_handlers/configure_handler.php
@@ -29840,6 +29845,11 @@ parameters:
 			path: app/cdash/xml_handlers/coverage_handler.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/coverage_handler.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 12
 			path: app/cdash/xml_handlers/coverage_handler.php
@@ -29922,6 +29932,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/coverage_junit_handler.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/coverage_junit_handler.php
 
 		-
@@ -30230,6 +30245,11 @@ parameters:
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 22
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -30357,6 +30377,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/note_handler.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/note_handler.php
 
 		-
@@ -30625,6 +30650,11 @@ parameters:
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: app/cdash/xml_handlers/testing_handler.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 34
 			path: app/cdash/xml_handlers/testing_handler.php
@@ -30787,6 +30817,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 4
+			path: app/cdash/xml_handlers/testing_j_unit_handler.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/testing_j_unit_handler.php
 
 		-
@@ -31022,6 +31057,11 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
+			path: app/cdash/xml_handlers/upload_handler.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
 			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
@@ -31869,6 +31909,11 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Http\\\\Response\\:\\:content\\(\\)\\.$#"
 			count: 1
 			path: tests/Feature/SlowPageTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: tests/Feature/Traits/UpdatesSiteInformationTest.php
 
 		-
 			message: "#^Cannot access property \\$admin on App\\\\Models\\\\User\\|null\\.$#"

--- a/tests/Browser/Pages/SitesIdPageTest.php
+++ b/tests/Browser/Pages/SitesIdPageTest.php
@@ -134,35 +134,33 @@ class SitesIdPageTest extends BrowserTestCase
     public function testHistoryList(): void
     {
         $this->sites['site1'] = $this->makeSite();
-        $this->sites['site1']->information()->createMany([
-            [
-                'timestamp' => Carbon::now()->subMinutes(5),
-                'totalphysicalmemory' => 5678,
-                'numberphysicalcpus' => 2,
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(4),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 4,
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(3),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 4,
-                'description' => 'description1',
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(2),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 4,
-                'description' => 'description2',
-            ],
-            [
-                'timestamp' => Carbon::now(),
-                'totalphysicalmemory' => 10765,
-                'numberphysicalcpus' => 8,
-                'description' => 'description2',
-            ],
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(5),
+            'totalphysicalmemory' => 5678,
+            'numberphysicalcpus' => 2,
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(4),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 4,
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(3),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 4,
+            'description' => 'description1',
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(2),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 4,
+            'description' => 'description2',
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now(),
+            'totalphysicalmemory' => 10765,
+            'numberphysicalcpus' => 8,
+            'description' => 'description2',
         ]);
 
         $this->browse(function (Browser $browser) {
@@ -198,27 +196,25 @@ class SitesIdPageTest extends BrowserTestCase
     public function testHistoryDeduplication(): void
     {
         $this->sites['site1'] = $this->makeSite();
-        $this->sites['site1']->information()->createMany([
-            [
-                'timestamp' => Carbon::now()->subMinutes(5),
-                'totalphysicalmemory' => 5678,
-                'numberphysicalcpus' => 2,
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(4),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 4,
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(3),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 4,
-            ],
-            [
-                'timestamp' => Carbon::now()->subMinutes(2),
-                'totalphysicalmemory' => 8765,
-                'numberphysicalcpus' => 6,
-            ],
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(5),
+            'totalphysicalmemory' => 5678,
+            'numberphysicalcpus' => 2,
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(4),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 4,
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(3),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 4,
+        ]);
+        $this->sites['site1']->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinutes(2),
+            'totalphysicalmemory' => 8765,
+            'numberphysicalcpus' => 6,
         ]);
 
         $this->browse(function (Browser $browser) {

--- a/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
@@ -99,7 +99,7 @@ class UpdateSiteDescriptionTest extends TestCase
 
     public function testMutationPreservesPreviousInformation(): void
     {
-        $this->site->information()->create([
+        $this->site->information()->forceCreate([
             'timestamp' => Carbon::create(2020),
             'description' => Str::uuid()->toString(),
             'processorclockfrequency' => 1234,

--- a/tests/Feature/Traits/UpdatesSiteInformationTest.php
+++ b/tests/Feature/Traits/UpdatesSiteInformationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Traits;
+
+use App\Http\Submission\Traits\UpdatesSiteInformation;
+use App\Models\Site;
+use App\Models\SiteInformation;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+use Tests\Traits\CreatesSites;
+
+class UpdatesSiteInformationTest extends TestCase
+{
+    use CreatesSites;
+    use UpdatesSiteInformation;
+
+    private Site $site;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->site = $this->makeSite();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->site->delete();
+
+        parent::tearDown();
+    }
+
+    public function testCreatesWhenNoInformation(): void
+    {
+        self::assertEmpty($this->site->information()->get());
+
+        $site_information = new SiteInformation([
+            'processorclockfrequency' => 1234,
+        ]);
+        $this->updateSiteInfoIfChanged($this->site, $site_information);
+
+        $this->site->refresh();
+        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+    }
+
+    public function testUpdatesWhenChangedInformation(): void
+    {
+        $this->site->information()->forceCreate([
+            'timestamp' => Carbon::now()->subMinute(),
+            'processorclockfrequency' => 1234,
+        ]);
+        $this->site->refresh();
+        self::assertCount(1, $this->site->information()->get());
+
+        $site_information = new SiteInformation([
+            'processorclockfrequency' => 2345,
+        ]);
+        $this->updateSiteInfoIfChanged($this->site, $site_information);
+
+        $this->site->refresh();
+        self::assertEquals(2345, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertCount(2, $this->site->information()->get());
+    }
+
+    public function testDoesNotUpdateWhenNoChange(): void
+    {
+        $this->site->information()->create([
+            'processorclockfrequency' => 1234,
+        ]);
+        $this->site->refresh();
+        self::assertCount(1, $this->site->information()->get());
+        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+
+        $site_information = new SiteInformation([
+            'processorclockfrequency' => 1234,
+        ]);
+        $this->updateSiteInfoIfChanged($this->site, $site_information);
+
+        $this->site->refresh();
+        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertCount(1, $this->site->information()->get());
+    }
+
+    public function testDoesNotSaveWhenAllNull(): void
+    {
+        $this->site->information()->create([
+            'processorclockfrequency' => 1234,
+        ]);
+        $this->site->refresh();
+        self::assertCount(1, $this->site->information()->get());
+        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation());
+
+        $this->site->refresh();
+        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertCount(1, $this->site->information()->get());
+    }
+
+    public function testCreatesInitialInformationWhenAllNull(): void
+    {
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation());
+
+        $this->site->refresh();
+        self::assertCount(1, $this->site->information()->get());
+    }
+}


### PR DESCRIPTION
Site information is currently mistakenly saved on every submission, regardless of whether any information actually changed.  This PR fixes the issue and adds tests to prevent it from occurring again.