### PR TITLE
Clean up legacy test dependencies

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -361,6 +361,9 @@ set_tests_properties(buildproperties PROPERTIES DEPENDS /CDash/XmlHandler/Update
 add_php_test(issuecreation)
 set_tests_properties(issuecreation PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(junithandler)
+set_tests_properties(junithandler PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -399,6 +402,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   filterbuilderrors
   buildproperties
   issuecreation
+  junithandler
 )
 
 
@@ -606,11 +610,8 @@ set_tests_properties(multiplesubprojects PROPERTIES DEPENDS disabledtests)
 add_php_test(authtoken)
 set_tests_properties(authtoken PROPERTIES DEPENDS multiplesubprojects)
 
-add_php_test(junithandler)
-set_tests_properties(junithandler PROPERTIES DEPENDS authtoken)
-
 add_php_test(limitedbuilds)
-set_tests_properties(limitedbuilds PROPERTIES DEPENDS junithandler)
+set_tests_properties(limitedbuilds PROPERTIES DEPENDS authtoken)
 
 add_php_test(managemeasurements)
 set_tests_properties(managemeasurements PROPERTIES DEPENDS limitedbuilds)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -331,6 +331,9 @@ add_browser_test(/Browser/Pages/BuildFilesPageTest)
 add_php_test(changeid)
 set_tests_properties(changeid PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(consistenttestingday)
+set_tests_properties(consistenttestingday PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -359,6 +362,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   /CDash/Messaging/Topic/TopicDecorator
   cypress/e2e/user-profile
   changeid
+  consistenttestingday
 )
 
 
@@ -623,11 +627,8 @@ set_tests_properties(commitauthornotification PROPERTIES DEPENDS putdynamicbuild
 add_php_test(subscribeprojectshowlabels)
 set_tests_properties(subscribeprojectshowlabels PROPERTIES DEPENDS putdynamicbuilds)
 
-add_php_test(consistenttestingday)
-set_tests_properties(consistenttestingday PROPERTIES DEPENDS subscribeprojectshowlabels)
-
 add_php_test(numericupdate)
-set_tests_properties(numericupdate PROPERTIES DEPENDS consistenttestingday)
+set_tests_properties(numericupdate PROPERTIES DEPENDS subscribeprojectshowlabels)
 
 add_php_test(attachedfiles)
 set_tests_properties(attachedfiles PROPERTIES DEPENDS numericupdate)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -88,6 +88,10 @@ add_legacy_unit_test(/CDash/LinkifyCompilerOutput)
 
 add_unit_test(/Unit/app/Console/Command/ValidateXmlCommandTest)
 
+add_php_test(seconds_from_interval)
+
+add_php_test(extracttar)
+
 ###################################################################################################
 
 add_laravel_test(/Feature/CDashTest)
@@ -516,11 +520,8 @@ set_tests_properties(configurewarnings PROPERTIES DEPENDS aggregatesubprojectcov
 add_php_test(filtertestlabels)
 set_tests_properties(filtertestlabels PROPERTIES DEPENDS configurewarnings)
 
-add_php_test(seconds_from_interval)
-set_tests_properties(seconds_from_interval PROPERTIES DEPENDS filtertestlabels)
-
 add_php_test(dynamicanalysissummary)
-set_tests_properties(dynamicanalysissummary PROPERTIES DEPENDS seconds_from_interval)
+set_tests_properties(dynamicanalysissummary PROPERTIES DEPENDS filtertestlabels)
 
 add_php_test(viewsubprojects)
 set_tests_properties(viewsubprojects PROPERTIES DEPENDS dynamicanalysissummary)
@@ -543,11 +544,8 @@ set_tests_properties(createprojectpermissions PROPERTIES DEPENDS imagecomparison
 add_php_test(testgraphpermissions)
 set_tests_properties(testgraphpermissions PROPERTIES DEPENDS createprojectpermissions)
 
-add_php_test(extracttar)
-set_tests_properties(extracttar PROPERTIES DEPENDS testgraphpermissions)
-
 add_php_test(pdoexecutelogserrors)
-set_tests_properties(pdoexecutelogserrors PROPERTIES DEPENDS extracttar)
+set_tests_properties(pdoexecutelogserrors PROPERTIES DEPENDS testgraphpermissions)
 
 add_php_test(revisionfilteracrossdates)
 set_tests_properties(revisionfilteracrossdates PROPERTIES DEPENDS actualtrilinossubmission)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -358,6 +358,9 @@ set_tests_properties(filterbuilderrors PROPERTIES DEPENDS /CDash/XmlHandler/Upda
 add_php_test(buildproperties)
 set_tests_properties(buildproperties PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(issuecreation)
+set_tests_properties(issuecreation PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -395,6 +398,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   configureappend
   filterbuilderrors
   buildproperties
+  issuecreation
 )
 
 
@@ -605,11 +609,8 @@ set_tests_properties(authtoken PROPERTIES DEPENDS multiplesubprojects)
 add_php_test(junithandler)
 set_tests_properties(junithandler PROPERTIES DEPENDS authtoken)
 
-add_php_test(issuecreation)
-set_tests_properties(issuecreation PROPERTIES DEPENDS junithandler)
-
 add_php_test(limitedbuilds)
-set_tests_properties(limitedbuilds PROPERTIES DEPENDS issuecreation)
+set_tests_properties(limitedbuilds PROPERTIES DEPENDS junithandler)
 
 add_php_test(managemeasurements)
 set_tests_properties(managemeasurements PROPERTIES DEPENDS limitedbuilds)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -349,6 +349,9 @@ set_tests_properties(dynamicanalysislogs PROPERTIES DEPENDS /CDash/XmlHandler/Up
 add_php_test(dynamicanalysisdefectlongtype)
 set_tests_properties(dynamicanalysisdefectlongtype PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(configureappend)
+set_tests_properties(configureappend PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -383,6 +386,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   subprojectorder
   dynamicanalysislogs
   dynamicanalysisdefectlongtype
+  configureappend
 )
 
 
@@ -680,11 +684,8 @@ set_tests_properties(querytestsrevisionfilter PROPERTIES DEPENDS lotsofsubprojec
 add_php_test(redundanttests)
 set_tests_properties(redundanttests PROPERTIES DEPENDS querytestsrevisionfilter)
 
-add_php_test(configureappend)
-set_tests_properties(configureappend PROPERTIES DEPENDS redundanttests)
-
 add_php_test(notesparsererrormessages)
-set_tests_properties(notesparsererrormessages PROPERTIES DEPENDS configureappend)
+set_tests_properties(notesparsererrormessages PROPERTIES DEPENDS redundanttests)
 
 add_laravel_test(/Feature/SubProjectDependencies)
 set_tests_properties(/Feature/SubProjectDependencies PROPERTIES DEPENDS notesparsererrormessages)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -369,6 +369,8 @@ set_tests_properties(junithandler PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHan
 add_php_test(configurewarnings)
 set_tests_properties(configurewarnings PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_feature_test(/Feature/AutoRemoveBuildsCommand)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -352,6 +352,9 @@ set_tests_properties(dynamicanalysisdefectlongtype PROPERTIES DEPENDS /CDash/Xml
 add_php_test(configureappend)
 set_tests_properties(configureappend PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(filterbuilderrors)
+set_tests_properties(filterbuilderrors PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -387,6 +390,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   dynamicanalysislogs
   dynamicanalysisdefectlongtype
   configureappend
+  filterbuilderrors
 )
 
 
@@ -621,11 +625,8 @@ set_tests_properties(timestatus PROPERTIES DEPENDS buildproperties)
 add_php_test(bazeljson)
 set_tests_properties(bazeljson PROPERTIES DEPENDS timestatus)
 
-add_php_test(filterbuilderrors)
-set_tests_properties(filterbuilderrors PROPERTIES DEPENDS bazeljson)
-
 add_php_test(buildrelationship)
-set_tests_properties(buildrelationship PROPERTIES DEPENDS filterbuilderrors)
+set_tests_properties(buildrelationship PROPERTIES DEPENDS bazeljson)
 
 add_php_test(submission_assign_buildid)
 set_tests_properties(submission_assign_buildid PROPERTIES DEPENDS buildrelationship)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -340,6 +340,9 @@ set_tests_properties(numericupdate PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHa
 add_php_test(attachedfiles)
 set_tests_properties(attachedfiles PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(subprojectorder)
+set_tests_properties(subprojectorder PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -371,6 +374,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   consistenttestingday
   numericupdate
   attachedfiles
+  subprojectorder
 )
 
 
@@ -635,11 +639,8 @@ set_tests_properties(commitauthornotification PROPERTIES DEPENDS putdynamicbuild
 add_php_test(subscribeprojectshowlabels)
 set_tests_properties(subscribeprojectshowlabels PROPERTIES DEPENDS putdynamicbuilds)
 
-add_php_test(subprojectorder)
-set_tests_properties(subprojectorder PROPERTIES DEPENDS subscribeprojectshowlabels)
-
 add_php_test(testimages)
-set_tests_properties(testimages PROPERTIES DEPENDS subprojectorder)
+set_tests_properties(testimages PROPERTIES DEPENDS subscribeprojectshowlabels)
 
 add_php_test(dynamicanalysislogs)
 set_tests_properties(dynamicanalysislogs PROPERTIES DEPENDS testimages)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -355,6 +355,9 @@ set_tests_properties(configureappend PROPERTIES DEPENDS /CDash/XmlHandler/Update
 add_php_test(filterbuilderrors)
 set_tests_properties(filterbuilderrors PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(buildproperties)
+set_tests_properties(buildproperties PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -391,6 +394,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   dynamicanalysisdefectlongtype
   configureappend
   filterbuilderrors
+  buildproperties
 )
 
 
@@ -616,11 +620,8 @@ set_tests_properties(coveragedirectories PROPERTIES DEPENDS managemeasurements)
 add_php_test(outputcolor)
 set_tests_properties(outputcolor PROPERTIES DEPENDS coveragedirectories)
 
-add_php_test(buildproperties)
-set_tests_properties(buildproperties PROPERTIES DEPENDS outputcolor)
-
 add_php_test(timestatus)
-set_tests_properties(timestatus PROPERTIES DEPENDS buildproperties)
+set_tests_properties(timestatus PROPERTIES DEPENDS outputcolor)
 
 add_php_test(bazeljson)
 set_tests_properties(bazeljson PROPERTIES DEPENDS timestatus)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -346,6 +346,9 @@ set_tests_properties(subprojectorder PROPERTIES DEPENDS /CDash/XmlHandler/Update
 add_php_test(dynamicanalysislogs)
 set_tests_properties(dynamicanalysislogs PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(dynamicanalysisdefectlongtype)
+set_tests_properties(dynamicanalysisdefectlongtype PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -379,6 +382,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   attachedfiles
   subprojectorder
   dynamicanalysislogs
+  dynamicanalysisdefectlongtype
 )
 
 
@@ -658,11 +662,8 @@ set_tests_properties(multiplelabelsfortests PROPERTIES DEPENDS longbuildname)
 add_php_test(subprojecttestfilters)
 set_tests_properties(subprojecttestfilters PROPERTIES DEPENDS multiplelabelsfortests)
 
-add_php_test(dynamicanalysisdefectlongtype)
-set_tests_properties(dynamicanalysisdefectlongtype PROPERTIES DEPENDS multiplelabelsfortests)
-
 add_php_test(starttimefromnotes)
-set_tests_properties(starttimefromnotes PROPERTIES DEPENDS dynamicanalysisdefectlongtype)
+set_tests_properties(starttimefromnotes PROPERTIES DEPENDS subprojecttestfilters)
 
 add_php_test(starttimefromupload)
 set_tests_properties(starttimefromupload PROPERTIES DEPENDS starttimefromnotes)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -92,6 +92,8 @@ add_php_test(seconds_from_interval)
 
 add_php_test(extracttar)
 
+add_php_test(passwordcomplexity)
+
 ###################################################################################################
 
 add_laravel_test(/Feature/CDashTest)
@@ -557,11 +559,8 @@ set_tests_properties(replacebuild PROPERTIES DEPENDS buildgetdate)
 add_php_test(sequenceindependence)
 set_tests_properties(sequenceindependence PROPERTIES DEPENDS replacebuild)
 
-add_php_test(passwordcomplexity)
-set_tests_properties(passwordcomplexity PROPERTIES DEPENDS sequenceindependence)
-
 add_php_test(crosssubprojectcoverage)
-set_tests_properties(crosssubprojectcoverage PROPERTIES DEPENDS passwordcomplexity)
+set_tests_properties(crosssubprojectcoverage PROPERTIES DEPENDS sequenceindependence)
 
 add_php_test(aggregatesubprojectcoverage)
 set_tests_properties(aggregatesubprojectcoverage PROPERTIES DEPENDS crosssubprojectcoverage)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -343,6 +343,9 @@ set_tests_properties(attachedfiles PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHa
 add_php_test(subprojectorder)
 set_tests_properties(subprojectorder PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(dynamicanalysislogs)
+set_tests_properties(dynamicanalysislogs PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -375,6 +378,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   numericupdate
   attachedfiles
   subprojectorder
+  dynamicanalysislogs
 )
 
 
@@ -642,11 +646,8 @@ set_tests_properties(subscribeprojectshowlabels PROPERTIES DEPENDS putdynamicbui
 add_php_test(testimages)
 set_tests_properties(testimages PROPERTIES DEPENDS subscribeprojectshowlabels)
 
-add_php_test(dynamicanalysislogs)
-set_tests_properties(dynamicanalysislogs PROPERTIES DEPENDS testimages)
-
 add_php_test(namedmeasurements)
-set_tests_properties(namedmeasurements PROPERTIES DEPENDS dynamicanalysislogs)
+set_tests_properties(namedmeasurements PROPERTIES DEPENDS testimages)
 
 add_php_test(longbuildname)
 set_tests_properties(longbuildname PROPERTIES DEPENDS namedmeasurements)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -364,6 +364,9 @@ set_tests_properties(issuecreation PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHa
 add_php_test(junithandler)
 set_tests_properties(junithandler PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(configurewarnings)
+set_tests_properties(configurewarnings PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -403,6 +406,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   buildproperties
   issuecreation
   junithandler
+  configurewarnings
 )
 
 
@@ -562,11 +566,8 @@ set_tests_properties(crosssubprojectcoverage PROPERTIES DEPENDS passwordcomplexi
 add_php_test(aggregatesubprojectcoverage)
 set_tests_properties(aggregatesubprojectcoverage PROPERTIES DEPENDS crosssubprojectcoverage)
 
-add_php_test(configurewarnings)
-set_tests_properties(configurewarnings PROPERTIES DEPENDS aggregatesubprojectcoverage)
-
 add_php_test(filtertestlabels)
-set_tests_properties(filtertestlabels PROPERTIES DEPENDS configurewarnings)
+set_tests_properties(filtertestlabels PROPERTIES DEPENDS aggregatesubprojectcoverage)
 
 add_php_test(dynamicanalysissummary)
 set_tests_properties(dynamicanalysissummary PROPERTIES DEPENDS filtertestlabels)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -337,6 +337,9 @@ set_tests_properties(consistenttestingday PROPERTIES DEPENDS /CDash/XmlHandler/U
 add_php_test(numericupdate)
 set_tests_properties(numericupdate PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(attachedfiles)
+set_tests_properties(attachedfiles PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -367,6 +370,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   changeid
   consistenttestingday
   numericupdate
+  attachedfiles
 )
 
 
@@ -631,11 +635,8 @@ set_tests_properties(commitauthornotification PROPERTIES DEPENDS putdynamicbuild
 add_php_test(subscribeprojectshowlabels)
 set_tests_properties(subscribeprojectshowlabels PROPERTIES DEPENDS putdynamicbuilds)
 
-add_php_test(attachedfiles)
-set_tests_properties(attachedfiles PROPERTIES DEPENDS subscribeprojectshowlabels)
-
 add_php_test(subprojectorder)
-set_tests_properties(subprojectorder PROPERTIES DEPENDS attachedfiles)
+set_tests_properties(subprojectorder PROPERTIES DEPENDS subscribeprojectshowlabels)
 
 add_php_test(testimages)
 set_tests_properties(testimages PROPERTIES DEPENDS subprojectorder)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -328,6 +328,9 @@ add_browser_test(/Browser/Pages/UsersPageTest)
 
 add_browser_test(/Browser/Pages/BuildFilesPageTest)
 
+add_php_test(changeid)
+set_tests_properties(changeid PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -355,6 +358,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   /CDash/Messaging/Topic/TestFailureTopic
   /CDash/Messaging/Topic/TopicDecorator
   cypress/e2e/user-profile
+  changeid
 )
 
 
@@ -601,11 +605,8 @@ set_tests_properties(submission_assign_buildid PROPERTIES DEPENDS buildrelations
 add_php_test(donehandler)
 set_tests_properties(donehandler PROPERTIES DEPENDS submission_assign_buildid)
 
-add_php_test(changeid)
-set_tests_properties(changeid PROPERTIES DEPENDS donehandler)
-
 add_php_test(expiredbuildrules)
-set_tests_properties(expiredbuildrules PROPERTIES DEPENDS changeid)
+set_tests_properties(expiredbuildrules PROPERTIES DEPENDS donehandler)
 
 add_php_test(filterblocks)
 set_tests_properties(filterblocks PROPERTIES DEPENDS expiredbuildrules)

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -334,6 +334,9 @@ set_tests_properties(changeid PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler
 add_php_test(consistenttestingday)
 set_tests_properties(consistenttestingday PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(numericupdate)
+set_tests_properties(numericupdate PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 ###################################################################################################
 
 set_property(TEST install_2 APPEND PROPERTY DEPENDS
@@ -363,6 +366,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   cypress/e2e/user-profile
   changeid
   consistenttestingday
+  numericupdate
 )
 
 
@@ -627,11 +631,8 @@ set_tests_properties(commitauthornotification PROPERTIES DEPENDS putdynamicbuild
 add_php_test(subscribeprojectshowlabels)
 set_tests_properties(subscribeprojectshowlabels PROPERTIES DEPENDS putdynamicbuilds)
 
-add_php_test(numericupdate)
-set_tests_properties(numericupdate PROPERTIES DEPENDS subscribeprojectshowlabels)
-
 add_php_test(attachedfiles)
-set_tests_properties(attachedfiles PROPERTIES DEPENDS numericupdate)
+set_tests_properties(attachedfiles PROPERTIES DEPENDS subscribeprojectshowlabels)
 
 add_php_test(subprojectorder)
 set_tests_properties(subprojectorder PROPERTIES DEPENDS attachedfiles)

--- a/app/cdash/tests/autoremovebuilds/CMakeLists.txt
+++ b/app/cdash/tests/autoremovebuilds/CMakeLists.txt
@@ -39,6 +39,3 @@ set_tests_properties(removebuilds PROPERTIES
   FAIL_REGULAR_EXPRESSION ".*Failures: [1-9]+.*;.*Exceptions: [1-9]+.*"
   DEPENDS deletesubproject
 )
-
-add_laravel_test(/Feature/AutoRemoveBuildsCommand)
-set_tests_properties(/Feature/AutoRemoveBuildsCommand PROPERTIES DEPENDS removebuilds)

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -6,12 +6,16 @@ use App\Utils\RepositoryUtils;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\Project;
+use Tests\Traits\CreatesUsers;
 
 class IssueCreationTestCase extends KWWebTestCase
 {
+    use CreatesUsers;
+
     protected $PDO;
     protected $Builds;
     protected $Projects;
+    protected User $user;
 
     public function __construct()
     {
@@ -19,6 +23,7 @@ class IssueCreationTestCase extends KWWebTestCase
         $this->Builds = [];
         $this->Projects = [];
         $this->PDO = Database::getInstance()->getPdo();
+        $this->user = $this->makeAdminUser();
     }
 
     public function __destruct()
@@ -27,6 +32,7 @@ class IssueCreationTestCase extends KWWebTestCase
             remove_project_builds($project->Id);
             $project->Delete();
         }
+        $this->user->delete();
     }
 
     public function testIssueCreation()
@@ -85,8 +91,8 @@ class IssueCreationTestCase extends KWWebTestCase
         $clean_build->AddBuild(0, 0);
         $this->Builds['clean'] = $clean_build;
 
-        // Add user1@kw as a project administrator.
-        $userid = User::where('email', 'user1@kw')->firstOrFail()->id;
+        // Add out user as a project administrator.
+        $userid = $this->user->id;
         EloquentProject::findOrFail((int) $this->Projects['CDash']->Id)->users()
             ->attach($userid, [
                 'emailtype' => 3, // receive all emails

--- a/tests/cypress/e2e/tests.cy.js
+++ b/tests/cypress/e2e/tests.cy.js
@@ -20,7 +20,7 @@ describe('the test page', () => {
 
 
   it('can be reached from the testSummary page', () => {
-    cy.visit('testSummary.php?project=27&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
     // find the link to the test page and click it
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(0).find('td').eq(3).find('a').click();
     // make sure we're really on the test page
@@ -29,7 +29,7 @@ describe('the test page', () => {
 
 
   it('loads the right navigation links', () => {
-    cy.visit('testSummary.php?project=27&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).as('test_td');
     cy.get('@test_td').find('a').invoke('attr', 'href').then(test_url => {
       const test_id = test_url.match(/tests?\/([0-9]+)/)[1];
@@ -55,7 +55,7 @@ describe('the test page', () => {
 
 
   it('displays information about the test', () => {
-    cy.visit('testSummary.php?project=27&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     // verify information for the test we clicked on
@@ -65,7 +65,7 @@ describe('the test page', () => {
     // test name
     cy.get('a#summary_link').should('contain', 'nap');
     // link to test summary page
-    cy.get('a#summary_link').invoke('attr', 'href').should('contain', 'testSummary.php?project=27&name=nap&date=2018-01-25');
+    cy.get('a#summary_link').invoke('attr', 'href').should('contain', 'testSummary.php?project=23&name=nap&date=2018-01-25');
     // build name this test belongs to
     cy.get('a#build_link').should('contain', 'test_timing');
     // link to corresponding build page
@@ -95,7 +95,7 @@ describe('the test page', () => {
 
 
   it('loads the "Test Time" and "Failing/Passing" graphs', () => {
-    cy.visit('testSummary.php?project=27&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     cy.on('uncaught:exception', (err, runnable) => {

--- a/tests/cypress/e2e/tests.cy.js
+++ b/tests/cypress/e2e/tests.cy.js
@@ -20,7 +20,7 @@ describe('the test page', () => {
 
 
   it('can be reached from the testSummary page', () => {
-    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=22&name=nap&date=2018-01-25');
     // find the link to the test page and click it
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(0).find('td').eq(3).find('a').click();
     // make sure we're really on the test page
@@ -29,7 +29,7 @@ describe('the test page', () => {
 
 
   it('loads the right navigation links', () => {
-    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=22&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).as('test_td');
     cy.get('@test_td').find('a').invoke('attr', 'href').then(test_url => {
       const test_id = test_url.match(/tests?\/([0-9]+)/)[1];
@@ -55,7 +55,7 @@ describe('the test page', () => {
 
 
   it('displays information about the test', () => {
-    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=22&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     // verify information for the test we clicked on
@@ -65,7 +65,7 @@ describe('the test page', () => {
     // test name
     cy.get('a#summary_link').should('contain', 'nap');
     // link to test summary page
-    cy.get('a#summary_link').invoke('attr', 'href').should('contain', 'testSummary.php?project=23&name=nap&date=2018-01-25');
+    cy.get('a#summary_link').invoke('attr', 'href').should('contain', 'testSummary.php?project=22&name=nap&date=2018-01-25');
     // build name this test belongs to
     cy.get('a#build_link').should('contain', 'test_timing');
     // link to corresponding build page
@@ -95,7 +95,7 @@ describe('the test page', () => {
 
 
   it('loads the "Test Time" and "Failing/Passing" graphs', () => {
-    cy.visit('testSummary.php?project=23&name=nap&date=2018-01-25');
+    cy.visit('testSummary.php?project=22&name=nap&date=2018-01-25');
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     cy.on('uncaught:exception', (err, runnable) => {


### PR DESCRIPTION
This PR supersedes https://github.com/Kitware/CDash/pull/2903, moving tests which have no dependencies to the parallel section at the beginning of the test suite instead of creating parallel blocks in the middle of the test suite.  This approach is far safer than the aggressive approach taken in https://github.com/Kitware/CDash/pull/2903, reducing the chances of additional flakiness being introduced.  In addition to improving the overall test time, these changes make it easier to debug tests late in the test by reducing the length of the longest dependency chain.