### PR TITLE
Use cache-busting Webpack chunk names in development

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -112,6 +112,9 @@ mix.webpackConfig({
   stats: {
     children: true,
   },
+  output: {
+    chunkFilename: 'assets/js/[contenthash].js',
+  },
   optimization: {
     runtimeChunk: false,
   },


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2864 introduced Webpack bundle splitting.  While the chunk names are based on a rolling integer number in production, they are deterministically computed based on the filename in development.  Browser caching causes this to be annoying in development.  This PR changes the naming scheme to instead depend on the content hash, eliminating the issue.