### PR TITLE
Fix configuration checks for local vs. remote storage

### DIFF
--- a/app/Http/Controllers/RemoteProcessingController.php
+++ b/app/Http/Controllers/RemoteProcessingController.php
@@ -104,7 +104,7 @@ final class RemoteProcessingController extends AbstractController
             return response('File not found', Response::HTTP_NOT_FOUND);
         }
 
-        $retry_handler = new RetryHandler(Storage::path("inprogress/{$filename}"));
+        $retry_handler = new RetryHandler("inprogress/{$filename}");
         $retry_handler->increment();
 
         // Move file back to inbox.

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -872,7 +872,7 @@ function extract_tar(string $stored_filepath): string
     Storage::disk('local')->makeDirectory($localTmpDirPath);
     $dirName = Storage::disk('local')->path($localTmpDirPath);
 
-    if (config('filesystem.default') !== 'local') {
+    if (config('filesystems.default') !== 'local') {
         // Download this file to the local Storage tmp dir.
         $remote_stored_filepath = $stored_filepath;
         $stored_filepath = 'tmp/' . basename($stored_filepath);
@@ -889,7 +889,7 @@ function extract_tar(string $stored_filepath): string
             throw new PEAR_Exception($pear_error->getMessage());
         });
         $tar_extract_result = $tar->extract($dirName);
-        if (config('filesystem.default') !== 'local') {
+        if (config('filesystems.default') !== 'local') {
             Storage::disk('local')->delete($stored_filepath);
         }
         if ($tar_extract_result === false) {
@@ -898,7 +898,7 @@ function extract_tar(string $stored_filepath): string
         }
         return $dirName;
     } catch (PEAR_Exception $e) {
-        if (config('filesystem.default') !== 'local') {
+        if (config('filesystems.default') !== 'local') {
             Storage::disk('local')->delete($stored_filepath);
         }
         Storage::disk('local')->deleteDirectory($localTmpDirPath);

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -29,7 +29,7 @@ class DoneHandlerTestCase extends KWWebTestCase
 
     public function testDoneHandlerRemote()
     {
-        if (config('filesystem.default') !== 'local') {
+        if (config('filesystems.default') !== 'local') {
             // Skip this test case if we're already testing remote storage.
             return;
         }

--- a/app/cdash/xml_handlers/abstract_xml_handler.php
+++ b/app/cdash/xml_handlers/abstract_xml_handler.php
@@ -72,7 +72,7 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
             if (!Storage::exists($path)) {
                 throw new FileNotFoundException($path);
             }
-            if (config('filesystem.default') === 'local') {
+            if (config('filesystems.default') === 'local') {
                 $xml->load(Storage::path($path), LIBXML_PARSEHUGE);
             } else {
                 // Temporarily download the file because DOMDocument->load takes a path,

--- a/app/cdash/xml_handlers/retry_handler.php
+++ b/app/cdash/xml_handlers/retry_handler.php
@@ -20,10 +20,10 @@
  **/
 class RetryHandler
 {
-    private $FileName;
+    private string $FileName;
     public int $Retries;
 
-    public function __construct($filename)
+    public function __construct(string $filename)
     {
         $this->FileName = $filename;
         $this->Retries = 0;
@@ -32,7 +32,7 @@ class RetryHandler
     /** Increments the "retries" attribute on the root element of the specified
      * XML  file,or sets it to 1 if it does not yet exist.
      **/
-    public function increment()
+    public function increment(): bool
     {
         if (!Storage::exists($this->FileName)) {
             return false;
@@ -44,6 +44,9 @@ class RetryHandler
         }
 
         $xml = simplexml_load_string($contents);
+        if ($xml === false) {
+            return false;
+        }
         $attributes = $xml->attributes();
         if (isset($attributes['retries'])) {
             $this->Retries = intval($attributes['retries']) + 1;
@@ -52,6 +55,6 @@ class RetryHandler
         }
         $xml['retries'] = $this->Retries;
 
-        return Storage::put($this->FileName, $xml->asXML());
+        return Storage::put($this->FileName, (string) $xml->asXML());
     }
 }

--- a/app/cdash/xml_handlers/retry_handler.php
+++ b/app/cdash/xml_handlers/retry_handler.php
@@ -26,6 +26,7 @@ class RetryHandler
     public function __construct($filename)
     {
         $this->FileName = $filename;
+        $this->Retries = 0;
     }
 
     /** Increments the "retries" attribute on the root element of the specified

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27950,32 +27950,7 @@ parameters:
 			path: app/cdash/xml_handlers/project_handler.php
 
 		-
-			message: "#^Cannot access offset 'retries' on SimpleXMLElement\\|false\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: "#^Cannot call method attributes\\(\\) on SimpleXMLElement\\|false\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: "#^Class RetryHandler has an uninitialized property \\$Retries\\. Give it default value or assign it in the constructor\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: "#^Method RetryHandler\\:\\:__construct\\(\\) has parameter \\$filename with no type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: "#^Method RetryHandler\\:\\:increment\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: "#^Property RetryHandler\\:\\:\\$FileName has no type specified\\.$#"
+			message: "#^SimpleXMLElement does not accept int\\.$#"
 			count: 1
 			path: app/cdash/xml_handlers/retry_handler.php
 


### PR DESCRIPTION
The name of the relevant config file is "filesystems", not "filesystem".