### PR TITLE
Increase the size of the testmeasurement.name field

### DIFF
--- a/database/migrations/2025_05_19_172027_increase_testmeasurement_name_size.php
+++ b/database/migrations/2025_05_19_172027_increase_testmeasurement_name_size.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('testmeasurement', function ($table) {
+            $table->text('name')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('testmeasurement', function ($table) {
+            $table->string('name', 70)->change();
+        });
+    }
+};


### PR DESCRIPTION
This change resolves the following type of database errors:

```
insert into "testmeasurement" ...  value too long for type character varying(70)
```