### PR TITLE
Bump PHP minimum version to 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ ENTRYPOINT ["/bin/bash", "/cdash/docker/docker-entrypoint.sh"]
 # The base image for UBI-based images
 ###############################################################################
 
-FROM registry.access.redhat.com/ubi9/php-82 AS cdash-ubi-intermediate
+FROM registry.access.redhat.com/ubi9/php-83 AS cdash-ubi-intermediate
 
 ARG BASE_IMAGE
 ARG DEVELOPMENT_BUILD

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "wiki": "http://public.kitware.com/Wiki/CDash"
   },
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-fileinfo": "*",


### PR DESCRIPTION
#2644 changed the default version of PHP used in our default Debian-based Docker image.  At the time, Red Hat had not released a RHEL-based image containing PHP 8.3.  Red Hat has now released an image with 8.3, meaning that we can require a minimum version of PHP 8.3 for all CDash instances.