### PR TITLE
Fix flaky `SitesIdPageTest`

### DIFF
--- a/tests/Browser/Pages/SitesIdPageTest.php
+++ b/tests/Browser/Pages/SitesIdPageTest.php
@@ -250,7 +250,8 @@ class SitesIdPageTest extends BrowserTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit("/sites/{$this->sites['site1']->id}")
                 ->whenAvailable('@site-details', function (Browser $browser) {
-                    $browser->assertSee('No information available for this site.');
+                    $browser->waitForText('No information available for this site.')
+                        ->assertSee('No information available for this site.');
                 });
         });
     }


### PR DESCRIPTION
`SitesIdPageTest` [failed](https://github.com/Kitware/CDash/actions/runs/14404622114/job/40397991509?pr=2798) in CI with because the page didn't render before the assertion was made.  This is unfortunately a common issue with Dusk tests because assertions do not keep trying until a timeout like they do in Cypress.