### PR TITLE
Bump Node.js to 22.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
          | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
          | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
[Node.js 22.x](https://nodejs.org/en) is now the latest LTS version.  This PR bumps the version of Node.js we use in our Debian-based image to 22.x from 20.x.  The UBI image is still stuck at 20.x since Node.js is bundled with the base image.  Node.js is only used to build the site UI, and is not involved in the operation of CDash itself.  Its inclusion in the final layer of the image is for convenience only, in case users wish to make temporary changes within a running CDash container.