### PR TITLE
Fix project and global invitation access control issues

### DIFF
--- a/app/Policies/GlobalInvitationPolicy.php
+++ b/app/Policies/GlobalInvitationPolicy.php
@@ -7,6 +7,11 @@ use App\Models\User;
 
 class GlobalInvitationPolicy
 {
+    public function viewInvitations(?User $currentUser): bool
+    {
+        return $this->createInvitation($currentUser);
+    }
+
     public function createInvitation(?User $currentUser): bool
     {
         if (config('cdash.username_password_authentication_enabled') === false) {

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -202,7 +202,7 @@ add_feature_test(/Feature/GraphQL/NoteTypeTest)
 
 add_feature_test(/Feature/GraphQL/CoverageTypeTest)
 
-add_feature_test(/Feature/GraphQL/UserInvitationTypeTest)
+add_feature_test(/Feature/GraphQL/ProjectInvitationTypeTest)
 
 add_feature_test(/Feature/GraphQL/LabelTypeTest)
 
@@ -311,6 +311,10 @@ add_feature_test(/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest)
 # Needs RUN_SERIAL to verify that only the expected users are created
 add_feature_test(/Feature/GlobalInvitationAcceptanceTest)
 set_property(TEST /Feature/GlobalInvitationAcceptanceTest APPEND PROPERTY RUN_SERIAL TRUE)
+
+# Requires exclusive access to the global_invitations table
+add_feature_test(/Feature/GraphQL/GlobalInvitationTypeTest)
+set_property(TEST /Feature/GraphQL/GlobalInvitationTypeTest APPEND PROPERTY RUN_SERIAL TRUE)
 
 add_feature_test(/Feature/GraphQL/Mutations/RemoveUserTest)
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -53,7 +53,7 @@ type Query {
     id: ID @eq
   ): Site @find
 
-  invitations: [GlobalInvitation!]! @paginate(type: CONNECTION) @orderBy(column: "id")
+  invitations: [GlobalInvitation!]! @canResolved(ability: "viewInvitations") @paginate(type: CONNECTION) @orderBy(column: "id")
 }
 
 
@@ -176,8 +176,9 @@ type Project {
   "Users with the administrator role for this project."
   administrators: [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 
+  # Can't return null on authorization failure due to Lighthouse bug with connections and can* directives.
   "Invitations to this project which have not been accepted yet."
-  invitations: [ProjectInvitation!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
+  invitations: [ProjectInvitation!]! @canRoot(ability: "inviteUser") @hasMany(type: CONNECTION) @orderBy(column: "id")
 }
 
 enum ProjectVisibility {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29126,6 +29126,16 @@ parameters:
 			path: tests/Feature/GraphQL/FilterTest.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
+			count: 2
+			path: tests/Feature/GraphQL/GlobalInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\GlobalInvitationTypeTest\\:\\:createInvitation\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/GlobalInvitationTypeTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
 			count: 64
 			path: tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
@@ -29247,6 +29257,26 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
+			count: 2
+			path: tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\ProjectInvitationTypeTest\\:\\:testAdminCanViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\ProjectInvitationTypeTest\\:\\:testAnonymousUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\ProjectInvitationTypeTest\\:\\:testNormalUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
+			count: 1
+			path: tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Testing\\\\TestResponse\\:\\:assertGraphQLErrorMessage\\(\\)\\.$#"
 			count: 5
 			path: tests/Feature/GraphQL/ProjectTypeTest.php
 
@@ -29294,21 +29324,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$time of static method Carbon\\\\Carbon\\:\\:parse\\(\\) expects DateTimeInterface\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: tests/Feature/GraphQL/SiteTypeTest.php
-
-		-
-			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testAdminCanViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
-
-		-
-			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testAnonymousUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
-
-		-
-			message: "#^Method Tests\\\\Feature\\\\GraphQL\\\\UserInvitationTypeTest\\:\\:testNormalUserCannotViewInvitations\\(\\) throws checked exception OverflowException but it's missing from the PHPDoc @throws tag\\.$#"
-			count: 1
-			path: tests/Feature/GraphQL/UserInvitationTypeTest.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Models\\\\SuccessfulJob\\>\\:\\:count\\(\\)\\.$#"

--- a/tests/Feature/GraphQL/GlobalInvitationTypeTest.php
+++ b/tests/Feature/GraphQL/GlobalInvitationTypeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Enums\GlobalRole;
+use App\Models\GlobalInvitation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class GlobalInvitationTypeTest extends TestCase
+{
+    use CreatesUsers;
+    use DatabaseTruncation;
+
+    private User $normalUser;
+    private User $adminUser;
+
+    /** @var array<GlobalInvitation> */
+    private array $invitations = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->normalUser = $this->makeNormalUser();
+        $this->adminUser = $this->makeAdminUser();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->invitations as $invitation) {
+            $invitation->delete();
+        }
+        $this->invitations = [];
+
+        $this->normalUser->delete();
+        $this->adminUser->delete();
+
+        parent::tearDown();
+    }
+
+    private function createInvitation(): GlobalInvitation
+    {
+        /** @var GlobalInvitation $invitation */
+        $invitation = GlobalInvitation::create([
+            'email' => fake()->unique()->email(),
+            'invited_by_id' => $this->adminUser->id,
+            'role' => GlobalRole::USER,
+            'invitation_timestamp' => Carbon::now(),
+            'password' => Hash::make(Str::password()),
+        ]);
+        $this->invitations[] = $invitation;
+
+        return $invitation;
+    }
+
+    public function testAdminCanViewInvitations(): void
+    {
+        $invitation = $this->createInvitation();
+
+        $this->actingAs($this->adminUser)->graphQL('
+            query {
+                invitations {
+                    edges {
+                        node {
+                            id
+                            email
+                            invitedBy {
+                                id
+                            }
+                            role
+                            invitationTimestamp
+                        }
+                    }
+                }
+            }
+        ')->assertExactJson([
+            'data' => [
+                'invitations' => [
+                    'edges' => [
+                        [
+                            'node' => [
+                                'id' => (string) $invitation->id,
+                                'email' => $invitation->email,
+                                'invitedBy' => [
+                                    'id' => (string) $this->adminUser->id,
+                                ],
+                                'role' => 'USER',
+                                'invitationTimestamp' => $invitation->invitation_timestamp->toIso8601String(),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testNormalUserCannotViewInvitations(): void
+    {
+        $this->createInvitation();
+        $this->actingAs($this->normalUser)->graphQL('
+            query {
+                invitations {
+                    edges {
+                        node {
+                            id
+                            email
+                            invitedBy {
+                                id
+                            }
+                            role
+                            invitationTimestamp
+                        }
+                    }
+                }
+            }
+        ')->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
+
+    public function testAnonymousUserCannotViewInvitations(): void
+    {
+        $this->createInvitation();
+        $this->graphQL('
+            query {
+                invitations {
+                    edges {
+                        node {
+                            id
+                            email
+                            invitedBy {
+                                id
+                            }
+                            role
+                            invitationTimestamp
+                        }
+                    }
+                }
+            }
+        ')->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
+}

--- a/tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectInvitationTypeTest.php
@@ -11,7 +11,7 @@ use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
 
-class UserInvitationTypeTest extends TestCase
+class ProjectInvitationTypeTest extends TestCase
 {
     use CreatesUsers;
     use CreatesProjects;
@@ -71,7 +71,7 @@ class UserInvitationTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'invitations' => [
@@ -94,7 +94,7 @@ class UserInvitationTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testNormalUserCannotViewInvitations(): void
@@ -107,7 +107,7 @@ class UserInvitationTypeTest extends TestCase
             'invitation_timestamp' => Carbon::now(),
         ]);
 
-        $this->actingAs($this->adminUser)->graphQL('
+        $this->actingAs($this->normalUser)->graphQL('
             query($id: ID) {
                 project(id: $id) {
                     invitations {
@@ -121,15 +121,7 @@ class UserInvitationTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
-            'data' => [
-                'project' => [
-                    'invitations' => [
-                        'edges' => [],
-                    ],
-                ],
-            ],
-        ], true);
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testAnonymousUserCannotViewInvitations(): void
@@ -156,14 +148,6 @@ class UserInvitationTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
-            'data' => [
-                'project' => [
-                    'invitations' => [
-                        'edges' => [],
-                    ],
-                ],
-            ],
-        ], true);
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 }


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2778 and https://github.com/Kitware/CDash/pull/2830 both suffer from a logical flaw which was missed in testing because the Laravel `assertJson(..., strict: true)` does not actually do an exact JSON match as it was believed to do.  This PR resolves the access control issues in these unreleased features.  I plan to make a separate PR to convert the rest of the `assertJson()` assertions throughout the codebase to `assertExactJson()`.