### PR TITLE
Fix flaky test-related Cypress tests

### DIFF
--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -27,6 +27,15 @@ set_tests_properties(cypress/e2e/all-projects PROPERTIES DEPENDS projectindb)
 add_cypress_e2e_test(query-tests)
 set_tests_properties(cypress/e2e/query-tests PROPERTIES DEPENDS cypress/e2e/remove-build)
 
+add_cypress_e2e_test(view-test)
+set_tests_properties(cypress/e2e/view-test PROPERTIES DEPENDS cypress/e2e/remove-build)
+
+add_cypress_e2e_test(test-summary)
+set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS cypress/e2e/remove-build)
+
+add_cypress_e2e_test(tests)
+set_tests_properties(cypress/e2e/tests PROPERTIES DEPENDS cypress/e2e/remove-build)
+
 # These tests don't have all of the dependencies worked out
 add_cypress_e2e_test(manage-overview)
 set_tests_properties(cypress/e2e/manage-overview PROPERTIES DEPENDS simple2_async)
@@ -43,9 +52,6 @@ set_tests_properties(cypress/e2e/manage-sub-project PROPERTIES DEPENDS simple2_a
 add_cypress_e2e_test(view-build-error)
 set_tests_properties(cypress/e2e/view-build-error PROPERTIES DEPENDS simple2_async)
 
-add_cypress_e2e_test(view-test)
-set_tests_properties(cypress/e2e/view-test PROPERTIES DEPENDS simple2_async)
-
 add_cypress_e2e_test(sort-index)
 set_tests_properties(cypress/e2e/sort-index PROPERTIES DEPENDS simple2_async)
 
@@ -57,9 +63,6 @@ set_tests_properties(cypress/e2e/remove-build PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-sub-projects)
 set_tests_properties(cypress/e2e/view-sub-projects PROPERTIES DEPENDS simple2_async)
-
-add_cypress_e2e_test(test-summary)
-set_tests_properties(cypress/e2e/test-summary PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(filter-labels)
 set_tests_properties(cypress/e2e/filter-labels PROPERTIES DEPENDS simple2_async)
@@ -90,9 +93,6 @@ set_tests_properties(cypress/e2e/sites PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(view-coverage)
 set_tests_properties(cypress/e2e/view-coverage PROPERTIES DEPENDS simple2_async)
-
-add_cypress_e2e_test(tests)
-set_tests_properties(cypress/e2e/tests PROPERTIES DEPENDS simple2_async)
 
 add_cypress_e2e_test(build-configure)
 set_tests_properties(cypress/e2e/build-configure PROPERTIES DEPENDS simple2_async)


### PR DESCRIPTION
Implicit dependencies between Cypress tests weren't caught in https://github.com/Kitware/CDash/pull/2790.  This PR resolves the issues by forcing Cypress tests for test-related pages to run after the `remove-build` test which operates on the same data.  This should fix the Cypress flakiness in CI we've observed over the course of the last few weeks.