### PR TITLE
Fix sporadic email unique constraint testing issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29110,6 +29110,21 @@ parameters:
 			path: tests/Browser/Pages/ProjectMembersPageTest.php
 
 		-
+			message: "#^Method Tests\\\\Browser\\\\Pages\\\\ProjectMembersPageTest\\:\\:testFullInvitationWorkflow\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Browser/Pages/ProjectMembersPageTest.php
+
+		-
+			message: "#^Method Tests\\\\Browser\\\\Pages\\\\ProjectMembersPageTest\\:\\:testHandlesMisformattedEmail\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Browser/Pages/ProjectMembersPageTest.php
+
+		-
+			message: "#^Method Tests\\\\Browser\\\\Pages\\\\ProjectMembersPageTest\\:\\:testInvitationTablePagination\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Browser/Pages/ProjectMembersPageTest.php
+
+		-
 			message: "#^Cannot access property \\$description on App\\\\Models\\\\SiteInformation\\|null\\.$#"
 			count: 1
 			path: tests/Browser/Pages/SitesIdPageTest.php
@@ -29206,6 +29221,11 @@ parameters:
 			path: tests/Feature/GlobalInvitationAcceptanceTest.php
 
 		-
+			message: "#^Method Tests\\\\Feature\\\\GlobalInvitationAcceptanceTest\\:\\:createInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GlobalInvitationAcceptanceTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
 			count: 1
 			path: tests/Feature/GraphQL/FilterTest.php
@@ -29214,6 +29234,66 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
 			count: 64
 			path: tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\CreateGlobalInvitationTest\\:\\:testAdminCreatesInvitationCorrectly\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\CreateGlobalInvitationTest\\:\\:testAnonymousUserCantCreateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\CreateGlobalInvitationTest\\:\\:testCantCreateDuplicateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\CreateGlobalInvitationTest\\:\\:testCantCreateInvitationWhenPasswordAuthTurnedOff\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\CreateGlobalInvitationTest\\:\\:testRegularUserCantCreateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testAdminCreatesInvitationCorrectly\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testCantCreateDuplicateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testCantCreateInvitationForMissingProject\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testUserOutsideProjectCantCreateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testUserWithProjectAdminRoleCanCreateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testUserWithProjectAdminRoleCannotCreateInvitationWhenConfigured\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\InviteToProjectTest\\:\\:testUserWithProjectUserRoleCantCreateInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\User\\>\\:\\:exists\\(\\)\\.$#"
@@ -29229,6 +29309,46 @@ parameters:
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\GlobalInvitation\\>\\:\\:exists\\(\\)\\.$#"
 			count: 5
 			path: tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeGlobalInvitationTest\\:\\:testAdminCanDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeGlobalInvitationTest\\:\\:testAnonymousUserCannotDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeGlobalInvitationTest\\:\\:testRegularUserCannotDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeProjectInvitationTest\\:\\:testAdminCanDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeProjectInvitationTest\\:\\:testAnonymousUserCannotDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeProjectInvitationTest\\:\\:testMemberUserWithAdminRoleCanDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeProjectInvitationTest\\:\\:testMemberUserWithUserRoleCannotDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\Mutations\\\\RevokeProjectInvitationTest\\:\\:testNonMemberUserCannotDeleteInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
@@ -29279,6 +29399,21 @@ parameters:
 			message: "#^Parameter \\#1 \\$time of static method Carbon\\\\Carbon\\:\\:parse\\(\\) expects DateTimeInterface\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testAdminCanViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testAnonymousUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testNormalUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SuccessfulJob\\>\\:\\:count\\(\\)\\.$#"
@@ -29378,6 +29513,11 @@ parameters:
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\ProjectInvitation\\>\\:\\:pluck\\(\\)\\.$#"
 			count: 14
+			path: tests/Feature/ProjectInvitationAcceptanceTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\ProjectInvitationAcceptanceTest\\:\\:createInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
 			path: tests/Feature/ProjectInvitationAcceptanceTest.php
 
 		-

--- a/tests/Browser/Pages/ProjectMembersPageTest.php
+++ b/tests/Browser/Pages/ProjectMembersPageTest.php
@@ -204,7 +204,7 @@ class ProjectMembersPageTest extends BrowserTestCase
     {
         $this->users['admin'] = $this->makeAdminUser();
 
-        $fakeEmail = fake()->email();
+        $fakeEmail = fake()->unique()->email();
 
         $this->browse(function (Browser $browser) use ($fakeEmail) {
             $browser->loginAs($this->users['admin'])
@@ -248,7 +248,7 @@ class ProjectMembersPageTest extends BrowserTestCase
 
         $email = '';
         for ($i = 0; $i < 120; $i++) {
-            $email = fake()->email();  // We store the oldest email to make the following assertions less flaky...
+            $email = fake()->unique()->email();  // We store the oldest email to make the following assertions less flaky...
             $this->project->invitations()->create([
                 'email' => $email,
                 'invited_by_id' => $this->users['admin']->id,
@@ -418,7 +418,7 @@ class ProjectMembersPageTest extends BrowserTestCase
     {
         $this->users['admin'] = $this->makeAdminUser();
 
-        $fakeEmail = fake()->email();
+        $fakeEmail = fake()->unique()->email();
 
         $this->browse(function (Browser $browser) use ($fakeEmail) {
             $browser->loginAs($this->users['admin'])

--- a/tests/Feature/GlobalInvitationAcceptanceTest.php
+++ b/tests/Feature/GlobalInvitationAcceptanceTest.php
@@ -61,7 +61,7 @@ class GlobalInvitationAcceptanceTest extends TestCase
 
         /** @var GlobalInvitation $invitation */
         $invitation = GlobalInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
             'invitation_timestamp' => Carbon::now(),

--- a/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
@@ -73,7 +73,7 @@ class CreateGlobalInvitationTest extends TestCase
 
         self::assertEmpty(GlobalInvitation::all());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $role: GlobalRole!) {
@@ -119,7 +119,7 @@ class CreateGlobalInvitationTest extends TestCase
 
         self::assertEmpty(GlobalInvitation::all());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->actingAs($this->users['normal'])->graphQL('
             mutation ($email: String!, $role: GlobalRole!) {
@@ -159,7 +159,7 @@ class CreateGlobalInvitationTest extends TestCase
 
         self::assertEmpty(GlobalInvitation::all());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->graphQL('
             mutation ($email: String!, $role: GlobalRole!) {
@@ -199,7 +199,7 @@ class CreateGlobalInvitationTest extends TestCase
 
         self::assertEmpty(GlobalInvitation::all());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $role: GlobalRole!) {
@@ -350,7 +350,7 @@ class CreateGlobalInvitationTest extends TestCase
 
         self::assertEmpty(GlobalInvitation::all());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $role: GlobalRole!) {

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -69,7 +69,7 @@ class InviteToProjectTest extends TestCase
 
         self::assertEmpty($this->project->invitations()->get());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $projectId: ID!, $role: ProjectRole!) {
@@ -137,7 +137,7 @@ class InviteToProjectTest extends TestCase
                 }
             }
         ', [
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
         ])->assertJson([
@@ -183,7 +183,7 @@ class InviteToProjectTest extends TestCase
                 }
             }
         ', [
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
         ])->assertJson([
@@ -205,7 +205,7 @@ class InviteToProjectTest extends TestCase
 
         self::assertEmpty($this->project->invitations()->get());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
 
         $this->project
             ->users()
@@ -281,7 +281,7 @@ class InviteToProjectTest extends TestCase
                 }
             }
         ', [
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
         ])->assertJson([
@@ -315,7 +315,7 @@ class InviteToProjectTest extends TestCase
                 }
             }
         ', [
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'projectId' => 1234567,
             'role' => 'USER',
         ])->assertJson([
@@ -336,7 +336,7 @@ class InviteToProjectTest extends TestCase
 
         self::assertEmpty($this->project->invitations()->get());
 
-        $email = fake()->email();
+        $email = fake()->unique()->email();
         $this->actingAs($this->users['admin'])->graphQL('
             mutation ($email: String!, $projectId: ID!, $role: ProjectRole!) {
                 inviteToProject(input: {

--- a/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
@@ -53,7 +53,7 @@ class RevokeGlobalInvitationTest extends TestCase
     public function testAdminCanDeleteInvitation(): void
     {
         $invitation = GlobalInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
             'invitation_timestamp' => Carbon::now(),
@@ -87,7 +87,7 @@ class RevokeGlobalInvitationTest extends TestCase
     public function testAnonymousUserCannotDeleteInvitation(): void
     {
         $invitation = GlobalInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
             'invitation_timestamp' => Carbon::now(),
@@ -121,7 +121,7 @@ class RevokeGlobalInvitationTest extends TestCase
     public function testRegularUserCannotDeleteInvitation(): void
     {
         $invitation = GlobalInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
             'invitation_timestamp' => Carbon::now(),

--- a/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
@@ -50,7 +50,7 @@ class RevokeProjectInvitationTest extends TestCase
     public function testAdminCanDeleteInvitation(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -83,7 +83,7 @@ class RevokeProjectInvitationTest extends TestCase
     public function testAnonymousUserCannotDeleteInvitation(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -116,7 +116,7 @@ class RevokeProjectInvitationTest extends TestCase
     public function testNonMemberUserCannotDeleteInvitation(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -149,7 +149,7 @@ class RevokeProjectInvitationTest extends TestCase
     public function testMemberUserWithUserRoleCannotDeleteInvitation(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -192,7 +192,7 @@ class RevokeProjectInvitationTest extends TestCase
     public function testMemberUserWithAdminRoleCanDeleteInvitation(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,

--- a/tests/Feature/GraphQL/UserInvitationTypeTest.php
+++ b/tests/Feature/GraphQL/UserInvitationTypeTest.php
@@ -41,7 +41,7 @@ class UserInvitationTypeTest extends TestCase
     public function testAdminCanViewInvitations(): void
     {
         $invitation = ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->adminUser->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -100,7 +100,7 @@ class UserInvitationTypeTest extends TestCase
     public function testNormalUserCannotViewInvitations(): void
     {
         ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->adminUser->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
@@ -135,7 +135,7 @@ class UserInvitationTypeTest extends TestCase
     public function testAnonymousUserCannotViewInvitations(): void
     {
         ProjectInvitation::create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->adminUser->id,
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,

--- a/tests/Feature/ProjectInvitationAcceptanceTest.php
+++ b/tests/Feature/ProjectInvitationAcceptanceTest.php
@@ -48,7 +48,7 @@ class ProjectInvitationAcceptanceTest extends TestCase
     {
         /** @var ProjectInvitation $invitation */
         $invitation = $this->project->invitations()->create([
-            'email' => fake()->email(),
+            'email' => fake()->unique()->email(),
             'invited_by_id' => $this->users['admin']->id,
             'role' => ProjectRole::USER,
             'invitation_timestamp' => Carbon::now(),


### PR DESCRIPTION
Several of the tests which generate placeholder email addresses have recently started experiencing sporadic failures due to tests violating unique constraints on various email columns.  This PR aims to address the issue by instead using emails generated from a larger set of possible options.