### PR TITLE
Use auto-generated container names

### DIFF
--- a/.github/workflows/submit.sh
+++ b/.github/workflows/submit.sh
@@ -25,7 +25,7 @@ echo "submit_type=$submit_type"
 sleep 2
 
 # Wait for migrations to finish running by checking for maintenance mode to be lifted
-docker exec cdash bash -c "\
+docker exec cdash-website-1 bash -c "\
   until [ ! -f /cdash/storage/framework/down ]; \
   do \
     sleep 1; \
@@ -33,9 +33,9 @@ docker exec cdash bash -c "\
 "
 
 # Suppress any uncommitted changes left after the image build
-docker exec cdash bash -c "cd /cdash && /usr/bin/git checkout ."
+docker exec cdash-website-1 bash -c "cd /cdash && /usr/bin/git checkout ."
 
-docker exec cdash bash -c "\
+docker exec cdash-website-1 bash -c "\
   ctest \
     -VV \
     -j 4 \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 services:
-  cdash:
+  website:
     image: kitware/cdash:testing
     ports:
       - 8080:8080
@@ -17,7 +17,6 @@ services:
   # Used for testing LDAP authentication
   ldap:
     image: bitnami/openldap
-    container_name: ldap
     ports:
       - 389:389
       - 636:636
@@ -31,7 +30,6 @@ services:
   # Development mail server available at http://localhost:8025
   mailpit:
     image: axllent/mailpit
-    container_name: mailpit
     ports:
       - 8025:8025
       - 1025:1025
@@ -39,7 +37,6 @@ services:
   # Used for live browser testing
   selenium:
     image: selenium/standalone-chromium
-    container_name: selenium
     volumes:
       - /dev/shm:/dev/shm
     ports:

--- a/docker/docker-compose.minio.yml
+++ b/docker/docker-compose.minio.yml
@@ -1,5 +1,5 @@
 services:
-  cdash:
+  website:
     environment:
       FILESYSTEM_DRIVER: s3
       AWS_BUCKET: cdash

--- a/docker/docker-compose.mysql.yml
+++ b/docker/docker-compose.mysql.yml
@@ -1,5 +1,5 @@
 services:
-  cdash:
+  website:
     environment:
       DB_CONNECTION: mysql
       DB_LOGIN: root
@@ -7,7 +7,6 @@ services:
 
   database:
     image: mysql/mysql-server:8.0
-    container_name: cdash_mysql
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_DATABASE}

--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -1,5 +1,5 @@
 services:
-  cdash:
+  website:
     environment:
       DB_CONNECTION: pgsql
       DB_LOGIN: postgres
@@ -13,7 +13,6 @@ services:
 
   database:
     image: postgres
-    container_name: cdash_postgres
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE}

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -1,5 +1,5 @@
 services:
-  cdash:
+  website:
     env_file:
       - ../.env
     ports:
@@ -24,7 +24,7 @@ services:
       restart_policy:
         condition: any
     depends_on:
-      cdash:
+      website:
         condition: service_started
     volumes:
       - type: volume

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,7 @@
 name: cdash
 services:
-  cdash:
+  website:
     image: kitware/cdash
-    container_name: cdash
     build:
       context: ..
       target: cdash

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -32,9 +32,9 @@ abstract class BrowserTestCase extends BaseTestCase
         }
         $this->original_env_contents = $env_contents;
 
-        file_put_contents(base_path('.env'), str_replace('localhost:8080', 'cdash:8080', $this->original_env_contents));
+        file_put_contents(base_path('.env'), str_replace('localhost:8080', 'website:8080', $this->original_env_contents));
 
-        Browser::$baseUrl = 'http://cdash:8080';
+        Browser::$baseUrl = 'http://website:8080';
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Our docker compose files currently hardcode each of the container names, making it difficult to run multiple deployments at the same time.  This is particularly annoying when developing locally.  This PR removes the hardcoded container names, letting docker compose give each container a name automatically.