### PR TITLE
Expose coverage file path via GraphQL

### DIFF
--- a/app/Models/Coverage.php
+++ b/app/Models/Coverage.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @property int $buildid
@@ -43,5 +44,21 @@ class Coverage extends Model
     public function build(): BelongsTo
     {
         return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return HasOne<CoverageFile, $this>
+     */
+    public function file(): HasOne
+    {
+        return $this->hasOne(CoverageFile::class, 'id', 'fileid');
+    }
+
+    /**
+     * A helper method used by Lighthouse to hide the fact that the path lives in a separate table.
+     */
+    public function getFilePath(): ?string
+    {
+        return $this->file?->fullpath;
     }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -787,6 +787,8 @@ type Coverage {
   "Unique primary key."
   id: ID! @filterable
 
+  filePath: String! @with(relation: "file") @method(name: "getFilePath")
+
   linesOfCodeTested: Int! @rename(attribute: "loctested") @filterable
 
   linesOfCodeUntested: Int! @rename(attribute: "locuntested") @filterable


### PR DESCRIPTION
The filename for coverage files is stored in the `coveragefile` table.  While it should eventually be moved to the `coverage` table, doing so is nontrivial.  This PR exposes it via the `Coverage` type, with the caveat that it cannot be used in filters until the column is fully moved to the `coverage` table.