### PR TITLE
Fix undefined variable code path in remove builds method

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -95,7 +95,7 @@ final class AdminController extends AbstractController
                 $builds[] = (int) $build_array->id;
             }
 
-            DatabaseCleanupUtils::removeBuildChunked($builds);
+            DatabaseCleanupUtils::removeBuildsChunked($builds);
             $alert = 'Removed ' . count($builds) . ' builds.';
         }
 

--- a/app/Utils/DatabaseCleanupUtils.php
+++ b/app/Utils/DatabaseCleanupUtils.php
@@ -62,7 +62,7 @@ class DatabaseCleanupUtils
         $s = 'removing old buildids for projectid: ' . $projectid;
         Log::info($s);
         echo '  -- ' . $s . "\n";
-        self::removeBuildChunked($buildids);
+        self::removeBuildsChunked($buildids);
     }
 
     /** Remove the first builds that are at the beginning of the queue */
@@ -97,7 +97,7 @@ class DatabaseCleanupUtils
         if ($echo) {
             echo '  -- ' . $s . "\n"; // for "interactive" command line feedback
         }
-        self::removeBuildChunked($buildids);
+        self::removeBuildsChunked($buildids);
     }
 
     /**
@@ -281,13 +281,10 @@ class DatabaseCleanupUtils
     /**
      * Call removeBuild() in batches of 100.
      *
-     * @param array<int>|int $buildids
+     * @param array<int> $buildids
      */
-    public static function removeBuildChunked($buildids): void
+    public static function removeBuildsChunked(array $buildids): void
     {
-        if (!is_array($buildids)) {
-            self::removeBuild($buildid);
-        }
         foreach (array_chunk($buildids, 100) as $chunk) {
             self::removeBuild($chunk);
         }

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -422,7 +422,7 @@ function remove_project_builds($projectid): void
     foreach ($build as $build_array) {
         $buildids[] = (int) $build_array->id;
     }
-    DatabaseCleanupUtils::removeBuildChunked($buildids);
+    DatabaseCleanupUtils::removeBuildsChunked($buildids);
 }
 
 /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3279,17 +3279,7 @@ parameters:
 			path: app/Utils/DatabaseCleanupUtils.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_chunk expects array, array\\<int\\>\\|int given\\.$#"
-			count: 1
-			path: app/Utils/DatabaseCleanupUtils.php
-
-		-
-			message: "#^Parameter \\#1 \\$buildids of static method App\\\\Utils\\\\DatabaseCleanupUtils\\:\\:removeBuildChunked\\(\\) expects array\\<int\\>\\|int, array given\\.$#"
-			count: 1
-			path: app/Utils/DatabaseCleanupUtils.php
-
-		-
-			message: "#^Undefined variable\\: \\$buildid$#"
+			message: "#^Parameter \\#1 \\$buildids of static method App\\\\Utils\\\\DatabaseCleanupUtils\\:\\:removeBuildsChunked\\(\\) expects array\\<int\\>, array given\\.$#"
 			count: 1
 			path: app/Utils/DatabaseCleanupUtils.php
 


### PR DESCRIPTION
A simple maintenance PR to remove an unused code path which contains an undefined variable.