### PR TITLE
Add ModelName as valid Site attribute

### DIFF
--- a/app/Validators/Schemas/common.xsd
+++ b/app/Validators/Schemas/common.xsd
@@ -18,6 +18,7 @@
     <xs:attribute name="VendorID" type="xs:string" />
     <xs:attribute name="FamilyID" type="xs:int" />
     <xs:attribute name="ModelID" type="xs:int" />
+    <xs:attribute name="ModelName" type="xs:string" />
     <xs:attribute name="ProcessorCacheSize" type="xs:int" />
     <xs:attribute name="NumberOfLogicalCPU" type="xs:int" />
     <xs:attribute name="NumberOfPhysicalCPU" type="xs:int" />


### PR DESCRIPTION
Following the MR in CMake found here:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9860

Add ModelName as a valid attibute in the schema checker. https://github.com/Kitware/CDash/issues/2752 has been created for future work to ensure that the information is properly stored and displayed.