### PR TITLE
Use text emails for auth token notifications

### DIFF
--- a/app/Mail/AuthTokenExpired.php
+++ b/app/Mail/AuthTokenExpired.php
@@ -43,7 +43,7 @@ class AuthTokenExpired extends Mailable implements ShouldQueue
     public function content(): Content
     {
         return new Content(
-            view: 'email.auth-token-expired',
+            text: 'email.auth-token-expired',
         );
     }
 }

--- a/app/Mail/AuthTokenExpiring.php
+++ b/app/Mail/AuthTokenExpiring.php
@@ -39,7 +39,7 @@ class AuthTokenExpiring extends Mailable implements ShouldQueue
     public function content(): Content
     {
         return new Content(
-            view: 'email.auth-token-expiring',
+            text: 'email.auth-token-expiring',
         );
     }
 }


### PR DESCRIPTION
#2669 added email notifications for expiring authentication tokens.  Those email notifications are sent as HTML emails when they're meant to be sent as plaintext emails, resulting in poor formatting in most modern email clients.  We'd like to eventually move everything to HTML emails, but that's a future endeavor.  For now, this PR issues the auth token expiration emails as plaintext.