### PR TITLE
Update `laravel-graphiql` to 4.0.1

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ vendor/*
 _build/*
 cypress_cache/*
 public/assets/*
+public/vendor/*
 resources/js/angular/ui.tabs.js
 resources/js/angular/tabNavigation.js
 resources/js/angular/services/renderTimer.js

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "laravel/ui": "4.6.1",
     "lcobucci/jwt": "5.5.0",
     "league/flysystem-aws-s3-v3": "^3.29",
-    "mll-lab/laravel-graphiql": "3.3.2",
+    "mll-lab/laravel-graphiql": "4.0.1",
     "nuwave/lighthouse": "6.54.0",
     "pear/archive_tar": "1.5.0",
     "php-di/php-di": "7.0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f86f726a80071ee879d1a4486687b12c",
+    "content-hash": "d3622126bc3eddec422e7fc4f31ac15c",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -3129,16 +3129,16 @@
         },
         {
             "name": "mll-lab/laravel-graphiql",
-            "version": "v3.3.2",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mll-lab/laravel-graphiql.git",
-                "reference": "ddad2580094fc0ea68065546ada07b3eabe02baa"
+                "reference": "2ebe7c4405b58028c93d3a08623f3b162a90012d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mll-lab/laravel-graphiql/zipball/ddad2580094fc0ea68065546ada07b3eabe02baa",
-                "reference": "ddad2580094fc0ea68065546ada07b3eabe02baa",
+                "url": "https://api.github.com/repos/mll-lab/laravel-graphiql/zipball/2ebe7c4405b58028c93d3a08623f3b162a90012d",
+                "reference": "2ebe7c4405b58028c93d3a08623f3b162a90012d",
                 "shasum": ""
             },
             "require": {
@@ -3189,9 +3189,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mll-lab/laravel-graphiql/issues",
-                "source": "https://github.com/mll-lab/laravel-graphiql/tree/v3.3.2"
+                "source": "https://github.com/mll-lab/laravel-graphiql/tree/v4.0.1"
             },
-            "time": "2025-04-01T08:12:53+00:00"
+            "time": "2025-05-07T16:45:31+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -12414,7 +12414,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -12437,5 +12437,5 @@
         "ext-xdebug": "*",
         "ext-zip": "*"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,9 @@ else
     fi
 fi
 
+echo "Downloading GraphiQL assets..."
+php artisan graphiql:download-assets
+
 echo "Waiting for database to come online..."
 until php artisan db:monitor ; do sleep 1; done
 

--- a/resources/views/vendor/graphiql/index.blade.php
+++ b/resources/views/vendor/graphiql/index.blade.php
@@ -1,81 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-@php use MLL\GraphiQL\DownloadAssetsCommand; @endphp
+@php use MLL\GraphiQL\GraphiQLAsset; @endphp
 <head>
-    <meta charset=utf-8/>
-    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>GraphiQL</title>
     <style>
         body {
-            height: 100%;
             margin: 0;
-            width: 100%;
-            overflow: hidden;
+            overflow: hidden; /* in Firefox */
         }
 
         #graphiql {
-            height: 100vh;
+            height: 100dvh;
         }
 
-        /* Make the explorer feel more integrated */
-        .docExplorerWrap {
-            overflow: auto !important;
-            width: 100% !important;
-            height: auto !important;
-        }
-
-        .doc-explorer-title-bar {
-            font-weight: var(--font-weight-medium);
-            font-size: var(--font-size-h2);
-            overflow-x: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-
-        .doc-explorer-rhs {
-            display: none;
-        }
-
-        .doc-explorer-contents {
-            margin: var(--px-16) 0 0;
-        }
-
-        .graphiql-explorer-actions select {
-            margin-left: var(--px-12);
+        #graphiql-loading {
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 4rem;
         }
     </style>
-    <script src="{{ DownloadAssetsCommand::reactPath() }}"></script>
-    <script src="{{ DownloadAssetsCommand::reactDOMPath() }}"></script>
-    <link rel="stylesheet" href="{{ DownloadAssetsCommand::cssPath() }}"/>
-    <link rel="shortcut icon" href="{{ DownloadAssetsCommand::faviconPath() }}"/>
+    <script src="{{ GraphiQLAsset::reactJS() }}"></script>
+    <script src="{{ GraphiQLAsset::reactDOMJS() }}"></script>
+    <link rel="stylesheet" href="{{ GraphiQLAsset::graphiQLCSS() }}"/>
+    <link rel="stylesheet" href="{{ GraphiQLAsset::pluginExplorerCSS() }}"/>
+    <link rel="shortcut icon" href="{{ GraphiQLAsset::favicon() }}"/>
 </head>
 
 <body>
 
-<div id="graphiql">Loading...</div>
-<script src="{{ DownloadAssetsCommand::jsPath() }}"></script>
-<script src="{{ DownloadAssetsCommand::pluginExplorerPath() }}"></script>
+<div id="graphiql">
+    <div id="graphiql-loading">Loading…</div>
+</div>
+
+<script src="{{ GraphiQLAsset::graphiQLJS() }}"></script>
+<script src="{{ GraphiQLAsset::pluginExplorerJS() }}"></script>
 <script>
     const fetcher = GraphiQL.createFetcher({
         url: '{{ $url }}',
         subscriptionUrl: '{{ $subscriptionUrl }}',
     });
+    const explorer = GraphiQLPluginExplorer.explorerPlugin();
 
     function GraphiQLWithExplorer() {
-        const [query, setQuery] = React.useState('');
-
         return React.createElement(GraphiQL, {
             fetcher,
-            query,
-            onEditQuery: setQuery,
-            defaultEditorToolsVisibility: true,
             plugins: [
-                GraphiQLPluginExplorer.useExplorerPlugin({
-                    query,
-                    onEdit: setQuery,
-                }),
+                explorer,
             ],
+            // See https://github.com/graphql/graphiql/tree/main/packages/graphiql#props for available settings
         });
     }
 


### PR DESCRIPTION
The library we use to provide GraphiQL [recently broke](https://github.com/mll-lab/laravel-graphiql/issues/53) due to an unpinned upstream dependency.  This PR fixes the issue by updating `laravel-graphiql` to the newest version which pins dependencies appropriately.  I also enabled asset downloading to prevent this issue from occurring in the future if the CDN ever goes down again.