### PR TITLE
Fix missing log messages for UBI images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,6 +201,11 @@ RUN chmod -R g=u,o-w /etc/pki/ca-trust/extracted /etc/pki/ca-trust/source/anchor
 # In the future, we may want to consider limiting this for security reasons.
 RUN echo "clear_env = no" >> /etc/php-fpm.d/www.conf
 
+# Redirect PHP worker stdout and stderr into main error log
+# instead of /dev/null
+# https://www.php.net/manual/en/install.fpm.configuration.php
+RUN echo "catch_workers_output = yes" >> /etc/php-fpm.d/www.conf
+
 USER 1001
 
 # Copy CDash (current folder) into /cdash


### PR DESCRIPTION
Our UBI Docker image uses PHP FPM. Its default behavior is to redirect stdout and stderr to /dev/null for worker processes.

Override this behavior by setting catch_workers_output = yes. This causes log messages to show up on stderr, which is the expected behavior for our container-based deployments.