### PR TITLE
Fix divide-by-zero error when coverage results have no lines

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -385,8 +385,9 @@ final class BuildController extends AbstractBuildController
         $response['hascoverage'] = false;
         $coverage_array = DB::select('SELECT * FROM coveragesummary WHERE buildid=?', [$this->build->Id])[0] ?? [];
         if ($coverage_array !== []) {
-            $coverage_percent = round($coverage_array->loctested /
-                ($coverage_array->loctested + $coverage_array->locuntested) * 100, 2);
+            $total_lines = (int) $coverage_array->loctested + (int) $coverage_array->locuntested;
+
+            $coverage_percent = $total_lines > 0 ? round(($coverage_array->loctested / $total_lines) * 100, 2) : 0;
             $response['coverage'] = $coverage_percent;
             $response['hascoverage'] = true;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -712,11 +712,6 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:apiBuildSummary\\(\\) throws checked exception DivisionByZeroError but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
 			message: "#^Method App\\\\Http\\\\Controllers\\\\BuildController\\:\\:buildOverview\\(\\) never returns Illuminate\\\\Http\\\\RedirectResponse so it can be removed from the return type\\.$#"
 			count: 1
 			path: app/Http/Controllers/BuildController.php
@@ -784,11 +779,6 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
 			count: 2
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: "#^Only numeric types are allowed in /, \\(array\\|float\\|int\\) given on the right side\\.$#"
-			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-


### PR DESCRIPTION
Coverage results with no lines covered or uncovered currently produces a divide-by-zero error when viewing a build.  This PR fixes the issue by returning zero if the divide-by-zero case would occur.