### PR TITLE
Improve submission times by indexing `updatefile(filename)

### DIFF
--- a/database/migrations/2025_03_21_201854_updatefile_filename_index.php
+++ b/database/migrations/2025_03_21_201854_updatefile_filename_index.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('updatefile', function (Blueprint $table) {
+            $table->index(['filename']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('updatefile', function (Blueprint $table) {
+            $table->dropIndex(['filename']);
+        });
+    }
+};


### PR DESCRIPTION
[This](https://github.com/Kitware/CDash/blob/5de4c0123b89a80c0968d14586f21215f12baeff/app/cdash/app/Lib/Repository/GitHub.php#L563) query was found to be responsible for a large fraction of the database wait time for a production CDash instance.  By indexing `updatefile(filename)`, the aforementioned check is much cheaper and no longer accounts for a disproportionate amount of the overall submission time.