### PR TITLE
Fix flaky `manage-build-group` test

### DIFF
--- a/tests/cypress/e2e/manage-build-group.cy.js
+++ b/tests/cypress/e2e/manage-build-group.cy.js
@@ -176,7 +176,8 @@ describe('manageBuildGroup', () => {
     // click on the delete icons and verify that no rows are present
     cy.get('@dynamic_rows').find('span.glyphicon-trash').as('delete_icons');
     cy.get('@delete_icons').should('have.length', 2);
-    cy.get('@delete_icons').click({ multiple: true });
+    cy.get('@delete_icons').eq(1).click();
+    cy.get('@delete_icons').eq(0).click();
 
     // reload the page to make sure they're really gone
     cy.reload();


### PR DESCRIPTION
The `manage-build-group` test is [flaky](https://open.cdash.org/queryTests.php?project=CDash&begin=2024-04-07&end=2025-04-07&filtercount=2&showfilters=1&filtercombine=and&field1=status&compare1=61&value1=Failed&field2=testname&compare2=61&value2=cypress%2Fe2e%2Fmanage-build-group).  This PR resolves the flakiness by explicitly clicking two elements rather than relying on Cypress' "click multiple" functionality.