### PR TITLE
Move JS spec and Cypress component tests to dedicated files

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,3 @@
-function(add_vue_test TestName)
-  add_test(
-    NAME ${TestName}
-    COMMAND "node_modules/.bin/jest" "tests/${TestName}.spec.js"
-    WORKING_DIRECTORY "${CDash_SOURCE_DIR}"
-  )
-endfunction()
-
 function(set_app_url)
   if(DEFINED ENV{APP_URL})
     set(APP_URL "$ENV{APP_URL}" PARENT_SCOPE)
@@ -99,12 +91,6 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/helm/cdash
 )
 
-add_vue_test(Spec/build-configure)
-add_vue_test(Spec/build-summary)
-add_vue_test(Spec/edit-project)
-add_vue_test(Spec/manage-measurements)
-add_vue_test(Spec/test-details)
-
 add_cypress_component_test(loading-indicator)
 
 cdash_install()
@@ -113,3 +99,4 @@ add_cypress_e2e_test(user-profile)
 set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 
 add_subdirectory(cypress/e2e)
+add_subdirectory(Spec)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,24 +32,6 @@ function(add_cypress_e2e_test TestName)
   )
 endfunction()
 
-function(add_cypress_component_test TestName)
-  set_app_url()
-
-  add_test(
-    NAME cypress/component/${TestName}
-    COMMAND ${NPX_EXE} cypress run
-      --component
-      --project ${CDash_SOURCE_DIR}
-      --spec ${CDash_SOURCE_DIR}/tests/cypress/component/${TestName}.cy.js
-      --config baseUrl=${APP_URL}
-  )
-  # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
-  set_tests_properties(cypress/component/${TestName} PROPERTIES
-    ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
-    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
-  )
-endfunction()
-
 add_test(
   NAME php_style_check
   COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes
@@ -91,12 +73,11 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/helm/cdash
 )
 
-add_cypress_component_test(loading-indicator)
-
 cdash_install()
 
 add_cypress_e2e_test(user-profile)
 set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 
 add_subdirectory(cypress/e2e)
+add_subdirectory(cypress/component)
 add_subdirectory(Spec)

--- a/tests/Spec/CMakeLists.txt
+++ b/tests/Spec/CMakeLists.txt
@@ -1,0 +1,13 @@
+function(add_vue_test TestName)
+  add_test(
+    NAME "Spec/${TestName}"
+    COMMAND "node_modules/.bin/jest" "tests/Spec/${TestName}.spec.js"
+    WORKING_DIRECTORY "${CDash_SOURCE_DIR}"
+  )
+endfunction()
+
+add_vue_test(build-configure)
+add_vue_test(build-summary)
+add_vue_test(edit-project)
+add_vue_test(manage-measurements)
+add_vue_test(test-details)

--- a/tests/cypress/component/CMakeLists.txt
+++ b/tests/cypress/component/CMakeLists.txt
@@ -1,0 +1,21 @@
+function(add_cypress_component_test TestName)
+  set_app_url()
+
+  add_test(
+    NAME cypress/component/${TestName}
+    COMMAND ${NPX_EXE} cypress run
+      --component
+      --project ${CDash_SOURCE_DIR}
+      --spec ${CDash_SOURCE_DIR}/tests/cypress/component/${TestName}.cy.js
+      --config baseUrl=${APP_URL}
+  )
+  # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
+  set_tests_properties(cypress/component/${TestName} PROPERTIES
+    ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
+    RESOURCE_LOCK "dev-server-port"
+  )
+endfunction()
+
+add_cypress_component_test(data-table)
+add_cypress_component_test(loading-indicator)

--- a/tests/cypress/component/data-table.cy.js
+++ b/tests/cypress/component/data-table.cy.js
@@ -171,7 +171,7 @@ describe('Data table component tests', () => {
           {
             test: 'Data value 1',
             test2: {
-              value: 'Link 1',
+              text: 'Link 1',
               href: 'http://localhost:8080/test',
             },
           },


### PR DESCRIPTION
This PR contains a subset of the changes in #2698 for clarity.  Spec and Cypress component test definitions have been moved to dedicated files instead of the top-level `CMakeLists.txt`.  In addition to moving logic around, this PR re-introduces the forgotten `data-table` Cypress component test and allows Cypress component tests to run in parallel with other tests, utilizing a resource lock to ensure two Cypress component tests never run at the same time.