### PR TITLE
Make partial text match filters case-insensitive

### DIFF
--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -897,28 +897,28 @@ function get_sql_compare_and_value($compare, $value)
 
         case 63:
             // string contains
-            $sql_compare = 'LIKE';
+            $sql_compare = 'ILIKE';
             $sql_value = "'%$value%'";
 
             break;
 
         case 64:
             // string does not contain
-            $sql_compare = 'NOT LIKE';
+            $sql_compare = 'NOT ILIKE';
             $sql_value = "'%$value%'";
 
             break;
 
         case 65:
             // string starts with
-            $sql_compare = 'LIKE';
+            $sql_compare = 'ILIKE';
             $sql_value = "'$value%'";
 
             break;
 
         case 66:
             // string ends with
-            $sql_compare = 'LIKE';
+            $sql_compare = 'ILIKE';
             $sql_value = "'%$value'";
 
             break;


### PR DESCRIPTION
Some users previously used MySQL's case-insensitivity to deliberately create case-insensitive filters for build and test names.  While it's not practical to implement case-insensitivity for very selective filters while retaining their current performance, there is no real difference in performance for filters which are not selective enough to make use of indexes.  This PR changes all of the "LIKE"-based filters to use "ILIKE" instead.  Note that this will make the "starts with" filter less performant, in exchange for maintaining consistency with the other LIKE-based filters.