### PR TITLE
Add support for build command outputs

### DIFF
--- a/app/Models/BuildCommand.php
+++ b/app/Models/BuildCommand.php
@@ -79,4 +79,12 @@ class BuildCommand extends Model
     {
         return $this->belongsTo(Target::class, 'targetid');
     }
+
+    /**
+     * @return HasMany<BuildCommandOutput>
+     */
+    public function outputs(): HasMany
+    {
+        return $this->hasMany(BuildCommandOutput::class, 'buildcommandid');
+    }
 }

--- a/app/Models/BuildCommandOutput.php
+++ b/app/Models/BuildCommandOutput.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $buildcommandid
+ * @property int $size
+ * @property string $name
+ *
+ * @mixin Builder<BuildCommandOutput>
+ */
+class BuildCommandOutput extends Model
+{
+    protected $table = 'buildcommandoutputs';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'size',
+        'name',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'size' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<BuildCommand, self>
+     */
+    public function command(): BelongsTo
+    {
+        return $this->belongsTo(BuildCommand::class, 'buildcommandid');
+    }
+}

--- a/app/Validators/Schemas/Build.xsd
+++ b/app/Validators/Schemas/Build.xsd
@@ -10,6 +10,18 @@
       <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>
   </xs:element>
+  <xs:element name="Outputs">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Output">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="size" type="xs:unsignedLong" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="Site">
     <xs:complexType>
       <xs:sequence>
@@ -104,7 +116,10 @@
                                       <xs:element name="Compile">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                            <xs:choice maxOccurs="unbounded">
+                                              <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                              <xs:element maxOccurs="unbounded" ref="Outputs"/>
+                                            </xs:choice>
                                           </xs:sequence>
                                           <xs:attribute name="command" use="required"/>
                                           <xs:attribute name="workingDir" use="required"/>
@@ -120,7 +135,10 @@
                                       <xs:element name="Link">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                            <xs:choice maxOccurs="unbounded">
+                                              <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                              <xs:element maxOccurs="unbounded" ref="Outputs"/>
+                                            </xs:choice>
                                           </xs:sequence>
                                           <xs:attribute name="command" use="required"/>
                                           <xs:attribute name="workingDir" use="required"/>
@@ -177,7 +195,10 @@
                           <xs:element name="Custom">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                <xs:choice maxOccurs="unbounded">
+                                  <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
+                                  <xs:element maxOccurs="unbounded" ref="Outputs"/>
+                                </xs:choice>
                               </xs:sequence>
                               <xs:attribute name="command" use="required"/>
                               <xs:attribute name="workingDir" use="required"/>

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -214,6 +214,9 @@ set_tests_properties(/Feature/GraphQL/TargetTypeTest PROPERTIES DEPENDS /CDash/X
 add_laravel_test(/Feature/GraphQL/BuildCommandTypeTest)
 set_tests_properties(/Feature/GraphQL/BuildCommandTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/GraphQL/BuildCommandOutputTypeTest)
+set_tests_properties(/Feature/GraphQL/BuildCommandOutputTypeTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_laravel_test(/Feature/Submission/Instrumentation/BuildInstrumentationTest)
 set_tests_properties(/Feature/Submission/Instrumentation/BuildInstrumentationTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
@@ -360,6 +363,7 @@ set_property(TEST install_2 PROPERTY DEPENDS
   /Feature/GraphQL/LabelTypeTest
   /Feature/GraphQL/TargetTypeTest
   /Feature/GraphQL/BuildCommandTypeTest
+  /Feature/GraphQL/BuildCommandOutputTypeTest
   /Feature/Submission/Instrumentation/BuildInstrumentationTest
   /Feature/RouteAccessTest
   /Feature/Monitor

--- a/database/migrations/2025_04_30_110457_build_command_outputs.php
+++ b/database/migrations/2025_04_30_110457_build_command_outputs.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('buildcommandoutputs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('buildcommandid')->nullable()->index()->references('id')->on('buildcommands')->cascadeOnDelete();
+            $table->bigInteger('size');
+            $table->text('name')->nullable(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('buildcommandoutputs');
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -515,6 +515,14 @@ type BuildCommand @model(class: "App\\Models\\BuildCommand") {
   measurements(
     filters: _ @filter(inputType: "BuildMeasurementFilterInput")
   ): [BuildMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
+
+  """
+  Output filenames and corresponding sizes associated with this command.  Most command types only
+  produce one output file.
+  """
+  outputs(
+    filters: _ @filter(inputType: "BuildCommandOutputFilterInput")
+  ): [BuildCommandOutput!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
 }
 
 input BuildCommandFilterInput {
@@ -556,6 +564,26 @@ input BuildMeasurementFilterInput {
   name: String
   type: String
   value: String
+}
+
+
+"An individual file produced by a build command."
+type BuildCommandOutput {
+  "Unique primary key."
+  id: ID!
+
+  "Output filename."
+  name: String!
+
+  "Output file size in bytes."
+  size: Int!
+}
+
+
+input BuildCommandOutputFilterInput {
+  id: ID
+  name: String
+  size: Int
 }
 
 

--- a/tests/Feature/GraphQL/BuildCommandOutputTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandOutputTypeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Enums\BuildCommandType;
+use App\Models\Build;
+use App\Models\BuildCommand;
+use App\Models\BuildCommandOutput;
+use App\Models\Project;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+
+class BuildCommandOutputTypeTest extends TestCase
+{
+    use CreatesProjects;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    public function testBasicFieldAccess(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var BuildCommand $command */
+        $command = $build->commands()->create([
+            'type' => BuildCommandType::CUSTOM,
+            'starttime' => Carbon::now(),
+            'duration' => 12345,
+            'command' => Str::random(10),
+            'result' => Str::random(10),
+            'workingdirectory' => Str::uuid()->toString(),
+        ]);
+
+        /** @var BuildCommandOutput $output */
+        $output = $command->outputs()->create([
+            'name' => Str::uuid()->toString(),
+            'size' => fake()->randomDigitNotNull(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    commands {
+                        edges {
+                            node {
+                                outputs {
+                                    edges {
+                                        node {
+                                            id
+                                            name
+                                            size
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertJson([
+            'data' => [
+                'build' => [
+                    'commands' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'outputs' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'id' => (string) $output->id,
+                                                    'name' => $output->name,
+                                                    'size' => $output->size,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
+++ b/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
@@ -92,6 +92,14 @@ class BuildInstrumentationTest extends TestCase
                                                                 }
                                                             }
                                                         }
+                                                        outputs {
+                                                            edges {
+                                                                node {
+                                                                    name
+                                                                    size
+                                                                }
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -126,6 +134,14 @@ class BuildInstrumentationTest extends TestCase
                                                         name
                                                         type
                                                         value
+                                                    }
+                                                }
+                                            }
+                                            outputs {
+                                                edges {
+                                                    node {
+                                                        name
+                                                        size
                                                     }
                                                 }
                                             }
@@ -165,6 +181,14 @@ class BuildInstrumentationTest extends TestCase
                                                                             }
                                                                         }
                                                                     }
+                                                                    outputs {
+                                                                        edges {
+                                                                            node {
+                                                                                name
+                                                                                size
+                                                                            }
+                                                                        }
+                                                                    }
                                                                 }
                                                             }
                                                         }
@@ -199,6 +223,14 @@ class BuildInstrumentationTest extends TestCase
                                                                     name
                                                                     type
                                                                     value
+                                                                }
+                                                            }
+                                                        }
+                                                        outputs {
+                                                            edges {
+                                                                node {
+                                                                    name
+                                                                    size
                                                                 }
                                                             }
                                                         }

--- a/tests/Feature/Submission/Instrumentation/data/Build.xml
+++ b/tests/Feature/Submission/Instrumentation/data/Build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Site BuildName="test_instrument"
-	BuildStamp="20250328-1619-Experimental"
+	BuildStamp="20250424-1534-Experimental"
 	Name="test-site"
 	Generator="ctest-4.0.xyz"
 	CompilerName=""
@@ -34,8 +34,8 @@
 		<Label>Tutorial</Label>
 	</Subproject>
 	<Build>
-		<StartDateTime>Mar 28 12:19 EDT</StartDateTime>
-		<StartBuildTime>1743178749</StartBuildTime>
+		<StartDateTime>Apr 24 11:34 EDT</StartDateTime>
+		<StartBuildTime>1745508870</StartBuildTime>
 		<BuildCommand>/my/path/projects/CMake_bin/bin/cmake --build . --config "Release" --target "install"</BuildCommand>
 		<Failure type="Warning">
 			<!-- Meta-information about the build action -->
@@ -50,7 +50,7 @@
 			<Command>
 				<WorkingDirectory>/my/path/projects/tmp_for_cdash/bin_instrument</WorkingDirectory>
 				<Argument>/usr/bin/c++</Argument>
-				<Argument>-std=gnu++11</Argument>
+				<Argument>-g</Argument>
 				<Argument>-arch</Argument>
 				<Argument>arm64</Argument>
 				<Argument>-Wall</Argument>
@@ -91,33 +91,39 @@
 					<Label>Label2</Label>
 				</Labels>
 				<Commands>
-					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="70" language="C++" result="0" timeStart="1743178751667" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="57" language="C++" result="0" timeStart="1745508872439" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51395712.0</Value>
+							<Value>29929392.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51400464.0</Value>
+							<Value>29926256.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="Tutoriald" size="44056"/>
+						</Outputs>
 					</Link>
-					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="365" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx" timeStart="1743178750573" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="316" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx" timeStart="1745508871459" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51398064.0</Value>
+							<Value>29622544.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.74755859375</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51406128.0</Value>
+							<Value>29527728.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="CMakeFiles/Tutorial.dir/tutorial.cxx.o" size="108104"/>
+						</Outputs>
 					</Compile>
 				</Commands>
 			</Target>
@@ -127,33 +133,39 @@
 					<Label>Label4</Label>
 				</Labels>
 				<Commands>
-					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="76" language="C++" result="0" timeStart="1743178750216" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="75" language="C++" result="0" timeStart="1745508871084" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.74755859375</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51399056.0</Value>
+							<Value>29475808.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.74755859375</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51405264.0</Value>
+							<Value>29428976.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="MakeTable" size="46392"/>
+						</Outputs>
 					</Link>
-					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="340" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx" timeStart="1743178749799" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="290" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx" timeStart="1745508870720" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.74755859375</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51401328.0</Value>
+							<Value>29392944.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.74755859375</Value>
+							<Value>6.1201171875</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51365504.0</Value>
+							<Value>29279824.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o" size="119000"/>
+						</Outputs>
 					</Compile>
 				</Commands>
 			</Target>
@@ -163,34 +175,40 @@
 					<Label>Label3</Label>
 				</Labels>
 				<Commands>
-					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="67" language="C++" result="0" timeStart="1743178751470" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="84" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx" timeStart="1745508871459" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51400864.0</Value>
+							<Value>29595536.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51400288.0</Value>
+							<Value>29532944.0</Value>
 						</NamedMeasurement>
-					</Link>
-					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="99" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx" timeStart="1743178750573" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
-						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.74755859375</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51428640.0</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.74755859375</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51405616.0</Value>
-						</NamedMeasurement>
+						<Outputs>
+							<Output name="MathFunctions/CMakeFiles/MathFunctions.dir/MathFunctions.cxx.o" size="10272"/>
+						</Outputs>
 					</Compile>
+					<Link command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="59" language="C++" result="0" timeStart="1745508872257" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>29657296.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>29640896.0</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="libMathFunctionsd.1.0.0.dylib" size="60088"/>
+						</Outputs>
+					</Link>
 				</Commands>
 			</Target>
 			<Target name="SqrtLibrary" type="STATIC_LIBRARY">
@@ -199,154 +217,175 @@
 					<Label>Label3</Label>
 				</Labels>
 				<Commands>
-					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="" duration="64" language="C++" result="0" timeStart="1743178751022" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Link command="&quot;/usr/bin/ar&quot; (truncated)" config="Debug" duration="24" language="C++" result="0" timeStart="1745508871971" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51401440.0</Value>
+							<Value>29609568.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51401152.0</Value>
+							<Value>29629808.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="libSqrtLibraryd.a" size="111144"/>
+						</Outputs>
 					</Link>
-					<Link command="&quot;/usr/bin/ranlib&quot; (truncated)" config="" duration="24" language="C++" result="0" timeStart="1743178751245" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="Debug" duration="314" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx" timeStart="1745508871459" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51400672.0</Value>
+							<Value>29622320.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51400576.0</Value>
+							<Value>29528576.0</Value>
 						</NamedMeasurement>
-					</Link>
-					<Link command="&quot;/usr/bin/ar&quot; (truncated)" config="" duration="29" language="C++" result="0" timeStart="1743178751153" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
-						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51400704.0</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51400912.0</Value>
-						</NamedMeasurement>
-					</Link>
-					<Compile command="&quot;/usr/bin/c++&quot; (truncated)" config="" duration="365" language="C++" result="0" source="/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx" timeStart="1743178750574" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
-						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51397360.0</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.74755859375</Value>
-						</NamedMeasurement>
-						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51405904.0</Value>
-						</NamedMeasurement>
+						<Outputs>
+							<Output name="MathFunctions/CMakeFiles/SqrtLibrary.dir/mysqrt.cxx.o" size="107128"/>
+						</Outputs>
 					</Compile>
-					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="" duration="60" language="C++" result="0" timeStart="1743178751337" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="Debug" duration="62" language="C++" result="0" timeStart="1745508871848" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-							<Value>51407712.0</Value>
+							<Value>29628176.0</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-							<Value>4.84765625</Value>
+							<Value>7.3916015625</Value>
 						</NamedMeasurement>
 						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-							<Value>51400720.0</Value>
+							<Value>29621392.0</Value>
 						</NamedMeasurement>
+						<Outputs>
+							<Output name="libSqrtLibraryd.a" size="0"/>
+						</Outputs>
+					</Link>
+					<Link command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" config="Debug" duration="57" language="C++" result="0" timeStart="1745508872132" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>29642096.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>29641936.0</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="libSqrtLibraryd.a" size="111144"/>
+						</Outputs>
+					</Link>
+					<Link command="&quot;/usr/bin/ranlib&quot; (truncated)" config="Debug" duration="20" language="C++" result="0" timeStart="1745508872055" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+							<Value>29628128.0</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+							<Value>7.3916015625</Value>
+						</NamedMeasurement>
+						<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+							<Value>29627744.0</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="libSqrtLibraryd.a" size="111144"/>
+						</Outputs>
 					</Link>
 				</Commands>
 			</Target>
 		</Targets>
 		<Commands>
-			<Custom command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="195" result="0" timeStart="1743178751806" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+			<CmakeInstall command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="156" result="0" timeStart="1745508872617" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-					<Value>4.84765625</Value>
+					<Value>7.3916015625</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-					<Value>51396352.0</Value>
+					<Value>29999408.0</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-					<Value>4.84765625</Value>
+					<Value>7.3916015625</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-					<Value>51395488.0</Value>
-				</NamedMeasurement>
-			</Custom>
-			<Custom command="&quot;/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable&quot; (truncated)" duration="135" result="0" timeStart="1743178750362" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument/MathFunctions">
-				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-					<Value>4.74755859375</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-					<Value>51402880.0</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-					<Value>4.74755859375</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-					<Value>51398928.0</Value>
-				</NamedMeasurement>
-			</Custom>
-			<Install command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="126" result="0" timeStart="1743178752075" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
-				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-					<Value>4.84765625</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-					<Value>51397248.0</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-					<Value>4.84765625</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-					<Value>51395936.0</Value>
-				</NamedMeasurement>
-			</Install>
-			<CmakeInstall command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="122" result="0" timeStart="1743178751867" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
-				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-					<Value>4.84765625</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-					<Value>51400928.0</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-					<Value>4.84765625</Value>
-				</NamedMeasurement>
-				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-					<Value>51398320.0</Value>
+					<Value>29959744.0</Value>
 				</NamedMeasurement>
 			</CmakeInstall>
-			<CmakeBuild command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="2488" result="0" timeStart="1743178749725" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+			<Install command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="114" result="0" timeStart="1745508872873" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
 				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
-					<Value>4.84765625</Value>
+					<Value>7.3916015625</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
-					<Value>51391872.0</Value>
+					<Value>30030496.0</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
-					<Value>4.74755859375</Value>
+					<Value>7.3916015625</Value>
 				</NamedMeasurement>
 				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
-					<Value>51340336.0</Value>
+					<Value>30025664.0</Value>
+				</NamedMeasurement>
+			</Install>
+			<Custom command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="234" result="0" timeStart="1745508872560" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>7.3916015625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>29994752.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>7.3916015625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>29956800.0</Value>
+				</NamedMeasurement>
+				<Outputs>
+					<Output name="CMakeFiles/my_install" size="0"/>
+				</Outputs>
+			</Custom>
+			<Custom command="&quot;/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable&quot; (truncated)" duration="138" result="0" timeStart="1745508871223" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument/MathFunctions">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>7.3916015625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>29519120.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>7.3916015625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>29479504.0</Value>
+				</NamedMeasurement>
+				<Outputs>
+					<Output name="Table.h" size="0"/>
+				</Outputs>
+			</Custom>
+			<CmakeBuild command="&quot;/my/path/projects/CMake_bin/bin/cmake&quot; (truncated)" duration="2346" result="0" timeStart="1745508870653" version="1" workingDir="/my/path/projects/tmp_for_cdash/bin_instrument">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>7.3916015625</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="AfterHostMemoryUsed">
+					<Value>30039824.0</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeCPULoadAverage">
+					<Value>6.1201171875</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="BeforeHostMemoryUsed">
+					<Value>29132864.0</Value>
 				</NamedMeasurement>
 			</CmakeBuild>
 		</Commands>
 		<Log Encoding="base64" Compression="bin/gzip"/>
-		<EndDateTime>Mar 28 12:19 EDT</EndDateTime>
-		<EndBuildTime>1743178752</EndBuildTime>
+		<EndDateTime>Apr 24 11:34 EDT</EndDateTime>
+		<EndBuildTime>1745508873</EndBuildTime>
 		<ElapsedMinutes>0</ElapsedMinutes>
 	</Build>
 </Site>

--- a/tests/Feature/Submission/Instrumentation/data/result.json
+++ b/tests/Feature/Submission/Instrumentation/data/result.json
@@ -13,9 +13,9 @@
                 "edges": [
                   {
                     "node": {
-                      "type": "CUSTOM",
-                      "startTime": "2025-03-28T16:19:11+00:00",
-                      "duration": 195,
+                      "type": "CMAKE_INSTALL",
+                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "duration": 156,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
                       "source": null,
@@ -28,28 +28,134 @@
                             "node": {
                               "name": "AfterCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.84765625"
+                              "value": "7.3916015625"
                             }
                           },
                           {
                             "node": {
                               "name": "AfterHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51396352.0"
+                              "value": "29999408.0"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.84765625"
+                              "value": "7.3916015625"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51395488.0"
+                              "value": "29959744.0"
+                            }
+                          }
+                        ]
+                      },
+                      "outputs": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "INSTALL",
+                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "duration": 114,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "7.3916015625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "30030496.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "7.3916015625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "30025664.0"
+                            }
+                          }
+                        ]
+                      },
+                      "outputs": {
+                        "edges": []
+                      }
+                    }
+                  },
+                  {
+                    "node": {
+                      "type": "CUSTOM",
+                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "duration": 234,
+                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                      "result": "0",
+                      "source": null,
+                      "language": null,
+                      "config": null,
+                      "target": null,
+                      "measurements": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "AfterCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "7.3916015625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "AfterHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "29994752.0"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeCPULoadAverage",
+                              "type": "numeric/double",
+                              "value": "7.3916015625"
+                            }
+                          },
+                          {
+                            "node": {
+                              "name": "BeforeHostMemoryUsed",
+                              "type": "numeric/double",
+                              "value": "29956800.0"
+                            }
+                          }
+                        ]
+                      },
+                      "outputs": {
+                        "edges": [
+                          {
+                            "node": {
+                              "name": "CMakeFiles/my_install",
+                              "size": 0
                             }
                           }
                         ]
@@ -59,8 +165,8 @@
                   {
                     "node": {
                       "type": "CUSTOM",
-                      "startTime": "2025-03-28T16:19:10+00:00",
-                      "duration": 135,
+                      "startTime": "2025-04-24T15:34:31+00:00",
+                      "duration": 138,
                       "command": "\"/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable\" (truncated)",
                       "result": "0",
                       "source": null,
@@ -73,118 +179,38 @@
                             "node": {
                               "name": "AfterCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.74755859375"
+                              "value": "7.3916015625"
                             }
                           },
                           {
                             "node": {
                               "name": "AfterHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51402880.0"
+                              "value": "29519120.0"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.74755859375"
+                              "value": "7.3916015625"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51398928.0"
+                              "value": "29479504.0"
                             }
                           }
                         ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "type": "INSTALL",
-                      "startTime": "2025-03-28T16:19:12+00:00",
-                      "duration": 126,
-                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
-                      "result": "0",
-                      "source": null,
-                      "language": null,
-                      "config": null,
-                      "target": null,
-                      "measurements": {
+                      },
+                      "outputs": {
                         "edges": [
                           {
                             "node": {
-                              "name": "AfterCPULoadAverage",
-                              "type": "numeric/double",
-                              "value": "4.84765625"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "AfterHostMemoryUsed",
-                              "type": "numeric/double",
-                              "value": "51397248.0"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "BeforeCPULoadAverage",
-                              "type": "numeric/double",
-                              "value": "4.84765625"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "BeforeHostMemoryUsed",
-                              "type": "numeric/double",
-                              "value": "51395936.0"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "node": {
-                      "type": "CMAKE_INSTALL",
-                      "startTime": "2025-03-28T16:19:11+00:00",
-                      "duration": 122,
-                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
-                      "result": "0",
-                      "source": null,
-                      "language": null,
-                      "config": null,
-                      "target": null,
-                      "measurements": {
-                        "edges": [
-                          {
-                            "node": {
-                              "name": "AfterCPULoadAverage",
-                              "type": "numeric/double",
-                              "value": "4.84765625"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "AfterHostMemoryUsed",
-                              "type": "numeric/double",
-                              "value": "51400928.0"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "BeforeCPULoadAverage",
-                              "type": "numeric/double",
-                              "value": "4.84765625"
-                            }
-                          },
-                          {
-                            "node": {
-                              "name": "BeforeHostMemoryUsed",
-                              "type": "numeric/double",
-                              "value": "51398320.0"
+                              "name": "Table.h",
+                              "size": 0
                             }
                           }
                         ]
@@ -194,8 +220,8 @@
                   {
                     "node": {
                       "type": "CMAKE_BUILD",
-                      "startTime": "2025-03-28T16:19:09+00:00",
-                      "duration": 2488,
+                      "startTime": "2025-04-24T15:34:30+00:00",
+                      "duration": 2346,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
                       "source": null,
@@ -208,31 +234,34 @@
                             "node": {
                               "name": "AfterCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.84765625"
+                              "value": "7.3916015625"
                             }
                           },
                           {
                             "node": {
                               "name": "AfterHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51391872.0"
+                              "value": "30039824.0"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeCPULoadAverage",
                               "type": "numeric/double",
-                              "value": "4.74755859375"
+                              "value": "6.1201171875"
                             }
                           },
                           {
                             "node": {
                               "name": "BeforeHostMemoryUsed",
                               "type": "numeric/double",
-                              "value": "51340336.0"
+                              "value": "29132864.0"
                             }
                           }
                         ]
+                      },
+                      "outputs": {
+                        "edges": []
                       }
                     }
                   }
@@ -254,13 +283,13 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:10+00:00",
-                                      "duration": 76,
+                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "duration": 75,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
                                       "source": null,
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "MakeTable",
                                         "type": "EXECUTABLE"
@@ -271,28 +300,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51399056.0"
+                                              "value": "29475808.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51405264.0"
+                                              "value": "29428976.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "MakeTable",
+                                              "size": 46392
                                             }
                                           }
                                         ]
@@ -302,13 +341,13 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-03-28T16:19:09+00:00",
-                                      "duration": 340,
+                                      "startTime": "2025-04-24T15:34:30+00:00",
+                                      "duration": 290,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
                                       "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx",
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "MakeTable",
                                         "type": "EXECUTABLE"
@@ -319,28 +358,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51401328.0"
+                                              "value": "29392944.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "6.1201171875"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51365504.0"
+                                              "value": "29279824.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o",
+                                              "size": 119000
                                             }
                                           }
                                         ]
@@ -372,13 +421,13 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-03-28T16:19:10+00:00",
-                              "duration": 76,
+                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "duration": 75,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": null,
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "MakeTable",
                                 "type": "EXECUTABLE"
@@ -389,28 +438,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51399056.0"
+                                      "value": "29475808.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51405264.0"
+                                      "value": "29428976.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "MakeTable",
+                                      "size": 46392
                                     }
                                   }
                                 ]
@@ -420,13 +479,13 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-03-28T16:19:09+00:00",
-                              "duration": 340,
+                              "startTime": "2025-04-24T15:34:30+00:00",
+                              "duration": 290,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MakeTable.cxx",
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "MakeTable",
                                 "type": "EXECUTABLE"
@@ -437,28 +496,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51401328.0"
+                                      "value": "29392944.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "6.1201171875"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51365504.0"
+                                      "value": "29279824.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "MathFunctions/CMakeFiles/MakeTable.dir/MakeTable.cxx.o",
+                                      "size": 119000
                                     }
                                   }
                                 ]
@@ -482,14 +551,14 @@
                                 "edges": [
                                   {
                                     "node": {
-                                      "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
-                                      "duration": 67,
+                                      "type": "COMPILE",
+                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "duration": 84,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
-                                      "source": null,
+                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx",
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "MathFunctions",
                                         "type": "SHARED_LIBRARY"
@@ -500,28 +569,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400864.0"
+                                              "value": "29595536.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400288.0"
+                                              "value": "29532944.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "MathFunctions/CMakeFiles/MathFunctions.dir/MathFunctions.cxx.o",
+                                              "size": 10272
                                             }
                                           }
                                         ]
@@ -530,14 +609,14 @@
                                   },
                                   {
                                     "node": {
-                                      "type": "COMPILE",
-                                      "startTime": "2025-03-28T16:19:10+00:00",
-                                      "duration": 99,
+                                      "type": "LINK",
+                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "duration": 59,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
-                                      "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx",
+                                      "source": null,
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "MathFunctions",
                                         "type": "SHARED_LIBRARY"
@@ -548,28 +627,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51428640.0"
+                                              "value": "29657296.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51405616.0"
+                                              "value": "29640896.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "libMathFunctionsd.1.0.0.dylib",
+                                              "size": 60088
                                             }
                                           }
                                         ]
@@ -603,109 +692,13 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
-                                      "duration": 64,
-                                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
-                                      "result": "0",
-                                      "source": null,
-                                      "language": "C++",
-                                      "config": "",
-                                      "target": {
-                                        "name": "SqrtLibrary",
-                                        "type": "STATIC_LIBRARY"
-                                      },
-                                      "measurements": {
-                                        "edges": [
-                                          {
-                                            "node": {
-                                              "name": "AfterCPULoadAverage",
-                                              "type": "numeric/double",
-                                              "value": "4.84765625"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "AfterHostMemoryUsed",
-                                              "type": "numeric/double",
-                                              "value": "51401440.0"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "BeforeCPULoadAverage",
-                                              "type": "numeric/double",
-                                              "value": "4.84765625"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "BeforeHostMemoryUsed",
-                                              "type": "numeric/double",
-                                              "value": "51401152.0"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
+                                      "startTime": "2025-04-24T15:34:31+00:00",
                                       "duration": 24,
-                                      "command": "\"/usr/bin/ranlib\" (truncated)",
-                                      "result": "0",
-                                      "source": null,
-                                      "language": "C++",
-                                      "config": "",
-                                      "target": {
-                                        "name": "SqrtLibrary",
-                                        "type": "STATIC_LIBRARY"
-                                      },
-                                      "measurements": {
-                                        "edges": [
-                                          {
-                                            "node": {
-                                              "name": "AfterCPULoadAverage",
-                                              "type": "numeric/double",
-                                              "value": "4.84765625"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "AfterHostMemoryUsed",
-                                              "type": "numeric/double",
-                                              "value": "51400672.0"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "BeforeCPULoadAverage",
-                                              "type": "numeric/double",
-                                              "value": "4.84765625"
-                                            }
-                                          },
-                                          {
-                                            "node": {
-                                              "name": "BeforeHostMemoryUsed",
-                                              "type": "numeric/double",
-                                              "value": "51400576.0"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
-                                      "duration": 29,
                                       "command": "\"/usr/bin/ar\" (truncated)",
                                       "result": "0",
                                       "source": null,
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "SqrtLibrary",
                                         "type": "STATIC_LIBRARY"
@@ -716,28 +709,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400704.0"
+                                              "value": "29609568.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400912.0"
+                                              "value": "29629808.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "libSqrtLibraryd.a",
+                                              "size": 111144
                                             }
                                           }
                                         ]
@@ -747,13 +750,13 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-03-28T16:19:10+00:00",
-                                      "duration": 365,
+                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "duration": 314,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
                                       "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx",
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "SqrtLibrary",
                                         "type": "STATIC_LIBRARY"
@@ -764,28 +767,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51397360.0"
+                                              "value": "29622320.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51405904.0"
+                                              "value": "29528576.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "MathFunctions/CMakeFiles/SqrtLibrary.dir/mysqrt.cxx.o",
+                                              "size": 107128
                                             }
                                           }
                                         ]
@@ -795,13 +808,13 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
-                                      "duration": 60,
+                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "duration": 62,
                                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                                       "result": "0",
                                       "source": null,
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "SqrtLibrary",
                                         "type": "STATIC_LIBRARY"
@@ -812,28 +825,154 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51407712.0"
+                                              "value": "29628176.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400720.0"
+                                              "value": "29621392.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "libSqrtLibraryd.a",
+                                              "size": 0
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "duration": 57,
+                                      "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "Debug",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "7.3916015625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "29642096.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "7.3916015625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "29641936.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "libSqrtLibraryd.a",
+                                              "size": 111144
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "type": "LINK",
+                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "duration": 20,
+                                      "command": "\"/usr/bin/ranlib\" (truncated)",
+                                      "result": "0",
+                                      "source": null,
+                                      "language": "C++",
+                                      "config": "Debug",
+                                      "target": {
+                                        "name": "SqrtLibrary",
+                                        "type": "STATIC_LIBRARY"
+                                      },
+                                      "measurements": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "AfterCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "7.3916015625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "AfterHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "29628128.0"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeCPULoadAverage",
+                                              "type": "numeric/double",
+                                              "value": "7.3916015625"
+                                            }
+                                          },
+                                          {
+                                            "node": {
+                                              "name": "BeforeHostMemoryUsed",
+                                              "type": "numeric/double",
+                                              "value": "29627744.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "libSqrtLibraryd.a",
+                                              "size": 111144
                                             }
                                           }
                                         ]
@@ -864,62 +1003,14 @@
                         "edges": [
                           {
                             "node": {
-                              "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
-                              "duration": 67,
-                              "command": "\"/usr/bin/c++\" (truncated)",
-                              "result": "0",
-                              "source": null,
-                              "language": "C++",
-                              "config": "",
-                              "target": {
-                                "name": "MathFunctions",
-                                "type": "SHARED_LIBRARY"
-                              },
-                              "measurements": {
-                                "edges": [
-                                  {
-                                    "node": {
-                                      "name": "AfterCPULoadAverage",
-                                      "type": "numeric/double",
-                                      "value": "4.84765625"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "AfterHostMemoryUsed",
-                                      "type": "numeric/double",
-                                      "value": "51400864.0"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "BeforeCPULoadAverage",
-                                      "type": "numeric/double",
-                                      "value": "4.84765625"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "BeforeHostMemoryUsed",
-                                      "type": "numeric/double",
-                                      "value": "51400288.0"
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-03-28T16:19:10+00:00",
-                              "duration": 99,
+                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "duration": 84,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/MathFunctions.cxx",
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "MathFunctions",
                                 "type": "SHARED_LIBRARY"
@@ -930,28 +1021,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51428640.0"
+                                      "value": "29595536.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51405616.0"
+                                      "value": "29532944.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "MathFunctions/CMakeFiles/MathFunctions.dir/MathFunctions.cxx.o",
+                                      "size": 10272
                                     }
                                   }
                                 ]
@@ -961,16 +1062,16 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
-                              "duration": 64,
-                              "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "duration": 59,
+                              "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": null,
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
-                                "name": "SqrtLibrary",
-                                "type": "STATIC_LIBRARY"
+                                "name": "MathFunctions",
+                                "type": "SHARED_LIBRARY"
                               },
                               "measurements": {
                                 "edges": [
@@ -978,28 +1079,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51401440.0"
+                                      "value": "29657296.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51401152.0"
+                                      "value": "29640896.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "libMathFunctionsd.1.0.0.dylib",
+                                      "size": 60088
                                     }
                                   }
                                 ]
@@ -1009,61 +1120,13 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
+                              "startTime": "2025-04-24T15:34:31+00:00",
                               "duration": 24,
-                              "command": "\"/usr/bin/ranlib\" (truncated)",
-                              "result": "0",
-                              "source": null,
-                              "language": "C++",
-                              "config": "",
-                              "target": {
-                                "name": "SqrtLibrary",
-                                "type": "STATIC_LIBRARY"
-                              },
-                              "measurements": {
-                                "edges": [
-                                  {
-                                    "node": {
-                                      "name": "AfterCPULoadAverage",
-                                      "type": "numeric/double",
-                                      "value": "4.84765625"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "AfterHostMemoryUsed",
-                                      "type": "numeric/double",
-                                      "value": "51400672.0"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "BeforeCPULoadAverage",
-                                      "type": "numeric/double",
-                                      "value": "4.84765625"
-                                    }
-                                  },
-                                  {
-                                    "node": {
-                                      "name": "BeforeHostMemoryUsed",
-                                      "type": "numeric/double",
-                                      "value": "51400576.0"
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "node": {
-                              "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
-                              "duration": 29,
                               "command": "\"/usr/bin/ar\" (truncated)",
                               "result": "0",
                               "source": null,
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "SqrtLibrary",
                                 "type": "STATIC_LIBRARY"
@@ -1074,28 +1137,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51400704.0"
+                                      "value": "29609568.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51400912.0"
+                                      "value": "29629808.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "libSqrtLibraryd.a",
+                                      "size": 111144
                                     }
                                   }
                                 ]
@@ -1105,13 +1178,13 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-03-28T16:19:10+00:00",
-                              "duration": 365,
+                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "duration": 314,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": "/my/path/projects/tmp_for_cdash/src_instrument/MathFunctions/mysqrt.cxx",
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "SqrtLibrary",
                                 "type": "STATIC_LIBRARY"
@@ -1122,28 +1195,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51397360.0"
+                                      "value": "29622320.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51405904.0"
+                                      "value": "29528576.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "MathFunctions/CMakeFiles/SqrtLibrary.dir/mysqrt.cxx.o",
+                                      "size": 107128
                                     }
                                   }
                                 ]
@@ -1153,13 +1236,13 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
-                              "duration": 60,
+                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "duration": 62,
                               "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                               "result": "0",
                               "source": null,
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "SqrtLibrary",
                                 "type": "STATIC_LIBRARY"
@@ -1170,28 +1253,154 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51407712.0"
+                                      "value": "29628176.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51400720.0"
+                                      "value": "29621392.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "libSqrtLibraryd.a",
+                                      "size": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "duration": 57,
+                              "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "Debug",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "7.3916015625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "29642096.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "7.3916015625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "29641936.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "libSqrtLibraryd.a",
+                                      "size": 111144
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "node": {
+                              "type": "LINK",
+                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "duration": 20,
+                              "command": "\"/usr/bin/ranlib\" (truncated)",
+                              "result": "0",
+                              "source": null,
+                              "language": "C++",
+                              "config": "Debug",
+                              "target": {
+                                "name": "SqrtLibrary",
+                                "type": "STATIC_LIBRARY"
+                              },
+                              "measurements": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "AfterCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "7.3916015625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "AfterHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "29628128.0"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeCPULoadAverage",
+                                      "type": "numeric/double",
+                                      "value": "7.3916015625"
+                                    }
+                                  },
+                                  {
+                                    "node": {
+                                      "name": "BeforeHostMemoryUsed",
+                                      "type": "numeric/double",
+                                      "value": "29627744.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "libSqrtLibraryd.a",
+                                      "size": 111144
                                     }
                                   }
                                 ]
@@ -1216,13 +1425,13 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-03-28T16:19:11+00:00",
-                                      "duration": 70,
+                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "duration": 57,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
                                       "source": null,
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "Tutorial",
                                         "type": "EXECUTABLE"
@@ -1233,28 +1442,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51395712.0"
+                                              "value": "29929392.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51400464.0"
+                                              "value": "29926256.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "Tutoriald",
+                                              "size": 44056
                                             }
                                           }
                                         ]
@@ -1264,13 +1483,13 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-03-28T16:19:10+00:00",
-                                      "duration": 365,
+                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "duration": 316,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
                                       "source": "/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx",
                                       "language": "C++",
-                                      "config": "",
+                                      "config": "Debug",
                                       "target": {
                                         "name": "Tutorial",
                                         "type": "EXECUTABLE"
@@ -1281,28 +1500,38 @@
                                             "node": {
                                               "name": "AfterCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.84765625"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "AfterHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51398064.0"
+                                              "value": "29622544.0"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeCPULoadAverage",
                                               "type": "numeric/double",
-                                              "value": "4.74755859375"
+                                              "value": "7.3916015625"
                                             }
                                           },
                                           {
                                             "node": {
                                               "name": "BeforeHostMemoryUsed",
                                               "type": "numeric/double",
-                                              "value": "51406128.0"
+                                              "value": "29527728.0"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "outputs": {
+                                        "edges": [
+                                          {
+                                            "node": {
+                                              "name": "CMakeFiles/Tutorial.dir/tutorial.cxx.o",
+                                              "size": 108104
                                             }
                                           }
                                         ]
@@ -1339,13 +1568,13 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-03-28T16:19:11+00:00",
-                              "duration": 70,
+                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "duration": 57,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": null,
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "Tutorial",
                                 "type": "EXECUTABLE"
@@ -1356,28 +1585,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51395712.0"
+                                      "value": "29929392.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51400464.0"
+                                      "value": "29926256.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "Tutoriald",
+                                      "size": 44056
                                     }
                                   }
                                 ]
@@ -1387,13 +1626,13 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-03-28T16:19:10+00:00",
-                              "duration": 365,
+                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "duration": 316,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
                               "source": "/my/path/projects/tmp_for_cdash/src_instrument/tutorial.cxx",
                               "language": "C++",
-                              "config": "",
+                              "config": "Debug",
                               "target": {
                                 "name": "Tutorial",
                                 "type": "EXECUTABLE"
@@ -1404,28 +1643,38 @@
                                     "node": {
                                       "name": "AfterCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.84765625"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "AfterHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51398064.0"
+                                      "value": "29622544.0"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeCPULoadAverage",
                                       "type": "numeric/double",
-                                      "value": "4.74755859375"
+                                      "value": "7.3916015625"
                                     }
                                   },
                                   {
                                     "node": {
                                       "name": "BeforeHostMemoryUsed",
                                       "type": "numeric/double",
-                                      "value": "51406128.0"
+                                      "value": "29527728.0"
+                                    }
+                                  }
+                                ]
+                              },
+                              "outputs": {
+                                "edges": [
+                                  {
+                                    "node": {
+                                      "name": "CMakeFiles/Tutorial.dir/tutorial.cxx.o",
+                                      "size": 108104
                                     }
                                   }
                                 ]


### PR DESCRIPTION
Following the work started in https://github.com/Kitware/CDash/pull/2612, this PR adds supports for the `output` and `outputSizes` [snippet file](https://cmake.org/cmake/help/latest/manual/cmake-instrumentation.7.html#v1-snippet-file) fields.