### PR TITLE
Fallback to case insensitive searching in some cases

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -211,7 +211,7 @@ class Build extends Model
      */
     public function buildGroups(): BelongsToMany
     {
-        return $this->belongsToMany(BuildGroup::class, 'build2group', 'groupid', 'buildid');
+        return $this->belongsToMany(BuildGroup::class, 'build2group', 'buildid', 'groupid');
     }
 
     /**

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -308,6 +308,17 @@ class Project
             $this->Fill();
             return true;
         }
+
+        // Do a case insensitive search to more gracefully support users of
+        // CDash instances that migrated from MySQL to Postgres.
+        $name_lower = strtolower($this->Name);
+        $project_row = EloquentProject::whereRaw('LOWER(name) = ?', [$name_lower])->first();
+        if ($project_row !== null) {
+            $this->Id = $project_row->id;
+            $this->Name = $project_row->name;
+            return true;
+        }
+
         return false;
     }
 

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -214,6 +214,8 @@ add_feature_test(/Feature/GraphQL/BuildCommandOutputTypeTest)
 
 add_feature_test(/Feature/Submission/Instrumentation/BuildInstrumentationTest)
 
+add_feature_test(/Feature/Submission/CaseInsensitivity/CaseInsensitivityTest)
+
 add_feature_test(/Feature/RouteAccessTest)
 
 add_feature_test(/Feature/Monitor)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29441,6 +29441,16 @@ parameters:
 			path: tests/Feature/SlowPageTest.php
 
 		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:count\\(\\)\\.$#"
+			count: 1
+			path: tests/Feature/Submission/CaseInsensitivity/CaseInsensitivityTest.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\Build\\>\\:\\:first\\(\\)\\.$#"
+			count: 1
+			path: tests/Feature/Submission/CaseInsensitivity/CaseInsensitivityTest.php
+
+		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<App\\\\Models\\\\SiteInformation\\>\\:\\:count\\(\\)\\.$#"
 			count: 1
 			path: tests/Feature/Traits/UpdatesSiteInformationTest.php

--- a/tests/Feature/Submission/CaseInsensitivity/CaseInsensitivityTest.php
+++ b/tests/Feature/Submission/CaseInsensitivity/CaseInsensitivityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Submission\CaseInsensitivity;
+
+use App\Models\Build;
+use App\Models\BuildGroup;
+use App\Models\Project;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSubmissions;
+
+class CaseInsensitivityTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSubmissions;
+
+    private BuildGroup $buildgroup;
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        // The trait doesn't initialize the default buildgroups for us, so we do it manually
+        $legacy_project = new \CDash\Model\Project();
+        $legacy_project->Id = $this->project->id;
+        $legacy_project->InitialSetup();
+
+        $this->project->refresh();
+
+        // The XML file associated with this test uses 'my-custom-group' instead.
+        $this->buildgroup = BuildGroup::create([
+            'name' => 'My-Custom-Group',
+            'projectid' => $this->project->id,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that submissions are parsed successfully when the case doesn't match
+     * for their project and build group names.
+     */
+    public function testCaseInsensitiveSubmission(): void
+    {
+        $this->submitFiles(strtoupper($this->project->name), [
+            base_path('tests/Feature/Submission/CaseInsensitivity/data/Build.xml'),
+        ]);
+
+        self::assertEquals($this->project->builds()->count(), 1);
+
+        $build = $this->project->builds()->first();
+        self::assertNotNull($build);
+
+        $group_from_build = $build->buildGroups()->first();
+        self::assertNotNull($group_from_build);
+
+        self::assertEquals($group_from_build->id, $this->buildgroup->id);
+    }
+}

--- a/tests/Feature/Submission/CaseInsensitivity/data/Build.xml
+++ b/tests/Feature/Submission/CaseInsensitivity/data/Build.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="test_case_insensitivity"
+	BuildStamp="20250522-1338-my-custom-group"
+	Name="localhost"
+	Generator="ctest-3.31"
+	CompilerName=""
+	CompilerVersion=""
+	OSName="macOS"
+	Hostname="localhost"
+	>
+	<Build>
+		<StartDateTime>May 22 09:38 EDT</StartDateTime>
+		<StartBuildTime>1747921120</StartBuildTime>
+		<BuildCommand>cmake --build . --config "Release"</BuildCommand>
+		<Log Encoding="base64" Compression="bin/gzip"/>
+		<EndDateTime>May 22 09:38 EDT</EndDateTime>
+		<EndBuildTime>1747921122</EndBuildTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Build>
+</Site>


### PR DESCRIPTION
Perform case insensitive searches for projects and build groups.

The background here is that MySQL performs case insensitive searches by default, while Postgres does not.

Thus, the motivation behind this change is to reduce the impact on our users as CDash instances are being migrated from MySQL to Postgres.