### PR TITLE
Change `QUEUE_CONNECTION` default to `database`

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'database'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
`QUEUE_CONNECTION` is currently set to `sync` by default.  We recommend using asynchronous workers for production systems, which means that CDash administrators have to perform unnecessary configuration right out of the box.  This PR changes the default to `database`, meaning that asynchronous parsing is now the default behavior.