### PR TITLE
Fix GraphQL-based filter interface

### DIFF
--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -73,6 +73,7 @@ export default {
       query: gql`
         query($buildid: ID, $filters: BuildTestsFiltersMultiFilterInput, $after: String) {
           build(id: $buildid) {
+            id
             tests(filters: $filters, after: $after, first: 100) {
               edges {
                 node {

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -38,8 +38,8 @@
           />
           <filter-row
             v-else-if="entry !== 'deleted'"
-            :operators="result.typeInformation.inputFields.filter(f => f.type.kind !== 'LIST').map(o => o.name)"
-            :type="result.typeInformation.inputFields.filter(f => f.type.kind !== 'LIST')[0].type.name"
+            :operators="operatorTypes.map(o => o.name)"
+            :type="operatorTypes[0].type.name"
             :initial-field="filterToFilterRow(entry).field"
             :initial-operator="filterToFilterRow(entry).operator"
             :initial-value="filterToFilterRow(entry).value"
@@ -157,6 +157,10 @@ export default {
 
     currentCombineType() {
       return this.filters.hasOwnProperty('any') ? 'any' : 'all';
+    },
+
+    operatorTypes() {
+      return this.result.typeInformation.inputFields.filter(f => f.type.kind !== 'LIST' && !f.type.name.endsWith('RelationshipFilterInput'));
     },
   },
 

--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -122,8 +122,8 @@ export default {
 
   setup(props) {
     const { result, error } = useQuery(gql`
-      query {
-        typeInformation: __type(name: "${props.type}") {
+      query($typeName: String!){
+        typeInformation: __type(name: $typeName) {
           inputFields {
             name
             type {
@@ -136,7 +136,9 @@ export default {
           }
         }
       }
-    `);
+    `, {
+      typeName: props.type,
+    });
 
     return {
       result,


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2889 broke the new GraphQL-based filter interface.  This PR restores that functionality, plus a handful of other minor changes to related code.