### PR TITLE
Limit scope of default route handler

### DIFF
--- a/app/Http/Controllers/CDash.php
+++ b/app/Http/Controllers/CDash.php
@@ -66,7 +66,7 @@ final class CDash extends AbstractController
     /**
      * Determines if the file being requested is in the CDash filesystem
      */
-    public function isValidRequest(): bool
+    protected function isValidRequest(): bool
     {
         $valid = false;
         $path = $this->getPath();
@@ -80,7 +80,7 @@ final class CDash extends AbstractController
     /**
      * Determines if the request is a request for a CDash api endpoint
      */
-    public function isApiRequest(): bool
+    protected function isApiRequest(): bool
     {
         $path = $this->getPath();
         return str_starts_with($path, 'api/');
@@ -89,7 +89,7 @@ final class CDash extends AbstractController
     /**
      * Processes the CDash file for a given request
      */
-    public function getRequestContents()
+    protected function getRequestContents()
     {
         $file = $this->getAbsolutePath();
         chdir($this->disk->path(''));
@@ -111,7 +111,7 @@ final class CDash extends AbstractController
      *
      * @return ResponseFactory|JsonResponse|Response|\Symfony\Component\HttpFoundation\Response
      */
-    public function handleApiRequest()
+    protected function handleApiRequest()
     {
         $json = $this->getRequestContents();
         $status = http_response_code(); // this should be empty if not previously set
@@ -136,7 +136,7 @@ final class CDash extends AbstractController
     /**
      * Returns the path of the request with consideration given to the root path
      */
-    public function getPath(): string
+    protected function getPath(): string
     {
         if (!$this->path) {
             $path = $this->request->path();
@@ -146,7 +146,7 @@ final class CDash extends AbstractController
         return $this->path;
     }
 
-    public function getAbsolutePath(): string
+    protected function getAbsolutePath(): string
     {
         $path = $this->getPath();
         $file = $this->disk->path($path);

--- a/routes/web.php
+++ b/routes/web.php
@@ -271,6 +271,3 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/monitor.php', fn () => redirect('/monitor', 301));
     });
 });
-
-// this *MUST* be the last route in the file
-Route::any('{url}', 'CDash')->where('url', '.*');


### PR DESCRIPTION
The current default route handler was initially conceived as a way to integrate Laravel into the existing routing system.  This route handler only applies to a handful of legacy API routes at this point, falling through with a 404 otherwise.  This PR limits the scope of the default route handler to only apply to routes under `/api`, using Laravel's default route handler for the rest of the routes.  I also changed the visibility of most of the functions in the file to better reflect their purpose.