### PR TITLE
Update confusing "user note" language

### DIFF
--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -761,18 +761,15 @@
       </div>
       <br>
 
-      <!-- Display notes for that build -->
+      <!-- Display comments for this build -->
       <div
         v-if="cdash.notes.length > 0 || cdash.user.id > 0"
         class="title-divider"
       >
-        Notes
+        Comments ({{ cdash.notes.length }})
       </div>
 
       <div v-if="cdash.notes.length > 0">
-        <div class="title-divider">
-          Users notes ({{ cdash.notes.length }})
-        </div>
         <div v-for="note in cdash.notes">
           <b>{{ note.status }}</b> by <b>{{ note.user }}</b> at {{ note.date }}
           <pre>{{ note.text }}</pre>
@@ -782,7 +779,7 @@
 
 
       <div v-if="cdash.user.id > 0">
-        <!-- Add Notes -->
+        <!-- Add Comments -->
         <img
           :src="$baseURL + '/img/document.png'"
           title="graph"
@@ -791,7 +788,7 @@
           id="toggle_note"
           @click="toggleNote()"
         >
-          Add a Note to this Build
+          Add a comment to this Build
         </a>
         <div
           v-show="showNote"
@@ -800,7 +797,7 @@
           <table>
             <tbody>
               <tr>
-                <td><b>Note:</b></td>
+                <td><b>Comment:</b></td>
                 <td>
                   <textarea
                     id="note_text"


### PR DESCRIPTION
CDash previously had the concept of "build notes" and "user notes" which was endlessly confusing to both developers and users.  #2398 changed most of the internal references to rename "user notes" to "comments".  This PR continues that effort by changing the UI to reflect the new terminology.