### PR TITLE
Replace `note` `crc32` column with hash index

### DIFF
--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int $id
  * @property string $text
  * @property string $name
- * @property int $crc32
  *
  * @mixin Builder<Note>
  */
@@ -21,14 +20,12 @@ class Note extends Model
     public $timestamps = false;
 
     protected $fillable = [
-        'crc32',
         'name',
         'text',
     ];
 
     protected $casts = [
         'id' => 'integer',
-        'crc32' => 'integer',
     ];
 
     /**

--- a/app/Utils/NoteCreator.php
+++ b/app/Utils/NoteCreator.php
@@ -30,28 +30,12 @@ class NoteCreator
     public $time;
     public $text;
 
-    private $crc32;
-
     public function __construct()
     {
         $this->buildid = null;
         $this->name = '';
         $this->time = '';
         $this->text = '';
-        $this->crc32 = '';
-    }
-
-    /** Get the CRC32 */
-    public function computeCrc32()
-    {
-        if (strlen($this->crc32) > 0) {
-            return $this->crc32;
-        }
-        // Compute the CRC32 for the note.
-        $text = pdo_real_escape_string($this->text);
-        $name = pdo_real_escape_string($this->name);
-        $this->crc32 = crc32($text . $name);
-        return $this->crc32;
     }
 
     /**
@@ -60,11 +44,9 @@ class NoteCreator
     public function create()
     {
         // Create the note if it doesn't already exist.
-        $this->computeCrc32();
-        $note = Note::firstOrCreate(['crc32' => $this->crc32], [
+        $note = Note::firstOrCreate([
             'name' => $this->name,
             'text' => $this->text,
-            'crc32' => $this->crc32,
         ]);
 
         // Create the build2note record.

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -412,7 +412,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $note_id = DB::table('note')->insertGetId([
             'text' => 'note for test_removebuildds',
             'name' => 'test_removebuilds.log',
-            'crc32' => $crc32,
         ]);
         $testoutput_id = DB::table('testoutput')->insertGetId([
             'output' => 'testoutput for test_removebuildds',

--- a/database/migrations/2025_06_17_140642_drop_note_crc32.php
+++ b/database/migrations/2025_06_17_140642_drop_note_crc32.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE note DROP COLUMN IF EXISTS crc32');
+        DB::statement('CREATE INDEX ON note USING HASH (text)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3655,21 +3655,6 @@ parameters:
 			path: app/Utils/LdapUtils.php
 
 		-
-			message: '''
-				#^Call to deprecated function pdo_real_escape_string\(\)\:
-				04/01/2023$#
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: app/Utils/NoteCreator.php
-
-		-
-			message: '#^Method App\\Utils\\NoteCreator\:\:computeCrc32\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/Utils/NoteCreator.php
-
-		-
 			message: '#^Method App\\Utils\\NoteCreator\:\:create\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3677,12 +3662,6 @@ parameters:
 
 		-
 			message: '#^Property App\\Utils\\NoteCreator\:\:\$buildid has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/Utils/NoteCreator.php
-
-		-
-			message: '#^Property App\\Utils\\NoteCreator\:\:\$crc32 has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: app/Utils/NoteCreator.php

--- a/tests/Feature/GraphQL/NoteTypeTest.php
+++ b/tests/Feature/GraphQL/NoteTypeTest.php
@@ -46,19 +46,16 @@ class NoteTypeTest extends TestCase
         $this->note1 = Note::create([
             'name' => Str::uuid()->toString(),
             'text' => Str::uuid()->toString(),
-            'crc32' => random_int(0, 100000),
         ]);
 
         $this->note2 = Note::create([
             'name' => Str::uuid()->toString(),
             'text' => Str::uuid()->toString(),
-            'crc32' => random_int(0, 100000),
         ]);
 
         $this->note3 = Note::create([
             'name' => Str::uuid()->toString(),
             'text' => Str::uuid()->toString(),
-            'crc32' => random_int(0, 100000),
         ]);
 
         $this->public_project->builds()->create([


### PR DESCRIPTION
Modern versions of Postgres have good [hash index](https://www.postgresql.org/docs/current/hash-index.html) support, allowing us to efficiently perform equality comparisons on large text columns.  Our current crc32-based hashing system suffers from hash conflicts, in addition to adding unnecessary and easily-broken logic.  This PR replaces the crc32 column with a hash index and explicit equality comparison against all fields on insertion.