### PR TITLE
Reinstate `viewTest.php` filters

### DIFF
--- a/resources/views/test/view-test.blade.php
+++ b/resources/views/test/view-test.blade.php
@@ -118,7 +118,7 @@
             </a>
         </div>
     @endverbatim
-        <ng-include src="{{ asset(mix('assets/js/angular/views/partials/filterdataTemplate.html')) }}"></ng-include>
+        <ng-include src="'{{ asset(mix('assets/js/angular/views/partials/filterdataTemplate.html')) }}'"></ng-include>
     @verbatim
 
         <div ng-switch="::cdash.display">


### PR DESCRIPTION
The filters on `viewTest.php` were broken by #2560, as reported in https://github.com/Kitware/CDash/issues/2721.  I mistakenly thought this was an issue with the filters themselves and failed to attribute it to a recent change.  This PR restores the filters.