### PR TITLE
Move join/leave project functionality to members page

### DIFF
--- a/app/GraphQL/Mutations/JoinProject.php
+++ b/app/GraphQL/Mutations/JoinProject.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Project;
+use App\Models\User;
+use Exception;
+
+final class JoinProject extends AbstractMutation
+{
+    /**
+     * @param array{
+     *     projectId: int,
+     * } $args
+     *
+     * @throws Exception
+     */
+    protected function mutate(array $args): void
+    {
+        /** @var ?User $user */
+        $user = auth()->user();
+        $project = isset($args['projectId']) ? Project::find((int) $args['projectId']) : null;
+
+        if (
+            $user === null
+            || $project === null
+            || $user->cannot('join', $project)
+        ) {
+            abort(401, 'This action is unauthorized.');
+        }
+
+        $project
+            ->users()
+            ->attach($user->id, [
+                'emailtype' => 0,
+                'emailcategory' => 62,
+                'emailsuccess' => false,
+                'emailmissingsites' => false,
+                'role' => Project::PROJECT_USER,
+            ]);
+    }
+}

--- a/app/GraphQL/Mutations/RemoveProjectUser.php
+++ b/app/GraphQL/Mutations/RemoveProjectUser.php
@@ -26,8 +26,14 @@ final class RemoveProjectUser extends AbstractMutation
             $user === null
             || $project === null
             || $userToRemove === null
-            || $userToRemove->id === $user->id
-            || $user->cannot('removeUser', $project)
+            || (
+                $userToRemove->id === $user->id
+                && $user->cannot('leave', $project)
+            )
+            || (
+                $userToRemove->id !== $user->id
+                && $user->cannot('removeUser', $project)
+            )
             || !$project->users()->where('id', $userToRemove->id)->exists()
         ) {
             abort(401, 'This action is unauthorized.');

--- a/app/Http/Controllers/ProjectMembersController.php
+++ b/app/Http/Controllers/ProjectMembersController.php
@@ -24,6 +24,8 @@ final class ProjectMembersController extends AbstractProjectController
             'user-id' => $user?->id,
             'can-invite-users' => $user?->can('inviteUser', $eloquentProject) ?? false,
             'can-remove-users' => $user?->can('removeUser', $eloquentProject) ?? false,
+            'can-join-project' => $user?->can('join', $eloquentProject) ?? false,
+            'can-leave-project' => $user?->can('leave', $eloquentProject) ?? false,
         ]);
     }
 }

--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -48,67 +48,12 @@
   <div id="wizard">
       <ul>
           <li>
-            <a class="cdash-link" href="#fragment-1"><span>Select your role in this project</span></a></li>
-          <li>
             <a class="cdash-link" href="#fragment-3"><span>Email Notifications</span></a></li>
           <li>
             <a class="cdash-link" href="#fragment-4"><span>Email Category</span></a></li>
           <li>
             <a class="cdash-link" href="#fragment-5"><span>Email Labels</span></a></li>
       </ul>
-    <div id="fragment-1" class="tab_content" >
-      <div class="tab_help"></div>
-        <table width="800" >
-          <tr>
-            <td></td>
-            <td><input type="radio" onchange="saveChanges();" name="role" value="0" checked="checked">
-            <xsl:if test="/cdash/role=0">
-            <xsl:attribute name="checked"></xsl:attribute>
-            </xsl:if>
-            </input>
-             Normal user <i>(you are working on or using this project)</i></td>
-          </tr>
-           <tr>
-            <td></td>
-            <td><input type="radio" onchange="saveChanges();" name="role" value="1">
-             <xsl:if test="/cdash/role=1">
-            <xsl:attribute name="checked"></xsl:attribute>
-            </xsl:if>
-            </input>
-             Site maintainer <i>(you are responsible for machines that are submitting builds for this project)</i></td>
-          </tr>
-          <xsl:if test="/cdash/role>1">
-           <tr>
-            <td></td>
-            <td ><b>Warning: if you change to a normal or maintainer role you won't be able to go back.</b> </td>
-            </tr>
-          <tr>
-            <td></td>
-            <td ><input type="radio" onchange="saveChanges();" name="role" value="2" checked="checked">
-            <xsl:if test="/cdash/role=2">
-            <xsl:attribute name="checked"></xsl:attribute>
-            </xsl:if>
-            </input>
-             Project Administrator <i>(You are administering the project)</i></td>
-          </tr>
-          </xsl:if>
-          <xsl:if test="/cdash/role>2">
-           <tr>
-            <td></td>
-            <td ><input type="radio" onchange="saveChanges();" name="role" value="3">
-             <xsl:if test="/cdash/role=3">
-            <xsl:attribute name="checked"></xsl:attribute>
-            </xsl:if>
-            </input>
-              Project Super Administrator<i>(You have full control of this project)</i></td>
-          </tr>
-          </xsl:if>
-           <tr>
-            <td></td>
-            <td bgcolor="#FFFFFF"></td>
-          </tr>
-        </table>
-    </div>
     <div id="fragment-3" class="tab_content" >
       <div class="tab_help"></div>
         <table width="800" >
@@ -312,18 +257,12 @@
   <div style="width:900px;margin-left:auto;margin-right:auto;text-align:right;">
   <table width="100%" border="0">
   <tr>
-    <td style="text-align:left;" ><input type="submit" onclick="return confirm('Are you sure you want to unsubscribe?')" name="unsubscribe" value="Unsubscribe"/></td>
     <td><span id="changesmade" style="color:red;display:none;">*Changes need to be updated </span>
     <input type="submit" onclick="SubmitForm()" name="updatesubscription" value="Update Subscription"/></td>
    </tr>
   </table>
   </div>
   </xsl:if>
-  <xsl:if test="/cdash/edit=0">
-   <div style="width:900px;margin-left:auto;margin-right:auto;text-align:right;"><br/>
-  <input type="submit" name="subscribe" value="Subscribe"/>
-  </div>
-</xsl:if>
 
 </form>
 </td>

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -302,6 +302,8 @@ add_feature_test(/Feature/Traits/UpdatesSiteInformationTest)
 
 add_feature_test(/Feature/GraphQL/Mutations/ChangeGlobalRoleTest)
 
+add_feature_test(/Feature/GraphQL/Mutations/JoinProjectTest)
+
 # Needs RUN_SERIAL to verify that no unexpected invitations are created
 add_feature_test(/Feature/GraphQL/Mutations/CreateGlobalInvitationTest)
 set_property(TEST /Feature/GraphQL/Mutations/CreateGlobalInvitationTest APPEND PROPERTY RUN_SERIAL TRUE)

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -43,11 +43,14 @@ class EmailTestCase extends KWWebTestCase
             return;
         }
 
-        $this->actingAs(['email' => 'user1@kw', 'password' => 'user1'])
-            ->connect($this->url . "/subscribeProject.php?projectid={$this->project}");
-        $this->setField('credentials[0]', 'user1kw');
-        $this->setField('emailsuccess', '1');
-        $this->clickSubmitByName('subscribe');
+        $user->projects()->attach($this->project, [
+            'role' => 0,
+            'emailtype' => 1,
+            'emailcategory' => 126,
+            'emailsuccess' => 1,
+            'emailmissingsites' => 0,
+        ]);
+
         if (!$this->checkLog($this->logfilename)) {
             $this->fail('Errors logged');
         }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -82,6 +82,9 @@ type Mutation {
   "Remove a user from a project."
   removeProjectUser(input: RemoveProjectUserInput! @spread): RemoveProjectUserMutationPayload! @field(resolver: "RemoveProjectUser")
 
+  "Join a project directly.  Only useful for public and protected projects.  Use invitations to add users to private projects."
+  joinProject(input: JoinProjectInput! @spread): JoinProjectMutationPayload! @field(resolver: "JoinProject")
+
   "Invite a user to this CDash instance by email."
   createGlobalInvitation(input: CreateGlobalInvitationInput! @spread): CreateGlobalInvitationMutationPayload! @field(resolver: "CreateGlobalInvitation")
 
@@ -280,6 +283,17 @@ input RemoveProjectUserInput {
 
 
 type RemoveProjectUserMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+}
+
+
+input JoinProjectInput {
+  projectId: ID!
+}
+
+
+type JoinProjectMutationPayload implements MutationPayloadInterface {
   "Optional error message."
   message: String
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -334,6 +334,16 @@ parameters:
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Contracts\\\\Auth\\\\Guard\\:\\:user\\(\\)\\.$#"
 			count: 1
+			path: app/GraphQL/Mutations/JoinProject.php
+
+		-
+			message: "#^Parameter \\#1 \\$args \\(array\\{projectId\\: int\\}\\) of method App\\\\GraphQL\\\\Mutations\\\\JoinProject\\:\\:mutate\\(\\) should be contravariant with parameter \\$args \\(array\\<string, mixed\\>\\) of method App\\\\GraphQL\\\\Mutations\\\\AbstractMutation\\:\\:mutate\\(\\)$#"
+			count: 1
+			path: app/GraphQL/Mutations/JoinProject.php
+
+		-
+			message: "#^Dynamic call to static method Illuminate\\\\Contracts\\\\Auth\\\\Guard\\:\\:user\\(\\)\\.$#"
+			count: 1
 			path: app/GraphQL/Mutations/RemoveProjectUser.php
 
 		-
@@ -2249,7 +2259,7 @@ parameters:
 				#^Call to deprecated method executePrepared\\(\\) of class CDash\\\\Database\\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			"""
-			count: 4
+			count: 2
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -2262,17 +2272,12 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
 			message: "#^Loose comparison via \"\\=\\=\" is not allowed\\.$#"
-			count: 8
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
-			count: 2
+			count: 6
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -2292,7 +2297,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 13
+			count: 7
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
@@ -3157,12 +3162,12 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:exists\\(\\)\\.$#"
-			count: 3
+			count: 5
 			path: app/Policies/ProjectPolicy.php
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:where\\(\\)\\.$#"
-			count: 3
+			count: 5
 			path: app/Policies/ProjectPolicy.php
 
 		-
@@ -28920,7 +28925,7 @@ parameters:
 
 		-
 			message: "#^Dynamic call to static method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsToMany\\<App\\\\Models\\\\User\\>\\:\\:pluck\\(\\)\\.$#"
-			count: 3
+			count: 4
 			path: tests/Browser/Pages/ProjectMembersPageTest.php
 
 		-

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -3,94 +3,144 @@
     class="tw-flex tw-flex-col tw-gap-4"
     data-test="project-members-page"
   >
-    <div
-      v-if="canInviteUsers"
-      class="tw-flex tw-flex-row tw-w-full"
-    >
+    <div class="tw-flex tw-flex-row tw-w-full tw-gap-2 tw-justify-end">
       <button
-        class="tw-ml-auto tw-btn"
+        v-if="canInviteUsers"
+        class="tw-btn"
         data-test="invite-members-button"
         onclick="invite_members_modal.showModal()"
       >
         Invite Members
       </button>
-      <dialog
-        id="invite_members_modal"
-        data-test="invite-members-modal"
-        class="tw-modal"
+      <button
+        v-if="canJoinProject"
+        class="tw-btn tw-btn-outline tw-btn-success"
+        data-test="join-project-button"
+        @click="joinProject"
       >
-        <div class="tw-modal-box tw-flex tw-flex-col tw-gap-4 tw-w-full">
-          <h3 class="tw-text-lg tw-font-bold">
-            Invite Members
-          </h3>
-          <div
-            v-if="inviteMembersModalError"
-            class="tw-text-error tw-font-bold"
-            data-test="invite-members-modal-error-text"
+        Join Project
+      </button>
+      <button
+        v-if="canLeaveProject"
+        class="tw-btn tw-btn-outline tw-btn-error"
+        data-test="leave-project-button"
+        onclick="leave_project_modal.showModal()"
+      >
+        Leave Project
+      </button>
+    </div>
+    <dialog
+      id="leave_project_modal"
+      data-test="leave-project-modal"
+      class="tw-modal"
+    >
+      <div class="tw-modal-box tw-flex tw-flex-col tw-gap-4 tw-w-full">
+        <h3 class="tw-text-lg tw-font-bold">
+          Confirm
+        </h3>
+        Are you sure you want to leave this project?
+        <form
+          method="dialog"
+          class="tw-flex tw-flex-row tw-w-full tw-gap-2"
+        >
+          <button
+            class="tw-btn tw-ml-auto"
+            data-test="leave-project-modal-cancel-button"
           >
-            {{ inviteMembersModalError }}
-          </div>
-          <div>
-            <div class="tw-label tw-font-bold">
-              Email
-            </div>
-            <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
-              <font-awesome-icon :icon="FA.faEnvelope" />
-              <input
-                v-model="inviteMembersModalEmail"
-                type="email"
-                class="tw-grow"
-                placeholder="example@example.com"
-                required
-                data-test="invite-members-modal-email"
-              >
-            </label>
-          </div>
-          <div>
-            <div class="tw-label tw-font-bold">
-              Role
-            </div>
-            <select
-              v-model="inviteMembersModalRole"
-              class="tw-select tw-select-bordered tw-w-full"
-              data-test="invite-members-modal-role"
-            >
-              <option
-                v-for="type in USER_TYPES"
-                :value="type"
-              >
-                {{ humanReadableRole(type) }}
-              </option>
-            </select>
-          </div>
-          <form
-            method="dialog"
-            class="tw-flex tw-flex-row tw-w-full tw-gap-2"
+            Cancel
+          </button>
+          <button
+            class="tw-btn tw-btn-error"
+            data-test="leave-project-modal-button"
+            @click="leaveProject"
           >
-            <button
-              class="tw-btn tw-ml-auto"
-              data-test="invite-members-modal-cancel-button"
+            Leave
+          </button>
+        </form>
+      </div>
+      <form
+        method="dialog"
+        class="tw-modal-backdrop"
+      >
+        <button>Cancel</button>
+      </form>
+    </dialog>
+    <dialog
+      id="invite_members_modal"
+      data-test="invite-members-modal"
+      class="tw-modal"
+    >
+      <div class="tw-modal-box tw-flex tw-flex-col tw-gap-4 tw-w-full">
+        <h3 class="tw-text-lg tw-font-bold">
+          Invite Members
+        </h3>
+        <div
+          v-if="inviteMembersModalError"
+          class="tw-text-error tw-font-bold"
+          data-test="invite-members-modal-error-text"
+        >
+          {{ inviteMembersModalError }}
+        </div>
+        <div>
+          <div class="tw-label tw-font-bold">
+            Email
+          </div>
+          <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
+            <font-awesome-icon :icon="FA.faEnvelope" />
+            <input
+              v-model="inviteMembersModalEmail"
+              type="email"
+              class="tw-grow"
+              placeholder="example@example.com"
+              required
+              data-test="invite-members-modal-email"
             >
-              Cancel
-            </button>
-            <button
-              class="tw-btn tw-btn-primary"
-              :disabled="inviteMembersModalEmail.length === 0"
-              data-test="invite-members-modal-invite-button"
-              @click="inviteUserByEmail"
+          </label>
+        </div>
+        <div>
+          <div class="tw-label tw-font-bold">
+            Role
+          </div>
+          <select
+            v-model="inviteMembersModalRole"
+            class="tw-select tw-select-bordered tw-w-full"
+            data-test="invite-members-modal-role"
+          >
+            <option
+              v-for="type in USER_TYPES"
+              :value="type"
             >
-              Invite
-            </button>
-          </form>
+              {{ humanReadableRole(type) }}
+            </option>
+          </select>
         </div>
         <form
           method="dialog"
-          class="tw-modal-backdrop"
+          class="tw-flex tw-flex-row tw-w-full tw-gap-2"
         >
-          <button>Cancel</button>
+          <button
+            class="tw-btn tw-ml-auto"
+            data-test="invite-members-modal-cancel-button"
+          >
+            Cancel
+          </button>
+          <button
+            class="tw-btn tw-btn-primary"
+            :disabled="inviteMembersModalEmail.length === 0"
+            data-test="invite-members-modal-invite-button"
+            @click="inviteUserByEmail"
+          >
+            Invite
+          </button>
         </form>
-      </dialog>
-    </div>
+      </div>
+      <form
+        method="dialog"
+        class="tw-modal-backdrop"
+      >
+        <button>Cancel</button>
+      </form>
+    </dialog>
     <loading-indicator
       v-if="canInviteUsers"
       :is-loading="!projectInvitations"
@@ -245,6 +295,21 @@ export default {
       type: Boolean,
       required: true,
     },
+
+    canJoinProject: {
+      type: Boolean,
+      required: true,
+    },
+
+    canLeaveProject: {
+      type: Boolean,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    // Basic sanity checks...
+    console.assert(!(props.canJoinProject && props.canLeaveProject));
   },
 
   data() {
@@ -388,6 +453,9 @@ export default {
             },
           });
         }
+      },
+      skip() {
+        return !this.canInviteUsers;
       },
     },
   },
@@ -582,6 +650,46 @@ export default {
         },
       }).catch((error) => {
         console.error(error);
+      });
+    },
+
+    joinProject() {
+      this.$apollo.mutate({
+        mutation: gql`mutation ($projectId: ID!) {
+          joinProject(input: {
+            projectId: $projectId
+          }) {
+            message
+          }
+        }`,
+        variables: {
+          projectId: this.projectId,
+        },
+      }).catch((error) => {
+        console.error(error);
+      }).then(() => {
+        window.location.reload();
+      });
+    },
+
+    leaveProject() {
+      this.$apollo.mutate({
+        mutation: gql`mutation ($userId: ID!, $projectId: ID!) {
+          removeProjectUser(input: {
+            userId: $userId
+            projectId: $projectId
+          }) {
+            message
+          }
+        }`,
+        variables: {
+          userId: this.userId,
+          projectId: this.projectId,
+        },
+      }).catch((error) => {
+        console.error(error);
+      }).then(() => {
+        window.location.reload();
       });
     },
   },

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -6,6 +6,8 @@ if (isset($project)) {
 $hideRegistration = config('auth.user_registration_form_enabled') === false;
 
 $currentDateString = now()->toDateString();
+
+$userInProject = isset($project) && auth()->user() !== null && \App\Models\Project::findOrFail($project->Id)->users()->where('id', auth()->user()->id)->exists();
 @endphp
 
 <div id="header">
@@ -152,9 +154,14 @@ $currentDateString = now()->toDateString();
                                 ng-class="::{endsubmenu: cdash.projectrole}">
                                 <a class="cdash-link" ng-href="@{{::cdash.bugtracker}}"> Bug Tracker</a>
                             </li>
-                            <li ng-if="!cdash.projectrole" class="endsubmenu">
-                                <a class="cdash-link" ng-href="{{ url('/subscribeProject.php') }}?projectid=@{{::cdash.projectid}}">Subscribe</a>
+                            <li class="endsubmenu">
+                                <a class="cdash-link" ng-href="{{ url('/projects') }}/@{{::cdash.projectid}}/members">Members</a>
                             </li>
+                            @if($userInProject)
+                                <li class="endsubmenu">
+                                    <a class="cdash-link" ng-href="{{ url('/subscribeProject.php') }}?projectid=@{{::cdash.projectid}}">Notifications</a>
+                                </li>
+                            @endif
                         </ul>
                     </li>
                     <li ng-if="cdash.user.admin == 1 && !cdash.noproject && cdash.projectid !== undefined" id="admin">
@@ -163,11 +170,6 @@ $currentDateString = now()->toDateString();
                             <li>
                                 <a class="cdash-link" ng-href="{{ url('/project') }}/@{{::cdash.projectid}}/edit">
                                     Project
-                                </a>
-                            </li>
-                            <li>
-                                <a class="cdash-link" ng-href="{{ url('/projects') }}/@{{::cdash.projectid}}/members">
-                                    Users
                                 </a>
                             </li>
                             <li>
@@ -261,11 +263,20 @@ $currentDateString = now()->toDateString();
                                     </a>
                                 </li>
                             @endif
-                            <li>
-                                <a href="{{ url('/subscribeProject.php') }}?projectid={{ $project->Id }}">
-                                    Subscribe
-                                </a>
-                            </li>
+                            @if(isset($project))
+                                <li>
+                                    <a href="{{ url("/projects/{$project->Id}/members") }}">
+                                        Users
+                                    </a>
+                                </li>
+                            @endif
+                            @if($userInProject)
+                                <li>
+                                    <a href="{{ url('/subscribeProject.php') }}?projectid={{ $project->Id }}">
+                                        Notifications
+                                    </a>
+                                </li>
+                            @endif
                         </ul>
                     </li>
                     @can('edit-project', $project)
@@ -275,11 +286,6 @@ $currentDateString = now()->toDateString();
                                 <li>
                                     <a href="{{ url('/project') }}/{{ $project->Id }}/edit">
                                         Project
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ url("/projects/{$project->Id}/members") }}">
-                                        Users
                                     </a>
                                 </li>
                                 <li>

--- a/tests/Feature/GraphQL/Mutations/JoinProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/JoinProjectTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\Project;
+use App\Models\User;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class JoinProjectTest extends TestCase
+{
+    use CreatesUsers;
+    use CreatesProjects;
+
+    private ?Project $project = null;
+
+    private ?User $user = null;
+
+    protected function tearDown(): void
+    {
+        $this->project?->delete();
+        $this->user?->delete();
+
+        parent::tearDown();
+    }
+
+    public function testCanJoinPublicProject(): void
+    {
+        $this->project = $this->makePublicProject();
+        $this->user = $this->makeNormalUser();
+
+        self::assertEmpty($this->project->users()->get());
+
+        $this->actingAs($this->user)->graphQL('
+            mutation ($projectId: ID!) {
+                joinProject(input: {
+                    projectId: $projectId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project?->id,
+        ])->assertExactJson([
+            'data' => [
+                'joinProject' => [
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertContains($this->user?->id, $this->project?->users()->pluck('id') ?? []);
+        self::assertCount(1, $this->project?->users()->get() ?? []);
+    }
+
+    public function testCanJoinProtectedProject(): void
+    {
+        $this->project = $this->makeProtectedProject();
+        $this->user = $this->makeNormalUser();
+
+        self::assertEmpty($this->project->users()->get());
+
+        $this->actingAs($this->user)->graphQL('
+            mutation ($projectId: ID!) {
+                joinProject(input: {
+                    projectId: $projectId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project?->id,
+        ])->assertExactJson([
+            'data' => [
+                'joinProject' => [
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertContains($this->user?->id, $this->project?->users()->pluck('id') ?? []);
+        self::assertCount(1, $this->project?->users()->get() ?? []);
+    }
+
+    public function testCannotJoinPrivateProject(): void
+    {
+        $this->project = $this->makePrivateProject();
+        $this->user = $this->makeNormalUser();
+
+        self::assertEmpty($this->project->users()->get());
+
+        $this->actingAs($this->user)->graphQL('
+            mutation ($projectId: ID!) {
+                joinProject(input: {
+                    projectId: $projectId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project?->id,
+        ])->assertExactJson([
+            'data' => [
+                'joinProject' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ]);
+
+        self::assertEmpty($this->project?->users()->get());
+    }
+
+    public function testAnonymousUserCannotJoinProject(): void
+    {
+        $this->project = $this->makePublicProject();
+
+        self::assertEmpty($this->project->users()->get());
+
+        $this->graphQL('
+            mutation ($projectId: ID!) {
+                joinProject(input: {
+                    projectId: $projectId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => $this->project->id,
+        ])->assertExactJson([
+            'data' => [
+                'joinProject' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ]);
+
+        self::assertEmpty($this->project->users()->get());
+    }
+
+    public function testCannotJoinMissingProject(): void
+    {
+        $this->user = $this->makeNormalUser();
+
+        $this->actingAs($this->user)->graphQL('
+            mutation ($projectId: ID!) {
+                joinProject(input: {
+                    projectId: $projectId
+                }) {
+                    message
+                }
+            }
+        ', [
+            'projectId' => 123456789,
+        ])->assertExactJson([
+            'data' => [
+                'joinProject' => [
+                    'message' => 'This action is unauthorized.',
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -183,7 +183,7 @@ class RemoveProjectUserTest extends TestCase
         $this->assertNotProjectMember($userToDelete);
     }
 
-    public function testProjectAdminCannotDeleteSelf(): void
+    public function testProjectAdminCanDeleteSelf(): void
     {
         $projectAdmin = $this->addUserToProject(true);
 
@@ -204,12 +204,12 @@ class RemoveProjectUserTest extends TestCase
         ])->assertJson([
             'data' => [
                 'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
+                    'message' => null,
                 ],
             ],
         ], true);
 
-        $this->assertProjectMember($projectAdmin);
+        $this->assertNotProjectMember($projectAdmin);
     }
 
     public function testRegularProjectUserCannotDeleteProjectMembers(): void


### PR DESCRIPTION
This PR finishes our recent effort to modernize the project membership experience started in https://github.com/Kitware/CDash/pull/2778.  The join/leave functionality has been moved to the project members page, leaving `subscribeProject.php` as only a place to configure notifications.