### PR TITLE
Use GHA arm64 runners for arm64 image build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,11 @@ jobs:
           bash .github/workflows/submit.sh ${{matrix.database}} "${BUILD_GROUP}"
 
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.architecture}}
     strategy:
       fail-fast: false
       matrix:
+        architecture: [ 'ubuntu-24.04', 'ubuntu-24.04-arm' ]
         base-image: [ 'debian', 'ubi' ]
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +74,6 @@ jobs:
         name: Build ${{matrix.base-image}} production image
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: false
           target: cdash
           build-args: |


### PR DESCRIPTION
Our current CI Docker image build uses QEMU emulation to build `arm64` images.  The `arm64` component of the build process takes a disproportionate amount of time, and is the longest-running job in our test suite.  Thanks to GitHub's new `arm64` runners, we can now build each architecture without emulation.