### PR TITLE
Specify multiple processors for resource-intensive tests

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -54,9 +54,10 @@ endfunction()
 
 function(add_browser_test TestName)
   add_feature_test(${TestName})
-  set_property(TEST ${TestName} PROPERTY RESOURCE_LOCK
+  set_property(TEST ${TestName} APPEND PROPERTY RESOURCE_LOCK
     APP_URL # All browser tests need exclusive access to the APP_URL configuration setting
   )
+  set_property(TEST ${TestName} APPEND PROPERTY PROCESSORS 2)
 endfunction()
 
 # phpunit tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -54,6 +54,9 @@ parameters:
     checkBenevolentUnionTypes: true
     reportAnyTypeWideningInVarTag: true
 
+    parallel:
+        maximumNumberOfProcesses: int(%env.PHPSTAN_CPU%)
+
     level: 9
 
 includes:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ add_test(
 )
 set_tests_properties(php_static_analysis PROPERTIES
   DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>" # Disable PHPStan on the UBI image since lcobucci/jwt gets removed
+  ENVIRONMENT PHPSTAN_CPU=2
+  PROCESSORS 2 # We could eventually do something more intelligent to give PHPStan more CPU based on the current load...
 )
 
 # Run the JS linter

--- a/tests/cypress/component/CMakeLists.txt
+++ b/tests/cypress/component/CMakeLists.txt
@@ -11,6 +11,7 @@ function(add_cypress_component_test TestName)
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
     RESOURCE_LOCK "cypress"
+    PROCESSORS 2
   )
 endfunction()
 

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -14,6 +14,7 @@ function(add_cypress_e2e_test TestName)
     ENVIRONMENT "HOME=${CDash_BINARY_DIR};"
     DISABLED "$<STREQUAL:${CDASH_IMAGE},ubi>"
     RESOURCE_LOCK "cypress;APP_URL" # Cypress can only run one at a time due to xvfb issues and needs a consistent APP_URL
+    PROCESSORS 2
   )
 endfunction()
 


### PR DESCRIPTION
The first part of our test suite consists of a number of tests which can be run up to a relatively high parallel level.  Some of these tests require more than one processor, which causes thrashing when multiple tests are run concurrently.  This PR attempts to address the issue by specifying 2 processors for PHPStan, Cypress, and Dusk tests.