### PR TITLE
Remove `ACTIVE_PROJECT_DAYS` env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,6 @@ DB_PASSWORD=secret
 
 # cdash.php
 
-# How long since the last submission before considering a project inactive.
-# Set to 0 to always show all projects on viewProjects.php.
-#ACTIVE_PROJECT_DAYS=7
-
 # Should CDash automatically remove old builds?
 #AUTOREMOVE_BUILDS=true
 

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -43,7 +43,6 @@ return [
             'duration' => env('LOCKOUT_LENGTH', 1),
         ],
     ],
-    'active_project_days' => env('ACTIVE_PROJECT_DAYS', 7),
     'autoremove_builds' => env('AUTOREMOVE_BUILDS', true),
     'backup_timeframe' => env('BACKUP_TIMEFRAME', 48),
     'builds_per_project' => env('BUILDS_PER_PROJECT', 0),

--- a/docs/config.md
+++ b/docs/config.md
@@ -102,7 +102,6 @@ AWS_URL=<bucket URL> (e.g. http://127.0.0.1:9001/cdash/)
 ## Other settings
 | Variable  | Description | Default |
 | --------- | ----------- | ------- |
-| ACTIVE_PROJECT_DAYS | How long (in days) since the last submission before considering a project inactive and hidden on the /projects page | 7 |
 | BACKUP_TIMEFRAME |  How long (in hours) CDash will store parsed input files | 48 |
 | DEFAULT_PROJECT | Display a given project by default when one isn't specified | '' |
 | LARGE_TEXT_LIMIT | How many bytes of build/test data CDash should accept before truncating away the center (0 for unlimited) | 0 |


### PR DESCRIPTION
The `ACTIVE_PROJECT_DAYS` environment variable is no longer used by `/projects` to determine what classifies a project as "active".  This PR removes the environment variable.