### PR TITLE
Add admin button to delete project members

### DIFF
--- a/app/GraphQL/Mutations/RemoveProjectUser.php
+++ b/app/GraphQL/Mutations/RemoveProjectUser.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Project;
+use App\Models\User;
+
+final class RemoveProjectUser extends AbstractMutation
+{
+    /**
+     * @param array{
+     *     userId: int,
+     *     projectId: int,
+     * } $args
+     */
+    protected function mutate(array $args): void
+    {
+        /** @var ?User $user */
+        $user = auth()->user();
+        $project = isset($args['projectId']) ? Project::find((int) $args['projectId']) : null;
+        $userToRemove = isset($args['userId']) ? User::find((int) $args['userId']) : null;
+
+        if (
+            $user === null
+            || $project === null
+            || $userToRemove === null
+            || $userToRemove->id === $user->id
+            || $user->cannot('removeUser', $project)
+            || !$project->users()->where('id', $userToRemove->id)->exists()
+        ) {
+            abort(401, 'This action is unauthorized.');
+        }
+
+        $project->users()->detach($userToRemove->id);
+    }
+}

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -105,4 +105,9 @@ class ProjectPolicy
     {
         return $this->inviteUser($currentUser, $project);
     }
+
+    public function removeUser(User $currentUser, Project $project): bool
+    {
+        return $this->update($currentUser, $project);
+    }
 }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -325,6 +325,9 @@ set_tests_properties(/Feature/GraphQL/Mutations/RevokeProjectInvitationTest PROP
 add_laravel_test(/Feature/GraphQL/Mutations/ChangeProjectRoleTest)
 set_tests_properties(/Feature/GraphQL/Mutations/ChangeProjectRoleTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_laravel_test(/Feature/GraphQL/Mutations/RemoveProjectUserTest)
+set_tests_properties(/Feature/GraphQL/Mutations/RemoveProjectUserTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_laravel_test(/Feature/Traits/UpdatesSiteInformationTest)
 set_tests_properties(/Feature/Traits/UpdatesSiteInformationTest PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -79,6 +79,9 @@ type Mutation {
   "Change an existing user's role in a project."
   changeProjectRole(input: ChangeProjectRoleInput! @spread): ChangeProjectRoleMutationPayload! @field(resolver: "ChangeProjectRole")
 
+  "Remove a user from a project."
+  removeProjectUser(input: RemoveProjectUserInput! @spread): RemoveProjectUserMutationPayload! @field(resolver: "RemoveProjectUser")
+
   "Invite a user to this CDash instance by email."
   createGlobalInvitation(input: CreateGlobalInvitationInput! @spread): CreateGlobalInvitationMutationPayload! @field(resolver: "CreateGlobalInvitation")
 
@@ -279,6 +282,18 @@ type ChangeProjectRoleMutationPayload implements MutationPayloadInterface {
 
   "The project associated with the user whose role was changed."
   project: Project
+}
+
+
+input RemoveProjectUserInput {
+  userId: ID!
+  projectId: ID!
+}
+
+
+type RemoveProjectUserMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -302,6 +302,26 @@ parameters:
 			path: app/GraphQL/Mutations/InviteToProject.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Contracts\\\\Auth\\\\Guard\\:\\:user\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Mutations/RemoveProjectUser.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Mutations/RemoveProjectUser.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:where\\(\\)\\.$#"
+			count: 1
+			path: app/GraphQL/Mutations/RemoveProjectUser.php
+
+		-
+			message: "#^Parameter \\#1 \\$args \\(array\\{userId\\: int, projectId\\: int\\}\\) of method App\\\\GraphQL\\\\Mutations\\\\RemoveProjectUser\\:\\:mutate\\(\\) should be contravariant with parameter \\$args \\(array\\<string, mixed\\>\\) of method App\\\\GraphQL\\\\Mutations\\\\AbstractMutation\\:\\:mutate\\(\\)$#"
+			count: 1
+			path: app/GraphQL/Mutations/RemoveProjectUser.php
+
+		-
 			message: "#^Parameter \\#1 \\$args \\(array\\{userId\\: int\\}\\) of method App\\\\GraphQL\\\\Mutations\\\\RemoveUser\\:\\:mutate\\(\\) should be contravariant with parameter \\$args \\(array\\<string, mixed\\>\\) of method App\\\\GraphQL\\\\Mutations\\\\AbstractMutation\\:\\:mutate\\(\\)$#"
 			count: 1
 			path: app/GraphQL/Mutations/RemoveUser.php
@@ -29149,8 +29169,13 @@ parameters:
 			path: server.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\:\\:exists\\(\\)\\.$#"
+			count: 1
+			path: tests/Browser/Pages/ProjectMembersPageTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
-			count: 2
+			count: 3
 			path: tests/Browser/Pages/ProjectMembersPageTest.php
 
 		-
@@ -29253,6 +29278,16 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
 			count: 64
 			path: tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\:\\:exists\\(\\)\\.$#"
+			count: 4
+			path: tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
+			count: 2
+			path: tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\GlobalInvitation\\>\\:\\:exists\\(\\)\\.$#"

--- a/resources/views/project/members.blade.php
+++ b/resources/views/project/members.blade.php
@@ -7,6 +7,7 @@
     <project-members-page
         :project-id="@js($project->Id)"
         :user-id="@js(auth()->user()?->id)"
-        :can-edit-users="@js(auth()->user()?->can('inviteUser', \App\Models\Project::findOrFail((int) $project->Id)) ?? false)"
+        :can-invite-users="@js(auth()->user()?->can('inviteUser', \App\Models\Project::findOrFail((int) $project->Id)) ?? false)"
+        :can-remove-users="@js(auth()->user()?->can('removeUser', \App\Models\Project::findOrFail((int) $project->Id)) ?? false)"
     ></project-members-page>
 @endsection

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\Project;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class RemoveProjectUserTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private Project $project;
+
+    /**
+     * @var array<User>
+     */
+    private array $users = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        foreach ($this->users as $user) {
+            $user->delete();
+        }
+        $this->users = [];
+
+        parent::tearDown();
+    }
+
+    private function addUserToProject(bool $admin = false): User
+    {
+        $user = $this->makeNormalUser();
+        $this->users[] = $user;
+
+        $this->project->users()->attach($user->id, [
+            'role' => $admin ? Project::PROJECT_ADMIN : Project::PROJECT_USER,
+        ]);
+
+        return $user;
+    }
+
+    private function assertProjectMember(User $user): void
+    {
+        self::assertTrue($user->refresh()->exists());
+        self::assertContains($user->id, $this->project->users()->pluck('id'));
+    }
+
+    private function assertNotProjectMember(User $user): void
+    {
+        self::assertTrue($user->refresh()->exists());
+        self::assertNotContains($user->id, $this->project->users()->pluck('id'));
+    }
+
+    public function testAdminUserCanDeleteProjectMembers(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => null,
+                ],
+            ],
+        ], true);
+
+        $this->assertNotProjectMember($userToDelete);
+    }
+
+    public function testNormalNonmemberUserCannotDeleteProjectMembers(): void
+    {
+        $this->users['normal'] = $this->makeNormalUser();
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        $this->actingAs($this->users['normal'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        $this->assertProjectMember($userToDelete);
+    }
+
+    public function testAnonymousUserCannotDeleteProjectMembers(): void
+    {
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        $this->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        $this->assertProjectMember($userToDelete);
+    }
+
+    public function testProjectAdminCanDeleteProjectMembers(): void
+    {
+        $projectAdmin = $this->addUserToProject(true);
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        $this->actingAs($projectAdmin)->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => null,
+                ],
+            ],
+        ], true);
+
+        $this->assertNotProjectMember($userToDelete);
+    }
+
+    public function testProjectAdminCannotDeleteSelf(): void
+    {
+        $projectAdmin = $this->addUserToProject(true);
+
+        $this->assertProjectMember($projectAdmin);
+
+        $this->actingAs($projectAdmin)->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $projectAdmin->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        $this->assertProjectMember($projectAdmin);
+    }
+
+    public function testRegularProjectUserCannotDeleteProjectMembers(): void
+    {
+        $projectUser = $this->addUserToProject();
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        $this->actingAs($projectUser)->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        $this->assertProjectMember($userToDelete);
+    }
+
+    public function testCannotDeleteNonmemberUser(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+        $this->users['normal'] = $this->makeNormalUser();
+
+        self::assertTrue($this->users['normal']->refresh()->exists());
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $this->users['normal']->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        self::assertTrue($this->users['normal']->refresh()->exists());
+    }
+
+    public function testCannotDeleteMissingUser(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => 123456789,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+    }
+
+    public function testHandlesMissingProject(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+        $this->users['normal'] = $this->makeNormalUser();
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => 123456789,
+            'userId' => $this->users['normal']->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+    }
+}


### PR DESCRIPTION
Following the work in https://github.com/Kitware/CDash/pull/2778, this PR adds an admin-only column containing a button which removes project members to the project members page.  As of now, anyone with project admin access can delete members.  I plan to make a follow-up PR which fine-tunes this behavior when 3rd-party authentication providers are used.