### PR TITLE
Remove MySQL-specific code paths

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -65,11 +65,7 @@ final class AdminController extends AbstractController
 
         // Delete the builds
         if (isset($_POST['Submit'])) {
-            if (config('database.default') === 'pgsql') {
-                $timestamp_sql = "CAST(CONCAT(?, '-', ?, '-', ?, ' 00:00:00') AS timestamp)";
-            } else {
-                $timestamp_sql = "TIMESTAMP(CONCAT(?, '-', ?, '-', ?, ' 00:00:00'))";
-            }
+            $timestamp_sql = "CAST(CONCAT(?, '-', ?, '-', ?, ' 00:00:00') AS timestamp)";
 
             $build = DB::select("
                          SELECT id

--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -137,46 +137,6 @@ final class MonitorController extends AbstractController
      */
     private function resultsPerHour(string $table, string $field): Collection
     {
-        if (config('database.default') === 'mysql') {
-            return $this->mySQLResultsPerHour($table, $field);
-        } else {
-            return $this->postgreSQLResultsPerHour($table, $field);
-        }
-    }
-
-    /**
-     * MySQL implementation of resultsPerHour
-     *
-     * @return Collection<int,stdClass>
-     */
-    private function mySQLResultsPerHour(string $table, string $field): Collection
-    {
-        // Group jobs by hour.
-        // We achieve this by:
-        // 1) subtracting the seconds
-        // 2) subtracting the minutes
-        // 3) casting the result to a UNIX timestamp
-        return DB::table($table)
-            ->select(DB::raw("
-              UNIX_TIMESTAMP(
-                DATE_SUB(
-                  DATE_SUB({$field}, INTERVAL MINUTE({$field}) MINUTE),
-                  INTERVAL SECOND({$field}) SECOND
-                )
-              ) AS truncated_time,
-              COUNT(1) AS n_jobs
-            "))
-            ->groupBy('truncated_time')
-            ->get();
-    }
-
-    /**
-     * Postgres implementation of resultsPerHour
-     *
-     * @return Collection<int,stdClass>
-     */
-    private function postgreSQLResultsPerHour(string $table, string $field): Collection
-    {
         // Group jobs by hour.
         // We achieve this by:
         // 1) using DATE_TRUNC() to truncate timestamps to the hour

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -11,82 +11,44 @@ final class SiteController extends AbstractController
 {
     public function siteStatistics(): View|RedirectResponse
     {
-        if (config('database.default') === 'pgsql') {
-            $sites = DB::select("
-                         SELECT
-                             siteid,
-                             sitename,
-                             SUM(elapsed) AS busytime
-                         FROM (
-                             SELECT
-                                 site.id AS siteid,
-                                 site.name AS sitename,
-                                 project.name AS projectname,
-                                 build.name AS buildname,
-                                 build.type,
-                                 AVG(submittime - buildupdate.starttime) AS elapsed
-                             FROM
-                                 build,
-                                 build2update,
-                                 buildupdate,
-                                 project,
-                                 site
-                             WHERE
-                                 submittime > NOW() - interval '168 hours'
-                                 AND build2update.buildid = build.id
-                                 AND buildupdate.id = build2update.updateid
-                                 AND site.id = build.siteid
-                                 AND build.projectid = project.id
-                             GROUP BY
-                                 sitename,
-                                 projectname,
-                                 buildname,
-                                 build.type,
-                                 site.id
-                             ORDER BY elapsed DESC
-                         ) AS summary
-                         GROUP BY
-                             sitename,
-                             summary.siteid
-                         ORDER BY busytime DESC
-                     ");
-        } else {
-            $sites = DB::select('
-                         SELECT
-                             siteid,
-                             sitename,
-                             SEC_TO_TIME(SUM(elapsed)) AS busytime
-                         FROM (
-                             SELECT
-                                 site.id AS siteid,
-                                 site.name AS sitename,
-                                 project.name AS projectname,
-                                 build.name AS buildname,
-                                 build.type,
-                                 AVG(TIME_TO_SEC(TIMEDIFF(submittime, buildupdate.starttime))) AS elapsed
-                             FROM
-                                 build,
-                                 build2update,
-                                 buildupdate,
-                                 project,
-                                 site
-                             WHERE
-                                 submittime > TIMESTAMPADD(HOUR, -168, NOW())
-                                 AND build2update.buildid = build.id
-                                 AND buildupdate.id = build2update.updateid
-                                 AND site.id = build.siteid
-                                 AND build.projectid = project.id
-                             GROUP BY
-                                 sitename,
-                                 projectname,
-                                 buildname,
-                                 build.type
-                             ORDER BY elapsed DESC
-                         ) AS summary
-                         GROUP BY sitename
-                         ORDER BY busytime DESC
-                     ');
-        }
+        $sites = DB::select("
+            SELECT
+                siteid,
+                sitename,
+                SUM(elapsed) AS busytime
+            FROM (
+                SELECT
+                    site.id AS siteid,
+                    site.name AS sitename,
+                    project.name AS projectname,
+                    build.name AS buildname,
+                    build.type,
+                    AVG(submittime - buildupdate.starttime) AS elapsed
+                FROM
+                    build,
+                    build2update,
+                    buildupdate,
+                    project,
+                    site
+                WHERE
+                    submittime > NOW() - interval '168 hours'
+                    AND build2update.buildid = build.id
+                    AND buildupdate.id = build2update.updateid
+                    AND site.id = build.siteid
+                    AND build.projectid = project.id
+                GROUP BY
+                    sitename,
+                    projectname,
+                    buildname,
+                    build.type,
+                    site.id
+                ORDER BY elapsed DESC
+            ) AS summary
+            GROUP BY
+                sitename,
+                summary.siteid
+            ORDER BY busytime DESC
+        ");
 
         return $this->view('site.site-statistics', 'Site Statistics')
             ->with('sites', $sites);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,6 @@ define('FMT_DATETIMEDISPLAY', 'M d, Y - H:i T');  // date and time standard
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -30,11 +29,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         Validator::extendImplicit('complexity', 'App\Validators\Password@complexity');
-
-        /* For migrations on MySQL older than 5.7.7 * */
-        if (config('database.default') !== 'pgsql') {
-            Schema::defaultStringLength(191);
-        }
 
         URL::forceRootUrl(Config::get('app.url'));
 

--- a/app/Utils/SubmissionUtils.php
+++ b/app/Utils/SubmissionUtils.php
@@ -279,16 +279,10 @@ class SubmissionUtils
             WHERE buildid=:buildid AND type=:type');
         } else {
             // Insert new record.
-            $duplicate_sql = '';
-            if (config('database.default') !== 'pgsql') {
-                $duplicate_sql =
-                    'ON DUPLICATE KEY UPDATE difference_positive=:npositives, difference_negative=:nnegatives';
-            }
             $stmt = $pdo->prepare(
-                "INSERT INTO builderrordiff
+                'INSERT INTO builderrordiff
             (buildid, type, difference_positive, difference_negative)
-            VALUES (:buildid, :type, :npositives, :nnegatives)
-            $duplicate_sql");
+            VALUES (:buildid, :type, :npositives, :nnegatives)');
         }
         $stmt->bindValue(':buildid', $buildid);
         $stmt->bindValue(':type', $warning);

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -337,12 +337,6 @@ class QueryTests extends ResultsApi
             $output_select = ', testoutput.output';
         }
 
-        if (config('database.default') === 'pgsql') {
-            $text_concat = "array_to_string(array_agg(DISTINCT text), ', ')";
-        } else {
-            $text_concat = "GROUP_CONCAT(DISTINCT text SEPARATOR ', ')";
-        }
-
         $query_params[':projectid'] = $this->project->Id;
         $rows = DB::select("
                     SELECT
@@ -361,7 +355,7 @@ class QueryTests extends ResultsApi
                         site.name AS sitename,
                         build2test.testname AS testname,
                         (
-                            SELECT $text_concat
+                            SELECT array_to_string(array_agg(DISTINCT text), ', ')
                             FROM
                                 label,
                                 label2test

--- a/app/cdash/app/Model/BuildUpdate.php
+++ b/app/cdash/app/Model/BuildUpdate.php
@@ -175,28 +175,16 @@ class BuildUpdate
                 $nwarnings += $this->GetNumberOfWarnings();
                 $nfiles += $this->GetNumberOfFiles();
 
-                if (config('database.default') == 'pgsql') {
-                    // pgsql doesn't have concat...
-                    DB::table('buildupdate')
-                        ->where('id', $this->UpdateId)
-                        ->update([
-                            'endtime' => $this->EndTime,
-                            'status' => $this->Status,
-                            'command' => DB::raw("command || '$this->Command'"),
-                            'nfiles' => $nfiles,
-                            'warnings' => $nwarnings,
-                        ]);
-                } else {
-                    DB::table('buildupdate')
-                        ->where('id', $this->UpdateId)
-                        ->update([
-                            'endtime' => $this->EndTime,
-                            'status' => $this->Status,
-                            'command' => DB::raw("CONCAT(command, '$this->Command')"),
-                            'nfiles' => $nfiles,
-                            'warnings' => $nwarnings,
-                        ]);
-                }
+                // pgsql doesn't have concat...
+                DB::table('buildupdate')
+                    ->where('id', $this->UpdateId)
+                    ->update([
+                        'endtime' => $this->EndTime,
+                        'status' => $this->Status,
+                        'command' => DB::raw("command || '$this->Command'"),
+                        'nfiles' => $nfiles,
+                        'warnings' => $nwarnings,
+                    ]);
             }
 
             foreach ($this->Files as $file) {

--- a/app/cdash/app/Model/CoverageFileLog.php
+++ b/app/cdash/app/Model/CoverageFileLog.php
@@ -126,11 +126,7 @@ class CoverageFileLog
             return false;
         }
 
-        if (config('database.default') == 'pgsql') {
-            $log = stream_get_contents($row->log);
-        } else {
-            $log = $row->log;
-        }
+        $log = stream_get_contents($row->log);
 
         $log_entries = explode(';', $log);
         // Make an initial pass through $log_entries to see what lines

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -95,29 +95,16 @@ class DynamicAnalysis
 
         $this->BuildId = intval($this->BuildId);
 
-        if (config('database.default') == 'pgsql') {
-            // postgresql doesn't support multiple delete
-            //
-            // TODO: (williamjallen) Figure out what to do with the potential race condition caused here.
-            //       Ideally this should be done via a cascading delete, or at least in a single transaction.
-            DB::delete('
-                 DELETE FROM dynamicanalysisdefect
-                 USING dynamicanalysis
-                 WHERE
-                     dynamicanalysis.buildid = ?
-                     AND dynamicanalysis.id = dynamicanalysisdefect.dynamicanalysisid
-            ', [$this->BuildId]);
+        // postgresql doesn't support multiple delete
+        DB::delete('
+             DELETE FROM dynamicanalysisdefect
+             USING dynamicanalysis
+             WHERE
+                 dynamicanalysis.buildid = ?
+                 AND dynamicanalysis.id = dynamicanalysisdefect.dynamicanalysisid
+        ', [$this->BuildId]);
 
-            DB::delete('DELETE FROM dynamicanalysis WHERE dynamicanalysis.buildid = ?', [$this->BuildId]);
-        } else {
-            DB::delete('
-                DELETE dynamicanalysisdefect, dynamicanalysis
-                FROM dynamicanalysisdefect, dynamicanalysis
-                WHERE
-                 dynamicanalysis.buildid=?
-                 AND dynamicanalysis.id=dynamicanalysisdefect.dynamicanalysisid
-            ', [$this->BuildId]);
-        }
+        DB::delete('DELETE FROM dynamicanalysis WHERE dynamicanalysis.buildid = ?', [$this->BuildId]);
         DB::delete('DELETE FROM dynamicanalysis WHERE buildid=?', [$this->BuildId]);
     }
 

--- a/app/cdash/app/Model/Label.php
+++ b/app/cdash/app/Model/Label.php
@@ -64,10 +64,6 @@ class Label
 
     private function InsertAssociation(string $table, string $field1, ?int $value1 = null, ?string $field2 = null, ?int $value2 = null): void
     {
-        $duplicate_sql = '';
-        if (config('database.default') !== 'pgsql') {
-            $duplicate_sql = 'ON DUPLICATE KEY UPDATE labelid=labelid';
-        }
         if (!empty($value1)) {
             if (!empty($value2)) {
                 $query = DB::select("
@@ -85,7 +81,6 @@ class Label
                     DB::insert("
                         INSERT INTO $table (labelid, $field1, $field2)
                         VALUES (?, ?, ?)
-                        $duplicate_sql
                     ", [intval($this->Id), $value1, $value2]);
                 }
             } else {
@@ -104,7 +99,6 @@ class Label
                     DB::insert("
                         INSERT INTO $table (labelid, $field1)
                         VALUES (?, ?)
-                        $duplicate_sql
                     ", [intval($this->Id), $value1]);
                 }
             }

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -820,12 +820,7 @@ class Project
         $todaytime -= 3600 * 24 * $days;
         $today = date(FMT_DATETIMESTD, $todaytime);
 
-        $straightjoin = '';
-        if (config('database.default') != 'pgsql') {
-            $straightjoin = 'STRAIGHT_JOIN';
-        }
-
-        $labels = DB::select("
+        $labels = DB::select('
                       (
                           SELECT labelid AS id
                           FROM label2build, build
@@ -842,14 +837,14 @@ class Project
                               AND build.projectid=?
                               AND build.starttime>?
                       ) UNION (
-                          SELECT $straightjoin labelid AS id
+                          SELECT labelid AS id
                           FROM build, label2coveragefile
                           WHERE
                               label2coveragefile.buildid=build.id
                               AND build.projectid=?
                               AND build.starttime>?
                       ) UNION (
-                          SELECT $straightjoin labelid AS id
+                          SELECT labelid AS id
                           FROM build, buildfailure, label2buildfailure
                           WHERE
                               label2buildfailure.buildfailureid=buildfailure.id
@@ -857,7 +852,7 @@ class Project
                               AND build.projectid=?
                               AND build.starttime>?
                       ) UNION (
-                          SELECT $straightjoin labelid AS id
+                          SELECT labelid AS id
                           FROM build, dynamicanalysis, label2dynamicanalysis
                           WHERE
                               label2dynamicanalysis.dynamicanalysisid=dynamicanalysis.id
@@ -865,7 +860,7 @@ class Project
                               AND build.projectid=?
                               AND build.starttime>?
                       )
-                  ", [
+                  ', [
             intval($this->Id),
             $today,
             intval($this->Id),

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -559,13 +559,7 @@ function make_cdash_url(string $url): string
  */
 function qnum($num)
 {
-    if (!config('database.default') || (config('database.default') == 'mysql')) {
-        return "'$num'";
-    } elseif (config('database.default') == 'pgsql') {
-        return $num != '' ? $num : '0';
-    } else {
-        return $num;
-    }
+    return $num != '' ? $num : '0';
 }
 
 /**

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -46,14 +46,7 @@ class DefaultFilters implements PageSpecificFilters
 {
     public function __construct()
     {
-        // The way we concatenate text into a single value
-        // depends on our database backend.
-
-        if (config('database.default') === 'pgsql') {
-            $this->TextConcat = "array_to_string(array_agg(text), ', ')";
-        } else {
-            $this->TextConcat = "GROUP_CONCAT(text SEPARATOR ', ')";
-        }
+        $this->TextConcat = "array_to_string(array_agg(text), ', ')";
     }
 
     public function getDefaultFilter()
@@ -312,11 +305,7 @@ class IndexPhpFilters extends DefaultFilters
                 break;
 
             case 'updateduration':
-                if (config('database.default') === 'pgsql') {
-                    $sql_field = 'ROUND(EXTRACT(EPOCH FROM (bu.endtime - bu.starttime))::numeric / 60, 1)';
-                } else {
-                    $sql_field = 'ROUND(TIMESTAMPDIFF(SECOND,bu.starttime,bu.endtime)/60.0,1)';
-                }
+                $sql_field = 'ROUND(EXTRACT(EPOCH FROM (bu.endtime - bu.starttime))::numeric / 60, 1)';
 
                 break;
 

--- a/app/cdash/public/api/v1/buildgroup.php
+++ b/app/cdash/public/api/v1/buildgroup.php
@@ -145,20 +145,11 @@ function rest_post($pdo, $projectid)
         $inputRows = $_POST['newLayout'];
         if (count($inputRows) > 0) {
             // Remove old build group layout for this project.
-            if (config('database.default') == 'pgsql') {
-                // We use a subquery here because postgres doesn't support
-                // JOINs in a DELETE statement.
-                $sql = "
-                    DELETE FROM buildgroupposition WHERE buildgroupid IN
-                    (SELECT bgp.buildgroupid FROM buildgroupposition AS bgp
-                    LEFT JOIN buildgroup AS bg ON (bgp.buildgroupid = bg.id)
-                    WHERE bg.projectid = ?)";
-            } else {
-                $sql = "
-                    DELETE bgp FROM buildgroupposition AS bgp
-                    LEFT JOIN buildgroup AS bg ON (bgp.buildgroupid = bg.id)
-                    WHERE bg.projectid = ?";
-            }
+            $sql = "
+                DELETE FROM buildgroupposition WHERE buildgroupid IN
+                (SELECT bgp.buildgroupid FROM buildgroupposition AS bgp
+                LEFT JOIN buildgroup AS bg ON (bgp.buildgroupid = bg.id)
+                WHERE bg.projectid = ?)";
             $stmt = $pdo->prepare($sql);
             pdo_execute($stmt, [$projectid]);
 

--- a/app/cdash/tests/kwtest/kw_db.php
+++ b/app/cdash/tests/kwtest/kw_db.php
@@ -27,11 +27,6 @@ class database
     public function __construct($type)
     {
         switch ($type) {
-            case 'mysql':
-                $this->dbo = new dbo_mysql();
-                $this->type = 'mysql';
-                break;
-
             case 'pgsql':
                 $this->dbo = new dbo_pgsql();
                 $this->type = 'pgsql';
@@ -157,66 +152,6 @@ class dbo
     public function setConnection($connection)
     {
         $this->connection = $connection;
-    }
-}
-
-class dbo_mysql extends dbo
-{
-    public function connect()
-    {
-    }
-
-    public function getDSN()
-    {
-        return "mysql:{$this->connection}={$this->host}";
-    }
-
-    public function disconnect()
-    {
-        $this->dbconnect = null;
-    }
-
-    public function create($db)
-    {
-        $dbh = new PDO($this->getDSN(), $this->user, $this->password);
-        if (!$dbh->query("CREATE DATABASE IF NOT EXISTS $db")) {
-            $this->disconnect();
-            return false;
-        }
-        $this->disconnect();
-        return true;
-    }
-
-    public function drop($db)
-    {
-        $dbh = new PDO($this->getDSN(), $this->user, $this->password);
-        if (!$dbh->query("DROP DATABASE IF EXISTS $db")) {
-            $this->disconnect();
-            return false;
-        }
-        $this->disconnect();
-        return true;
-    }
-
-    public function connectToDb()
-    {
-        $db = CDash\Database::getInstance();
-        return $db->getPdo() instanceof PDO;
-    }
-
-    public function query($query)
-    {
-        $this->connectToDb();
-        $resource = pdo_query($query);
-        if (!$resource || $resource === true) {
-            return false;
-        }
-        $result = [];
-        while ($row = pdo_fetch_array($resource, PDO::FETCH_ASSOC)) {
-            $result[] = $row;
-        }
-        $this->disconnect();
-        return $result;
     }
 }
 

--- a/app/cdash/tests/test_projectindb.php
+++ b/app/cdash/tests/test_projectindb.php
@@ -55,11 +55,7 @@ class ProjectInDbTestCase extends KWWebTestCase
         $query = 'SELECT COUNT(*) FROM buildgroupposition WHERE buildgroupid IN (SELECT id FROM buildgroup WHERE projectid=';
         $query .= $this->projecttestid . ')';
         $result = $this->db->query($query);
-        if (!strcmp($this->db->getType(), 'pgsql')) {
-            $this->assertEqual($result[0]['count'], 3);
-        } elseif (!strcmp($this->db->getType(), 'mysql')) {
-            $this->assertEqual($result[0]['COUNT(*)'], 3);
-        }
+        $this->assertEqual($result[0]['count'], 3);
     }
 
     public function testUser2Project()

--- a/config/database.php
+++ b/config/database.php
@@ -37,29 +37,6 @@ return [
     */
 
     'connections' => [
-        'sqlite' => [
-            'driver' => 'sqlite',
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
-            'prefix' => '',
-            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-        ],
-
-        'mysql' => [
-            'driver' => 'mysql',
-            'host' => env('DB_HOST', 'localhost'),
-            'port' => env('DB_PORT', 3306),
-            'database' => env('DB_DATABASE', 'cdash'),
-            'username' => env('DB_USERNAME', 'root'),
-            'password' => env('DB_PASSWORD', ''),
-            'unix_socket' => env('DB_SOCKET', ''),
-            'charset' => 'utf8',
-            'collation' => 'utf8_general_ci',
-            'prefix' => '',
-            'prefix_indexes' => true,
-            'strict' => false,
-            'engine' => null,
-        ],
-
         'pgsql' => [
             'driver' => 'pgsql',
             'host' => env('DB_HOST', 'localhost'),
@@ -72,18 +49,6 @@ return [
             'prefix_indexes' => true,
             'search_path' => 'public',
             'sslmode' => 'prefer',
-        ],
-
-        'sqlsrv' => [
-            'driver' => 'sqlsrv',
-            'host' => env('DB_HOST', 'localhost'),
-            'port' => env('DB_PORT', '1433'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
-            'charset' => 'utf8',
-            'prefix' => '',
-            'prefix_indexes' => true,
         ],
     ],
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4543,14 +4543,6 @@ parameters:
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
-			message: """
-				#^Call to deprecated method executePreparedSingleRow\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			"""
-			count: 1
-			path: app/cdash/app/Controller/Api/Index.php
-
-		-
 			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 2
 			path: app/cdash/app/Controller/Api/Index.php
@@ -4558,11 +4550,6 @@ parameters:
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 5
-			path: app/cdash/app/Controller/Api/Index.php
-
-		-
-			message: "#^Cannot access offset 'a' on array\\|false\\|null\\.$#"
-			count: 1
 			path: app/cdash/app/Controller/Api/Index.php
 
 		-
@@ -5473,7 +5460,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 7
+			count: 6
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
@@ -7371,7 +7358,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 4
+			count: 3
 			path: app/cdash/app/Model/BuildUpdate.php
 
 		-
@@ -7738,7 +7725,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$log\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
@@ -7771,7 +7758,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
@@ -7851,6 +7838,11 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, object\\|null given\\.$#"
+			count: 1
+			path: app/cdash/app/Model/CoverageFileLog.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, string\\|false given\\.$#"
 			count: 1
 			path: app/cdash/app/Model/CoverageFileLog.php
 
@@ -8090,7 +8082,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 6
+			count: 5
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -8817,7 +8809,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\!\\=\" is not allowed\\.$#"
-			count: 3
+			count: 2
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -11888,7 +11880,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 7
+			count: 5
 			path: app/cdash/include/common.php
 
 		-
@@ -11898,7 +11890,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/include/common.php
 
 		-
@@ -12150,7 +12142,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property DefaultFilters\\:\\:\\$TextConcat\\.$#"
-			count: 2
+			count: 1
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
@@ -13014,7 +13006,7 @@ parameters:
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 4
+			count: 3
 			path: app/cdash/public/api/v1/buildgroup.php
 
 		-
@@ -16310,21 +16302,13 @@ parameters:
 				#^Call to deprecated function pdo_fetch_array\\(\\)\\:
 				04/01/2023$#
 			"""
-			count: 2
+			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
 
 		-
 			message: """
 				#^Call to deprecated function pdo_query\\(\\)\\:
 				04/01/2023$#
-			"""
-			count: 2
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: """
-				#^Call to deprecated method getPdo\\(\\) of class CDash\\\\Database\\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
 			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
@@ -16510,56 +16494,6 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_db.php
 
 		-
-			message: "#^Method dbo_mysql\\:\\:connect\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:connectToDb\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:create\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:create\\(\\) has parameter \\$db with no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:disconnect\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:drop\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:drop\\(\\) has parameter \\$db with no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:getDSN\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:query\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Method dbo_mysql\\:\\:query\\(\\) has parameter \\$query with no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
 			message: "#^Method dbo_pgsql\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
@@ -16596,7 +16530,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PDOStatement\\|false given\\.$#"
-			count: 4
+			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
 
 		-
@@ -16641,11 +16575,6 @@ parameters:
 
 		-
 			message: "#^Property dbo\\:\\:\\$user has no type specified\\.$#"
-			count: 1
-			path: app/cdash/tests/kwtest/kw_db.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between PDOStatement and true will always evaluate to false\\.$#"
 			count: 1
 			path: app/cdash/tests/kwtest/kw_db.php
 
@@ -23309,11 +23238,6 @@ parameters:
 		-
 			message: "#^Method ProjectInDbTestCase\\:\\:testUser2Project\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: app/cdash/tests/test_projectindb.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<\\-1, 1\\> given\\.$#"
-			count: 2
 			path: app/cdash/tests/test_projectindb.php
 
 		-


### PR DESCRIPTION
This PR follows https://github.com/Kitware/CDash/pull/2885, removing almost all of the MySQL-specific logic throughout the codebase.  A couple database-specific code paths remain since changing them interferes with the test suite.  I plan to address them in a separate PR.