### PR TITLE
Increase robustness of `TestOutput::DecompressOutput()`

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -61,6 +61,8 @@ add_laravel_test(/Unit/app/Validators/PasswordTest)
 
 add_laravel_test(/Unit/app/Middleware/InternalTest)
 
+add_laravel_test(/Unit/app/Models/TestOutputTest)
+
 # TODO: Is this test useful now?
 add_unit_test(/PHPUnitTest)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2996,26 +2996,11 @@ parameters:
 
 		-
 			message: "#^Call to function base64_decode\\(\\) requires parameter \\#2 to be set\\.$#"
-			count: 2
-			path: app/Models/TestOutput.php
-
-		-
-			message: "#^Method App\\\\Models\\\\TestOutput\\:\\:DecompressOutput\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/Models/TestOutput.php
-
-		-
-			message: "#^Method App\\\\Models\\\\TestOutput\\:\\:DecompressOutput\\(\\) has parameter \\$output with no type specified\\.$#"
 			count: 1
 			path: app/Models/TestOutput.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: app/Models/TestOutput.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function base64_decode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/Models/TestOutput.php
 

--- a/tests/Unit/app/Models/TestOutputTest.php
+++ b/tests/Unit/app/Models/TestOutputTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\app\Models;
+
+use App\Models\TestOutput;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Tests the TestOutput model.
+ */
+class TestOutputTest extends TestCase
+{
+    protected static string $expected = 'this is my test output';
+
+    protected function validateDecompressTestOutputFromStream(string $value): void
+    {
+        $fp = tmpfile();
+        if ($fp === false) {
+            $this::fail('Failed to create temporary file');
+        }
+        fwrite($fp, $value);
+        fseek($fp, 0);
+        $this::assertEquals(TestOutput::DecompressOutput($fp), TestOutputTest::$expected);
+        fclose($fp);
+    }
+
+    /**
+     * Data provider for testDecompressOutput
+     *
+     * @return array<string,array<string>>
+     */
+    public static function compressedOutputProvider()
+    {
+        return [
+            'compressed' => [(string) gzcompress(TestOutputTest::$expected)],
+            'compressed and encoded' => [base64_encode((string) gzcompress(TestOutputTest::$expected))],
+        ];
+    }
+
+    /**
+     * Test the various types of input that TestOutput::DecompressOutput()
+     * may receive.
+     */
+    #[DataProvider('compressedOutputProvider')]
+    public function testDecompressOutput(string $value): void
+    {
+        $this::assertEquals(TestOutput::DecompressOutput($value), TestOutputTest::$expected);
+        $this->validateDecompressTestOutputFromStream($value);
+    }
+
+    /**
+     * Data provider for testDecompressOutputDatabaseSpecificBehavior
+     *
+     * @return array<string,array<string>>
+     */
+    public static function databaseSpecificCompressedOutputProvider()
+    {
+        return [
+            'MySQL' => ['mysql', TestOutputTest::$expected],
+            'Postgres' => ['pgsql', base64_encode(TestOutputTest::$expected)],
+        ];
+    }
+
+    /**
+     * Test MySQL and Postgres specific behavior of TestOutput::DecompressOutput()
+     */
+    #[DataProvider('databaseSpecificCompressedOutputProvider')]
+    public function testDecompressOutputDatabaseSpecificBehavior(string $db_type, string $value): void
+    {
+        config(['database.default' => $db_type]);
+        $this::assertEquals(TestOutput::DecompressOutput($value), TestOutputTest::$expected);
+        $this->validateDecompressTestOutputFromStream($value);
+    }
+}


### PR DESCRIPTION
We currently base64 encode test output for Postgres, but not MySQL. This difference in behavior is a problem as we plan to drop suport for MySQL in CDash 4.0. Migrating data from MySQL to Postgres (using pgloader) results in a Postgres database that contains test output which is not base64 encoded. This currently results in an error when attempting to view this data on CDash.

Update `TestOutput::DecompressOutput()` to mitigate this issue by allowing Postgres-backed CDash instances to decompress data that originally came from a MySQL database, and thus isn't base64 encoded.