### PR TITLE
Increase size of configure.log from text to mediumtext

### DIFF
--- a/database/migrations/2025_04_09_150429_configure_log_medium_text.php
+++ b/database/migrations/2025_04_09_150429_configure_log_medium_text.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('configure', function (Blueprint $table) {
+            $table->mediumText('log')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('configure', function (Blueprint $table) {
+            $table->text('log')->change();
+        });
+    }
+};


### PR DESCRIPTION
This was inadvertently reduced when we started using Laravel migrations in #904