### PR TITLE
Wait for element to be visible in SitesIdPageTest

### DIFF
--- a/tests/Browser/Pages/SitesIdPageTest.php
+++ b/tests/Browser/Pages/SitesIdPageTest.php
@@ -166,6 +166,7 @@ class SitesIdPageTest extends BrowserTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit("/sites/{$this->sites['site1']->id}")
                 ->whenAvailable('@site-history', function (Browser $browser) {
+                    $browser->waitFor('@site-history-item');
                     // Can't use nth child with @ selector unfortunately
                     $browser->assertSeeIn('[data-test="site-history-item"]:nth-child(1)', 'System Update');
                     $browser->assertSeeIn('[data-test="site-history-item"]:nth-child(1)', '10.51 GiB');


### PR DESCRIPTION
`SitesIdPageTest` is currently flaky because the site history list is sometimes not fully rendered before the assertions begin running.  This PR adds an explicit wait for the history items to be rendered.