### PR TITLE
Don't show dynamic buildgroups on the wildcard tab

### DIFF
--- a/resources/js/angular/views/manageBuildGroup.html
+++ b/resources/js/angular/views/manageBuildGroup.html
@@ -194,7 +194,7 @@
             <div class="">
               <div class="form-group">
                 <label for="wildcardBuildGroupSelection">Define Wildcard rule for:</label>
-                <select name="wildcardBuildGroupSelection" ng-model="wildcardBuildGroupSelection" ng-options="buildgroup as buildgroup.name for buildgroup in cdash.buildgroups | orderBy:'name'" class="form-control">
+                <select name="wildcardBuildGroupSelection" ng-model="wildcardBuildGroupSelection" ng-options="buildgroup as buildgroup.name for buildgroup in cdash.buildgroups | orderBy:'name' | filter_buildgroups:'Daily'" class="form-control">
                   <option value="">Choose...</option>
                 </select>
               </div>


### PR DESCRIPTION
Wildcard buildgroup rules only make sense in the context of "daily" groups.

The rules for dynamic ("latest") buildgroups are defined on a separate tab.