### PR TITLE
Fix abstract class mock deprecation warnings

### DIFF
--- a/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -69,7 +69,7 @@ class UserSubscriptionBuilderTest extends TestCase
     private function getMockHandler(BuildCollection $builds)
     {
         $mock_handler = $this->getMockBuilder(ActionableBuildInterface::class)
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $mock_project = $this->getMockBuilder(Project::class)
             ->onlyMethods(['GetSubscriberCollection'])

--- a/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
@@ -26,14 +26,9 @@ class AuthoredTopicTest extends CDashTestCase
 {
     public function testSubscribesToBuild()
     {
-        $mock_topic = $this->getMockForAbstractClass(
-            Topic::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['subscribesToBuild']);
+        $mock_topic = $this->getMockBuilder(Topic::class)
+            ->onlyMethods(['subscribesToBuild'])
+            ->getMock();
 
         $mock_topic->expects($this->any())
             ->method('subscribesToBuild')

--- a/app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
@@ -33,7 +33,7 @@ class ConfigureTopicTest extends CDashTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->parent = $this->getMockForAbstractClass(Topic::class);
+        $this->parent = $this->getMockBuilder(Topic::class)->getMock();
     }
 
     public function testSubscribesToBuild()

--- a/app/cdash/tests/case/CDash/Messaging/Topic/EmailSentTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/EmailSentTopicTest.php
@@ -29,15 +29,9 @@ class EmailSentTopicTest extends CDashTestCase
 {
     public function testSubscribesToBuild()
     {
-        $mock_topic = $this->getMockForAbstractClass(
-            Topic::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['subscribesToBuild', 'getTopicName']
-        );
+        $mock_topic = $this->getMockBuilder(Topic::class)
+            ->onlyMethods(['subscribesToBuild', 'getTopicName'])
+            ->getMock();
 
         $mock_topic->expects($this->exactly(3))
             ->method('subscribesToBuild')

--- a/app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
@@ -153,20 +153,11 @@ class TopicDecoratorTest extends TestCase
         $this->assertNotInstanceOf(AuthoredTopic::class, $collection->get('MockTopic'));
     }
 
-    /**
-     * @return PHPUnit_Framework_MockObject_MockObject
-     */
     private function getMockTopic($named)
     {
-        $mock_topic = $this->getMockForAbstractClass(
-            MockTopic::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getTopicName']
-        );
+        $mock_topic = $this->getMockBuilder(MockTopic::class)
+            ->onlyMethods(['getTopicName', 'isSubscribedToBy', 'subscribesToBuild'])
+            ->getMock();
 
         $mock_topic->expects($this->any())
             ->method('getTopicName')
@@ -177,15 +168,9 @@ class TopicDecoratorTest extends TestCase
 
     private function getMockTopicFixable($named)
     {
-        $mock_topic = $this->getMockForAbstractClass(
-            MockTopicFixable::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getTopicName']
-        );
+        $mock_topic = $this->getMockBuilder(MockTopicFixable::class)
+            ->onlyMethods(['getTopicName', 'isSubscribedToBy', 'subscribesToBuild', 'hasFixes', 'getFixes'])
+            ->getMock();
 
         $mock_topic->expects($this->any())
             ->method('getTopicName')
@@ -196,15 +181,9 @@ class TopicDecoratorTest extends TestCase
 
     private function getMockTopicLabelable($named)
     {
-        $mock_topic = $this->getMockForAbstractClass(
-            MockTopicLabelable::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getTopicName']
-        );
+        $mock_topic = $this->getMockBuilder(MockTopicLabelable::class)
+            ->onlyMethods(['getTopicName', 'isSubscribedToBy', 'subscribesToBuild', 'getLabelsFromBuild', 'setTopicDataWithLabels'])
+            ->getMock();
 
         $mock_topic->expects($this->any())
             ->method('getTopicName')

--- a/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
+++ b/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
@@ -32,7 +32,7 @@ class RepositoryServiceTest extends CDashTestCase
         parent::setUp();
         $this->setDatabaseMocked();
         $this->repository = $this->getMockBuilder(RepositoryInterface::class)
-            ->getMockForAbstractClass();
+            ->getMock();
     }
 
     public function testConstruct()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16552,12 +16552,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\MockObject\\MockBuilder\.$#'
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
 			count: 2
@@ -16682,12 +16676,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\TestCase\.$#'
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
 
 		-
 			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
@@ -16930,12 +16918,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
 		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\TestCase\.$#'
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
-
-		-
 			message: '#^Call to method method\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
 			identifier: class.notFound
 			count: 1
@@ -17144,12 +17126,6 @@ parameters:
 			identifier: phpunit.assertEquals
 			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Topic/DynamicAnalysisTopicTest.php
-
-		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\TestCase\.$#'
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/EmailSentTopicTest.php
 
 		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertFalse\(\)\.$#'
@@ -17617,12 +17593,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
 		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\TestCase\.$#'
-			identifier: method.deprecated
-			count: 3
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
-
-		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 5
@@ -17635,20 +17605,14 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
 
 		-
-			message: '#^Method TopicDecoratorTest\:\:getMockTopic\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
+			message: '#^Method TopicDecoratorTest\:\:getMockTopic\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
 
 		-
 			message: '#^Method TopicDecoratorTest\:\:getMockTopic\(\) has parameter \$named with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
-
-		-
-			message: '#^Method TopicDecoratorTest\:\:getMockTopic\(\) should return PHPUnit_Framework_MockObject_MockObject but returns MockTopic&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: return.type
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
 
@@ -18488,12 +18452,6 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/tests/case/CDash/NightlyTimeTest.php
-
-		-
-			message: '#^Call to deprecated method getMockForAbstractClass\(\) of class PHPUnit\\Framework\\MockObject\\MockBuilder\.$#'
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Service\\\\RepositoryService'' and CDash\\Service\\RepositoryService will always evaluate to true\.$#'


### PR DESCRIPTION
`getMockForAbstractClass()` is deprecated and will be [removed](https://github.com/sebastianbergmann/phpunit/blob/11.5/DEPRECATIONS.md) in PHPUnit 12.  This PR addresses our usages of the method.