### PR TITLE
Download GraphiQL assets during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -283,6 +283,8 @@ RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \
         npm install --omit=dev; \
     fi
 
+RUN php artisan graphiql:download-assets
+
 # In development, we install the development .env by default
 # This could be switched to regular environment variables inserted via docker compose in the future.
 RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,7 @@ php artisan down --render="maintenance" --refresh=5
 
 if $INITIAL_DOCKER_INSTALL; then
   echo "Skipping vendor installation..."
+  echo "Skipping GraphiQL update..."
 else
   echo "Updating vendor dependencies..."
     if $DEVELOPMENT; then
@@ -61,10 +62,10 @@ else
       npm install --omit=dev
       composer install --no-dev --optimize-autoloader
     fi
-fi
 
-echo "Downloading GraphiQL assets..."
-php artisan graphiql:download-assets
+    echo "Downloading GraphiQL assets..."
+    php artisan graphiql:download-assets
+fi
 
 echo "Waiting for database to come online..."
 until php artisan db:monitor ; do sleep 1; done


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2876 added a command to download the assets for GraphiQL at container runtime.  In addition to causing containers to start more slowly, this approach can be problematic in air gapped networks or systems where the vendor directory is read-only.  Another downside is that the assets could be different when new container is deployed from the same image.  This PR changes the behavior to instead download the assets at image build time, or whenever the install command is run manually.