### PR TITLE
Add option to customize OAuth button text

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -20,7 +20,7 @@ return [
         'redirect' => env('APP_URL') . '/auth/github/callback',
         'enable' => env('GITHUB_ENABLE', false),
         'oauth' => true,
-        'display_name' => 'GitHub',
+        'display_name' => env('GITHUB_DISPLAY_NAME', 'GitHub'),
     ],
     'gitlab' => [
         'client_id' => env('GITLAB_CLIENT_ID'),
@@ -29,7 +29,7 @@ return [
         'instance_uri' => env('GITLAB_DOMAIN'),
         'enable' => env('GITLAB_ENABLE', false),
         'oauth' => true,
-        'display_name' => 'GitLab',
+        'display_name' => env('GITLAB_DISPLAY_NAME', 'GitLab'),
     ],
 
     'google' => [
@@ -39,7 +39,7 @@ return [
         'redirect' => env('APP_URL') . '/auth/google/callback',
         'enable' => env('GOOGLE_ENABLE', false),
         'oauth' => true,
-        'display_name' => 'Google',
+        'display_name' => env('GOOGLE_DISPLAY_NAME', 'Google'),
     ],
 
     'pingidentity' => [
@@ -52,7 +52,7 @@ return [
         'user_endpoint' => env('PINGIDENTITY_USER_ENDPOINT', '/idp/userinfo.openid'),
         'enable' => env('PINGIDENTITY_ENABLE', false),
         'oauth' => true,
-        'display_name' => 'PingIdentity',
+        'display_name' => env('PINGIDENTITY_DISPLAY_NAME', 'PingIdentity'),
     ],
 
     'mailgun' => [

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,7 +68,8 @@ To begin, you will need to
 | GITHUB_ENABLE | Whether or not to use GitHub as an OAuth2 provider. | false |
 | GITHUB_CLIENT_ID | The Client ID assigned to your GitHub OAuth2 app. | '' |
 | GITHUB_CLIENT_SECRET | The Client Secret created for your GitHub OAuth2 app. | '' |
-| GITHUB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false
+| GITHUB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
+| GITHUB_DISPLAY_NAME | The text displayed on the GitHub OAuth2 login button | GitHub |
 
 ###### GitLab
 
@@ -80,7 +81,9 @@ First [configure GitLab as an OAuth2 authentication identity provider](https://d
 | GITLAB_CLIENT_ID | The OAuth 2 Client ID from the Application ID field. | '' |
 | GITLAB_CLIENT_SECRET | The OAuth 2 Client Secret from the Secret field. | '' |
 | GITLAB_DOMAIN | The GitLab server to authenticate against. | https://gitlab.com |
-| GITLAB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false
+| GITLAB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
+| GITLAB_DISPLAY_NAME | The text displayed on the GitLab OAuth2 login button | GitLab |
+
 ###### Google
 
 Begin by [creating OAuth2 credentials for your Google project](https://developers.google.com/identity/protocols/oauth2/web-server#prerequisites). Then fill out the following `.env` variables:
@@ -90,7 +93,8 @@ Begin by [creating OAuth2 credentials for your Google project](https://developer
 | GOOGLE_ENABLE | Whether or not to use Google as an OAuth2 provider. | false |
 | GOOGLE_CLIENT_ID | The client ID from your Google OAuth2 credentials. | '' |
 | GOOGLE_CLIENT_SECRET | The client secret from your Google OAuth2 credentials. | '' |
-| GOOGLE_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false
+| GOOGLE_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
+| GOOGLE_DISPLAY_NAME | The text displayed on the Google OAuth2 login button | Google |
 
 ###### PingIdentity
 
@@ -105,7 +109,8 @@ Begin by [creating OAuth2 client in your PingIdentity console](https://docs.ping
 | PINGIDENTITY_AUTH_ENDPOINT |  The URL fragment to the endpoint to ask for Authorization | '/as/authorization.oauth2' |
 | PINGIDENTITY_TOKEN_ENDPOINT | The URL fragment to the endpoint to ask for the Token | '/as/token.oauth2' |
 | PINGIDENTITY_USER_ENDPOINT | The URL fragment to the endpoint to ask for the user's information with the token | '/idp/userinfo.openid' |
-| PINGIDENTITY_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false
+| PINGIDENTITY_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
+| PINGIDENTITY_DISPLAY_NAME | The text displayed on the PingIdentity OAuth2 login button | PingIdentity |
 
 ## SAML2
 

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -268,6 +268,32 @@ class LoginAndRegistration extends TestCase
     }
 
     /**
+     * @return array<array<string>>
+     */
+    public static function oauthProviders(): array
+    {
+        return [
+            ['github'],
+            ['gitlab'],
+            ['google'],
+            ['pingidentity'],
+        ];
+    }
+
+    /**
+     * @dataProvider oauthProviders
+     */
+    public function testCustomOauthDisplayNames(string $serviceName): void
+    {
+        // Enable PingIdentity, verify the button appears.
+        config(["services.$serviceName.enable" => true]);
+        $displayName = Str::uuid()->toString();
+        config(["services.$serviceName.display_name" => $displayName]);
+        $response = $this->get('/login');
+        $response->assertSeeText($displayName);
+    }
+
+    /**
      * Test PingIdentity authentication
      */
     public function testPingIdentityProvider(): void


### PR DESCRIPTION
Some users may want to customize the text of the OAuth buttons to reflect internal names for providers we support.  This PR adds the ability to do so by setting `*_DISPLAY_NAME` environment variables for their respective OAuth2 providers.