### PR TITLE
Remove "site maintainer" project access level

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -107,7 +107,6 @@ class Project extends Model
     ];
 
     public const PROJECT_ADMIN = 2;
-    public const SITE_MAINTAINER = 1;
     public const PROJECT_USER = 0;
 
     public const ACCESS_PRIVATE = 0;
@@ -146,17 +145,6 @@ class Project extends Model
     {
         return $this->belongsToMany(User::class, 'user2project', 'projectid', 'userid')
             ->wherePivot('role', self::PROJECT_ADMIN);
-    }
-
-    /**
-     * Get the users who maintain a site for this project
-     *
-     * @return BelongsToMany<User>
-     */
-    public function siteMaintainers(): BelongsToMany
-    {
-        return $this->belongsToMany(User::class, 'user2project', 'projectid', 'userid')
-            ->wherePivot('role', self::SITE_MAINTAINER);
     }
 
     /**

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -45,7 +45,6 @@ use RuntimeException;
 class Project
 {
     public const PROJECT_ADMIN = 2;
-    public const SITE_MAINTAINER = 1;
     public const PROJECT_USER = 0;
 
     public const ACCESS_PRIVATE = 0;

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -661,8 +661,8 @@ function get_dashboard_JSON($projectname, $date, &$response)
     $userid = Auth::id();
     if ($userid) {
         $project = App\Models\Project::findOrFail((int) $project->Id);
-        $response['projectrole'] = $project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? 0;
-        if ($response['projectrole'] > Project::SITE_MAINTAINER) {
+        $response['projectrole'] = (int) ($project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? 0);
+        if ($response['projectrole'] === Project::PROJECT_ADMIN) {
             $response['user']['admin'] = 1;
         }
     }

--- a/database/migrations/2025_04_29_184206_remove_project_site_maintainer_role.php
+++ b/database/migrations/2025_04_29_184206_remove_project_site_maintainer_role.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::update('
+            UPDATE user2project
+            SET role=0
+            WHERE role=1
+        ');
+    }
+
+    public function down(): void
+    {
+        // This migration is irreversible
+    }
+};


### PR DESCRIPTION
CDash previously allowed users to "claim" sites, in addition to a separate "site maintainer" access control level.  That site maintainer role was associated with notification options, not an access level with its own designated permissions.  Additionally, the difference between users who had claimed sites and users who had the site maintainer role was unclear to users.  The site maintainer role is now obsolete and serves no purpose in CDash today.