### PR TITLE
Restructure Cypress e2e tests

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -375,11 +375,8 @@ set_tests_properties(image PROPERTIES DEPENDS committerinfo)
 add_php_test(displayimage)
 set_tests_properties(displayimage PROPERTIES DEPENDS image)
 
-add_cypress_e2e_test(banner)
-set_tests_properties(cypress/e2e/banner PROPERTIES DEPENDS displayimage)
-
 add_php_test(manageprojectroles)
-set_tests_properties(manageprojectroles PROPERTIES DEPENDS cypress/e2e/banner)
+set_tests_properties(manageprojectroles PROPERTIES DEPENDS displayimage)
 
 add_php_test(manageusers)
 set_tests_properties(manageusers PROPERTIES DEPENDS manageprojectroles)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -66,10 +66,9 @@ add_laravel_test(/Unit/app/Console/Command/ValidateXmlCommandTest)
 ###################################################################################################
 
 cdash_install()
-set_tests_properties(install_2 PROPERTIES DEPENDS cypress/e2e/user-profile)
 
 add_laravel_test(/Feature/CDashTest)
-set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_2)
+set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
 add_laravel_test(/Feature/LoginAndRegistration)
 set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /Feature/CDashTest)
@@ -287,7 +286,7 @@ set_tests_properties(/Feature/Traits/UpdatesSiteInformationTest PROPERTIES DEPEN
 ###################################################################################################
 
 cdash_install()
-set_property(TEST install_3 PROPERTY DEPENDS
+set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest
@@ -329,7 +328,7 @@ set_property(TEST install_3 PROPERTY DEPENDS
 
 
 add_php_test(compressedtest)
-set_tests_properties(compressedtest PROPERTIES DEPENDS install_3)
+set_tests_properties(compressedtest PROPERTIES DEPENDS install_2)
 
 add_php_test(createpublicdashboard)
 set_tests_properties(createpublicdashboard PROPERTIES DEPENDS compressedtest)

--- a/app/cdash/tests/autoremovebuilds/CMakeLists.txt
+++ b/app/cdash/tests/autoremovebuilds/CMakeLists.txt
@@ -1,7 +1,32 @@
 # These tests should go last so the removal of builds doesn't clobber other tests
-
+# TODO: Some of these dependencies may not be necessary.
 add_php_test(autoremovebuilds_on_submit)
-set_tests_properties(autoremovebuilds_on_submit PROPERTIES DEPENDS cypress/e2e/build-configure)
+set_property(TEST autoremovebuilds_on_submit PROPERTY DEPENDS
+  cypress/e2e/manage-overview
+  cypress/e2e/sub-project-dependencies
+  cypress/e2e/manage-build-group
+  cypress/e2e/manage-sub-project
+  cypress/e2e/view-build-error
+  cypress/e2e/view-test
+  cypress/e2e/sort-index
+  cypress/e2e/expected-build
+  cypress/e2e/remove-build
+  cypress/e2e/view-sub-projects
+  cypress/e2e/test-summary
+  cypress/e2e/query-tests
+  cypress/e2e/filter-labels
+  cypress/e2e/view-test-pagination
+  cypress/e2e/done-build
+  cypress/e2e/sub-project-group-order
+  cypress/e2e/calendar
+  cypress/e2e/colorblind
+  cypress/e2e/daterange
+  cypress/e2e/build-notes
+  cypress/e2e/sites
+  cypress/e2e/view-coverage
+  cypress/e2e/tests
+  cypress/e2e/build-configure
+)
 
 add_php_test(deletesubproject)
 set_tests_properties(deletesubproject PROPERTIES DEPENDS autoremovebuilds_on_submit)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,24 +14,6 @@ function(set_app_url)
   endif()
 endfunction()
 
-function(add_cypress_e2e_test TestName)
-  set_app_url()
-
-  add_test(
-    NAME cypress/e2e/${TestName}
-    COMMAND ${NPX_EXE} cypress run
-      --e2e
-      --project ${CDash_SOURCE_DIR}
-      --spec ${CDash_SOURCE_DIR}/tests/cypress/e2e/${TestName}.cy.js
-      --config baseUrl=${APP_URL}
-  )
-  # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
-  set_tests_properties(cypress/e2e/${TestName} PROPERTIES
-    ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
-    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
-  )
-endfunction()
-
 add_test(
   NAME php_style_check
   COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,11 +73,6 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/helm/cdash
 )
 
-cdash_install()
-
-add_cypress_e2e_test(user-profile)
-set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
-
 add_subdirectory(cypress/e2e)
 add_subdirectory(cypress/component)
 add_subdirectory(Spec)

--- a/tests/cypress/component/CMakeLists.txt
+++ b/tests/cypress/component/CMakeLists.txt
@@ -13,7 +13,7 @@ function(add_cypress_component_test TestName)
   set_tests_properties(cypress/component/${TestName} PROPERTIES
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
-    RESOURCE_LOCK "dev-server-port"
+    RESOURCE_LOCK "cypress"
   )
 endfunction()
 

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -23,6 +23,10 @@ set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 add_cypress_e2e_test(banner)
 set_tests_properties(cypress/e2e/banner PROPERTIES DEPENDS displayimage)
 
+add_cypress_e2e_test(all-projects)
+set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS projectindb)
+
+# These tests don't have all of the dependencies worked out
 add_cypress_e2e_test(manage-overview)
 set_tests_properties(cypress/e2e/manage-overview PROPERTIES DEPENDS simple2_async)
 
@@ -94,6 +98,3 @@ set_tests_properties(cypress/e2e/tests PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(build-configure)
 set_tests_properties(cypress/e2e/build-configure PROPERTIES DEPENDS simple2_async)
-
-add_cypress_e2e_test(all-projects)
-set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS simple2_async)

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -17,6 +17,7 @@ function(add_cypress_e2e_test TestName)
   )
 endfunction()
 
+# These tests have the correct dependencies set up
 add_cypress_e2e_test(user-profile)
 set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 
@@ -25,6 +26,9 @@ set_tests_properties(cypress/e2e/banner PROPERTIES DEPENDS displayimage)
 
 add_cypress_e2e_test(all-projects)
 set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS projectindb)
+
+add_cypress_e2e_test(query-tests)
+set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS cypress/e2e/remove-build)
 
 # These tests don't have all of the dependencies worked out
 add_cypress_e2e_test(manage-overview)
@@ -59,9 +63,6 @@ set_tests_properties(cypress/e2e/view-sub-projects PROPERTIES DEPENDS simple2_as
 
 add_cypress_e2e_test(test-summary)
 set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS simple2_async)
-
-add_cypress_e2e_test(query-tests)
-set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS cypress/e2e/test-summary)
 
 add_cypress_e2e_test(filter-labels)
 set_tests_properties(cypress/e2e/filter-labels PROPERTIES DEPENDS simple2_async)

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_cypress_e2e_test(user-profile)
 set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 
+add_cypress_e2e_test(banner)
+set_tests_properties(cypress/e2e/banner PROPERTIES DEPENDS displayimage)
+
 add_cypress_e2e_test(manage-overview)
 set_tests_properties(cypress/e2e/manage-overview PROPERTIES DEPENDS simple2_async)
 

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -13,6 +13,7 @@ function(add_cypress_e2e_test TestName)
   set_tests_properties(cypress/e2e/${TestName} PROPERTIES
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
+    RESOURCE_LOCK "cypress" # Cypress can only run one at a time due to xvfb issues
   )
 endfunction()
 
@@ -26,73 +27,73 @@ add_cypress_e2e_test(manage-overview)
 set_tests_properties(cypress/e2e/manage-overview PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(sub-project-dependencies)
-set_tests_properties(cypress/e2e/sub-project-dependencies PROPERTIES DEPENDS cypress/e2e/manage-overview)
+set_tests_properties(cypress/e2e/sub-project-dependencies PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(manage-build-group)
-set_tests_properties(cypress/e2e/manage-build-group PROPERTIES DEPENDS cypress/e2e/sub-project-dependencies)
+set_tests_properties(cypress/e2e/manage-build-group PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(manage-sub-project)
-set_tests_properties(cypress/e2e/manage-sub-project PROPERTIES DEPENDS cypress/e2e/manage-build-group)
+set_tests_properties(cypress/e2e/manage-sub-project PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-build-error)
-set_tests_properties(cypress/e2e/view-build-error PROPERTIES DEPENDS cypress/e2e/manage-sub-project)
+set_tests_properties(cypress/e2e/view-build-error PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-test)
-set_tests_properties(cypress/e2e/view-test PROPERTIES DEPENDS cypress/e2e/view-build-error)
+set_tests_properties(cypress/e2e/view-test PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(sort-index)
-set_tests_properties(cypress/e2e/sort-index PROPERTIES DEPENDS cypress/e2e/view-test)
+set_tests_properties(cypress/e2e/sort-index PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(expected-build)
-set_tests_properties(cypress/e2e/expected-build PROPERTIES DEPENDS cypress/e2e/sort-index)
+set_tests_properties(cypress/e2e/expected-build PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(remove-build)
-set_tests_properties(cypress/e2e/remove-build PROPERTIES DEPENDS cypress/e2e/expected-build)
+set_tests_properties(cypress/e2e/remove-build PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-sub-projects)
-set_tests_properties(cypress/e2e/view-sub-projects PROPERTIES DEPENDS cypress/e2e/remove-build)
+set_tests_properties(cypress/e2e/view-sub-projects PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(test-summary)
-set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS cypress/e2e/view-sub-projects)
+set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(query-tests)
-set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS cypress/e2e/test-summary)
+set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(filter-labels)
-set_tests_properties(cypress/e2e/filter-labels PROPERTIES DEPENDS cypress/e2e/query-tests)
+set_tests_properties(cypress/e2e/filter-labels PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-test-pagination)
-set_tests_properties(cypress/e2e/view-test-pagination PROPERTIES DEPENDS cypress/e2e/filter-labels)
+set_tests_properties(cypress/e2e/view-test-pagination PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(done-build)
-set_tests_properties(cypress/e2e/done-build PROPERTIES DEPENDS cypress/e2e/view-test-pagination)
+set_tests_properties(cypress/e2e/done-build PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(sub-project-group-order)
-set_tests_properties(cypress/e2e/sub-project-group-order PROPERTIES DEPENDS cypress/e2e/done-build)
+set_tests_properties(cypress/e2e/sub-project-group-order PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(calendar)
-set_tests_properties(cypress/e2e/calendar PROPERTIES DEPENDS cypress/e2e/sub-project-group-order)
+set_tests_properties(cypress/e2e/calendar PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(colorblind)
-set_tests_properties(cypress/e2e/colorblind PROPERTIES DEPENDS cypress/e2e/calendar)
+set_tests_properties(cypress/e2e/colorblind PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(daterange)
-set_tests_properties(cypress/e2e/daterange PROPERTIES DEPENDS cypress/e2e/colorblind)
+set_tests_properties(cypress/e2e/daterange PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(build-notes)
-set_tests_properties(cypress/e2e/build-notes PROPERTIES DEPENDS cypress/e2e/daterange)
+set_tests_properties(cypress/e2e/build-notes PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(sites)
-set_tests_properties(cypress/e2e/sites PROPERTIES DEPENDS cypress/e2e/build-notes)
+set_tests_properties(cypress/e2e/sites PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-coverage)
-set_tests_properties(cypress/e2e/view-coverage PROPERTIES DEPENDS cypress/e2e/sites)
+set_tests_properties(cypress/e2e/view-coverage PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(tests)
-set_tests_properties(cypress/e2e/tests PROPERTIES DEPENDS cypress/e2e/view-coverage)
+set_tests_properties(cypress/e2e/tests PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(build-configure)
-set_tests_properties(cypress/e2e/build-configure PROPERTIES DEPENDS cypress/e2e/tests)
+set_tests_properties(cypress/e2e/build-configure PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(all-projects)
-set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS cypress/e2e/build-configure)
+set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS simple2_async)

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -61,7 +61,7 @@ add_cypress_e2e_test(test-summary)
 set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(query-tests)
-set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS simple2_async)
+set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS cypress/e2e/test-summary)
 
 add_cypress_e2e_test(filter-labels)
 set_tests_properties(cypress/e2e/filter-labels PROPERTIES DEPENDS simple2_async)

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_cypress_e2e_test(user-profile)
+set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
+
 add_cypress_e2e_test(manage-overview)
 set_tests_properties(cypress/e2e/manage-overview PROPERTIES DEPENDS simple2_async)
 

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -1,3 +1,21 @@
+function(add_cypress_e2e_test TestName)
+  set_app_url()
+
+  add_test(
+    NAME cypress/e2e/${TestName}
+    COMMAND ${NPX_EXE} cypress run
+      --e2e
+      --project ${CDash_SOURCE_DIR}
+      --spec ${CDash_SOURCE_DIR}/tests/cypress/e2e/${TestName}.cy.js
+      --config baseUrl=${APP_URL}
+  )
+  # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
+  set_tests_properties(cypress/e2e/${TestName} PROPERTIES
+    ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
+  )
+endfunction()
+
 add_cypress_e2e_test(user-profile)
 set_tests_properties(cypress/e2e/user-profile PROPERTIES DEPENDS install_1)
 


### PR DESCRIPTION
This PR continues the work in #2698, moving Cypress-specific CTest content to dedicated files.  Additionally, I improved the dependency structure, leading to faster CI runs.  I plan to make a follow-up PR to further improve the dependency structure.