### PR TITLE
Stop publishing separate cdash-worker image

### DIFF
--- a/.github/workflows/build-latest-images.yml
+++ b/.github/workflows/build-latest-images.yml
@@ -51,50 +51,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  worker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        name: Build standard worker image
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          sbom: true
-          tags: "kitware/cdash-worker:latest"
-          target: cdash-worker
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  worker-ubi:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        name: Build UBI worker image
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          sbom: true
-          tags: "kitware/cdash-worker:latest-ubi"
-          target: cdash-worker
-          build-args: |
-            BASE_IMAGE=ubi
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   testing:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,3 @@ jobs:
             BASE_IMAGE=${{matrix.base-image}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      # Building the worker image should be almost instantaneous due to caching of the regular image
-      - uses: docker/build-push-action@v6
-        name: Build ${{matrix.base-image}} worker image
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: false
-          target: cdash-worker
-          build-args: |
-            BASE_IMAGE=${{matrix.base-image}}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,6 @@ jobs:
           target: cdash
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - uses: docker/build-push-action@v6
-        name: Build ${{ github.ref_name }} worker image
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: "kitware/cdash-worker:${{ github.ref_name }}"
-          target: cdash-worker
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   ubi:
     runs-on: ubuntu-latest
@@ -55,18 +45,6 @@ jobs:
           sbom: true
           tags: "kitware/cdash:${{ github.ref_name }}-ubi"
           target: cdash
-          build-args: |
-            BASE_IMAGE=ubi
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - uses: docker/build-push-action@v6
-        name: Build ${{ github.ref_name }} worker image
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: "kitware/cdash-worker:${{ github.ref_name }}-ubi"
-          target: cdash-worker
           build-args: |
             BASE_IMAGE=ubi
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ USER 1001
 # Do shared installation tasks as a non-root user
 ###############################################################################
 
-FROM cdash-${BASE_IMAGE}-non-root-intermediate AS cdash-non-root-intermediate
+FROM cdash-${BASE_IMAGE}-non-root-intermediate AS cdash
 
 LABEL MAINTAINER="Kitware, Inc. <cdash@public.kitware.com>"
 
@@ -303,17 +303,5 @@ ENV DEVELOPMENT_BUILD=$DEVELOPMENT_BUILD
 ENV BASE_IMAGE=$BASE_IMAGE
 
 ENTRYPOINT ["/bin/bash", "/cdash/docker/docker-entrypoint.sh"]
-
-###############################################################################
-# Add website-specific information
-###############################################################################
-
-FROM cdash-non-root-intermediate AS cdash
 CMD ["start-website"]
 
-###############################################################################
-# Add worker-specific information
-###############################################################################
-
-FROM cdash-non-root-intermediate AS cdash-worker
-CMD ["start-worker"]

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -10,13 +10,15 @@ services:
   worker:
     env_file:
       - ../.env
-    image: kitware/cdash-worker
+    image: kitware/cdash
     build:
       context: ..
-      target: cdash-worker
+      target: cdash
       # Set the environment variable BASE_IMAGE=ubi to use RedHat UBI as base image
       args:
         BASE_IMAGE: ${BASE_IMAGE-debian}
+    command:
+      - start-worker
     environment:
       DB_HOST: database
     deploy:


### PR DESCRIPTION
The `cdash-worker` image is the same as the regular website image, except that it uses a separate entrypoint argument.  There's no need to publish and maintain this separate image.  This PR removes all logic pertaining to the `cdash-worker` image.