### PR TITLE
Lock APP_URL in browser and cypress tests

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -36,6 +36,13 @@ function(add_laravel_test TestName)
   )
 endfunction()
 
+function(add_browser_test TestName)
+  add_laravel_test(${TestName})
+  set_property(TEST ${TestName} PROPERTY RESOURCE_LOCK
+    APP_URL # All browser tests need exclusive access to the APP_URL configuration setting
+  )
+endfunction()
+
 # phpunit tests
 set(phpunit_extra_arg "")
 if (CDASH_CONFIGURE_HTACCESS_FILE)
@@ -199,8 +206,7 @@ set_tests_properties(/Feature/Monitor PROPERTIES DEPENDS /CDash/XmlHandler/Updat
 add_laravel_test(/Feature/PasswordRotation)
 set_tests_properties(/Feature/PasswordRotation PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
-add_laravel_test(/Browser/Pages/SitesIdPageTest)
-set_tests_properties(/Browser/Pages/SitesIdPageTest PROPERTIES RUN_SERIAL TRUE)
+add_browser_test(/Browser/Pages/SitesIdPageTest)
 set_tests_properties(/Browser/Pages/SitesIdPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 # Technically this test doesn't have to run serially.  It just needs to have exclusive access to the .env
@@ -208,9 +214,7 @@ add_laravel_test(/Feature/LdapIntegration)
 set_tests_properties(/Feature/LdapIntegration PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Feature/LdapIntegration PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
-# TODO: Evaluate whether this test can be independent
-add_laravel_test(/Browser/Pages/ProjectSitesPageTest)
-set_tests_properties(/Browser/Pages/ProjectSitesPageTest PROPERTIES RUN_SERIAL TRUE)
+add_browser_test(/Browser/Pages/ProjectSitesPageTest)
 set_tests_properties(/Browser/Pages/ProjectSitesPageTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
 add_laravel_test(/Feature/PurgeUnusedProjectsCommand)

--- a/tests/Browser/Pages/ProjectSitesPageTest.php
+++ b/tests/Browser/Pages/ProjectSitesPageTest.php
@@ -2,7 +2,8 @@
 
 namespace Tests\Browser\Pages;
 
-use Illuminate\Foundation\Testing\DatabaseTruncation;
+use App\Models\Project;
+use App\Models\Site;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -13,12 +14,38 @@ class ProjectSitesPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use DatabaseTruncation;
+
+    /**
+     * @var array<Project>
+     */
+    private array $projects = [];
+
+    /**
+     * @var array<Site>
+     */
+    private array $sites = [];
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        foreach ($this->projects as $project) {
+            $project->delete();
+        }
+        $this->projects = [];
+
+        foreach ($this->sites as $site) {
+            $site->delete();
+        }
+        $this->sites = [];
+    }
 
     public function testSiteDisplaysLatestInformation(): void
     {
         $project = $this->makePublicProject();
+        $this->projects[] = $project;
         $site = $this->makeSite();
+        $this->sites[] = $site;
         $site->information()->createMany([
             [
                 'totalphysicalmemory' => 5678,
@@ -47,10 +74,12 @@ class ProjectSitesPageTest extends BrowserTestCase
     public function testSiteListPagination(): void
     {
         $project = $this->makePublicProject();
+        $this->projects[] = $project;
         $sites = [];
         for ($i = 0; $i < 120; $i++) {
             $sites[$i] = $this->makeSite();
         }
+        $this->sites = $sites;
 
         // No submissions to the project yet, so we shouldn't see any sites
         $this->browse(function (Browser $browser) use ($project) {

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -15,8 +15,6 @@ abstract class BrowserTestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    private string $original_env_contents = '';
-
     /**
      * @throws Exception
      */
@@ -30,9 +28,9 @@ abstract class BrowserTestCase extends BaseTestCase
         if ($env_contents === false) {
             throw new Exception('Unable to read .env file.');
         }
-        $this->original_env_contents = $env_contents;
 
-        file_put_contents(base_path('.env'), str_replace('localhost:8080', 'website:8080', $this->original_env_contents));
+        $env_after_substitution = str_replace('APP_URL=http://localhost:8080', 'APP_URL=http://website:8080', $env_contents);
+        file_put_contents(base_path('.env'), $env_after_substitution);
 
         Browser::$baseUrl = 'http://website:8080';
     }
@@ -41,7 +39,13 @@ abstract class BrowserTestCase extends BaseTestCase
     {
         parent::tearDown();
 
-        file_put_contents(base_path('.env'), $this->original_env_contents);
+        $env_contents = file_get_contents(base_path('.env'));
+        if ($env_contents === false) {
+            throw new Exception('Unable to read .env file.');
+        }
+
+        $env_after_substitution = str_replace('APP_URL=http://website:8080', 'APP_URL=http://localhost:8080', $env_contents);
+        file_put_contents(base_path('.env'), $env_after_substitution);
     }
 
     /**

--- a/tests/Feature/Mail/AuthTokenExpiredTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiredTest.php
@@ -43,7 +43,7 @@ class AuthTokenExpiredTest extends TestCase
 
         $mailable = new AuthTokenExpired($authtoken);
 
-        $mailable->assertSeeInHtml('http://localhost:8080/user');
+        $mailable->assertSeeInHtml(url('/user'));
     }
 
     public function testMailableNoDescription(): void

--- a/tests/Feature/Mail/AuthTokenExpiringTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiringTest.php
@@ -59,7 +59,7 @@ class AuthTokenExpiringTest extends TestCase
 
         $mailable = new AuthTokenExpiring($authtoken);
 
-        $mailable->assertSeeInHtml('http://localhost:8080/user');
+        $mailable->assertSeeInHtml(url('/user'));
     }
 
     public function testMailableNoDescription(): void

--- a/tests/cypress/component/CMakeLists.txt
+++ b/tests/cypress/component/CMakeLists.txt
@@ -1,13 +1,10 @@
 function(add_cypress_component_test TestName)
-  set_app_url()
-
   add_test(
     NAME cypress/component/${TestName}
     COMMAND ${NPX_EXE} cypress run
       --component
       --project ${CDash_SOURCE_DIR}
       --spec ${CDash_SOURCE_DIR}/tests/cypress/component/${TestName}.cy.js
-      --config baseUrl=${APP_URL}
   )
   # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
   set_tests_properties(cypress/component/${TestName} PROPERTIES

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -13,7 +13,7 @@ function(add_cypress_e2e_test TestName)
   set_tests_properties(cypress/e2e/${TestName} PROPERTIES
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
-    RESOURCE_LOCK "cypress" # Cypress can only run one at a time due to xvfb issues
+    RESOURCE_LOCK "cypress;APP_URL" # Cypress can only run one at a time due to xvfb issues and needs a consistent APP_URL
   )
 endfunction()
 


### PR DESCRIPTION
All of our browser tests currently require exclusivity because they change the `.env`.  It isn't actually necessary to run serially if we can guarantee that the only thing being changed in the `.env` is the `APP_URL`.  This PR resolves the issue by adding a new `RESOURCE_LOCK` and changing the existing browser tests to allow parallel execution.  This is especially important going forward because the browser tests are some of the longest-running tests we have.