### PR TITLE
Handle processor Model Name in Site information

### DIFF
--- a/app/Models/SiteInformation.php
+++ b/app/Models/SiteInformation.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $processorvendorid
  * @property int|null $processorfamilyid
  * @property int|null $processormodelid
+ * @property string|null $processormodelname
  * @property int|null $processorcachesize
  * @property int|null $numberlogicalcpus
  * @property int|null $numberphysicalcpus
@@ -38,6 +39,7 @@ class SiteInformation extends Model
         'processorvendorid',
         'processorfamilyid',
         'processormodelid',
+        'processormodelname',
         'processorcachesize',
         'numberlogicalcpus',
         'numberphysicalcpus',
@@ -90,6 +92,9 @@ class SiteInformation extends Model
                 break;
             case 'MODELID':
                 $this->processormodelid = (int) $value;
+                break;
+            case 'MODELNAME':
+                $this->processormodelname = (string) $value;
                 break;
             case 'PROCESSORCACHESIZE':
                 $this->processorcachesize = (int) $value;

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -86,6 +86,7 @@ class TestUseCaseTest extends CDashUseCaseTestCase
             'VendorID' => 'Intel Corporation',
             'FamilyID' => '6',
             'ModelID' => '69',
+            'ModelName' => 'Intel(R) Xenon',
             'ProcessorCacheSize' => '4096',
             'NumberOfLogicalCPU' => '4',
             'NumberOfPhysicalCPU' => '1',
@@ -111,6 +112,7 @@ class TestUseCaseTest extends CDashUseCaseTestCase
         $this->assertEquals($siteInformation['VendorID'], $information?->processorvendorid);
         $this->assertEquals($siteInformation['FamilyID'], $information?->processorfamilyid);
         $this->assertEquals($siteInformation['ModelID'], $information?->processormodelid);
+        $this->assertEquals($siteInformation['ModelName'], $information?->processormodelname);
         $this->assertEquals($siteInformation['ProcessorCacheSize'], $information?->processorcachesize);
         $this->assertEquals($siteInformation['NumberOfLogicalCPU'], $information?->numberlogicalcpus);
         $this->assertEquals($siteInformation['NumberOfPhysicalCPU'], $information?->numberphysicalcpus);

--- a/database/migrations/2025_03_31_124158_support_model_name_on_site.php
+++ b/database/migrations/2025_03_31_124158_support_model_name_on_site.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add position column on measurement table.
+        Schema::table('siteinformation', function (Blueprint $table) {
+            $table->text('processormodelname')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('siteinformation', 'processormodelname')) {
+            Schema::table('siteinformation', function (Blueprint $table) {
+                $table->dropColumn('processormodelname');
+            });
+        }
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -531,6 +531,8 @@ type SiteInformation {
 
   processorModelId: Int @rename(attribute: "processormodelid")
 
+  processorModelName: String @rename(attribute: "processormodelname")
+
   processorCacheSize: Int @rename(attribute: "processorcachesize")
 
   numberLogicalCpus: Int @rename(attribute: "numberlogicalcpus")

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17678,7 +17678,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
-			count: 28
+			count: 29
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-

--- a/resources/js/vue/components/SitesIdPage.vue
+++ b/resources/js/vue/components/SitesIdPage.vue
@@ -317,6 +317,7 @@ const SITE_INFORMATION_QUERY = gql`
             processorVendorId
             processorFamilyId
             processorModelId
+            processorModelName
             processorCacheSize
             numberLogicalCpus
             numberPhysicalCpus
@@ -392,6 +393,7 @@ export default {
               processorVendorId
               processorFamilyId
               processorModelId
+              processorModelName
               processorCacheSize
               numberLogicalCpus
               numberPhysicalCpus
@@ -543,6 +545,8 @@ export default {
         return 'Processor Family ID';
       case 'processorModelId':
         return 'Processor Model ID';
+      case 'processorModelName':
+        return 'Processor Model Name';
       case 'processorCacheSize':
         return 'Processor Cache Size';
       case 'numberLogicalCpus':
@@ -680,6 +684,7 @@ export default {
                 processorVendorId
                 processorFamilyId
                 processorModelId
+                processorModelName
                 processorCacheSize
                 numberLogicalCpus
                 numberPhysicalCpus
@@ -724,6 +729,7 @@ export default {
                 processorVendorId:  this.mostRecentInformation.processorVendorId,
                 processorFamilyId:  this.mostRecentInformation.processorFamilyId,
                 processorModelId:  this.mostRecentInformation.processorModelId,
+                processorModelName:  this.mostRecentInformation.processorModelName,
                 processorCacheSize:  this.mostRecentInformation.processorCacheSize,
                 numberLogicalCpus:  this.mostRecentInformation.numberLogicalCpus,
                 numberPhysicalCpus:  this.mostRecentInformation.numberPhysicalCpus,

--- a/resources/js/vue/components/shared/BuildSummaryCard.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCard.vue
@@ -188,6 +188,18 @@
                   </td>
                 </tr>
                 <tr>
+                  <th>Processor Model Name</th>
+                  <td v-if="build.site.mostRecentInformation.processorModelName">
+                    {{ build.site.mostRecentInformation.processorModelName }}
+                  </td>
+                  <td
+                    v-else
+                    class="tw-italic"
+                  >
+                    Unknown
+                  </td>
+                </tr>
+                <tr>
                   <th>Cache Size</th>
                   <td v-if="build.site.mostRecentInformation.processorCacheSize">
                     {{ build.site.mostRecentInformation.processorCacheSize }}

--- a/tests/Browser/Pages/SitesIdPageTest.php
+++ b/tests/Browser/Pages/SitesIdPageTest.php
@@ -79,8 +79,8 @@ class SitesIdPageTest extends BrowserTestCase
             $browser->visit("/sites/{$this->sites['site1']->id}")
                 ->whenAvailable('@site-details @site-details-table', function (Browser $browser) {
                     // Just spot check a couple fields
-                    self::assertEquals('4', $browser->elements('@site-details-table-cell')[6]->getText());
-                    self::assertEquals('8.56 GiB', $browser->elements('@site-details-table-cell')[8]->getText());
+                    self::assertEquals('4', $browser->elements('@site-details-table-cell')[7]->getText());
+                    self::assertEquals('8.56 GiB', $browser->elements('@site-details-table-cell')[9]->getText());
                 })
                 ->whenAvailable('@site-details @site-description', function (Browser $browser) {
                     $browser->assertSee('No description provided...');

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -447,6 +447,7 @@ class SiteTypeTest extends TestCase
             'processorvendorid' => 'Intel Corporation',
             'processorfamilyid' => 6,
             'processormodelid' => 7,
+            'processormodelname' => 'Intel(R) Xeon',
             'processorcachesize' => 123,
             'numberlogicalcpus' => 4,
             'numberphysicalcpus' => 2,
@@ -481,6 +482,7 @@ class SiteTypeTest extends TestCase
                                                     processorVendorId
                                                     processorFamilyId
                                                     processorModelId
+                                                    processorModelName
                                                     processorCacheSize
                                                     numberLogicalCpus
                                                     numberPhysicalCpus
@@ -520,6 +522,7 @@ class SiteTypeTest extends TestCase
                                                                 'processorVendorId' => 'Intel Corporation',
                                                                 'processorFamilyId' => 6,
                                                                 'processorModelId' => 7,
+                                                                'processorModelName' => 'Intel(R) Xeon',
                                                                 'processorCacheSize' => 123,
                                                                 'numberLogicalCpus' => 4,
                                                                 'numberPhysicalCpus' => 2,
@@ -559,6 +562,7 @@ class SiteTypeTest extends TestCase
             [['processorvendorid' => 'Intel Corporation']],
             [['processorfamilyid' => 6]],
             [['processormodelid' => 7]],
+            [['processormodelname' => 'Intel(R) Xeon']],
             [['processorcachesize' => 123]],
             [['numberlogicalcpus' => 4]],
             [['numberphysicalcpus' => 2]],
@@ -607,6 +611,7 @@ class SiteTypeTest extends TestCase
                                                     processorVendorId
                                                     processorFamilyId
                                                     processorModelId
+                                                    processorModelName
                                                     processorCacheSize
                                                     numberLogicalCpus
                                                     numberPhysicalCpus
@@ -646,6 +651,7 @@ class SiteTypeTest extends TestCase
                                                                 'processorVendorId' => $params['processorvendorid'] ?? null,
                                                                 'processorFamilyId' => $params['processorfamilyid'] ?? null,
                                                                 'processorModelId' => $params['processormodelid'] ?? null,
+                                                                'processorModelName' => $params['processormodelname'] ?? null,
                                                                 'processorCacheSize' => $params['processorcachesize'] ?? null,
                                                                 'numberLogicalCpus' => $params['numberlogicalcpus'] ?? null,
                                                                 'numberPhysicalCpus' => $params['numberphysicalcpus'] ?? null,


### PR DESCRIPTION
Add the updates which will allow the new information in the CMake XML files for the model name of the processor to be displayed on the CDash page for the site.

Fixes #2752