### PR TITLE
Remove unnecessary dependencies between mocked unit tests

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -76,14 +76,8 @@ set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /Feature/CDashTest)
 add_unit_test(/CDash/ConfigUseCase)
 set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/BuildUseCase)
 
-add_unit_test(/CDash/Lib/Repository/GitHub)
-set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES
-    DEPENDS /CDash/ConfigUseCase
-    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
-)
-
 add_unit_test(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
-set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /CDash/Lib/Repository/GitHub)
+set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /CDash/ConfigUseCase)
 
 add_unit_test(/CDash/Messaging/Subscription/UserSubscriptionBuilder)
 set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPERTIES DEPENDS /CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
@@ -152,6 +146,12 @@ set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /CDash/XmlHandler/
 
 add_laravel_test(/Feature/GitHubWebhook)
 set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Lib/Repository/GitHub)
+set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES
+    DEPENDS /CDash/XmlHandler/UpdateHandler
+    DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
+)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -291,6 +291,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/ProjectPermissions
   /Feature/SlowPageTest
   /Feature/GitHubWebhook
+  /CDash/Lib/Repository/GitHub
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,11 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_laravel_test(/Feature/ProjectPermissions)
-set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /Feature/CDashTest)
-
 add_laravel_test(/Feature/SlowPageTest)
-set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /Feature/ProjectPermissions)
+set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_laravel_test(/Feature/GitHubWebhook)
 set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /Feature/SlowPageTest)
@@ -152,6 +149,9 @@ set_tests_properties(/CDash/XmlHandler/UpdateHandler PROPERTIES DEPENDS /CDash/X
 
 add_laravel_test(/Feature/LoginAndRegistration)
 set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/ProjectPermissions)
+set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -288,6 +288,7 @@ set_tests_properties(/Feature/Traits/UpdatesSiteInformationTest PROPERTIES DEPEN
 cdash_install()
 set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/LoginAndRegistration
+  /Feature/ProjectPermissions
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,11 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_laravel_test(/Feature/GitHubWebhook)
-set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /Feature/CDashTest)
-
 add_unit_test(/CDash/BuildUseCase)
-set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /Feature/GitHubWebhook)
+set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_unit_test(/CDash/ConfigUseCase)
 set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/BuildUseCase)
@@ -152,6 +149,9 @@ set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /CDash/XmlHa
 
 add_laravel_test(/Feature/SlowPageTest)
 set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/GitHubWebhook)
+set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -290,6 +290,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/LoginAndRegistration
   /Feature/ProjectPermissions
   /Feature/SlowPageTest
+  /Feature/GitHubWebhook
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,14 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_unit_test(/CDash/BuildUseCase)
-set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /Feature/CDashTest)
-
-add_unit_test(/CDash/ConfigUseCase)
-set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/BuildUseCase)
-
 add_unit_test(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
-set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /CDash/ConfigUseCase)
+set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_unit_test(/CDash/Messaging/Subscription/UserSubscriptionBuilder)
 set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPERTIES DEPENDS /CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
@@ -152,6 +146,12 @@ set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES
     DEPENDS /CDash/XmlHandler/UpdateHandler
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
 )
+
+add_unit_test(/CDash/BuildUseCase)
+set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/ConfigUseCase)
+set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -292,6 +292,8 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/SlowPageTest
   /Feature/GitHubWebhook
   /CDash/Lib/Repository/GitHub
+  /CDash/BuildUseCase
+  /CDash/ConfigUseCase
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,11 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_laravel_test(/Feature/SlowPageTest)
-set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /Feature/CDashTest)
-
 add_laravel_test(/Feature/GitHubWebhook)
-set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /Feature/SlowPageTest)
+set_tests_properties(/Feature/GitHubWebhook PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_unit_test(/CDash/BuildUseCase)
 set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /Feature/GitHubWebhook)
@@ -152,6 +149,9 @@ set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /CDash/Xml
 
 add_laravel_test(/Feature/ProjectPermissions)
 set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/SlowPageTest)
+set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -289,6 +289,7 @@ cdash_install()
 set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/LoginAndRegistration
   /Feature/ProjectPermissions
+  /Feature/SlowPageTest
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -76,11 +76,8 @@ set_tests_properties(/CDash/MultipleSubprojectsEmail PROPERTIES DEPENDS /Feature
 add_unit_test(/CDash/NightlyTime)
 set_tests_properties(/CDash/NightlyTime PROPERTIES DEPENDS /CDash/MultipleSubprojectsEmail)
 
-add_unit_test(/CDash/Service/RepositoryService)
-set_tests_properties(/CDash/Service/RepositoryService PROPERTIES DEPENDS /CDash/NightlyTime)
-
 add_unit_test(/CDash/TestUseCase)
-set_tests_properties(/CDash/TestUseCase PROPERTIES DEPENDS /CDash/Service/RepositoryService)
+set_tests_properties(/CDash/TestUseCase PROPERTIES DEPENDS /CDash/NightlyTime)
 
 add_unit_test(/CDash/XmlHandler/BuildHandler)
 set_tests_properties(/CDash/XmlHandler/BuildHandler PROPERTIES DEPENDS /CDash/TestUseCase)
@@ -152,6 +149,9 @@ set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPE
 
 add_unit_test(/CDash/Messaging/Topic/UpdateErrorTopic)
 set_tests_properties(/CDash/Messaging/Topic/UpdateErrorTopic PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Service/RepositoryService)
+set_tests_properties(/CDash/Service/RepositoryService PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -303,6 +303,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder
   /CDash/Messaging/Subscription/UserSubscriptionBuilder
   /CDash/Messaging/Topic/UpdateErrorTopic
+  /CDash/Service/RepositoryService
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -82,11 +82,8 @@ set_tests_properties(/CDash/Service/RepositoryService PROPERTIES DEPENDS /CDash/
 add_unit_test(/CDash/TestUseCase)
 set_tests_properties(/CDash/TestUseCase PROPERTIES DEPENDS /CDash/Service/RepositoryService)
 
-add_unit_test(/CDash/UpdateUseCase)
-set_tests_properties(/CDash/UpdateUseCase PROPERTIES DEPENDS /CDash/TestUseCase)
-
 add_unit_test(/CDash/XmlHandler/BuildHandler)
-set_tests_properties(/CDash/XmlHandler/BuildHandler PROPERTIES DEPENDS /CDash/UpdateUseCase)
+set_tests_properties(/CDash/XmlHandler/BuildHandler PROPERTIES DEPENDS /CDash/TestUseCase)
 
 add_unit_test(/CDash/XmlHandler/ConfigureHandler)
 set_tests_properties(/CDash/XmlHandler/ConfigureHandler PROPERTIES DEPENDS /CDash/XmlHandler/BuildHandler)
@@ -128,6 +125,9 @@ set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /CDash/XmlHandler/Up
 
 add_unit_test(/CDash/ConfigUseCase)
 set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/UpdateUseCase)
+set_tests_properties(/CDash/UpdateUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 add_unit_test(/CDash/Model/BuildError)
 set_tests_properties(/CDash/Model/BuildError PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
@@ -294,6 +294,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /CDash/Lib/Repository/GitHub
   /CDash/BuildUseCase
   /CDash/ConfigUseCase
+  /CDash/UpdateUseCase
   /CDash/Model/BuildError
   /CDash/Model/BuildErrorFilter
   /CDash/Model/BuildFailure

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,11 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_laravel_test(/Feature/LoginAndRegistration)
-set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /Feature/CDashTest)
-
 add_laravel_test(/Feature/ProjectPermissions)
-set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /Feature/LoginAndRegistration)
+set_tests_properties(/Feature/ProjectPermissions PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_laravel_test(/Feature/SlowPageTest)
 set_tests_properties(/Feature/SlowPageTest PROPERTIES DEPENDS /Feature/ProjectPermissions)
@@ -152,6 +149,9 @@ set_tests_properties(/CDash/XmlHandler/UpdateHandler PROPERTIES DEPENDS /CDash/X
 # Tests from this point to the next cdash_install() are expected to be completely independent.
 # Tests may wipe the database, provided that they use RUN_SERIAL. All tests in this section should
 # depend upon the last test prior to this section.
+
+add_laravel_test(/Feature/LoginAndRegistration)
+set_tests_properties(/Feature/LoginAndRegistration PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -287,6 +287,7 @@ set_tests_properties(/Feature/Traits/UpdatesSiteInformationTest PROPERTIES DEPEN
 
 cdash_install()
 set_property(TEST install_2 PROPERTY DEPENDS
+  /Feature/LoginAndRegistration
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -70,17 +70,8 @@ cdash_install()
 add_laravel_test(/Feature/CDashTest)
 set_tests_properties(/Feature/CDashTest PROPERTIES DEPENDS install_1)
 
-add_unit_test(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
-set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /Feature/CDashTest)
-
-add_unit_test(/CDash/Messaging/Subscription/UserSubscriptionBuilder)
-set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPERTIES DEPENDS /CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
-
-add_unit_test(/CDash/Messaging/Topic/UpdateErrorTopic)
-set_tests_properties(/CDash/Messaging/Topic/UpdateErrorTopic PROPERTIES DEPENDS /CDash/Messaging/Subscription/UserSubscriptionBuilder)
-
 add_unit_test(/CDash/MultipleSubprojectsEmail)
-set_tests_properties(/CDash/MultipleSubprojectsEmail PROPERTIES DEPENDS /CDash/Messaging/Topic/UpdateErrorTopic)
+set_tests_properties(/CDash/MultipleSubprojectsEmail PROPERTIES DEPENDS /Feature/CDashTest)
 
 add_unit_test(/CDash/NightlyTime)
 set_tests_properties(/CDash/NightlyTime PROPERTIES DEPENDS /CDash/MultipleSubprojectsEmail)
@@ -152,6 +143,15 @@ set_tests_properties(/CDash/Model/BuildRelationship PROPERTIES DEPENDS /CDash/Xm
 
 add_unit_test(/CDash/Model/Repository)
 set_tests_properties(/CDash/Model/Repository PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder)
+set_tests_properties(/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Messaging/Subscription/UserSubscriptionBuilder)
+set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Messaging/Topic/UpdateErrorTopic)
+set_tests_properties(/CDash/Messaging/Topic/UpdateErrorTopic PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -299,6 +299,9 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /CDash/Model/BuildFailure
   /CDash/Model/BuildRelationship
   /CDash/Model/Repository
+  /CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilder
+  /CDash/Messaging/Subscription/UserSubscriptionBuilder
+  /CDash/Messaging/Topic/UpdateErrorTopic
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -79,23 +79,8 @@ set_tests_properties(/CDash/Messaging/Subscription/UserSubscriptionBuilder PROPE
 add_unit_test(/CDash/Messaging/Topic/UpdateErrorTopic)
 set_tests_properties(/CDash/Messaging/Topic/UpdateErrorTopic PROPERTIES DEPENDS /CDash/Messaging/Subscription/UserSubscriptionBuilder)
 
-add_unit_test(/CDash/Model/BuildError)
-set_tests_properties(/CDash/Model/BuildError PROPERTIES DEPENDS /CDash/Messaging/Topic/UpdateErrorTopic)
-
-add_unit_test(/CDash/Model/BuildErrorFilter)
-set_tests_properties(/CDash/Model/BuildErrorFilter PROPERTIES DEPENDS /CDash/Model/BuildError)
-
-add_unit_test(/CDash/Model/BuildFailure)
-set_tests_properties(/CDash/Model/BuildFailure PROPERTIES DEPENDS /CDash/Model/BuildErrorFilter)
-
-add_unit_test(/CDash/Model/BuildRelationship)
-set_tests_properties(/CDash/Model/BuildRelationship PROPERTIES DEPENDS /CDash/Model/BuildFailure)
-
-add_unit_test(/CDash/Model/Repository)
-set_tests_properties(/CDash/Model/Repository PROPERTIES DEPENDS /CDash/Model/BuildRelationship)
-
 add_unit_test(/CDash/MultipleSubprojectsEmail)
-set_tests_properties(/CDash/MultipleSubprojectsEmail PROPERTIES DEPENDS /CDash/Model/Repository)
+set_tests_properties(/CDash/MultipleSubprojectsEmail PROPERTIES DEPENDS /CDash/Messaging/Topic/UpdateErrorTopic)
 
 add_unit_test(/CDash/NightlyTime)
 set_tests_properties(/CDash/NightlyTime PROPERTIES DEPENDS /CDash/MultipleSubprojectsEmail)
@@ -152,6 +137,21 @@ set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /CDash/XmlHandler/Up
 
 add_unit_test(/CDash/ConfigUseCase)
 set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Model/BuildError)
+set_tests_properties(/CDash/Model/BuildError PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Model/BuildErrorFilter)
+set_tests_properties(/CDash/Model/BuildErrorFilter PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Model/BuildFailure)
+set_tests_properties(/CDash/Model/BuildFailure PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Model/BuildRelationship)
+set_tests_properties(/CDash/Model/BuildRelationship PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_unit_test(/CDash/Model/Repository)
+set_tests_properties(/CDash/Model/Repository PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Set this to RUN_SERIAL as we are changing the config and don't want to clobber other tests.
 # Only requires exclusive .env access.
@@ -294,6 +294,11 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /CDash/Lib/Repository/GitHub
   /CDash/BuildUseCase
   /CDash/ConfigUseCase
+  /CDash/Model/BuildError
+  /CDash/Model/BuildErrorFilter
+  /CDash/Model/BuildFailure
+  /CDash/Model/BuildRelationship
+  /CDash/Model/Repository
   /Feature/SubmissionValidation
   /Feature/GraphQL/FilterTest
   /Feature/GraphQL/ProjectTypeTest

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29925,7 +29925,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Http\\\\Response\\:\\:content\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: tests/Feature/SlowPageTest.php
 
 		-

--- a/tests/Feature/SlowPageTest.php
+++ b/tests/Feature/SlowPageTest.php
@@ -12,15 +12,16 @@ class SlowPageTest extends TestCase
     public function testSlowPageLogsWarning(): void
     {
         Log::shouldReceive('warning')
-            ->with(Mockery::pattern('#Slow page\: /\?projectid=10 took \d*\.?\d+ seconds to load#'));
+            ->with(Mockery::pattern('#Slow page\: /login took \d*\.?\d+ seconds to load#'));
         Config::set('cdash.slow_page_time', 0);
-        self::assertNotEmpty($this->get('/?projectid=10')->content());
+        self::assertNotEmpty($this->get('/login')->content());
     }
 
     public function testFastPageDoesntLogWarning(): void
     {
         Config::set('cdash.slow_page_time', 100);
         Log::shouldReceive('warning')->never();
-        $this->get('/?projectid=10');
+        $this->get('/login');
+        self::assertNotEmpty($this->get('/login')->content());
     }
 }


### PR DESCRIPTION
This PR continues our ongoing effort to modernize the test suite by removing unnecessary explicit and implicit dependencies between tests, allowing us to make better use of multiprocessor systems.  The entire first "unit test" section of the test suite is now largely independent, leading to a much faster overall running time.  A number of unnecessary dependencies still exist due to broken mocks in some of these legacy unit tests.  I plan to make a separate PR to clean these up and remove all dependencies from this initial set of tests.

On my developer machine, these changes made development iterations much faster.