### PR TITLE
Add GraphQL relationship filters

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,12 +193,12 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property GraphQL\\\\Language\\\\AST\\\\ListTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode\\:\\:\\$name\\.$#"
-			count: 1
+			count: 4
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
 			message: "#^Access to an undefined property GraphQL\\\\Language\\\\AST\\\\ListTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NamedTypeNode\\|GraphQL\\\\Language\\\\AST\\\\NonNullTypeNode\\:\\:\\$type\\.$#"
-			count: 1
+			count: 4
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
@@ -232,18 +232,28 @@ parameters:
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			message: "#^Method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:handleBuilder\\(\\) never returns Illuminate\\\\Database\\\\Query\\\\Builder so it can be removed from the return type\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			message: "#^Parameter \\#1 \\$array of function array_key_first expects array, mixed given\\.$#"
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, GraphQL\\\\Language\\\\AST\\\\Node&GraphQL\\\\Language\\\\AST\\\\TypeDefinitionNode\\>\\|GraphQL\\\\Language\\\\AST\\\\NodeList\\<GraphQL\\\\Language\\\\AST\\\\Node&GraphQL\\\\Language\\\\AST\\\\TypeDefinitionNode\\> given\\.$#"
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
-			count: 4
+			count: 5
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
 			message: "#^Parameter \\#2 \\$filterName of method App\\\\GraphQL\\\\Directives\\\\FilterDirective\\:\\:createMultiFilterInput\\(\\) expects string, mixed given\\.$#"
-			count: 1
+			count: 2
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-


### PR DESCRIPTION
The existing GraphQL filter input currently only allows users to filter by fields directly on the underlying table being filtered.  This PR improves the filter input by allowing users to search by relationships as well.  In other words, it's now possible to answer queries like "give me the list of builds which have a test named xyz".  These filters can be infinitely nested, essentially giving users the ability to query anything in the CDash database, subject to access control limitations.  This is an extremely powerful capability which will enable improvements to existing pages, brand new pages which were not previously possible, and 3rd-party extensions using the API.