### PR TITLE
Pin MinIO in Docker Compose config

### DIFF
--- a/docker/docker-compose.minio.yml
+++ b/docker/docker-compose.minio.yml
@@ -10,7 +10,7 @@ services:
       AWS_URL: http://minio:9000/cdash/
       AWS_ENDPOINT: http://minio:9000
   minio:
-    image: bitnami/minio:latest
+    image: bitnami/minio:2025.4.22
     ports:
       - "9000:9000"
     environment:


### PR DESCRIPTION
CI jobs recently started [failing](https://github.com/Kitware/CDash/actions/runs/15325557396/job/43119066230) due to a recent MinIO image update.  This PR pins MinIO to the previous working version until we resolve the issue with the latest version.