### PR TITLE
Restrict user email access

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class UserPolicy
+{
+    public function viewEmail(User $currentUser, User $user): bool
+    {
+        // We can always see our own email.
+        if ($currentUser->id === $user->id) {
+            return true;
+        }
+
+        // Admins can see emails for everyone
+        if ($currentUser->admin) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -173,6 +173,12 @@ add_laravel_test(/Feature/GraphQL/FilterTest)
 set_tests_properties(/Feature/GraphQL/FilterTest PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Feature/GraphQL/FilterTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/GraphQL/QueryTypeTest)
+set_tests_properties(/Feature/GraphQL/QueryTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
+add_laravel_test(/Feature/GraphQL/UserTypeTest)
+set_tests_properties(/Feature/GraphQL/UserTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_laravel_test(/Feature/GraphQL/ProjectTypeTest)
 set_tests_properties(/Feature/GraphQL/ProjectTypeTest PROPERTIES RUN_SERIAL TRUE)
 set_tests_properties(/Feature/GraphQL/ProjectTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
@@ -329,6 +335,8 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/SubmissionValidation
   /Feature/ProjectInvitationAcceptanceTest
   /Feature/GraphQL/FilterTest
+  /Feature/GraphQL/QueryTypeTest
+  /Feature/GraphQL/UserTypeTest
   /Feature/GraphQL/ProjectTypeTest
   /Feature/GraphQL/SiteTypeTest
   /Feature/GraphQL/BuildTypeTest

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -8,6 +8,19 @@ scalar NonNegativeSeconds @scalar(class: "App\\GraphQL\\Scalars\\NonNegativeSeco
 
 "Indicates what fields are available at the top level of a query operation."
 type Query {
+  "Find a single user by ID."
+  me: User @auth
+
+  "Find a single user by ID."
+  user(
+    id: ID @eq
+  ): User @find
+
+  "Get multiple users."
+  users(
+    filters: _ @filter(inputType: "UserFilterInput")
+  ): [User!]! @paginate(type: CONNECTION) @orderBy(column: "id")
+
   "Find a single project."
   project(
     "Search by primary key."
@@ -82,7 +95,7 @@ type User {
   lastname: String!
 
   "Unique email address."
-  email: String!
+  email: String @canRoot(ability: "viewEmail")
 
   "Institution."
   institution: String!
@@ -95,7 +108,6 @@ input UserFilterInput {
   id: ID
   firstname: String
   lastname: String
-  email: String
   institution: String
   admin: Boolean
 }

--- a/tests/Feature/GraphQL/QueryTypeTest.php
+++ b/tests/Feature/GraphQL/QueryTypeTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\User;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class QueryTypeTest extends TestCase
+{
+    use CreatesUsers;
+
+    /** @var array<User> */
+    private array $users = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->users as $user) {
+            $user->delete();
+        }
+        $this->users = [];
+
+        parent::tearDown();
+    }
+
+    public function testMeFieldWhenSignedIn(): void
+    {
+        $user = $this->makeNormalUser();
+        $this->users[] = $user;
+
+        $this->actingAs($user)->graphQL('
+            query {
+                me {
+                    id
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'me' => [
+                    'id' => (string) $user->id,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testMeFieldWhenSignedOut(): void
+    {
+        $this->graphQL('
+            query {
+                me {
+                    id
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'me' => null,
+            ],
+        ], true);
+    }
+
+    public function testUserFieldInvalidUser(): void
+    {
+        $this->graphQL('
+            query {
+                user(
+                    id: "123456789"
+                ){
+                    id
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'user' => null,
+            ],
+        ], true);
+    }
+
+    public function testUserFieldValidUser(): void
+    {
+        $user = $this->makeNormalUser();
+        $this->users[] = $user;
+
+        $this->graphQL('
+            query($userid: ID) {
+                user(
+                    id: $userid
+                ){
+                    id
+                }
+            }
+        ', [
+            'userid' => $user->id,
+        ])->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => (string) $user->id,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testUsersFieldBasicAccess(): void
+    {
+        $user1 = $this->makeNormalUser();
+        $user2 = $this->makeNormalUser();
+        $this->users[] = $user1;
+        $this->users[] = $user2;
+
+        $this->graphQL('
+            query($user1: ID, $user2: ID) {
+                users(filters: {
+                    any: [
+                        {
+                            eq: {
+                                id: $user1
+                            }
+                        },
+                        {
+                            eq: {
+                                id: $user2
+                            }
+                        }
+                    ]
+                }){
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        ', [
+            'user1' => $user1->id,
+            'user2' => $user2->id,
+        ])->assertJson([
+            'data' => [
+                'users' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'id' => (string) $user1->id,
+                            ],
+                        ],
+                        [
+                            'node' => [
+                                'id' => (string) $user2->id,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], true);
+    }
+}

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -1120,7 +1120,6 @@ class SiteTypeTest extends TestCase
                                     edges {
                                         node {
                                             id
-                                            email
                                         }
                                     }
                                 }
@@ -1174,7 +1173,6 @@ class SiteTypeTest extends TestCase
                                     edges {
                                         node {
                                             id
-                                            email
                                         }
                                     }
                                 }
@@ -1199,7 +1197,6 @@ class SiteTypeTest extends TestCase
                                             [
                                                 'node' => [
                                                     'id' => (string) $this->users['normal']->id,
-                                                    'email' => $this->users['normal']->email,
                                                 ],
                                             ],
                                         ],
@@ -1231,7 +1228,6 @@ class SiteTypeTest extends TestCase
                         edges {
                             node {
                                 id
-                                email
                             }
                         }
                     }
@@ -1248,7 +1244,6 @@ class SiteTypeTest extends TestCase
                             [
                                 'node' => [
                                     'id' => (string) $this->users['normal']->id,
-                                    'email' => $this->users['normal']->email,
                                 ],
                             ],
                         ],

--- a/tests/Feature/GraphQL/UserTypeTest.php
+++ b/tests/Feature/GraphQL/UserTypeTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\User;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class UserTypeTest extends TestCase
+{
+    use CreatesUsers;
+
+    private User $normalUser;
+    private User $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->normalUser = $this->makeNormalUser();
+        $this->adminUser = $this->makeAdminUser();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->normalUser->delete();
+        $this->adminUser->delete();
+
+        parent::tearDown();
+    }
+
+    public function testBasicFieldAccess(): void
+    {
+        $this->actingAs($this->normalUser)->graphQL('
+            query {
+                me {
+                    id
+                    email
+                    firstname
+                    lastname
+                    institution
+                    admin
+                }
+            }
+        ')->assertJson([
+            'data' => [
+                'me' => [
+                    'id' => (string) $this->normalUser->id,
+                    'email' => $this->normalUser->email,
+                    'firstname' => $this->normalUser->firstname,
+                    'lastname' => $this->normalUser->lastname,
+                    'institution' => $this->normalUser->institution,
+                    'admin' => $this->normalUser->admin,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testCanSeeOwnEmail(): void
+    {
+        $this->actingAs($this->normalUser)->graphQL('
+            query($userid: ID) {
+                user(id: $userid) {
+                    id
+                    email
+                }
+            }
+        ', [
+            'userid' => $this->normalUser->id,
+        ])->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => (string) $this->normalUser->id,
+                    'email' => $this->normalUser->email,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testCannotSeeEmailForOtherUsers(): void
+    {
+        $this->actingAs($this->normalUser)->graphQL('
+            query($userid: ID) {
+                user(id: $userid) {
+                    id
+                    email
+                }
+            }
+        ', [
+            'userid' => $this->adminUser->id,
+        ])->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => (string) $this->adminUser->id,
+                    'email' => null,
+                ],
+            ],
+        ], true);
+    }
+
+    public function testAdminCanSeeAllEmails(): void
+    {
+        $this->actingAs($this->adminUser)->graphQL('
+            query($userid: ID) {
+                user(id: $userid) {
+                    id
+                    email
+                }
+            }
+        ', [
+            'userid' => $this->normalUser->id,
+        ])->assertJson([
+            'data' => [
+                'user' => [
+                    'id' => (string) $this->normalUser->id,
+                    'email' => $this->normalUser->email,
+                ],
+            ],
+        ], true);
+    }
+}


### PR DESCRIPTION
Users' email addresses are currently considered public information.  This PR changes that, instead limiting access to users themselves and CDash administrators.  This opens the possibility for a user-specific configuration option to allow users to optionally display their email address in various places in the UI.  As part of this PR, new `me`, `user(id)`, and `users` fields have been added to the GraphQL schema.