### PR TITLE
Decrease batch size to 10 in test output migration

### DIFF
--- a/database/migrations/2025_06_16_152800_decompress_test_output.php
+++ b/database/migrations/2025_06_16_152800_decompress_test_output.php
@@ -10,7 +10,7 @@ return new class extends Migration {
 
         $max_id = 0;
         while (true) {
-            $batch_size = 5000;
+            $batch_size = 10;
             $batch = DB::select("
                 SELECT
                     id,


### PR DESCRIPTION
A batch size of 5000 proved to be too large for this migration in real-world testing.