### PR TITLE
Disable scheduled jobs when not in production

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,11 +9,15 @@ php artisan key:check || exit 1
 
 # If the "start-website" argument was provided, start the web server
 if [ "$1" = "start-website" ] ; then
-  echo "Starting background jobs..."
-  # Output will show up in the logs, but the system will not crash if the schedule process fails.
-  # In the future, it would be better to do this with a dedicated container which starts on a schedule.
-  # Bare metal systems should use cron instead (using cron in Docker is problematic).
-  php artisan schedule:work & # & puts the task in the background.
+  if [ "$DEVELOPMENT_BUILD" = "1" ]; then
+    echo "Skipping background jobs in development mode..."
+  else
+    echo "Starting background jobs..."
+    # Output will show up in the logs, but the system will not crash if the schedule process fails.
+    # In the future, it would be better to do this with a dedicated container which starts on a schedule.
+    # Bare metal systems should use cron instead (using cron in Docker is problematic).
+    php artisan schedule:work & # & puts the task in the background.
+  fi
 
   echo "Starting Apache..."
 


### PR DESCRIPTION
Several tests have been particularly flaky recently due to scheduled jobs running simultaneously and interfering with the test environment.  I've also run into issues with scheduled jobs deleting carefully constructed data while developing locally.  This PR disables scheduled jobs entirely when not in production mode to resolve these issues.