### PR TITLE
Load minimal set of icons for each page

### DIFF
--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -34,17 +34,7 @@ const SitesIdPage = Vue.defineAsyncComponent(() => import('./components/SitesIdP
 const ProjectMembersPage = Vue.defineAsyncComponent(() => import('./components/ProjectMembersPage.vue'));
 const UsersPage = Vue.defineAsyncComponent(() => import('./components/UsersPage.vue'));
 
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import * as FA from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
-import { far } from '@fortawesome/free-regular-svg-icons';
-import { fab } from '@fortawesome/free-brands-svg-icons';
-
-FA.library.add(fas, far, fab);
-FA.config.styleDefault = 'solid';
-
 const cdash_components = {
-  FontAwesomeIcon,
   BuildConfigure,
   BuildNotes,
   BuildSummary,

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -35,7 +35,7 @@
               Email
             </div>
             <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
-              <font-awesome-icon icon="fa-envelope" />
+              <font-awesome-icon :icon="FA.faEnvelope" />
               <input
                 v-model="inviteMembersModalEmail"
                 type="email"
@@ -136,7 +136,7 @@
             data-test="revoke-invitation-button"
             @click="revokeInvitation(invite)"
           >
-            Revoke Invitation <font-awesome-icon icon="fa-trash" />
+            Revoke Invitation <font-awesome-icon :icon="FA.faTrash" />
           </button>
         </template>
       </data-table>
@@ -197,7 +197,7 @@
             data-test="remove-user-button"
             @click="removeUser(user)"
           >
-            Remove User <font-awesome-icon icon="fa-trash" />
+            Remove User <font-awesome-icon :icon="FA.faTrash" />
           </button>
           <span v-else />
         </template>
@@ -212,6 +212,10 @@ import gql from 'graphql-tag';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import DataTable from './shared/DataTable.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  faEnvelope,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import { DateTime } from 'luxon';
 
 export default {
@@ -389,6 +393,13 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faEnvelope,
+        faTrash,
+      };
+    },
+
     formattedUserRows() {
       return this.projectAdministrators.edges?.map(edge => {
         return {

--- a/resources/js/vue/components/SitesIdPage.vue
+++ b/resources/js/vue/components/SitesIdPage.vue
@@ -76,7 +76,7 @@
                       data-test="edit-description-button"
                       @click="editDescription"
                     >
-                      <font-awesome-icon icon="fa-pencil" /> Edit
+                      <font-awesome-icon :icon="FA.faPencil" /> Edit
                     </button>
                   </div>
                 </div>
@@ -192,7 +192,7 @@
             data-test="site-history-item"
           >
             <div class="tw-timeline-middle">
-              <font-awesome-icon icon="circle-check" />
+              <font-awesome-icon :icon="FA.faCircleCheck" />
             </div>
             <div class="tw-timeline-end tw-mb-4">
               <time class="tw-font-mono tw-italic tw-text-neutral-500">{{ humanReadableTimestamp(information.node.timestamp) }}</time>
@@ -278,6 +278,10 @@ import gql from 'graphql-tag';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import { DateTime } from 'luxon';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  faPencil,
+  faCircleCheck,
+} from '@fortawesome/free-solid-svg-icons';
 
 const SITE_MAINTAINERS_QUERY = gql`
   query($siteid: ID) {
@@ -480,6 +484,13 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faPencil,
+        faCircleCheck,
+      };
+    },
+
     deduplicatedInformation() {
       return this.site?.information?.edges.filter((node, index, edges) => index === edges.length - 1 || !this.informationIsIdentical(node.node, edges[index + 1].node));
     },

--- a/resources/js/vue/components/UserHomepage.vue
+++ b/resources/js/vue/components/UserHomepage.vue
@@ -104,42 +104,42 @@
                 title="Edit subscription"
                 :href="$baseURL + '/subscribeProject.php?projectid=' + project.id + '&edit=1'"
               >
-                <font-awesome-icon icon="fa-bell" />
+                <font-awesome-icon :icon="FA.faBell" />
               </a>
               <a
                 v-if="project.role > 0"
                 title="Claim sites"
                 :href="$baseURL + '/projects/' + project.id + '/sites'"
               >
-                <font-awesome-icon icon="fa-computer" />
+                <font-awesome-icon :icon="FA.faComputer" />
               </a>
               <a
                 v-if="project.role > 1"
                 title="Edit project"
                 :href="$baseURL + '/project/' + project.id + '/edit'"
               >
-                <font-awesome-icon icon="fa-pencil" />
+                <font-awesome-icon :icon="FA.faPencil" />
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage subprojects"
                 :href="$baseURL + '/manageSubProject.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-folder-tree" />
+                <font-awesome-icon :icon="FA.faFolderTree" />
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project groups"
                 :href="$baseURL + '/manageBuildGroup.php?projectid=' + project.id"
               >
-                <font-awesome-icon icon="fa-layer-group" />
+                <font-awesome-icon :icon="FA.faLayerGroup" />
               </a>
               <a
                 v-if="project.role > 1"
                 title="Manage project users"
                 :href="$baseURL + '/projects/' + project.id + '/members'"
               >
-                <font-awesome-icon icon="fa-user-pen" />
+                <font-awesome-icon :icon="FA.faUserPen" />
               </a>
             </td>
             <td
@@ -698,6 +698,15 @@
 import ApiLoader from './shared/ApiLoader';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {
+  faBell,
+  faComputer,
+  faPencil,
+  faFolderTree,
+  faLayerGroup,
+  faUserPen,
+} from '@fortawesome/free-solid-svg-icons';
+
 export default {
   name: 'UserHomepage',
   components: { FontAwesomeIcon, LoadingIndicator },
@@ -710,6 +719,19 @@ export default {
       errored: false,
       tokenscope: 'full_access',
     };
+  },
+
+  computed: {
+    FA() {
+      return {
+        faBell,
+        faComputer,
+        faPencil,
+        faFolderTree,
+        faLayerGroup,
+        faUserPen,
+      };
+    },
   },
 
   mounted () {

--- a/resources/js/vue/components/UsersPage.vue
+++ b/resources/js/vue/components/UsersPage.vue
@@ -35,7 +35,7 @@
               Email
             </div>
             <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
-              <font-awesome-icon icon="fa-envelope" />
+              <font-awesome-icon :icon="FA.faEnvelope" />
               <input
                 v-model="inviteUsersModalEmail"
                 type="email"
@@ -140,7 +140,7 @@
             data-test="revoke-invitation-button"
             @click="revokeInvitation(invite)"
           >
-            Revoke Invitation <font-awesome-icon icon="fa-trash" />
+            Revoke Invitation <font-awesome-icon :icon="FA.faTrash" />
           </button>
         </template>
       </data-table>
@@ -214,7 +214,7 @@
             :data-test="'remove-user-button-' + user.id"
             @click="removeUser(user)"
           >
-            Remove User <font-awesome-icon icon="fa-trash" />
+            Remove User <font-awesome-icon :icon="FA.faTrash" />
           </button>
           <span v-else />
         </template>
@@ -230,6 +230,10 @@ import LoadingIndicator from './shared/LoadingIndicator.vue';
 import DataTable from './shared/DataTable.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { DateTime } from 'luxon';
+import {
+  faTrash,
+  faEnvelope,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: {
@@ -342,6 +346,13 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faTrash,
+        faEnvelope,
+      };
+    },
+
     formattedUserRows() {
       return this.users.edges?.map(edge => {
         return {

--- a/resources/js/vue/components/shared/BuildSummaryCard.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCard.vue
@@ -16,7 +16,7 @@
             :href="`${$baseURL}/sites/${build.site.id}`"
             class="tw-truncate"
           >
-            <font-awesome-icon icon="fa-computer" /> {{ build.site.name }}
+            <font-awesome-icon :icon="FA.faComputer" /> {{ build.site.name }}
           </a>
           &bull;
           <span
@@ -25,16 +25,16 @@
           >
             <font-awesome-icon
               v-if="build.operatingSystemName === 'Windows'"
-              :icon="['fab', 'windows']"
+              :icon="FA.faWindows"
             />
             <!-- TODO: Add more specific Linux types. May require CTest work. -->
             <font-awesome-icon
               v-else-if="build.operatingSystemName === 'Linux'"
-              :icon="['fab', 'linux']"
+              :icon="FA.faLinux"
             />
             <font-awesome-icon
               v-else-if="build.operatingSystemName === 'Darwin' || build.operatingSystemName === 'OSX'"
-              :icon="['fab', 'apple']"
+              :icon="FA.faApple"
             />
             {{ build.operatingSystemName }} {{ build.operatingSystemRelease }}
             <div
@@ -127,7 +127,7 @@
               :href="`${$baseURL}/sites/${build.site.id}`"
               class="tw-link tw-link-hover"
             >
-              <font-awesome-icon icon="fa-computer" /> {{ build.site.name }}
+              <font-awesome-icon :icon="FA.faComputer" /> {{ build.site.name }}
             </a>
           </div>
           <div class="tw-flex tw-flex-row tw-gap-4">
@@ -300,6 +300,12 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import LoadingIndicator from './LoadingIndicator.vue';
 import { DateTime, Interval, Duration } from 'luxon';
 import BuildSummaryCardStepSummary from './BuildSummaryCardStepSummary.vue';
+import { faComputer } from '@fortawesome/free-solid-svg-icons';
+import {
+  faWindows,
+  faLinux,
+  faApple,
+} from '@fortawesome/free-brands-svg-icons';
 
 export default {
   components: {BuildSummaryCardStepSummary, LoadingIndicator, FontAwesomeIcon},
@@ -381,6 +387,15 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faComputer,
+        faWindows,
+        faLinux,
+        faApple,
+      };
+    },
+
     hasConfigure() {
       return this.build.configureWarningsCount > -1 && this.build.configureErrorsCount > -1;
     },

--- a/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
@@ -8,7 +8,7 @@
   >
     <div class="tw-text-small tw-font-medium tw-text-neutral-500 tw-flex tw-flex-row tw-gap-2 group-hover:tw-font-bold">
       <div>
-        <font-awesome-icon icon="fa-link" />
+        <font-awesome-icon :icon="FA.faLink" />
         {{ upperLeftText }}
       </div>
       <div
@@ -55,6 +55,7 @@
 
 <script>
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {faLink} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: {FontAwesomeIcon},
@@ -83,6 +84,14 @@ export default {
     highlightColor: {
       type: String,
       default: null,
+    },
+  },
+
+  computed: {
+    FA() {
+      return {
+        faLink,
+      };
     },
   },
 };

--- a/resources/js/vue/components/shared/DataTable.vue
+++ b/resources/js/vue/components/shared/DataTable.vue
@@ -29,7 +29,7 @@
         >
           <font-awesome-icon
             v-if="sortable"
-            :icon="sortColumn === column.name ? (sortAsc ? 'fa-caret-up' : 'fa-caret-down') : 'fa-sort'"
+            :icon="sortColumn === column.name ? (sortAsc ? FA.faCaretUp : FA.faCaretDown) : FA.faSort"
           />
           {{ column.displayName }}
         </th>
@@ -80,6 +80,11 @@
 
 <script>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  faCaretUp,
+  faCaretDown,
+  faSort,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: {
@@ -201,6 +206,14 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faCaretUp,
+        faCaretDown,
+        faSort,
+      };
+    },
+
     sortedRows() {
       return [...this.rows].sort((row1, row2) => {
         // The "value" attribute is required.  Fail if it is not provided.

--- a/resources/js/vue/components/shared/FilterBuilder.vue
+++ b/resources/js/vue/components/shared/FilterBuilder.vue
@@ -4,7 +4,7 @@
       class="table-heading1 tw-font-bold"
       style="font-size: 16px; padding: 6px;"
     >
-      <font-awesome-icon icon="fa-filter" /> Filters
+      <font-awesome-icon :icon="FA.faFilter" /> Filters
     </div>
     <filter-group
       :type="filterType"
@@ -18,7 +18,7 @@
         class="tw-btn tw-btn-xs"
         :href="executeQueryLink"
       >
-        <font-awesome-icon icon="fa-magnifying-glass" /> Apply
+        <font-awesome-icon :icon="FA.faMagnifyingGlass" /> Apply
       </a>
       <a
         role="button"
@@ -27,7 +27,7 @@
         target="_blank"
         rel="noopener noreferrer"
       >
-        <font-awesome-icon icon="fa-terminal" /> GraphQL
+        <font-awesome-icon :icon="FA.faTerminal" /> GraphQL
       </a>
     </div>
   </div>
@@ -36,6 +36,11 @@
 <script>
 import FilterGroup from './FilterGroup.vue';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {
+  faMagnifyingGlass,
+  faTerminal,
+  faFilter,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: { FilterGroup, FontAwesomeIcon },
@@ -83,5 +88,15 @@ export default {
   emits: [
     'changeFilters',
   ],
+
+  computed: {
+    FA() {
+      return {
+        faMagnifyingGlass,
+        faTerminal,
+        faFilter,
+      };
+    },
+  },
 };
 </script>

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -52,19 +52,19 @@
             class="tw-btn tw-btn-xs"
             @click="addFilter"
           >
-            <font-awesome-icon icon="fa-plus" /> Add Filter
+            <font-awesome-icon :icon="FA.faPlus" /> Add Filter
           </button>
           <button
             class="tw-btn tw-btn-xs"
             @click="addGroup"
           >
-            <font-awesome-icon icon="fa-bars-staggered" /> Add Group
+            <font-awesome-icon :icon="FA.faBarsStaggered" /> Add Group
           </button>
           <button
             class="tw-btn tw-btn-xs"
             @click="$emit('delete')"
           >
-            <font-awesome-icon icon="fa-trash" /> Delete Group
+            <font-awesome-icon :icon="FA.faTrash" /> Delete Group
           </button>
         </div>
       </div>
@@ -78,6 +78,11 @@ import {useQuery} from '@vue/apollo-composable';
 import gql from 'graphql-tag';
 import FilterRow from './FilterRow.vue';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {
+  faPlus,
+  faBarsStaggered,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: { FontAwesomeIcon, FilterRow, LoadingIndicator },
@@ -142,6 +147,14 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faPlus,
+        faBarsStaggered,
+        faTrash,
+      };
+    },
+
     currentCombineType() {
       return this.filters.hasOwnProperty('any') ? 'any' : 'all';
     },

--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -5,7 +5,7 @@
         class="tw-btn tw-btn-xs"
         @click="$emit('delete')"
       >
-        <font-awesome-icon icon="fa-trash" /> Delete
+        <font-awesome-icon :icon="FA.faTrash" /> Delete
       </button>
       <!-- Field chooser -->
       <select
@@ -75,6 +75,7 @@ import {useQuery} from '@vue/apollo-composable';
 import gql from 'graphql-tag';
 import LoadingIndicator from './LoadingIndicator.vue';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {faTrash} from '@fortawesome/free-solid-svg-icons';
 
 export default {
   components: {FontAwesomeIcon, LoadingIndicator},
@@ -153,6 +154,12 @@ export default {
   },
 
   computed: {
+    FA() {
+      return {
+        faTrash,
+      };
+    },
+
     selectedType() {
       return this.result?.typeInformation.inputFields.filter(field => field.name === this.selectedField)[0].type;
     },

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -112,4 +112,7 @@ mix.webpackConfig({
   stats: {
     children: true,
   },
+  optimization: {
+    runtimeChunk: false,
+  },
 });


### PR DESCRIPTION
Font Awesome is currently responsible for the majority of our overall Vue bundle size because it includes all of the available icons in the main bundle.  This PR removes the global icon library in favor of per-component includes.  The end result is that the main bundle size is reduced by 75%+.  As part of this work, I fixed an issue with the webpack runtime configuration which was missed in #2864.