### PR TITLE
Remove `wget` from Debian-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN apt-get update && \
         nodejs \
         unzip \
         vim \
-        wget \
         zip \
         && \
     docker-php-ext-configure pgsql --with-pgsql=/usr/local/pgsql && \
@@ -57,8 +56,8 @@ RUN apt-get update && \
         xsl \
         opcache \
         && \
-    wget -q -O checksum https://composer.github.io/installer.sha384sum && \
-    wget -q -O composer-setup.php https://getcomposer.org/installer && \
+    curl -fsSL https://composer.github.io/installer.sha384sum > checksum && \
+    curl -fsSL https://getcomposer.org/installer > composer-setup.php && \
     sha384sum -c checksum && \
     php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
     php -r "unlink('composer-setup.php');" && \


### PR DESCRIPTION
`wget` is only used to download `composer` as part of the Debian-based image build process.  The version of `wget` embedded in a number of recent CDash releases is vulnerable to [CVE-2024-38428](https://nvd.nist.gov/vuln/detail/CVE-2024-38428), causing security scanners to flag our images unnecessarily.  We already use `curl` for CDash itself, so we can simply replace all existing usages of `wget` with `curl` to resolve this issue.