### PR TITLE
Sync LDAP GUID for users added via non-LDAP methods

### DIFF
--- a/app/Ldap/Rules/FilterRules.php
+++ b/app/Ldap/Rules/FilterRules.php
@@ -25,6 +25,10 @@ class FilterRules implements Rule
             return false;
         }
 
+        if ($model->ldapguid === null) {
+            return false;
+        }
+
         return match (env('LDAP_PROVIDER', 'openldap')) {
             'openldap' => \LdapRecord\Models\OpenLDAP\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\OpenLDAP\User,
             'activedirectory' => \LdapRecord\Models\ActiveDirectory\User::rawFilter($filter)->findByGuid($model->ldapguid) instanceof \LdapRecord\Models\ActiveDirectory\User,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,8 +21,8 @@ use LdapRecord\Laravel\Auth\LdapAuthenticatable;
  * @property string $password
  * @property Carbon $password_updated_at
  * @property string $institution
- * @property string $ldapdomain
- * @property string $ldapguid
+ * @property ?string $ldapdomain
+ * @property ?string $ldapguid
  *
  * @mixin Builder<User>
  */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3639,6 +3639,12 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 2
+			path: app/Utils/LdapUtils.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: app/Utils/LdapUtils.php
 
@@ -33726,7 +33732,13 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 48
+			count: 49
+			path: tests/Feature/LdapIntegration.php
+
+		-
+			message: '#^Property App\\Models\\User\:\:\$email \(string\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
 			path: tests/Feature/LdapIntegration.php
 
 		-


### PR DESCRIPTION
Users who log in with LDAP are able to by synced to projects specifying an LDAP filter thanks to https://github.com/Kitware/CDash/pull/2282.  Unfortunately, users who are added via other authentication providers are not currently associated with an LDAP user and aren't able to be synced.  This PR resolves the issue by attempting to look up users by email (or other configured primary key) to get the associated LDAP GUID.