### PR TITLE
Fixed download of mulitple attached files

### DIFF
--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -42,7 +42,7 @@ class TestDetails extends BuildTestApi
                     testid = ?
                     AND type = 'file'
                 ORDER BY id
-            ", [$this->buildtest->id])[0];
+            ", [$this->buildtest->id])[$_GET['fileid'] - 1];
 
             return response()->streamDownload(
                 function () use ($query) {


### PR DESCRIPTION
When attaching multiple files to a single test (via CTestMeasurementFile), the download of any file in BuildDetails.php would always redirect to downloading the first file since the retrieved list of files was accessed at index 0.
This was fixed by replacing the index 0 by the actual file id in $_GET['fileid'] (-1 since file ids start at 1).  
