### PR TITLE
Remove database queries from submission handler constructors

### DIFF
--- a/app/cdash/app/Model/BuildErrorFilter.php
+++ b/app/cdash/app/Model/BuildErrorFilter.php
@@ -21,8 +21,8 @@ use CDash\Database;
 
 class BuildErrorFilter
 {
-    private $ErrorsFilter = null;
-    private $WarningsFilter = null;
+    private $ErrorsFilter;
+    private $WarningsFilter;
     public $Project;
     private $PDO;
 

--- a/app/cdash/app/Model/BuildErrorFilter.php
+++ b/app/cdash/app/Model/BuildErrorFilter.php
@@ -21,20 +21,15 @@ use CDash\Database;
 
 class BuildErrorFilter
 {
-    private $ErrorsFilter;
-    private $WarningsFilter;
+    private $ErrorsFilter = null;
+    private $WarningsFilter = null;
     public $Project;
     private $PDO;
 
     public function __construct(Project $project)
     {
-        $this->ErrorsFilter = null;
-        $this->WarningsFilter = null;
-
         $this->PDO = Database::getInstance();
-
         $this->Project = $project;
-        $this->Fill();
     }
 
     public function Exists()
@@ -104,7 +99,7 @@ class BuildErrorFilter
         $this->WarningsFilter = $filter;
     }
 
-    private function Fill()
+    public function Fill()
     {
         $stmt = $this->PDO->prepare(
             'SELECT * FROM build_filters WHERE projectid = :projectid');

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -292,6 +292,7 @@ class Project
         $this->Id = $project->id;
 
         $buildErrorFilter = new BuildErrorFilter($this);
+        $buildErrorFilter->Fill();
         if ($buildErrorFilter->GetErrorsFilter() != $this->ErrorsFilter
             || $buildErrorFilter->GetWarningsFilter() != $this->WarningsFilter) {
             return $buildErrorFilter->AddOrUpdateFilters($this->WarningsFilter, $this->ErrorsFilter);

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -56,7 +56,6 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         $this->Builds[''] = $this->Build;
         $this->ParentBuild = null;
 
-
         $this->CommandLine = '';
 
         $this->NumTestsPassed = [];
@@ -80,7 +79,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
     protected function HasSubProjects(): bool
     {
         if ($this->_HasSubProjects === null) {
-            $this->_HasSubProjects = $this->Project->GetNumberOfSubProjects() > 0;
+            $this->_HasSubProjects = $this->GetProject()->GetNumberOfSubProjects() > 0;
         }
         return $this->_HasSubProjects;
     }
@@ -171,7 +170,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
             $testCreator = new TestCreator();
 
             $testCreator->buildTestTime = $testdata->time;
-            $testCreator->projectid = $this->Project->Id;
+            $testCreator->projectid = $this->GetProject()->Id;
             $testCreator->testCommand = $this->CommandLine;
             $testCreator->testDetails = $testdata->details;
             $testCreator->setTestName($testdata->name);
@@ -221,7 +220,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                 if ($this->HasSubProjects()) {
                     $target_name = $json_array['id']['pattern']['pattern'][0];
                     $subproject_name = self::GetSubProjectForPath(
-                        $target_name, intval($this->Project->Id));
+                        $target_name, intval($this->GetProject()->Id));
                     if (!empty($subproject_name)) {
                         $this->InitializeSubProjectBuild($subproject_name);
                     }
@@ -365,7 +364,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                                 $subproject_name = '';
                                 if ($this->HasSubProjects()) {
                                     $subproject_name = self::GetSubProjectForPath(
-                                        $source_file, intval($this->Project->Id));
+                                        $source_file, intval($this->GetProject()->Id));
                                     // Skip this defect if we cannot deduce what SubProject
                                     // it belongs to.
                                     if (empty($subproject_name)) {
@@ -489,7 +488,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                                     // Look up the subproject (if any) that contains
                                     // this source file.
                                     $subproject_name = self::GetSubProjectForPath(
-                                        $source_file, intval($this->Project->Id));
+                                        $source_file, intval($this->GetProject()->Id));
                                     // Skip this defect if we cannot deduce what SubProject
                                     // it belongs to.
                                     if (empty($subproject_name)) {
@@ -534,7 +533,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                         // builds instead.
                         $target_name = $json_array['id']['testResult']['label'];
                         $subproject_name = self::GetSubProjectForPath(
-                            $target_name, intval($this->Project->Id));
+                            $target_name, intval($this->GetProject()->Id));
                         // Skip this defect if we cannot deduce what SubProject
                         // it belongs to.
                         if (empty($subproject_name)) {
@@ -589,7 +588,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                     // builds instead.
                     $target_name = $json_array['id']['testSummary']['label'];
                     $subproject_name = self::GetSubProjectForPath(
-                        $target_name, intval($this->Project->Id));
+                        $target_name, intval($this->GetProject()->Id));
                     // Skip this defect if we cannot deduce what SubProject
                     // it belongs to.
                     if (empty($subproject_name)) {
@@ -637,7 +636,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
             return null;
         }
 
-        $subproject_exists = EloquentProject::findOrFail($this->Project->Id)
+        $subproject_exists = EloquentProject::findOrFail($this->GetProject()->Id)
             ->subprojects()
             ->where('name', $subproject_name)
             ->exists();
@@ -759,7 +758,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         $text_with_context = $build_error->Text . $build_error->PostContext;
 
         if ($this->BuildErrorFilter === null) {
-            $this->BuildErrorFilter = new BuildErrorFilter($this->Project);
+            $this->BuildErrorFilter = new BuildErrorFilter($this->GetProject());
             $this->BuildErrorFilter->Fill();
         }
 

--- a/app/cdash/xml_handlers/BazelJSON_handler.php
+++ b/app/cdash/xml_handlers/BazelJSON_handler.php
@@ -82,6 +82,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         $this->ParseConfigure = true;
 
         $this->BuildErrorFilter = new BuildErrorFilter($this->Project);
+        $this->BuildErrorFilter->Fill();
 
         $this->PDO = Database::getInstance()->getPdo();
     }

--- a/app/cdash/xml_handlers/GcovTar_handler.php
+++ b/app/cdash/xml_handlers/GcovTar_handler.php
@@ -32,7 +32,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
     private $SourceDirectory;
     private $BinaryDirectory;
     private $Labels;
-    private $SubProjectPath;
+    private ?string $SubProjectPath = null;
     private $SubProjectSummaries;
     private $AggregateBuildId;
     private $PreviousAggregateParentId;
@@ -46,18 +46,6 @@ class GcovTarHandler extends AbstractSubmissionHandler
         $this->SourceDirectory = '';
         $this->BinaryDirectory = '';
         $this->Labels = [];
-
-        $this->SubProjectPath = '';
-
-        // Check if we should support cross-SubProject coverage.
-        if ($this->Build->SubProjectId > 0) {
-            $subproject = new SubProject();
-            $subproject->SetId($this->Build->SubProjectId);
-            $path = $subproject->GetPath();
-            if ($path != '') {
-                $this->SubProjectPath = $path;
-            }
-        }
         $this->SubProjectSummaries = [];
         $this->PreviousAggregateParentId = null;
     }
@@ -189,6 +177,17 @@ class GcovTarHandler extends AbstractSubmissionHandler
         }
         if (empty($path)) {
             return;
+        }
+
+        // Check if we should support cross-SubProject coverage.
+        if ($this->SubProjectPath === null) {
+            if ($this->Build->SubProjectId > 0) {
+                $subproject = new SubProject();
+                $subproject->SetId($this->Build->SubProjectId);
+                $this->SubProjectPath = $subproject->GetPath();
+            } else {
+                $this->SubProjectPath = '';
+            }
         }
 
         // Check if this file belongs to a different SubProject.

--- a/app/cdash/xml_handlers/GcovTar_handler.php
+++ b/app/cdash/xml_handlers/GcovTar_handler.php
@@ -196,7 +196,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
             && !str_contains($path, $this->SubProjectPath)
         ) {
             // Find the SubProject that corresponds to this path.
-            $subproject = SubProject::GetSubProjectFromPath($path, $this->Project->Id);
+            $subproject = SubProject::GetSubProjectFromPath($path, $this->GetProject()->Id);
             if (is_null($subproject)) {
                 // Error already logged.
                 return;
@@ -209,7 +209,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
                 // Build doesn't exist yet, add it here.
                 $siblingBuild = new Build();
                 $siblingBuild->Name = $this->Build->Name;
-                $siblingBuild->ProjectId = $this->Project->Id;
+                $siblingBuild->ProjectId = $this->GetProject()->Id;
                 $siblingBuild->SiteId = $this->Build->SiteId;
                 $siblingBuild->SetParentId($this->Build->GetParentId());
                 $siblingBuild->SetStamp($this->Build->GetStamp());

--- a/app/cdash/xml_handlers/SubProjectDirectories_handler.php
+++ b/app/cdash/xml_handlers/SubProjectDirectories_handler.php
@@ -66,7 +66,7 @@ class SubProjectDirectoriesHandler extends AbstractSubmissionHandler
         // Save all of our SubProjects.
         foreach ($closed_list as $name => $path) {
             $subproject = new SubProject();
-            $subproject->SetProjectId($this->Project->Id);
+            $subproject->SetProjectId($this->GetProject()->Id);
             $subproject->SetName($name);
             $subproject->SetPath($path);
             $subproject->SetPosition($this->SubProjectOrder[$path]);

--- a/app/cdash/xml_handlers/abstract_submission_handler.php
+++ b/app/cdash/xml_handlers/abstract_submission_handler.php
@@ -7,7 +7,7 @@ abstract class AbstractSubmissionHandler
 {
     protected Build $Build;
 
-    protected Project $Project;
+    private ?Project $Project = null;
 
     /**
      * We prefer to accept a Build if one is known, but some (mostly XML) handlers determine the build
@@ -22,10 +22,17 @@ abstract class AbstractSubmissionHandler
         } else {
             $this->Build = $init;
             $this->Build->FillFromId($this->Build->Id);
+        }
+    }
+
+    public function GetProject(): Project
+    {
+        if ($this->Project === null) {
             $this->Project = $this->Build->GetProject();
         }
 
         $this->Project->Fill();
+        return $this->Project;
     }
 
     public function getBuild(): Build

--- a/app/cdash/xml_handlers/abstract_xml_handler.php
+++ b/app/cdash/xml_handlers/abstract_xml_handler.php
@@ -189,12 +189,6 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
         return $this->ModelFactory;
     }
 
-    public function GetProject(): Project
-    {
-        $this->Project->Fill();
-        return $this->Project;
-    }
-
     public function GetSite(): Site
     {
         return $this->Site;

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -65,7 +65,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
     private $BuildStamp;
     private $Generator;
     private $PullRequest;
-    private $BuildErrorFilter;
+    private ?BuildErrorFilter $BuildErrorFilter = null;
     protected static ?string $schema_file = '/app/Validators/Schemas/Build.xsd';
 
     /**
@@ -119,8 +119,6 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
         $this->BuildCommand = '';
         $this->Labels = [];
         $this->SubProjects = [];
-        $this->BuildErrorFilter = new BuildErrorFilter($this->GetProject());
-        $this->BuildErrorFilter->Fill();
     }
 
     public function startElement($parser, $name, $attributes): void
@@ -415,6 +413,11 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
             $skip_error = false;
             foreach (['StdOutput', 'StdError', 'Text'] as $field) {
                 if (isset($this->Error->$field)) {
+                    if ($this->BuildErrorFilter === null) {
+                        $this->BuildErrorFilter = new BuildErrorFilter($this->GetProject());
+                        $this->BuildErrorFilter->Fill();
+                    }
+
                     if ($this->Error->Type === 1) {
                         $skip_error = $this->BuildErrorFilter->FilterWarning($this->Error->$field);
                     } elseif ($this->Error->Type === 0) {

--- a/app/cdash/xml_handlers/build_handler.php
+++ b/app/cdash/xml_handlers/build_handler.php
@@ -120,6 +120,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
         $this->Labels = [];
         $this->SubProjects = [];
         $this->BuildErrorFilter = new BuildErrorFilter($this->GetProject());
+        $this->BuildErrorFilter->Fill();
     }
 
     public function startElement($parser, $name, $attributes): void

--- a/app/cdash/xml_handlers/coverage_handler.php
+++ b/app/cdash/xml_handlers/coverage_handler.php
@@ -48,7 +48,6 @@ class CoverageHandler extends AbstractXmlHandler
         $this->Site = new Site();
         $this->Coverages = [];
         $this->CoverageSummaries = [];
-        $this->HasSubProjects = $this->GetProject()->GetNumberOfSubProjects() > 0;
     }
 
     /** startElement */
@@ -134,11 +133,13 @@ class CoverageHandler extends AbstractXmlHandler
                 $this->Build->UpdateBuild($this->Build->Id, -1, -1);
             }
 
+            $hasSubProjects = $this->GetProject()->GetNumberOfSubProjects() > 0;
+
             foreach ($this->Coverages as $coverageInfo) {
                 $coverage = $coverageInfo[0];
                 $coverageFile = $coverageInfo[1];
                 $buildid = $this->Build->Id;
-                if ($this->HasSubProjects) {
+                if ($hasSubProjects) {
                     // Make sure this file gets associated with the correct SubProject.
                     $subproject = SubProject::GetSubProjectFromPath(
                         $coverageFile->FullPath, $this->GetProject()->Id);

--- a/app/cdash/xml_handlers/coverage_log_handler.php
+++ b/app/cdash/xml_handlers/coverage_log_handler.php
@@ -32,7 +32,6 @@ class CoverageLogHandler extends AbstractXmlHandler
     private $CurrentCoverageFileLog;
     private $CoverageFiles;
 
-    private $UpdateEndTime;
     private $CurrentLine;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/CoverageLog.xsd';
@@ -42,7 +41,6 @@ class CoverageLogHandler extends AbstractXmlHandler
     {
         parent::__construct($project);
         $this->Site = new Site();
-        $this->UpdateEndTime = false;
         $this->CoverageFiles = [];
         $this->CurrentLine = '';
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26034,11 +26034,6 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
-			message: "#^Method BazelJSONHandler\\:\\:InitializeConfigure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
 			message: "#^Method BazelJSONHandler\\:\\:InitializeConfigure\\(\\) has parameter \\$build with no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
@@ -26150,7 +26145,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
-			count: 9
+			count: 8
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
@@ -26169,11 +26164,6 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
-			message: "#^Property BazelJSONHandler\\:\\:\\$BuildErrorFilter has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
 			message: "#^Property BazelJSONHandler\\:\\:\\$BuildErrors has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
@@ -26189,12 +26179,7 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
-			message: "#^Property BazelJSONHandler\\:\\:\\$Configures has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: "#^Property BazelJSONHandler\\:\\:\\$HasSubProjects has no type specified\\.$#"
+			message: "#^Property BazelJSONHandler\\:\\:\\$Configures type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
@@ -26254,16 +26239,6 @@ parameters:
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
 
 		-
-			message: "#^Property BazelJSONHandler\\:\\:\\$WorkingDirectory has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: "#^Property BazelJSONHandler\\:\\:\\$WorkingDirectory is never read, only written\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
 			message: "#^Variable \\$source_file might not be defined\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/BazelJSON_handler.php
@@ -26316,11 +26291,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 5
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
 		-
@@ -26455,11 +26425,6 @@ parameters:
 
 		-
 			message: "#^Property GcovTarHandler\\:\\:\\$SourceDirectory has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: "#^Property GcovTarHandler\\:\\:\\$SubProjectPath has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/GcovTar_handler.php
 
@@ -27089,11 +27054,6 @@ parameters:
 			path: app/cdash/xml_handlers/build_handler.php
 
 		-
-			message: "#^Property BuildHandler\\:\\:\\$BuildErrorFilter has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
 			message: "#^Property BuildHandler\\:\\:\\$BuildGroup has no type specified\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/build_handler.php
@@ -27605,16 +27565,6 @@ parameters:
 
 		-
 			message: "#^Property CoverageLogHandler\\:\\:\\$StartTimeStamp has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: "#^Property CoverageLogHandler\\:\\:\\$UpdateEndTime has no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: "#^Property CoverageLogHandler\\:\\:\\$UpdateEndTime is never read, only written\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/coverage_log_handler.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27339,11 +27339,6 @@ parameters:
 			path: app/cdash/xml_handlers/configure_handler.php
 
 		-
-			message: "#^Access to an undefined property CoverageHandler\\:\\:\\$HasSubProjects\\.$#"
-			count: 2
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: app/cdash/xml_handlers/coverage_handler.php


### PR DESCRIPTION
It's not currently possible to instantiate some types of submission handlers without beginning the parsing process.  This PR removes all database queries from submission handler controllers, allowing handlers to be instantiated and passed around safely.  This is incremental progress towards a larger refactoring goal, and should have no effect on the submission parsing process itself.