### PR TITLE
Fix project members link

### DIFF
--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -183,7 +183,7 @@ $currentDateString = now()->toDateString();
                                 </a>
                             </li>
                             <li>
-                                <a class="cdash-link" ng-href="{{ url('/projects/') }}@{{::cdash.projectid}}/members">
+                                <a class="cdash-link" ng-href="{{ url('/projects') }}/@{{::cdash.projectid}}/members">
                                     Users
                                 </a>
                             </li>


### PR DESCRIPTION
The link to the new project members page added in #2778 in the header menu on legacy AngularJS pages is missing a slash.  This PR fixes the issue.