### PR TITLE
Fix UnableToMoveFile exception when requeuing Done.xml

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -169,6 +169,7 @@ class ProcessSubmission implements ShouldQueue
         // Resubmit the file if necessary.
         if (is_a($handler, 'DoneHandler') && $handler->shouldRequeue()) {
             $this->requeueSubmissionFile($handler->getBuild()->Id);
+            return;
         }
 
         if ((int) config('cdash.backup_timeframe') === 0) {

--- a/app/cdash/tests/test_donehandler.php
+++ b/app/cdash/tests/test_donehandler.php
@@ -109,6 +109,8 @@ class DoneHandlerTestCase extends KWWebTestCase
         $contents = Storage::get(Storage::files('parsed')[0]);
         $this->assertTrue(str_contains($contents, 'Done retries="5"'));
 
+        $this->assertTrue($this->checkLog($this->logfilename) !== false);
+
         unlink($tmpfname);
         DatabaseCleanupUtils::removeBuild($build->Id);
     }


### PR DESCRIPTION
After #2828 was merged, we started noticing the log entries of the following type:

```
WARNING: Failed to process <filename>.xml with message:
League\Flysystem\UnableToMoveFile:
Unable to move file from inprogress/<filename>.xml
to parsed/<filename>_Done.xml, because unknown reason in
/cdash/vendor/league/flysystem/src/UnableToMoveFile.php:56
```

We fix this error by returning early from `ProcessSubmission::handle()` after requeuing a Done.xml file.