### PR TITLE
Send httpd logs to stderr when using UBI as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,6 @@ RUN dnf install -y \
       zip \
       #> cdash
       php-bcmath \
-      php-fpm \
       php-gd \
       php-ldap \
       php-mbstring \
@@ -200,9 +199,6 @@ RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \
 RUN chmod -R g=u,o-w /etc/pki/ca-trust/extracted /etc/pki/ca-trust/source/anchors && \
 	  update-ca-trust enable && \
 	  update-ca-trust extract
-
-RUN mkdir /var/log/apache2 && \
-    chown 1001:1001 /var/log/apache2
 
 # Allow PHP to access all environment variables.
 # In the future, we may want to consider limiting this for security reasons.

--- a/docker/cdash-site.conf
+++ b/docker/cdash-site.conf
@@ -1,9 +1,6 @@
 <IfFile "/var/www/cdash.pem">
     <VirtualHost *:8080>
         DocumentRoot "/cdash/public"
-        ServerName localhost
-        ErrorLog "/var/log/apache2/error.log"
-        CustomLog "/var/log/apache2/access.log" combined
         SSLEngine on
         SSLCertificateFile /var/www/cdash.pem
         SSLCertificateKeyFile /var/www/cdash.key
@@ -20,9 +17,6 @@
             Require all granted
         </Directory>
         DocumentRoot "/cdash/public"
-        ServerName localhost
-        ErrorLog "/var/log/apache2/error.log"
-        CustomLog "/var/log/apache2/access.log" common
     </VirtualHost>
 </IfFile>
 


### PR DESCRIPTION
The UBI-based container currently sends logs to the same path the Debian container does, which means that they don't get redirected to stderr.  This PR removes our unintentional manual overrides, allowing apache logs to get sent to the container's stderr.  I plan to make a separate PR to resolve the CDash error logging issue.