### PR TITLE
Reduce CI parallelism from 4 to 3 processes

### DIFF
--- a/.github/workflows/submit.sh
+++ b/.github/workflows/submit.sh
@@ -38,7 +38,7 @@ docker exec cdash bash -c "cd /cdash && /usr/bin/git checkout ."
 docker exec cdash bash -c "\
   ctest \
     -VV \
-    -j 4 \
+    -j 3 \
     --schedule-random \
     -DSITENAME=\"${site}\" \
     -DDATABASE=\"${database}\" \


### PR DESCRIPTION
GitHub Actions runners have 4 vCPUs and we currently allow CTest to run 4 processes in parallel.  This doesn't leave enough CPU for the database and selenium containers to function efficiently.  This PR reduces the parallelism to 3 processes.