### PR TITLE
Fix docker compose postgres volume path

### DIFF
--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE}
     volumes:
-      - postgresqldata:/var/lib/postgresql
+      - postgresqldata:/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -U postgres"
       interval: 1s


### PR DESCRIPTION
Our docker compose configuration currently stores the postgres data filesystem in an anonymous volume.  This PR fixes the issue by changing the data volume path to the path described in the [docs](https://hub.docker.com/_/postgres).