### PR TITLE
Remove file download time limit

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -766,6 +766,7 @@ final class BuildController extends AbstractBuildController
 
     public function build_file(int $build_id, int $file_id): StreamedResponse
     {
+        set_time_limit(0);
         $this->setBuildById($build_id);
 
         /** @var ?UploadFile $file */


### PR DESCRIPTION
This commit fixes an issue experienced on one of our production systems where large file downloads failed to complete due to a PHP process timeout.  CDash supports very large uploaded files, meaning that we also need to support files which may take minutes to download.  In the future, we may want to consider setting a higher timeout rather than allowing the process to run forever.