### PR TITLE
Disable manual project membership when LDAP enabled

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
             ->daily()
             ->withoutOverlapping();
 
-        if ((bool) config('ldap_enabled')) {
+        if ((bool) config('cdash.ldap_enabled')) {
             $schedule->command('ldap:sync_projects')
                 ->everyFiveMinutes();
         }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
             ->daily()
             ->withoutOverlapping();
 
-        if (env('CDASH_AUTHENTICATION_PROVIDER') === 'ldap') {
+        if (config('ldap_enabled')) {
             $schedule->command('ldap:sync_projects')
                 ->everyFiveMinutes();
         }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
             ->daily()
             ->withoutOverlapping();
 
-        if (config('ldap_enabled')) {
+        if ((bool) config('ldap_enabled')) {
             $schedule->command('ldap:sync_projects')
                 ->everyFiveMinutes();
         }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -67,7 +67,7 @@ final class LoginController extends AbstractController
      */
     public function credentials(Request $request): array
     {
-        if (env('CDASH_AUTHENTICATION_PROVIDER', 'users') === 'ldap') {
+        if (config('ldap_enabled')) {
             return [
                 (string) env('LDAP_LOCATE_USERS_BY', 'mail') => $request->post('email'),
                 'password' => $request->post('password'),

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -67,7 +67,7 @@ final class LoginController extends AbstractController
      */
     public function credentials(Request $request): array
     {
-        if (config('ldap_enabled')) {
+        if ((bool) config('ldap_enabled')) {
             return [
                 (string) env('LDAP_LOCATE_USERS_BY', 'mail') => $request->post('email'),
                 'password' => $request->post('password'),

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -67,7 +67,7 @@ final class LoginController extends AbstractController
      */
     public function credentials(Request $request): array
     {
-        if ((bool) config('ldap_enabled')) {
+        if ((bool) config('cdash.ldap_enabled')) {
             return [
                 (string) env('LDAP_LOCATE_USERS_BY', 'mail') => $request->post('email'),
                 'password' => $request->post('password'),

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -157,7 +157,7 @@ final class ProjectController extends AbstractProjectController
 
         $response['max_project_visibility'] = $User->admin ? 'PUBLIC' : config('cdash.max_project_visibility');
 
-        $response['ldap_enabled'] = config('ldap_enabled');
+        $response['ldap_enabled'] = config('cdash.ldap_enabled');
 
         $pageTimer->end($response);
         return response()->json(cast_data_for_JSON($response));

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -157,7 +157,7 @@ final class ProjectController extends AbstractProjectController
 
         $response['max_project_visibility'] = $User->admin ? 'PUBLIC' : config('cdash.max_project_visibility');
 
-        $response['ldap_enabled'] = env('CDASH_AUTHENTICATION_PROVIDER', 'users') === 'ldap';
+        $response['ldap_enabled'] = config('ldap_enabled');
 
         $pageTimer->end($response);
         return response()->json(cast_data_for_JSON($response));

--- a/app/Http/Controllers/ProjectInvitationController.php
+++ b/app/Http/Controllers/ProjectInvitationController.php
@@ -31,6 +31,10 @@ final class ProjectInvitationController extends AbstractController
             abort(401, 'This invitation is not associated with that project.');
         }
 
+        if (config('ldap_enabled') && $user_invite->project->ldapfilter !== null && $user_invite->project->ldapfilter !== '') {
+            abort(401, 'Membership is managed by LDAP for this project.');
+        }
+
         if ($user->projects()->where('id', $user_invite->project_id)->exists()) {
             $user_invite->deleteOrFail();
             abort(401, 'You are already registered for this project.');

--- a/app/Http/Controllers/ProjectInvitationController.php
+++ b/app/Http/Controllers/ProjectInvitationController.php
@@ -31,7 +31,7 @@ final class ProjectInvitationController extends AbstractController
             abort(401, 'This invitation is not associated with that project.');
         }
 
-        if (config('ldap_enabled') && $user_invite->project->ldapfilter !== null && $user_invite->project->ldapfilter !== '') {
+        if ((bool) config('ldap_enabled') && $user_invite->project?->ldapfilter !== null && $user_invite->project->ldapfilter !== '') {
             abort(401, 'Membership is managed by LDAP for this project.');
         }
 

--- a/app/Http/Controllers/ProjectInvitationController.php
+++ b/app/Http/Controllers/ProjectInvitationController.php
@@ -31,7 +31,7 @@ final class ProjectInvitationController extends AbstractController
             abort(401, 'This invitation is not associated with that project.');
         }
 
-        if ((bool) config('ldap_enabled') && $user_invite->project?->ldapfilter !== null && $user_invite->project->ldapfilter !== '') {
+        if ((bool) config('cdash.ldap_enabled') && $user_invite->project?->ldapfilter !== null && $user_invite->project->ldapfilter !== '') {
             abort(401, 'Membership is managed by LDAP for this project.');
         }
 

--- a/app/Listeners/SuccessfulLdapAuthListener.php
+++ b/app/Listeners/SuccessfulLdapAuthListener.php
@@ -13,7 +13,7 @@ class SuccessfulLdapAuthListener
 {
     public function handle(Login $event): void
     {
-        if (env('CDASH_AUTHENTICATION_PROVIDER', 'users') === 'ldap') {
+        if (config('ldap_enabled')) {
             /**
              * @var User $user
              */

--- a/app/Listeners/SuccessfulLdapAuthListener.php
+++ b/app/Listeners/SuccessfulLdapAuthListener.php
@@ -13,7 +13,7 @@ class SuccessfulLdapAuthListener
 {
     public function handle(Login $event): void
     {
-        if (config('ldap_enabled')) {
+        if ((bool) config('ldap_enabled')) {
             /**
              * @var User $user
              */

--- a/app/Listeners/SuccessfulLdapAuthListener.php
+++ b/app/Listeners/SuccessfulLdapAuthListener.php
@@ -13,7 +13,7 @@ class SuccessfulLdapAuthListener
 {
     public function handle(Login $event): void
     {
-        if ((bool) config('ldap_enabled')) {
+        if ((bool) config('cdash.ldap_enabled')) {
             /**
              * @var User $user
              */

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -99,7 +99,7 @@ class ProjectPolicy
         }
 
         // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
-        if (config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+        if ((bool) config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
             return false;
         }
 
@@ -114,7 +114,7 @@ class ProjectPolicy
     public function removeUser(User $currentUser, Project $project): bool
     {
         // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
-        if (config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+        if ((bool) config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
             return false;
         }
 

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -98,16 +98,26 @@ class ProjectPolicy
             return false;
         }
 
+        // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
+        if (config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+            return false;
+        }
+
         return $this->update($currentUser, $project);
     }
 
     public function revokeInvitation(User $currentUser, Project $project): bool
     {
-        return $this->inviteUser($currentUser, $project);
+        return $this->update($currentUser, $project);
     }
 
     public function removeUser(User $currentUser, Project $project): bool
     {
+        // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
+        if (config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+            return false;
+        }
+
         return $this->update($currentUser, $project);
     }
 }

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -99,7 +99,7 @@ class ProjectPolicy
         }
 
         // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
-        if ((bool) config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+        if ((bool) config('cdash.ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
             return false;
         }
 
@@ -114,7 +114,7 @@ class ProjectPolicy
     public function removeUser(User $currentUser, Project $project): bool
     {
         // If an LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.
-        if ((bool) config('ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
+        if ((bool) config('cdash.ldap_enabled') && $project->ldapfilter !== null && $project->ldapfilter !== '') {
             return false;
         }
 

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -90,4 +90,5 @@ return [
     'global_banner' => env('GLOBAL_BANNER'),
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),
+    'ldap_enabled' => env('CDASH_AUTHENTICATION_PROVIDER') === 'ldap',
 ];

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -495,7 +495,7 @@ class InviteToProjectTest extends TestCase
         Mail::fake();
         self::assertEmpty($this->project->invitations()->get());
 
-        Config::set('ldap_enabled', true);
+        Config::set('cdash.ldap_enabled', true);
         $this->project->ldapfilter = '(uid=*group_1*)';
         $this->project->save();
 
@@ -534,7 +534,7 @@ class InviteToProjectTest extends TestCase
         Mail::fake();
         self::assertEmpty($this->project->invitations()->get());
 
-        Config::set('ldap_enabled', true);
+        Config::set('cdash.ldap_enabled', true);
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $projectId: ID!, $role: ProjectRole!) {

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -330,7 +330,7 @@ class RemoveProjectUserTest extends TestCase
 
         $this->assertProjectMember($userToDelete);
 
-        Config::set('ldap_enabled', true);
+        Config::set('cdash.ldap_enabled', true);
         $this->project->ldapfilter = '(uid=*group_1*)';
         $this->project->save();
 
@@ -364,7 +364,7 @@ class RemoveProjectUserTest extends TestCase
 
         $this->assertProjectMember($userToDelete);
 
-        Config::set('ldap_enabled', true);
+        Config::set('cdash.ldap_enabled', true);
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($userId: ID!, $projectId: ID!) {

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL\Mutations;
 
 use App\Models\Project;
 use App\Models\User;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -320,5 +321,71 @@ class RemoveProjectUserTest extends TestCase
                 ],
             ],
         ], true);
+    }
+
+    public function testCannotDeleteProjectMembersIfManagedByLdap(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        Config::set('ldap_enabled', true);
+        $this->project->ldapfilter = '(uid=*group_1*)';
+        $this->project->save();
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ], true);
+
+        $this->assertProjectMember($userToDelete);
+    }
+
+    public function testCanDeleteProjectMemberWhenLdapEnabledButNoLdapFilter(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+        $userToDelete = $this->addUserToProject();
+
+        $this->assertProjectMember($userToDelete);
+
+        Config::set('ldap_enabled', true);
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            mutation ($userId: ID!, $projectId: ID!) {
+                removeProjectUser(input: {
+                    projectId: $projectId
+                    userId: $userId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+            'userId' => $userToDelete->id,
+        ])->assertJson([
+            'data' => [
+                'removeProjectUser' => [
+                    'message' => null,
+                ],
+            ],
+        ], true);
+
+        $this->assertNotProjectMember($userToDelete);
     }
 }


### PR DESCRIPTION
It doesn't make sense to ever give users the ability to add or remove users to a project if a project's "LDAP filter" is set.  Even though it's currently possible to add and remove users manually when an LDAP filter is set, the changes will be overwritten automatically by the LDAP sync script.  This PR explicitly disallows manual membership changes by users of any access level, including global administrators.