### PR TITLE
Improve GraphQL filter validation

### DIFF
--- a/app/GraphQL/Directives/FilterDirective.php
+++ b/app/GraphQL/Directives/FilterDirective.php
@@ -149,19 +149,19 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
         return Parser::inputObjectTypeDefinition(/* @lang GraphQL */ <<<GRAPHQL
                 input {$multiFilterName} {
                     "Find nodes which match at least one of the provided filters."
-                    any: [{$multiFilterName}]
+                    any: [{$multiFilterName}] @rules(apply: ["prohibits:all,eq,ne,gt,lt,contains"])
                     "Find nodes which match all of the provided filters."
-                    all: [{$multiFilterName}]
+                    all: [{$multiFilterName}] @rules(apply: ["prohibits:any,eq,ne,gt,lt,contains"])
                     "Find nodes where the provided field is equal to the provided value."
-                    eq: {$filterName}
+                    eq: {$filterName} @rules(apply: ["prohibits:any,all,ne,gt,lt,contains"])
                     "Find nodes where the provided field is not equal to the provided value."
-                    ne: {$filterName}
+                    ne: {$filterName} @rules(apply: ["prohibits:any,all,eq,gt,lt,contains"])
                     "Find nodes where the provided field is greater than the provided value."
-                    gt: {$filterName}
+                    gt: {$filterName} @rules(apply: ["prohibits:any,all,eq,ne,lt,contains"])
                     "Find nodes where the provided field is less than the provided value."
-                    lt: {$filterName}
+                    lt: {$filterName} @rules(apply: ["prohibits:any,all,eq,ne,gt,contains"])
                     "Find nodes where the provided field contains the provided value."
-                    contains: {$filterName}
+                    contains: {$filterName} @rules(apply: ["prohibits:any,all,eq,ne,gt,lt"])
                 }
             GRAPHQL
         );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29250,6 +29250,11 @@ parameters:
 			path: tests/Feature/GlobalInvitationAcceptanceTest.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/FilterTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
 			count: 64
 			path: tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -477,4 +477,27 @@ class FilterTest extends TestCase
             ],
         ], true);
     }
+
+    public function testProhibitsMultipleFieldsInSingleFilterObject(): void
+    {
+        $this->actingAs($this->users['admin'])->graphQL('
+            query {
+                projects(filters: {
+                    eq: {
+                        visibility: PRIVATE
+                    }
+                    ne: {
+                        visibility: PUBLIC
+                    }
+                }) {
+                    edges {
+                        node {
+                            name
+                            visibility
+                        }
+                    }
+                }
+            }
+        ')->assertGraphQLErrorMessage('Validation failed for the field [projects].');
+    }
 }


### PR DESCRIPTION
As discussed in https://github.com/Kitware/CDash/issues/2777, it's not immediately clear that a filter input object like this is invalid:
```graphql
filters: {
    gt: {id: "123"},
    lt: {id: "456"},
}
```
This PR aims to address this confusion by explicitly prohibiting multiple fields from being used in the same filter object, instead of silently ignoring all but the first field.

Not addressed in this PR is this case:
```graphql
filters: {
    eq: {
        id: "123",
        name: "foo",
    },
}
```
A handful of separate changes need to be made before I can add validation to handle it, so I've deferred that work to a future PR.