### PR TITLE
Decompress `coveragefile` table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,6 @@ DB_PASSWORD=secret
 # The lack of spaces is important.
 #UNLIMITED_PROJECTS=[]
 
-# Should CDash compress test and coverage results in the database?
-#USE_COMPRESSION=true
-
 # Whether or not this CDash instance should attempt to communicate with
 # VCS (eg. GitHub) API endpoints.
 #USE_VCS_API=true

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -48,20 +48,7 @@ class CoverageFile
 
         // Compute the crc32 of the file (before compression for backward compatibility)
         $this->Crc32 = crc32($this->FullPath . $this->File);
-        if (config('cdash.use_compression')) {
-            $file = gzcompress($this->File);
-            if ($file === false) {
-                $file = $this->File;
-            } else {
-                if (strlen($this->File) < 2000) {
-                    // compression doesn't help for small chunk
-                    $file = $this->File;
-                }
-                $file = base64_encode($file);
-            }
-        } else {
-            $file = $this->File;
-        }
+        $file = $this->File;
 
         $existing_file_row = EloquentCoverageFile::firstWhere('crc32', $this->Crc32);
         if ($existing_file_row !== null) {
@@ -156,21 +143,7 @@ class CoverageFile
 
         $this->FullPath = $coverage_file->fullpath;
         $this->Crc32 = $coverage_file->crc32;
-        if (config('cdash.use_compression')) {
-            if (is_resource($coverage_file->file)) {
-                $this->File = base64_decode(stream_get_contents($coverage_file->file));
-            } else {
-                $this->File = base64_decode($coverage_file->file);
-            }
-
-            @$uncompressedrow = gzuncompress($this->File);
-            if ($uncompressedrow !== false) {
-                $this->File = $uncompressedrow;
-            }
-        } else {
-            // TODO: This branch of the conditional is possibly faulty.  Postgres should always return a resource here.
-            $this->File = $coverage_file->file;
-        }
+        $this->File = $coverage_file->file;
 
         return true;
     }

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -78,7 +78,6 @@ return [
     // Specify whether users are allowed to create "submit only" tokens which are valid for all projects
     'allow_submit_only_tokens' => env('ALLOW_SUBMIT_ONLY_TOKENS', true),
     'unlimited_projects' => $unlimited_projects,
-    'use_compression' => env('USE_COMPRESSION', true),
     'user_create_projects' => env('USER_CREATE_PROJECTS', false),
     // Defaults to public.  Only meaningful if USER_CREATE_PROJECT=true.
     'max_project_visibility' => env('MAX_PROJECT_VISIBILITY', 'PUBLIC'),

--- a/database/migrations/2025_07_17_142900_decompress_coveragefile.php
+++ b/database/migrations/2025_07_17_142900_decompress_coveragefile.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // We start by deleting any coverage files which are no longer referenced.  In theory, nothing
+        // should be deleted, but there are often missed rows in practice.  Since this is such a slow
+        // operation, it's worthwhile to do this check to make sure we're only decompressing data we
+        // actually need.
+        DB::delete('
+            DELETE FROM coveragefile
+            WHERE NOT EXISTS (
+                SELECT 1 FROM coverage
+                WHERE fileid = coveragefile.id
+            )
+        ');
+
+        DB::statement('ALTER TABLE coveragefile ADD COLUMN IF NOT EXISTS new_file text');
+
+        $max_id = 0;
+        while (true) {
+            $batch_size = 10;
+            $batch = DB::select("
+                SELECT
+                    id,
+                    file
+                FROM coveragefile
+                WHERE id > ? AND file IS NOT NULL -- file can apparently be NULL.
+                ORDER BY id ASC
+                LIMIT $batch_size
+            ", [$max_id]);
+
+            // No rows to migrate.  Probably a new database...
+            if (count($batch) === 0) {
+                break;
+            }
+
+            $values_prepare_string = '';
+            $values = [];
+            foreach ($batch as $row) {
+                // Start the next batch after the last ID in this set.  Ordered by id, so guaranteed to be the largest ID.
+                $max_id = (int) $row->id;
+                $values_prepare_string .= '(?::integer,?),';
+                $values[] = (int) $row->id;
+
+                $file = stream_get_contents($row->file);
+                if ($file === false) {
+                    throw new Exception('Error reading stream from database.');
+                }
+                $decompressed = $this->decompress($file);
+                if (mb_detect_encoding($decompressed, 'UTF-8', true) === false) {
+                    $decompressed = mb_convert_encoding($decompressed, 'UTF-8', 'UTF-8');
+                    if ($decompressed === false) {
+                        echo "Unable to convert coveragefile #{$row->id} to UTF-8\n";
+                        $decompressed = '';
+                    }
+                }
+                $values[] = $decompressed;
+            }
+
+            // Remove the trailing comma...
+            $values_prepare_string = rtrim($values_prepare_string, ',');
+
+            DB::update("
+                UPDATE coveragefile
+                SET new_file = temp.file
+                FROM (VALUES $values_prepare_string) AS temp(id, file)
+                WHERE coveragefile.id = temp.id
+            ", $values);
+
+            if (count($batch) < $batch_size) {
+                break;
+            }
+        }
+
+        DB::statement('ALTER TABLE coveragefile DROP COLUMN file');
+        DB::statement('ALTER TABLE coveragefile RENAME COLUMN new_file TO file');
+    }
+
+    public function down(): void
+    {
+    }
+
+    private function decompress(string $file): string
+    {
+        // This file could be:
+        // - compressed
+        // - compressed and base64 encoded
+        // - base64 encoded but not compressed
+        // - neither base64 encoded nor compressed
+
+        // Check if file is compressed.
+        // Note that compression is always applied before base64 encoding.
+        @$decompressed = gzuncompress($file);
+        if ($decompressed !== false) {
+            return $decompressed;
+        }
+
+        // Check if file is compressed and base64 encoded.
+        $decoded = base64_decode($file, true);
+        if ($decoded !== false) {
+            @$decompressed = gzuncompress($decoded);
+            if ($decompressed !== false) {
+                return $decompressed;
+            }
+        }
+
+        // File must not be compressed.
+        // If base64_decode failed then we can safely assume this file
+        // wasn't encoded.
+        if ($decoded === false) {
+            return $file;
+        }
+
+        // Otherwise it's difficult to tell if the file was actually base64
+        // encoded or not.  Take a guess and assume it was encoded.
+        return $decoded;
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8773,12 +8773,6 @@ parameters:
 			path: app/cdash/app/Model/CoverageFile.php
 
 		-
-			message: '#^Call to function base64_decode\(\) requires parameter \#2 to be set\.$#'
-			identifier: function.strict
-			count: 2
-			path: app/cdash/app/Model/CoverageFile.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 1
@@ -8811,18 +8805,6 @@ parameters:
 		-
 			message: '#^Method CDash\\Model\\CoverageFile\:\:Update\(\) has parameter \$buildid with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/CoverageFile.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
-			identifier: if.condNotBoolean
-			count: 2
-			path: app/cdash/app/Model/CoverageFile.php
-
-		-
-			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: app/cdash/app/Model/CoverageFile.php
 


### PR DESCRIPTION
Similar to #2941, this PR decompresses the `coveragefile(file)` since the current compression approach is problematic for a variety of reasons.  The default Postgres TOAST system is sufficient for our compression needs at the moment.