### PR TITLE
Fix configure hide/show when subprojects present

### DIFF
--- a/resources/js/vue/components/BuildConfigure.vue
+++ b/resources/js/vue/components/BuildConfigure.vue
@@ -106,7 +106,7 @@
             <td>
               <a
                 class="cdash-link"
-                :click="configure.show = !configure.show"
+                @click="configure.show = !configure.show"
               >
                 <span v-show="!configure.show">View</span>
                 <span v-show="configure.show">Hide</span>


### PR DESCRIPTION
The configure page (`/builds/<id>/configure`) currently has an infinite recursion issue which causes browsers to kill the process due to high memory usage when viewing projects with subprojects.  This is due to a vue event handler mistakenly written as a binding.