### PR TITLE
Enable HTTP Compression

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -27,3 +27,7 @@
 
     Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:"
 </IfModule>
+
+<IfModule mod_deflate.c>
+  SetOutputFilter DEFLATE
+</IfModule>


### PR DESCRIPTION
[HTTP compression](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression) is supported by all major browsers, and enabling it is now considered to be a standard practice.  I observed a baseline transfer size improvement of 1-5% for all pages, plus a 10-60% improvement for pages with large amounts of text data in a development environment.  Network overhead is the biggest contributor to initial page render time, so reducing the number of bytes transmitted corresponds to a reduction in page load time.