### PR TITLE
Add `user-profile` Cypress test to `install_2` dependency list

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -369,6 +369,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/GraphQL/Mutations/RevokeInvitationTest
   /Feature/GraphQL/Mutations/ChangeProjectRoleTest
   /Feature/Traits/UpdatesSiteInformationTest
+  cypress/e2e/user-profile
 )
 
 


### PR DESCRIPTION
The `user-profile` Cypress test does not rely upon data from prior tests, but needs data it creates to remain in the database for the duration of the test.  This causes a conflict with the `install_2` "test" which resets the entire database, as seen in [this](https://github.com/Kitware/CDash/actions/runs/14577369657/job/40886347190) failing job.  This PR adds `user-profile` to the list of dependencies for the `install_2` test.