### PR TITLE
Set basic Content Security Policy

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -24,4 +24,6 @@
     <FilesMatch "\.(css|js|svg|gif|png)$">
         Header set Cache-Control "max-age=31536000"
     </FilesMatch>
+
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:"
 </IfModule>


### PR DESCRIPTION
This PR adds a primitive [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) as another layer of protection against XSS attacks.  While a nonce- or hash-based approach is the ultimate goal, some of the legacy Javascript needs to be refactored before that is realistic.  As a basic starting point, this PR blocks all access to cross-origin scripts since CDash itself never uses scripts from a 3rd-party source.  This protects against one of the most common XSS attack vectors: small segments of malicious code which download a malicious payload from external sites.