### PR TITLE
Remove unused "bug tracker file url" UI

### DIFF
--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -253,26 +253,6 @@
                     <td />
                     <td>
                       <div align="right">
-                        <strong>Bug Tracker File URL:</strong>
-                      </div>
-                    </td>
-                    <td>
-                      <input
-                        id="bugFileURL"
-                        v-model="cdash.project.BugTrackerFilerUrl"
-                        name="bugFileURL"
-                        type="text"
-                        size="50"
-                        @change="cdash.changesmade = true"
-                        @focus="clearHelp()"
-                      >
-                    </td>
-                  </tr>
-
-                  <tr>
-                    <td />
-                    <td>
-                      <div align="right">
                         <strong>Bug Tracker Issue Creation:</strong>
                       </div>
                     </td>


### PR DESCRIPTION
The "bug tracker file URL" field has been unused for some time and https://github.com/Kitware/CDash/pull/2102 removed the column the data was stored in.  The UI was missed in that removal due to a typo in the HTML.  This PR cleans up the rest of the UI.