### PR TITLE
Use "passed" instead of "Passed" for default test filters

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -607,7 +607,7 @@ function begin_JSON_response(): array
     }
     $user_response['id'] = $userid;
     $response['user'] = $user_response;
-    $response['querytestfilters'] = '&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed';
+    $response['querytestfilters'] = '&filtercount=1&showfilters=1&field1=status&compare1=62&value1=passed';
     return $response;
 }
 

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -212,7 +212,7 @@ $currentDateString = now()->toDateString();
                             </li>
                             <li>
                                 <!-- This only excludes passing tests for performance reasons. TODO: show all tests. -->
-                                <a href="{{ url('/queryTests.php') }}?project={{rawurlencode($project->Name)}}&date={{$currentDateString}}&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed">
+                                <a href="{{ url('/queryTests.php') }}?project={{rawurlencode($project->Name)}}&date={{$currentDateString}}&filtercount=1&showfilters=1&field1=status&compare1=62&value1=passed">
                                     Tests
                                 </a>
                             </li>

--- a/tests/cypress/e2e/query-tests.cy.js
+++ b/tests/cypress/e2e/query-tests.cy.js
@@ -41,10 +41,14 @@ describe('query tests', () => {
     });
   });
 
-  it('displays the right default filters', () => {
-    cy.visit('index.php?project=InsightExample');
-    const today_str = new Date().toISOString().slice(0, 10);
-    const default_filters = `queryTests.php?project=InsightExample&date=${today_str}&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed`;
-    cy.get('#navigation').find('a').contains('Tests Query').should('have.attr', 'href').and('contains', default_filters);
+  it('displays the correct default filters', () => {
+    cy.visit('index.php?project=Trilinos');
+    const expected_url = 'queryTests.php?project=Trilinos&date=2011-07-22&filtercount=1&showfilters=1&field1=status&compare1=62&value1=passed';
+    cy.get('#navigation').find('a').contains('Tests Query').should('have.attr', 'href').and('contains', expected_url);
+
+    // load the page and verify the expected number of tests.
+    cy.visit(expected_url);
+    cy.get('#numtests').should('contain', 'Query  Tests: 126 matches');
+    cy.get('#queryTestsTable').find('tbody').find('tr').should('have.length', 25);
   });
 });

--- a/tests/cypress/e2e/view-test.cy.js
+++ b/tests/cypress/e2e/view-test.cy.js
@@ -9,7 +9,7 @@ describe('viewTest', () => {
   it('shows link to queryTests.php', () => {
     cy.visit('viewTest.php?buildid=1');
 
-    const default_filters = 'queryTests.php?project=TestCompressionExample&date=2009-12-18&filtercount=1&showfilters=1&field1=status&compare1=62&value1=Passed';
+    const default_filters = 'queryTests.php?project=TestCompressionExample&date=2009-12-18&filtercount=1&showfilters=1&field1=status&compare1=62&value1=passed';
     cy.get('#navigation').find('a').contains('Tests Query').should('have.attr', 'href').and('contains', default_filters);
   });
 


### PR DESCRIPTION
This fixes a bug where the default link to the "Query Tests" page would show all tests for Postgres-backed CDash instances.

This is because Postgres performs case sensitive comparisons by default, and test status is stored as "passed", "failed", or "notrun" in the database.