### PR TITLE
Renormalize label-coverage relationship

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -232,11 +232,12 @@ final class CoverageController extends AbstractBuildController
             $labels = [];
 
             $covlabels = $db->executePrepared('
-                             SELECT DISTINCT id, text
-                             FROM label, label2coveragefile
+                             SELECT DISTINCT label.id, label.text
+                             FROM label, label2coverage, coverage
                              WHERE
-                                 label.id=label2coveragefile.labelid
-                                 AND label2coveragefile.buildid=?
+                                 label.id=label2coverage.labelid
+                                 AND label2coverage.coverageid=coverage.id
+                                 AND coverage.buildid=?
                          ', [intval($this->build->Id)]);
             foreach ($covlabels as $row) {
                 $labels[$row['id']] = $row['text'];
@@ -253,12 +254,11 @@ final class CoverageController extends AbstractBuildController
                                SELECT
                                    SUM(loctested) AS loctested,
                                    SUM(locuntested) AS locuntested
-                               FROM label2coveragefile, coverage
+                               FROM label2coverage, coverage
                                WHERE
-                                   label2coveragefile.labelid=?
-                                   AND label2coveragefile.buildid=?
-                                   AND coverage.buildid=label2coveragefile.buildid
-                                   AND coverage.fileid=label2coveragefile.coveragefileid
+                                   label2coverage.labelid=?
+                                   AND coverage.buildid=?
+                                   AND coverage.id=label2coverage.coverageid
                            ', [intval($id), intval($this->build->Id)]);
 
                     $loctested = intval($row['loctested']);
@@ -1242,11 +1242,13 @@ final class CoverageController extends AbstractBuildController
                                       SELECT text
                                       FROM
                                           label,
-                                          label2coveragefile
+                                          label2coverage,
+                                          coverage
                                       WHERE
-                                          label.id=label2coveragefile.labelid
-                                          AND label2coveragefile.coveragefileid=?
-                                          AND label2coveragefile.buildid=?
+                                          label.id=label2coverage.labelid
+                                          AND label2coverage.coverageid=coverage.id
+                                          AND coverage.fileid=?
+                                          AND coverage.buildid=?
                                       ORDER BY text ASC
                                   ', [intval($fileid), $this->build->Id]);
                 foreach ($coveragelabels as $coveragelabels_array) {

--- a/app/Models/Coverage.php
+++ b/app/Models/Coverage.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
@@ -44,6 +45,14 @@ class Coverage extends Model
     public function build(): BelongsTo
     {
         return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return BelongsToMany<Label, $this>
+     */
+    public function labels(): BelongsToMany
+    {
+        return $this->belongsToMany(Label::class, 'label2coverage', 'coverageid', 'labelid');
     }
 
     /**

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -1493,8 +1493,9 @@ class Build
         if (empty($labelarray) || isset($labelarray['coverage']['errors'])) {
             $sql .=
                 ' OR label.id IN
-                    (SELECT labelid AS id FROM label2coveragefile
-                     WHERE label2coveragefile.buildid = :buildid)';
+                    (SELECT labelid AS id FROM label2coverage
+                     INNER JOIN coverage ON (coverage.id=label2coverage.coverageid)
+                     WHERE coverage.buildid = :buildid)';
         }
         if (empty($labelarray) || isset($labelarray['build']['errors'])) {
             $sql .=

--- a/app/cdash/app/Model/Coverage.php
+++ b/app/cdash/app/Model/Coverage.php
@@ -18,7 +18,6 @@
 namespace CDash\Model;
 
 use App\Models\Coverage as EloquentCoverage;
-use Illuminate\Support\Facades\Log;
 
 /**
  * Coverage class. Used by CoverageSummary
@@ -46,32 +45,7 @@ class Coverage
             $this->Labels = [];
         }
 
-        $label->CoverageFileId = $this->CoverageFile->Id;
-        $label->CoverageFileBuildId = (int) $this->BuildId;
         $this->Labels[] = $label;
-    }
-
-    /** Put labels for coverage */
-    public function InsertLabelAssociations($buildid)
-    {
-        if ($buildid
-            && isset($this->CoverageFile)
-            && $this->CoverageFile->Id
-        ) {
-            if (empty($this->Labels)) {
-                return;
-            }
-
-            foreach ($this->Labels as $label) {
-                $label->CoverageFileId = $this->CoverageFile->Id;
-                $label->CoverageFileBuildId = (int) $buildid;
-                $label->Insert();
-            }
-        } else {
-            Log::error('No buildid or coveragefile', [
-                'function' => 'Coverage::InsertLabelAssociations',
-            ]);
-        }
     }
 
     /** Return true if this build already has coverage for this file,

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -90,24 +90,6 @@ class CoverageFile
                     'fileid' => $this->Id,
                 ]);
 
-                // Similarly update any labels if necessary.
-                $stmt = $this->PDO->prepare(
-                    'SELECT COUNT(*) AS c FROM label2coveragefile
-                        WHERE buildid=:buildid AND coveragefileid=:prevfileid');
-                $stmt->bindParam(':buildid', $buildid);
-                $stmt->bindParam(':prevfileid', $prevfileid);
-                pdo_execute($stmt);
-                $count_labels_row = $stmt->fetch(PDO::FETCH_ASSOC);
-                if ($count_labels_row['c'] > 0) {
-                    $stmt = $this->PDO->prepare(
-                        'UPDATE label2coveragefile SET coveragefileid=:fileid
-                            WHERE buildid=:buildid AND coveragefileid=:prevfileid');
-                    $stmt->bindParam(':fileid', $this->Id);
-                    $stmt->bindParam(':buildid', $buildid);
-                    $stmt->bindParam(':prevfileid', $prevfileid);
-                    pdo_execute($stmt);
-                }
-
                 // Remove the file if the crc32 is NULL
                 EloquentCoverageFile::where([
                     'id' => $prevfileid,

--- a/app/cdash/app/Model/Label.php
+++ b/app/cdash/app/Model/Label.php
@@ -119,9 +119,6 @@ class Label
 
         $this->InsertAssociation('label2buildfailure', 'buildfailureid', intval($this->BuildFailureId));
 
-        $this->InsertAssociation('label2coveragefile', 'buildid',
-            $this->CoverageFileBuildId, 'coveragefileid', intval($this->CoverageFileId));
-
         $this->InsertAssociation('label2dynamicanalysis', 'dynamicanalysisid', intval($this->DynamicAnalysisId));
 
         $this->Test?->labels()->syncWithoutDetaching([$this->Id]);

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -838,9 +838,10 @@ class Project
                               AND build.starttime>?
                       ) UNION (
                           SELECT labelid AS id
-                          FROM build, label2coveragefile
+                          FROM build, label2coverage, coverage
                           WHERE
-                              label2coveragefile.buildid=build.id
+                              label2coverage.coverageid=coverage.id
+                              AND coverage.buildid=build.id
                               AND build.projectid=?
                               AND build.starttime>?
                       ) UNION (

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -506,7 +506,7 @@ class ViewCoveragePhpFilters extends DefaultFilters
                 break;
 
             case 'labels':
-                $sql_field = "(SELECT $this->TextConcat AS labels FROM (SELECT label.text, coverage.fileid, coverage.buildid FROM label, label2coveragefile, coverage WHERE label2coveragefile.labelid=label.id AND label2coveragefile.buildid=coverage.buildid AND label2coveragefile.coveragefileid=coverage.fileid) AS filelabels WHERE fileid=c.fileid AND buildid=c.buildid)";
+                $sql_field = "(SELECT $this->TextConcat AS labels FROM (SELECT label.text, coverage.fileid, coverage.buildid FROM label, label2coverage, coverage WHERE label2coverage.labelid=label.id AND label2coverage.coverageid=coverage.id) AS filelabels WHERE fileid=c.fileid AND buildid=c.buildid)";
 
                 break;
 

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -495,7 +495,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
             $this->verify_get_rows('label2build', 'labelid', 'buildid', '=', $build->Id, 1);
         $this->verify('label', 'id', '=', $labelid, 1);
         $this->verify('label2buildfailure', 'labelid', '=', $labelid, 2);
-        $this->verify('label2coveragefile', 'labelid', '=', $labelid, 3);
+        $this->verify('label2coverage', 'labelid', '=', $labelid, 3);
         $this->verify('label2dynamicanalysis', 'labelid', '=', $labelid, 1);
         $this->verify('label2test', 'labelid', '=', $labelid, 3);
 
@@ -533,7 +533,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('image', 'id', 'IN', $imgids, 1, $extra_msg);
         $this->verify('label2build', 'buildid', '=', $build->Id, 0, $extra_msg);
         $this->verify('label2buildfailure', 'labelid', '=', $labelid, 1, $extra_msg);
-        $this->verify('label2coveragefile', 'labelid', '=', $labelid, 1, $extra_msg);
+        $this->verify('label2coverage', 'labelid', '=', $labelid, 1, $extra_msg);
         $this->verify('label2dynamicanalysis', 'labelid', '=', $labelid, 0, $extra_msg);
         $this->verify('label2test', 'labelid', '=', $labelid, 1, $extra_msg);
         $this->verify('note', 'id', 'IN', $noteids, 1, $extra_msg);
@@ -576,7 +576,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('image', 'id', 'IN', $imgids, 0, $extra_msg);
         $this->verify('label2build', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
         $this->verify('label2buildfailure', 'labelid', '=', $labelid, 0, $extra_msg);
-        $this->verify('label2coveragefile', 'labelid', '=', $labelid, 0, $extra_msg);
+        $this->verify('label2coverage', 'labelid', '=', $labelid, 0, $extra_msg);
         $this->verify('label2dynamicanalysis', 'labelid', '=', $labelid, 0, $extra_msg);
         $this->verify('label2test', 'labelid', '=', $labelid, 0, $extra_msg);
         $this->verify('note', 'id', 'IN', $noteids, 0, $extra_msg);

--- a/database/migrations/2025_06_24_222844_renormalize_label2coveragefile.php
+++ b/database/migrations/2025_06_24_222844_renormalize_label2coveragefile.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS label2coverage (
+                labelid bigint REFERENCES label(id) ON DELETE CASCADE NOT NULL,
+                coverageid bigint REFERENCES coverage(id) ON DELETE CASCADE NOT NULL
+            )
+        ');
+
+        DB::insert('
+            INSERT INTO label2coverage(
+                labelid,
+                coverageid
+            )
+            SELECT
+                label2coveragefile.labelid AS labelid,
+                coverage.id AS coverageid
+            FROM label2coveragefile
+            INNER JOIN coverage ON (
+                label2coveragefile.buildid = coverage.buildid
+                AND label2coveragefile.coveragefileid = coverage.fileid
+            )
+        ');
+        DB::statement('DROP TABLE label2coveragefile');
+
+        DB::statement('CREATE UNIQUE INDEX ON label2coverage (labelid, coverageid)');
+        DB::statement('CREATE UNIQUE INDEX ON label2coverage (coverageid, labelid)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8683,12 +8683,6 @@ parameters:
 			path: app/cdash/app/Model/BuildUpdateFile.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
 			message: '#^Method CDash\\Model\\Coverage\:\:AddLabel\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8696,18 +8690,6 @@ parameters:
 
 		-
 			message: '#^Method CDash\\Model\\Coverage\:\:AddLabel\(\) has parameter \$label with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
-			message: '#^Method CDash\\Model\\Coverage\:\:InsertLabelAssociations\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/app/Model/Coverage.php
-
-		-
-			message: '#^Method CDash\\Model\\Coverage\:\:InsertLabelAssociations\(\) has parameter \$buildid with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/app/Model/Coverage.php
@@ -8778,7 +8760,7 @@ parameters:
 				v2\.5\.0 01/22/2018$#
 			'''
 			identifier: function.deprecated
-			count: 4
+			count: 2
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-


### PR DESCRIPTION
The `label2coveragefile` table implicitly relates the `coverage` and `label` tables via a three-way relationship, duplicating the role of the `coverage` table which relates the `build` and `coveragefile` tables.  This PR fixes that by creating a new `label2coverage` table which appropriately relates labels to coverage results.