### PR TITLE
Fix flaky email test

### DIFF
--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -270,7 +270,7 @@ class EmailTestCase extends KWWebTestCase
     {
         // Verify that we have three builds for this project.
         $project = DB::table('project')->where('name', 'EmailProjectExample')->first();
-        $builds = DB::table('build')->where('projectid', $project->id)->get();
+        $builds = DB::table('build')->where('projectid', $project->id)->orderBy('id')->get();
         $this->assertEqual(3, count($builds));
 
         // Verify that we have four rows in the testdiff table for these builds.


### PR DESCRIPTION
The `email` test is currently [very flaky](https://open.cdash.org/queryTests.php?project=CDash&begin=2024-04-05&end=2025-04-05&filtercount=2&showfilters=1&filtercombine=and&field1=status&compare1=62&value1=Passed&field2=testname&compare2=61&value2=email), particularly on Postgres due to Postgres not returning rows in the same order each time.  This PR fixes the test by explicitly ordering the builds in the expected order.