### PR TITLE
Move data providers to PHP attributes

### DIFF
--- a/tests/Feature/GraphQL/BuildCommandTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandTypeTest.php
@@ -8,6 +8,7 @@ use App\Models\BuildCommand;
 use App\Models\Project;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -116,9 +117,7 @@ class BuildCommandTypeTest extends TestCase
         return $return_arr;
     }
 
-    /**
-     * @dataProvider commandTypes
-     */
+    #[DataProvider('commandTypes')]
     public function testFilterByType(string $type): void
     {
         /** @var Build $build */

--- a/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesUsers;
 
@@ -64,9 +65,7 @@ class CreateGlobalInvitationTest extends TestCase
         return $return_arr;
     }
 
-    /**
-     * @dataProvider roles
-     */
+    #[DataProvider('roles')]
     public function testAdminCreatesInvitationCorrectly(string $role): void
     {
         Mail::fake();
@@ -271,9 +270,7 @@ class CreateGlobalInvitationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidEmails
-     */
+    #[DataProvider('invalidEmails')]
     public function testCantCreateInvitationWithInvalidEmail(string $email): void
     {
         Mail::fake();

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -8,6 +8,7 @@ use App\Models\Project;
 use App\Models\User;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -60,9 +61,7 @@ class InviteToProjectTest extends TestCase
         return $return_arr;
     }
 
-    /**
-     * @dataProvider roles
-     */
+    #[DataProvider('roles')]
     public function testAdminCreatesInvitationCorrectly(string $role): void
     {
         Mail::fake();
@@ -411,9 +410,7 @@ class InviteToProjectTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidEmails
-     */
+    #[DataProvider('invalidEmails')]
     public function testCantCreateInvitationWithInvalidEmail(string $email): void
     {
         self::assertEmpty($this->project->invitations()->get());

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -174,9 +175,8 @@ class ProjectTypeTest extends TestCase
 
     /**
      * @param array<string> $allowable_projects
-     *
-     * @dataProvider projectAccessByUser
      */
+    #[DataProvider('projectAccessByUser')]
     public function testProjectPermissions(?string $user, array $allowable_projects): void
     {
         $expected_json_response = [
@@ -208,9 +208,7 @@ class ProjectTypeTest extends TestCase
             ')->assertJson($expected_json_response, true);
     }
 
-    /**
-     * @dataProvider perProjectAccess
-     */
+    #[DataProvider('perProjectAccess')]
     public function testIndividualProjectPermissions(?string $user, string $project_name, bool $allow_access): void
     {
         $response = ($user === null ? $this : $this->actingAs($this->users[$user]))
@@ -907,9 +905,7 @@ class ProjectTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider createProjectVisibilityRules
-     */
+    #[DataProvider('createProjectVisibilityRules')]
     public function testCreateProjectMaxVisibility(string $user, string $visibility, string $max_visibility, bool $can_create): void
     {
         Config::set('cdash.user_create_projects', true);
@@ -976,9 +972,7 @@ class ProjectTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider authenticatedSubmissionRules
-     */
+    #[DataProvider('authenticatedSubmissionRules')]
     public function testRequireAuthenticatedSubmissions(
         string $user,
         bool $use_authenticated_submits,

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesSites;
@@ -576,9 +577,8 @@ class SiteTypeTest extends TestCase
 
     /**
      * @param array<string,mixed> $params
-     *
-     * @dataProvider nullabilityTestCases
      */
+    #[DataProvider('nullabilityTestCases')]
     public function testSiteInformationColumnNullability(array $params): void
     {
         $this->sites['site1'] = $this->makeSite([

--- a/tests/Feature/GraphQL/TargetTypeTest.php
+++ b/tests/Feature/GraphQL/TargetTypeTest.php
@@ -10,6 +10,7 @@ use App\Models\Project;
 use App\Models\Target;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -158,9 +159,7 @@ class TargetTypeTest extends TestCase
         return $return_arr;
     }
 
-    /**
-     * @dataProvider targetTypes
-     */
+    #[DataProvider('targetTypes')]
     public function testFilterByType(string $type): void
     {
         /** @var Build $build */

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\GraphQL;
 use App\Models\Project;
 use App\Models\TestOutput;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Random\RandomException;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
@@ -129,9 +130,7 @@ class TestTypeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider statuses
-     */
+    #[DataProvider('statuses')]
     public function testStatusEnum(string $db_value, string $enum_value): void
     {
         $this->project->builds()->create([

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 use LogicException;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\SimpleCache\InvalidArgumentException;
 use Slides\Saml2\Events\SignedIn as Saml2SignedInEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -277,9 +278,7 @@ class LoginAndRegistration extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider oauthProviders
-     */
+    #[DataProvider('oauthProviders')]
     public function testCustomOauthDisplayNames(string $serviceName): void
     {
         // Enable PingIdentity, verify the button appears.

--- a/tests/Feature/RouteAccessTest.php
+++ b/tests/Feature/RouteAccessTest.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\URL;
 use LogicException;
 use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -68,9 +69,7 @@ class RouteAccessTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider adminRoutes
-     */
+    #[DataProvider('adminRoutes')]
     public function testAdminRoutes(string $route): void
     {
         $this->get($route)->assertRedirect('login');
@@ -78,9 +77,7 @@ class RouteAccessTest extends TestCase
         $this->actingAs($this->admin_user)->get($route)->assertDontSeeText('You must be an administrator to access this page.');
     }
 
-    /**
-     * @dataProvider protectedRoutes
-     */
+    #[DataProvider('protectedRoutes')]
     public function testProtectedRoutes(string $route): void
     {
         $this->get($route)->assertRedirect('login');


### PR DESCRIPTION
PHPUnit 12 [removes](https://github.com/sebastianbergmann/phpunit/blob/11.5/DEPRECATIONS.md) support for doc comment parsing, instead using PHP's attributes to do the same thing.  This PR converts all of our data provider doc comments to PHP attributes in preparation for our upcoming migration to PHPUnit 12.