### PR TITLE
Adjust waits in flaky `sub-project-group-order` test

### DIFF
--- a/tests/cypress/e2e/sub-project-group-order.cy.js
+++ b/tests/cypress/e2e/sub-project-group-order.cy.js
@@ -3,6 +3,7 @@ describe('subProjectGroupOrder', () => {
   it('can change the group order', () => {
     cy.login();
     cy.visit('manageSubProject.php?projectid=16');
+    cy.wait(200);
 
     // navigate to the 'SubProjects Groups' tab
     cy.get('a').contains('SubProject Groups').click();
@@ -30,12 +31,14 @@ describe('subProjectGroupOrder', () => {
 
     // navigate to our example of coverage across groups
     cy.visit('index.php?project=CrossSubProjectExample&parentid=121');
+    cy.wait(200);
 
     // make sure that Production is the first group listed after Total
     cy.get('#coveragetable').find('tbody').eq(1).should('contain', 'Production'); // this page has some cursed html
 
     // restore group order
     cy.visit('manageSubProject.php?projectid=16');
+    cy.wait(200);
     cy.get('a').contains('SubProject Groups').click();
     // cy.get('tbody#sortable').contains('tr', 'Production').as('prod_group_tr'); // TODO: (sbelsk) this too
     cy.get('tbody#sortable').find('tr').first().find('td').eq(1).as('prod_group_tr');
@@ -49,6 +52,7 @@ describe('subProjectGroupOrder', () => {
 
     // verify that we restored it
     cy.visit('index.php?project=CrossSubProjectExample&parentid=121');
+    cy.wait(200);
     cy.get('#coveragetable').find('tbody').eq(3).should('contain', 'Production');
   });
 });

--- a/tests/cypress/e2e/sub-project-group-order.cy.js
+++ b/tests/cypress/e2e/sub-project-group-order.cy.js
@@ -3,7 +3,7 @@ describe('subProjectGroupOrder', () => {
   it('can change the group order', () => {
     cy.login();
     cy.visit('manageSubProject.php?projectid=16');
-    cy.wait(200);
+    cy.wait(1000);
 
     // navigate to the 'SubProjects Groups' tab
     cy.get('a').contains('SubProject Groups').click();
@@ -31,14 +31,14 @@ describe('subProjectGroupOrder', () => {
 
     // navigate to our example of coverage across groups
     cy.visit('index.php?project=CrossSubProjectExample&parentid=121');
-    cy.wait(200);
+    cy.wait(1000);
 
     // make sure that Production is the first group listed after Total
     cy.get('#coveragetable').find('tbody').eq(1).should('contain', 'Production'); // this page has some cursed html
 
     // restore group order
     cy.visit('manageSubProject.php?projectid=16');
-    cy.wait(200);
+    cy.wait(1000);
     cy.get('a').contains('SubProject Groups').click();
     // cy.get('tbody#sortable').contains('tr', 'Production').as('prod_group_tr'); // TODO: (sbelsk) this too
     cy.get('tbody#sortable').find('tr').first().find('td').eq(1).as('prod_group_tr');
@@ -52,7 +52,7 @@ describe('subProjectGroupOrder', () => {
 
     // verify that we restored it
     cy.visit('index.php?project=CrossSubProjectExample&parentid=121');
-    cy.wait(200);
+    cy.wait(1000);
     cy.get('#coveragetable').find('tbody').eq(3).should('contain', 'Production');
   });
 });


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2855 caused the `sub-project-group-order` Cypress test to run slightly slower, causing lots of test failures since then.  I believe this is due to a rendering optimization on the index page which renders the page in chunks.  This PR aims to address the issue by waiting for the page to fully render before moving on.  I plan to run the CI multiple times for this PR to gain confidence that this change actually does anything because I'm unable to reproduce the test failures locally.