### PR TITLE
Remove legacy User model passthrough

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,12 +13,6 @@ use LdapRecord\Laravel\Auth\AuthenticatesWithLdap;
 use LdapRecord\Laravel\Auth\LdapAuthenticatable;
 
 /**
- * All of these methods are accessed through reflection.  Only the ones currently necessary are
- * listed to encourage future developers to move User logic to this class.
- *
- * @method GetEmail()
- * @method int|false GetIdFromName($name)
- *
  * @property int $id
  * @property bool $admin
  * @property string $firstname
@@ -36,8 +30,6 @@ class User extends Authenticatable implements MustVerifyEmail, LdapAuthenticatab
 {
     use Notifiable;
     use AuthenticatesWithLdap;
-
-    protected $user;
 
     protected $table = 'users';
 
@@ -99,21 +91,5 @@ class User extends Authenticatable implements MustVerifyEmail, LdapAuthenticatab
     public function projects(): BelongsToMany
     {
         return $this->belongsToMany(Project::class, 'user2project', 'userid', 'projectid');
-    }
-
-    /**
-     * Passthrough to call legacy User model method.
-     **/
-    public function __call($method, $parameters)
-    {
-        $class = \CDash\Model\User::class;
-        $class_methods = get_class_methods($class);
-        if (in_array($method, $class_methods)) {
-            $user = new $class();
-            $user->Id = $this->id;
-            return $user->$method(...$parameters);
-        }
-
-        return parent::__call($method, $parameters);
     }
 }

--- a/app/cdash/app/Model/User.php
+++ b/app/cdash/app/Model/User.php
@@ -20,6 +20,9 @@ namespace CDash\Model;
 use CDash\Database;
 use PDO;
 
+/**
+ * @deprecated 04/22/2025  Used only in the legacy notification system.  Use Eloquent for new work.
+ */
 class User
 {
     public $Id;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3010,26 +3010,6 @@ parameters:
 			path: app/Models/TestOutput.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: "#^Method App\\\\Models\\\\User\\:\\:__call\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: "#^Property App\\\\Models\\\\User\\:\\:\\$user has no type specified\\.$#"
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: "#^Variable method call on CDash\\\\Model\\\\User\\.$#"
-			count: 1
-			path: app/Models/User.php
-
-		-
 			message: "#^Parameter \\$get of static method Illuminate\\\\Database\\\\Eloquent\\\\Casts\\\\Attribute\\<mixed,mixed\\>\\:\\:make\\(\\) expects \\(callable\\(mixed, mixed\\)\\: string\\)\\|null, Closure\\(mixed, array\\)\\: string given\\.$#"
 			count: 1
 			path: app/Models/UserInvitation.php
@@ -9362,6 +9342,14 @@ parameters:
 			path: app/cdash/app/Model/SubProjectGroup.php
 
 		-
+			message: """
+				#^Instantiation of deprecated class CDash\\\\Model\\\\User\\:
+				04/22/2025  Used only in the legacy notification system\\.  Use Eloquent for new work\\.$#
+			"""
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
@@ -9408,6 +9396,14 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$build of method CDash\\\\Messaging\\\\Topic\\\\TopicInterface\\:\\:subscribesToBuild\\(\\) expects CDash\\\\Model\\\\Build, mixed given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/Subscriber.php
+
+		-
+			message: """
+				#^Parameter \\$user of method CDash\\\\Model\\\\Subscriber\\:\\:__construct\\(\\) has typehint with deprecated class CDash\\\\Model\\\\User\\:
+				04/22/2025  Used only in the legacy notification system\\.  Use Eloquent for new work\\.$#
+			"""
 			count: 1
 			path: app/cdash/app/Model/Subscriber.php
 


### PR DESCRIPTION
This PR removes the reflection-based passthrough which allowed legacy User model fields and methods to be available via the Eloquent User model.  The legacy model is only used in the legacy notification system and will eventually be removed.