### PR TITLE
Only include jquery datatables on `viewCoverage.php`

### DIFF
--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -41,7 +41,6 @@
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/app.css')) }}"/>
         @else
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_3rdparty.css')) }}"/>
-            <link type="text/css" rel="stylesheet" href="{{ asset(mix('assets/css/jquery.dataTables.css')) }}"/>
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/vue_common.css')) }}"/>
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/bootstrap.min.css')) }}"/>
         @endif
@@ -49,11 +48,14 @@
         <script src="{{ asset(mix('assets/js/app.js')) }}" type="text/javascript" defer></script>
     @else
         <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_3rdparty.css')) }}"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/jquery.dataTables.css')) }}"/>
         <link rel="stylesheet" type="text/css" href="{{ asset(mix(get_css_file())) }}"/>
         <link rel="stylesheet" href="{{ asset(mix('assets/css/bootstrap.min.css')) }}"/>
         <script src="{{ asset(mix('assets/js/3rdparty.min.js')) }}"></script>
         <script src="{{ asset(mix('assets/js/legacy_1stparty.min.js')) }}"></script>
+        @if(str_contains(request()->url(), 'viewCoverage.php')) {{-- This last XSL page needs special treatment... --}}
+            <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/jquery.dataTables.css')) }}"/>
+            <script src="{{ asset(mix('assets/js/jquery.dataTables.min.js')) }}" defer></script>
+        @endif
     @endif
 
     @yield('header_script')

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -94,7 +94,6 @@ mix.scripts([
   'resources/js/angular/bulletchart.js',
   'resources/js/angular/cdash_angular.js',
   'resources/js/angular/jquery.tablesorter.js',
-  'resources/js/angular/jquery.dataTables.min.js',
   'resources/js/angular/jquery.metadata.js',
   'public/assets/js/angular/version.js',
   'resources/js/angular/directives/**.js',
@@ -102,6 +101,8 @@ mix.scripts([
   'resources/js/angular/services/**.js',
   'resources/js/angular/controllers/**.js',
 ], 'public/assets/js/legacy_1stparty.min.js');
+
+mix.copy('resources/js/angular/jquery.dataTables.min.js', 'public/assets/js/jquery.dataTables.min.js');
 
 // Boilerplate.
 mix.js('resources/js/vue/app.js', 'public/assets/js').vue();


### PR DESCRIPTION
The jQuery [DataTables](https://github.com/DataTables/DataTables) extension is only used on a single legacy page.  To prevent confusion about where legacy libraries are used, particularly given that CDash has its own Vue "DataTable" component, this PR only includes the resource on `viewCoverage.php`.  This also means that each page load will be slightly faster since the browser has to parse less CSS overall.