### PR TITLE
Remove "email administrator" project setting

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -467,10 +467,6 @@ class ProcessSubmission implements ShouldQueue
         if ($handler == null) {
             // TODO: Add as much context as possible to this message
             Log::error('error: could not create handler based on xml content');
-
-            $Project->SendEmailToAdmin('Cannot create handler based on XML content',
-                'An XML submission from ' . $ip . ' to the project ' . get_project_name($projectid) . ' cannot be parsed. The content of the file is as follows: ' . $content);
-
             abort(400, 'Could not create handler based on xml content');
         }
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Facades\Auth;
  * @property int $emailtesttimingchanged
  * @property int $emailbrokensubmission
  * @property int $emailredundantfailures
- * @property int $emailadministrator
  * @property int $showipaddresses
  * @property string $cvsviewertype
  * @property int $testtimestd
@@ -77,7 +76,6 @@ class Project extends Model
         'emailtesttimingchanged',
         'emailbrokensubmission',
         'emailredundantfailures',
-        'emailadministrator',
         'showipaddresses',
         'cvsviewertype',
         'testtimestd',

--- a/app/cdash/tests/test_createpublicdashboard.php
+++ b/app/cdash/tests/test_createpublicdashboard.php
@@ -18,7 +18,7 @@ class CreatePublicDashboardTestCase extends KWWebTestCase
         $settings = [
             'Name' => 'PublicDashboard',
             'Description' => "This project is for CMake dashboards run on this machine to submit to from their test suites... CMake dashboards on this machine should set CMAKE_TESTS_CDASH_SERVER to $this->url",
-            'EmailAdministrator' => 1];
+        ];
         $this->createProject($settings);
     }
 }

--- a/app/cdash/tests/test_pubproject.php
+++ b/app/cdash/tests/test_pubproject.php
@@ -21,7 +21,7 @@ class PubProjectTestCase extends KWWebTestCase
         $settings = [
             'Name' => 'ProjectTest',
             'Description' => 'This is a project test for cdash',
-            'EmailAdministrator' => 1];
+        ];
         $this->ProjectId = $this->createProject($settings);
     }
 

--- a/database/migrations/2025_05_12_145045_remove_emailadministrator_project_config.php
+++ b/database/migrations/2025_05_12_145045_remove_emailadministrator_project_config.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasColumn('project', 'emailadministrator')) {
+            Schema::dropColumns('project', 'emailadministrator');
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('project', 'emailadministrator')) {
+            Schema::table('project', function (Blueprint $table) {
+                $table->tinyInteger('emailadministrator')->default(1);
+            });
+        }
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2765,11 +2765,6 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			message: "#^Binary operation \"\\.\" between 'An XML submission…' and mixed results in an error\\.$#"
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			message: "#^Binary operation \"\\.\" between \\(list\\<string\\>\\|string\\|null\\) and '_' results in an error\\.$#"
 			count: 2
 			path: app/Jobs/ProcessSubmission.php
@@ -8822,7 +8817,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 19
+			count: 18
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -9042,11 +9037,6 @@ parameters:
 
 		-
 			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$DocumentationUrl has no type specified\\.$#"
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: "#^Property CDash\\\\Model\\\\Project\\:\\:\\$EmailAdministrator has no type specified\\.$#"
 			count: 1
 			path: app/cdash/app/Model/Project.php
 

--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -1301,42 +1301,6 @@
                     <td />
                     <td>
                       <div align="right">
-                        <strong>Email administrator:</strong>
-                      </div>
-                    </td>
-                    <td>
-                      <input
-                        v-model="cdash.project.EmailAdministrator"
-                        type="checkbox"
-                        name="emailAdministrator"
-                        @change="cdash.changesmade = true"
-                        @focus="showHelp('emailAdministrator_help')"
-                      >
-                      <a
-                        href="http://www.cdash.org/Wiki/CDash:Administration#Creating_a_project"
-                        target="blank"
-                      >
-                        <img
-                          :src="$baseURL + '/img/help.gif'"
-                          border="0"
-                          @mouseover="showHelp('emailAdministrator_help')"
-                        >
-                      </a>
-                      <span
-                        id="emailAdministrator_help"
-                        class="help_content"
-                      >
-                        <b>Email administator</b>
-                        <br>
-                        Enable/Disable sending email when the XML parsing fails or
-                        any issues related to the project administration.
-                      </span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td />
-                    <td>
-                      <div align="right">
                         <strong>Email low coverage:</strong>
                       </div>
                     </td>


### PR DESCRIPTION
The "email administrator" project setting has gradually become obsolete, now only used to report submissions which cannot be parsed.  This is no longer necessary in light of our [recent effort](https://github.com/Kitware/CDash/pull/2804) to rethink the submission validation process.  This PR removes the setting and all related logic.