### PR TITLE
Add XML path matching method to XML handlers

### DIFF
--- a/app/Utils/Stack.php
+++ b/app/Utils/Stack.php
@@ -2,10 +2,15 @@
 
 namespace App\Utils;
 
+use InvalidArgumentException;
+
+/**
+ * @template T
+ */
 class Stack
 {
     /**
-     * @var array<mixed>
+     * @var array<T>
      */
     private array $stack = [];
 
@@ -14,18 +19,29 @@ class Stack
         return count($this->stack);
     }
 
+    /**
+     * @param T $e
+     *
+     * @return self<T>
+     */
     public function push(mixed $e): self
     {
         $this->stack[] = $e;
         return $this;
     }
 
+    /**
+     * @return self<T>
+     */
     public function pop(): self
     {
         array_pop($this->stack);
         return $this;
     }
 
+    /**
+     * @return T
+     */
     public function top(): mixed
     {
         return $this->stack[count($this->stack) - 1];
@@ -36,10 +52,13 @@ class Stack
         return count($this->stack) === 0;
     }
 
+    /**
+     * @return T
+     */
     public function at(int $index): mixed
     {
         if ($index < 0 || $index >= count($this->stack)) {
-            return false;
+            throw new InvalidArgumentException("Invalid stack index: $index");
         }
         return $this->stack[$index];
     }

--- a/app/cdash/xml_handlers/abstract_xml_handler.php
+++ b/app/cdash/xml_handlers/abstract_xml_handler.php
@@ -26,6 +26,9 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 abstract class AbstractXmlHandler extends AbstractSubmissionHandler
 {
+    /**
+     * @var Stack<string>
+     */
     private Stack $stack;
     protected bool $Append = false;
     protected Site $Site;
@@ -103,9 +106,34 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
         return $errors;
     }
 
-    protected function getParent()
+    protected function getParent(): ?string
     {
+        if ($this->stack->size() <= 1) {
+            return null;
+        }
+
         return $this->stack->at($this->stack->size() - 2);
+    }
+
+    protected function currentPathMatches(string $path): bool
+    {
+        $path = explode('.', $path);
+
+        // We can return early if this isn't even the right level of the document
+        if ($this->stack->size() !== count($path)) {
+            return false;
+        }
+
+        for ($i = 0; $i < $this->stack->size(); $i++) {
+            if ($path[$i] === '*') {  // Wildcard matches any string at a given level (but only one level)
+                continue;
+            } elseif (strtoupper($path[$i]) === strtoupper((string) $this->stack->at($i))) {  // Match the specified string
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
     }
 
     protected function getElement()

--- a/app/cdash/xml_handlers/configure_handler.php
+++ b/app/cdash/xml_handlers/configure_handler.php
@@ -66,7 +66,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
     {
         parent::startElement($parser, $name, $attributes);
 
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $sitename = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $sitename], ['name' => $sitename]);
 
@@ -141,10 +141,6 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
 
     public function endElement($parser, $name): void
     {
-        $parent = $this->getParent();
-
-        parent::endElement($parser, $name);
-
         if ($name == 'CONFIGURE') {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
@@ -249,11 +245,13 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
             // so only need to do this once
             $build->UpdateParentConfigureNumbers(
                 (int) $this->Configure->NumberOfWarnings, (int) $this->Configure->NumberOfErrors);
-        } elseif ($name == 'LABEL' && $parent == 'LABELS') {
+        } elseif ($name === 'LABEL' && $this->getParent() === 'LABELS') {
             if (isset($this->Configure)) {
                 $this->Configure->AddLabel($this->Label);
             }
         }
+
+        parent::endElement($parser, $name);
     }
 
     public function text($parser, $data)

--- a/app/cdash/xml_handlers/coverage_handler.php
+++ b/app/cdash/xml_handlers/coverage_handler.php
@@ -52,7 +52,7 @@ class CoverageHandler extends AbstractXmlHandler
     public function startElement($parser, $name, $attributes): void
     {
         parent::startElement($parser, $name, $attributes);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 
@@ -110,8 +110,7 @@ class CoverageHandler extends AbstractXmlHandler
     /** End element */
     public function endElement($parser, $name): void
     {
-        parent::endElement($parser, $name);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
 
@@ -184,6 +183,7 @@ class CoverageHandler extends AbstractXmlHandler
                 $this->Coverage->AddLabel($this->Label);
             }
         }
+        parent::endElement($parser, $name);
     }
 
     /** Text function */

--- a/app/cdash/xml_handlers/coverage_junit_handler.php
+++ b/app/cdash/xml_handlers/coverage_junit_handler.php
@@ -48,7 +48,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
     {
         parent::startElement($parser, $name, $attributes);
         $parent = $this->getParent();
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 
@@ -132,8 +132,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
     /** End element */
     public function endElement($parser, $name): void
     {
-        parent::endElement($parser, $name);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
 
@@ -171,6 +170,8 @@ class CoverageJUnitHandler extends AbstractXmlHandler
                 $this->Coverage->AddLabel($this->Label);
             }
         }
+
+        parent::endElement($parser, $name);
     }
 
     /** Text function */

--- a/app/cdash/xml_handlers/coverage_log_handler.php
+++ b/app/cdash/xml_handlers/coverage_log_handler.php
@@ -51,7 +51,7 @@ class CoverageLogHandler extends AbstractXmlHandler
     public function startElement($parser, $name, $attributes): void
     {
         parent::startElement($parser, $name, $attributes);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 
@@ -77,9 +77,7 @@ class CoverageLogHandler extends AbstractXmlHandler
     /** End Element */
     public function endElement($parser, $name): void
     {
-        parent::endElement($parser, $name);
-
-        if ($name === 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
             $this->Build->ProjectId = $this->GetProject()->Id;
@@ -159,6 +157,8 @@ class CoverageLogHandler extends AbstractXmlHandler
                 $this->CoverageFiles[] = [new CoverageFile(), new CoverageFileLog()];
             }
         }
+
+        parent::endElement($parser, $name);
     }
 
     /** Text */

--- a/app/cdash/xml_handlers/dynamic_analysis_handler.php
+++ b/app/cdash/xml_handlers/dynamic_analysis_handler.php
@@ -68,7 +68,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
         parent::startElement($parser, $name, $attributes);
         $factory = $this->getModelFactory();
 
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 
@@ -149,10 +149,8 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
     /** Function endElement */
     public function endElement($parser, $name): void
     {
-        $parent = $this->getParent(); // should be before endElement
-        parent::endElement($parser, $name);
         $factory = $this->getModelFactory();
-        if ($name == 'STARTTESTTIME' && $parent == 'DYNAMICANALYSIS') {
+        if ($name === 'STARTTESTTIME' && $this->getParent() === 'DYNAMICANALYSIS') {
             if (empty($this->SubProjects)) {
                 // Not a SubProject build.
                 $this->createBuild('');
@@ -162,7 +160,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                     $this->createBuild($subproject);
                 }
             }
-        } elseif ($name == 'TEST' && $parent == 'DYNAMICANALYSIS') {
+        } elseif ($name === 'TEST' && $this->getParent() == 'DYNAMICANALYSIS') {
             /** @var Build $build */
             $build = $this->Builds[$this->SubProjectName];
             $GLOBALS['PHP_ERROR_BUILD_ID'] = $build->Id;
@@ -210,6 +208,8 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                 }
             }
         }
+
+        parent::endElement($parser, $name);
     }
 
     /** Function Text */

--- a/app/cdash/xml_handlers/note_handler.php
+++ b/app/cdash/xml_handlers/note_handler.php
@@ -42,7 +42,7 @@ class NoteHandler extends AbstractXmlHandler
     public function startElement($parser, $name, $attributes): void
     {
         parent::startElement($parser, $name, $attributes);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 

--- a/app/cdash/xml_handlers/testing_j_unit_handler.php
+++ b/app/cdash/xml_handlers/testing_j_unit_handler.php
@@ -68,7 +68,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
         parent::startElement($parser, $name, $attributes);
         $parent = $this->getParent(); // should be before endElement
 
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $this->HasSiteTag = true;
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);

--- a/app/cdash/xml_handlers/update_handler.php
+++ b/app/cdash/xml_handlers/update_handler.php
@@ -73,8 +73,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
     /** End element */
     public function endElement($parser, $name): void
     {
-        parent::endElement($parser, $name);
-        if ($name == 'SITE') {
+        if ($this->currentPathMatches('site')) {
             if (!isset($this->Site)) {
                 $this->Site = Site::firstOrCreate(['name' => '(unknown)']);
             } else {
@@ -142,6 +141,8 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
             $this->Update->AddFile($this->UpdateFile);
             unset($this->UpdateFile);
         }
+
+        parent::endElement($parser, $name);
     }
 
     /** Text */

--- a/app/cdash/xml_handlers/upload_handler.php
+++ b/app/cdash/xml_handlers/upload_handler.php
@@ -77,7 +77,7 @@ class UploadHandler extends AbstractXmlHandler
             return;
         }
 
-        if ($name === 'SITE') {
+        if ($this->currentPathMatches('site')) {
             $site_name = !empty($attributes['NAME']) ? $attributes['NAME'] : '(empty)';
             $this->Site = Site::firstOrCreate(['name' => $site_name], ['name' => $site_name]);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29410,11 +29410,6 @@ parameters:
 			path: app/cdash/xml_handlers/abstract_xml_handler.php
 
 		-
-			message: "#^Method AbstractXmlHandler\\:\\:getParent\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
 			message: "#^Method AbstractXmlHandler\\:\\:getSubProjectName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/abstract_xml_handler.php
@@ -29491,7 +29486,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 29
+			count: 21
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
@@ -29696,7 +29691,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 13
+			count: 10
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
@@ -29841,7 +29836,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 12
+			count: 10
 			path: app/cdash/xml_handlers/coverage_handler.php
 
 		-
@@ -29926,7 +29921,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 14
+			count: 12
 			path: app/cdash/xml_handlers/coverage_junit_handler.php
 
 		-
@@ -30021,7 +30016,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 7
+			count: 6
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 
 		-
@@ -30231,7 +30226,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 22
+			count: 18
 			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
 
 		-
@@ -30366,7 +30361,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 5
+			count: 4
 			path: app/cdash/xml_handlers/note_handler.php
 
 		-
@@ -30626,7 +30621,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 34
+			count: 25
 			path: app/cdash/xml_handlers/testing_handler.php
 
 		-
@@ -30791,7 +30786,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 21
+			count: 20
 			path: app/cdash/xml_handlers/testing_j_unit_handler.php
 
 		-
@@ -30946,7 +30941,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 23
+			count: 22
 			path: app/cdash/xml_handlers/update_handler.php
 
 		-


### PR DESCRIPTION
This PR pulls out some of the logic in https://github.com/Kitware/CDash/pull/2612 for matching full XML paths into a separate PR in anticipation of several upcoming PRs.  By specifying the full XML path for an element, the exact element being targeted is more clear.  For the sake of example, I used the new path method to locate all of the `<Site>` elements.