### PR TITLE
Check type of $cvsviewertype before converting to lowercase

### DIFF
--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -28,6 +28,9 @@ class RepositoryUtils
         $project = $service->get(Project::class);
         $project->Id = $projectid;
         $project->Fill();
+        if (is_null($project->CvsViewerType)) {
+            return;
+        }
         $cvsviewertype = strtolower($project->CvsViewerType);
 
         $target_fn = $cvsviewertype . '_get_source_dir';


### PR DESCRIPTION
This commit fixes the following error.

```
production.ERROR: strtolower():
Argument #1 ($string) must be of type string, null given /cdash/app/Utils/RepositoryUtils.php:31
```