### PR TITLE
Change `assertJson()` to `assertExactJson()`

### DIFF
--- a/tests/Feature/GraphQL/BuildCommandOutputTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandOutputTypeTest.php
@@ -78,7 +78,7 @@ class BuildCommandOutputTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'commands' => [

--- a/tests/Feature/GraphQL/BuildCommandTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandTypeTest.php
@@ -78,7 +78,7 @@ class BuildCommandTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'commands' => [
@@ -160,7 +160,7 @@ class BuildCommandTypeTest extends TestCase
         ', [
             'id' => $build->id,
             'type' => $type,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'commands' => [
@@ -232,7 +232,7 @@ class BuildCommandTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'commands' => [

--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -112,7 +112,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -151,7 +151,7 @@ class BuildTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testNoBasicWarningsOrBasicErrorsReturnsEmptyArray(): void
@@ -189,7 +189,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -261,7 +261,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -344,7 +344,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -434,7 +434,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -501,7 +501,7 @@ class BuildTypeTest extends TestCase
         ', [
             'projectid' => $this->project->id,
             'buildname' => $builds[2]->name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -522,7 +522,7 @@ class BuildTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testTopLevelBuildField(): void
@@ -546,10 +546,10 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build1->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
-                    'id' => $build1->id,
+                    'id' => (string) $build1->id,
                     'name' => 'build1',
                 ],
             ],
@@ -568,7 +568,7 @@ class BuildTypeTest extends TestCase
             'data' => [
                 'build' => null,
             ],
-        ]);
+        ], true)->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testLabelRelationship(): void
@@ -597,7 +597,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'labels' => [
@@ -653,7 +653,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'labels' => [
@@ -704,7 +704,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [
@@ -756,7 +756,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'commands' => [
@@ -797,7 +797,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'id' => (string) $build->id,
@@ -846,7 +846,7 @@ class BuildTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'id' => (string) $build->id,
@@ -918,7 +918,7 @@ class BuildTypeTest extends TestCase
         ', [
             'id' => $build->id,
             'childid' => $child2->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'id' => (string) $build->id,

--- a/tests/Feature/GraphQL/CoverageTypeTest.php
+++ b/tests/Feature/GraphQL/CoverageTypeTest.php
@@ -97,7 +97,7 @@ class CoverageTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -125,7 +125,7 @@ class CoverageTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testLabelRelationship(): void
@@ -173,7 +173,7 @@ class CoverageTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -203,6 +203,6 @@ class CoverageTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -102,13 +102,13 @@ class FilterTest extends TestCase
                     }
                 }
             }
-        ")->assertJson([
+        ")->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => $expected_edges,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testEqualOperator(): void
@@ -159,6 +159,8 @@ class FilterTest extends TestCase
             'public1',
             'public2',
             'public3',
+            'private1',
+            'private2',
         ]);
     }
 
@@ -288,7 +290,7 @@ class FilterTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -307,7 +309,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAttributeNotInQuery(): void
@@ -326,7 +328,7 @@ class FilterTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -343,7 +345,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testNestedFilters(): void
@@ -440,7 +442,7 @@ class FilterTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -487,7 +489,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testProhibitsMultipleFieldsInSingleFilterObject(): void
@@ -546,7 +548,7 @@ class FilterTest extends TestCase
             }
         ', [
             'uuid' => $build1uuid,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -558,7 +560,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByRelationshipAndRegularField(): void
@@ -604,7 +606,7 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'projectname' => $this->projects['public2']->name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -621,7 +623,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAnyMultipleFieldsInRelationship(): void
@@ -669,7 +671,7 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'buildname' => $build2name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -686,7 +688,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAllMultipleFieldsInRelationshipNoneIfNotOnSameRecord(): void
@@ -734,13 +736,13 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'buildname' => $build2name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAllMultipleFieldsInRelationshipReturnsIfConditionsOnSameRecord(): void
@@ -788,7 +790,7 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'buildname' => $build1name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -800,7 +802,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAnyMultipleRelationships(): void
@@ -853,7 +855,7 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'siteid' => $this->sites['site1']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -870,7 +872,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByAllMultipleRelationships(): void
@@ -923,7 +925,7 @@ class FilterTest extends TestCase
         ', [
             'uuid' => $build1uuid,
             'siteid' => $this->sites['site1']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -935,7 +937,7 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testFilterByRelationshipsOfRelationships(): void
@@ -984,7 +986,7 @@ class FilterTest extends TestCase
             }
         ', [
             'targetname' => $target1name,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -996,6 +998,6 @@ class FilterTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/LabelTypeTest.php
+++ b/tests/Feature/GraphQL/LabelTypeTest.php
@@ -67,7 +67,7 @@ class LabelTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'labels' => [
@@ -121,7 +121,7 @@ class LabelTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'labels' => [
@@ -175,7 +175,7 @@ class LabelTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [

--- a/tests/Feature/GraphQL/Mutations/ChangeGlobalRoleTest.php
+++ b/tests/Feature/GraphQL/Mutations/ChangeGlobalRoleTest.php
@@ -55,7 +55,7 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['normal']->id,
             'role' => GlobalRole::ADMINISTRATOR,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => null,
@@ -64,7 +64,7 @@ class ChangeGlobalRoleTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($this->users['normal']->refresh()->admin);
 
@@ -84,7 +84,7 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['normal']->id,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => null,
@@ -93,7 +93,7 @@ class ChangeGlobalRoleTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertFalse($this->users['normal']->refresh()->admin);
     }
@@ -117,14 +117,14 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::ADMINISTRATOR,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => 'Insufficient permissions.',
                     'user' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertFalse($this->users['normal']->refresh()->admin);
     }
@@ -148,14 +148,14 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => 'Insufficient permissions.',
                     'user' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($this->users['admin']->refresh()->admin);
     }
@@ -177,14 +177,14 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => 123456789,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => 'Cannot change role for user which does not exist.',
                     'user' => null,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testAnonymousUserCannotChangeRole(): void
@@ -206,14 +206,14 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeGlobalRole' => [
                     'message' => 'Attempt to invite user when not signed in.',
                     'user' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($this->users['admin']->refresh()->admin);
     }

--- a/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
+++ b/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
@@ -94,7 +94,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::ADMINISTRATOR,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => null,
@@ -106,7 +106,7 @@ class ChangeProjectRoleTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->administrators()->pluck('id'));
@@ -141,7 +141,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::ADMINISTRATOR,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => null,
@@ -153,7 +153,7 @@ class ChangeProjectRoleTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->administrators()->pluck('id'));
@@ -188,7 +188,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectAdmin']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'This action is unauthorized.',
@@ -196,7 +196,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -231,7 +231,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::ADMINISTRATOR,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'This action is unauthorized.',
@@ -239,7 +239,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -274,7 +274,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['admin']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'This action is unauthorized.',
@@ -282,7 +282,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -317,7 +317,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['nonmemberUser']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'This action is unauthorized.',
@@ -325,7 +325,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -360,7 +360,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => 12345678,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'Cannot change role for user which does not exist.',
@@ -368,7 +368,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -403,7 +403,7 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => 12345678,
             'role' => ProjectRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'changeProjectRole' => [
                     'message' => 'This action is unauthorized.',
@@ -411,7 +411,7 @@ class ChangeProjectRoleTest extends TestCase
                     'project' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));

--- a/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
@@ -93,7 +93,7 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => $role,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => null,
@@ -106,7 +106,7 @@ class CreateGlobalInvitationTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, GlobalInvitation::all());
         Mail::assertQueued(InvitedToCdash::class);
@@ -139,14 +139,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -179,14 +179,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'Attempt to invite user when not signed in.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -215,7 +215,7 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => null,
@@ -224,7 +224,7 @@ class CreateGlobalInvitationTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, GlobalInvitation::all());
         Mail::assertQueued(InvitedToCdash::class, 1);
@@ -244,14 +244,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'Duplicate invitations are not allowed.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, GlobalInvitation::all());
         Mail::assertQueued(InvitedToCdash::class, 1);
@@ -292,14 +292,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'The email must be a valid email address.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -326,14 +326,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $this->users['normal']->email,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'User is already a member of this instance.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -368,14 +368,14 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'createGlobalInvitation' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -94,7 +94,7 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => $role,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => null,
@@ -110,7 +110,7 @@ class InviteToProjectTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class);
@@ -139,14 +139,14 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -185,14 +185,14 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -233,7 +233,7 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => null,
@@ -242,7 +242,7 @@ class InviteToProjectTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class);
@@ -283,14 +283,14 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -317,14 +317,14 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => 1234567,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         Mail::assertNothingQueued();
     }
@@ -353,7 +353,7 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => null,
@@ -362,7 +362,7 @@ class InviteToProjectTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class, 1);
@@ -384,14 +384,14 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'Duplicate invitations are not allowed.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class, 1);
@@ -432,14 +432,14 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'The email must be a valid email address.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -475,14 +475,14 @@ class InviteToProjectTest extends TestCase
             'email' => $this->users['normal']->email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'User is already a member of this project.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -513,14 +513,14 @@ class InviteToProjectTest extends TestCase
             'email' => $this->users['normal']->email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => 'This action is unauthorized.',
                     'invitedUser' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -550,7 +550,7 @@ class InviteToProjectTest extends TestCase
             'email' => $this->users['normal']->email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'inviteToProject' => [
                     'message' => null,
@@ -559,7 +559,7 @@ class InviteToProjectTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class);

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -83,13 +83,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertNotProjectMember($userToDelete);
     }
@@ -113,13 +113,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertProjectMember($userToDelete);
     }
@@ -142,13 +142,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertProjectMember($userToDelete);
     }
@@ -172,13 +172,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertNotProjectMember($userToDelete);
     }
@@ -201,13 +201,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $projectAdmin->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertNotProjectMember($projectAdmin);
     }
@@ -231,13 +231,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertProjectMember($userToDelete);
     }
@@ -261,13 +261,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $this->users['normal']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($this->users['normal']->refresh()->exists());
     }
@@ -288,13 +288,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => 123456789,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testHandlesMissingProject(): void
@@ -314,13 +314,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => 123456789,
             'userId' => $this->users['normal']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testCannotDeleteProjectMembersIfManagedByLdap(): void
@@ -346,13 +346,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertProjectMember($userToDelete);
     }
@@ -378,13 +378,13 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeProjectUser' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         $this->assertNotProjectMember($userToDelete);
     }

--- a/tests/Feature/GraphQL/Mutations/RemoveUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveUserTest.php
@@ -48,13 +48,13 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['normal']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeUser' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
         self::assertNotContains($this->users['normal']->id, User::pluck('id'));
     }
 
@@ -71,13 +71,13 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
         self::assertContains($this->users['normal']->id, User::pluck('id'));
     }
 
@@ -94,13 +94,13 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
         self::assertContains($this->users['admin']->id, User::pluck('id'));
     }
 
@@ -117,13 +117,13 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeUser' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
         self::assertContains($this->users['admin']->id, User::pluck('id'));
     }
 
@@ -139,12 +139,12 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => 123456789,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'removeUser' => [
                     'message' => 'User does not exist.',
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
@@ -73,13 +73,13 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeGlobalInvitation' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertNull(GlobalInvitation::find($invitation->id));
     }
@@ -107,13 +107,13 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeGlobalInvitation' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($invitation->refresh()->exists());
     }
@@ -141,13 +141,13 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeGlobalInvitation' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertTrue($invitation->refresh()->exists());
     }
@@ -164,12 +164,12 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => 1234567,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeGlobalInvitation' => [
                     'message' => 'Invitation does not exist.',
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
@@ -69,13 +69,13 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -102,13 +102,13 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -135,13 +135,13 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -178,13 +178,13 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => 'This action is unauthorized.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -221,13 +221,13 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -244,12 +244,12 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => 1234567,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'revokeProjectInvitation' => [
                     'message' => 'Invitation does not exist.',
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
@@ -54,14 +54,14 @@ class UpdateSiteDescriptionTest extends TestCase
         ', [
             'siteid' => 123456789,
             'description' => Str::uuid()->toString(),
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'updateSiteDescription' => [
                     'site' => null,
                     'message' => 'Requested site not found.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->site->information()->get());
     }
@@ -85,14 +85,14 @@ class UpdateSiteDescriptionTest extends TestCase
         ', [
             'siteid' => $this->site->id,
             'description' => Str::uuid()->toString(),
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'updateSiteDescription' => [
                     'site' => null,
                     'message' => 'Authentication required to edit site descriptions.',
                 ],
             ],
-        ], true);
+        ]);
 
         self::assertEmpty($this->site->information()->get());
     }
@@ -127,7 +127,7 @@ class UpdateSiteDescriptionTest extends TestCase
         ', [
             'siteid' => $this->site->id,
             'description' => $new_description,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'updateSiteDescription' => [
                     'site' => [
@@ -141,7 +141,7 @@ class UpdateSiteDescriptionTest extends TestCase
                     'message' => null,
                 ],
             ],
-        ], true);
+        ]);
 
         $site_information = $this->site->information()->get();
         self::assertCount(2, $site_information);

--- a/tests/Feature/GraphQL/NoteTypeTest.php
+++ b/tests/Feature/GraphQL/NoteTypeTest.php
@@ -115,7 +115,7 @@ class NoteTypeTest extends TestCase
             }
         ', [
             'id' => $this->public_project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -147,6 +147,6 @@ class NoteTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -205,7 +205,7 @@ class ProjectTypeTest extends TestCase
                         }
                     }
                 }
-            ')->assertJson($expected_json_response, true);
+            ')->assertExactJson($expected_json_response);
     }
 
     #[DataProvider('perProjectAccess')]
@@ -223,19 +223,19 @@ class ProjectTypeTest extends TestCase
             ]);
 
         if ($allow_access) {
-            $response->assertJson([
+            $response->assertExactJson([
                 'data' => [
                     'project' => [
                         'name' => $this->projects[$project_name]->name,
                     ],
                 ],
-            ], true);
+            ]);
         } else {
-            $response->assertJson([
+            $response->assertExactJson([
                 'data' => [
                     'project' => null,
                 ],
-            ], true);
+            ]);
         }
     }
 
@@ -284,7 +284,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -334,7 +334,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testCreateProjectNoUser(): void
@@ -441,14 +441,14 @@ class ProjectTypeTest extends TestCase
 
         $project = Project::where('name', $name)->firstOrFail();
 
-        $response->assertJson([
+        $response->assertExactJson([
             'data' => [
                 'createProject' => [
                     'id' => (string) $project->id,
                     'name' => $name,
                 ],
             ],
-        ], true);
+        ]);
 
         $project->delete();
     }
@@ -475,14 +475,14 @@ class ProjectTypeTest extends TestCase
 
         $project = Project::where('name', $name)->firstOrFail();
 
-        $response->assertJson([
+        $response->assertExactJson([
             'data' => [
                 'createProject' => [
                     'id' => (string) $project->id,
                     'name' => $name,
                 ],
             ],
-        ], true);
+        ]);
 
         $project->delete();
     }
@@ -506,7 +506,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -532,13 +532,15 @@ class ProjectTypeTest extends TestCase
                         [
                             'node' => [
                                 'name' => $this->projects['public2']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testGetProjectAdministratorsAsNormalUser(): void
@@ -560,7 +562,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -586,25 +588,33 @@ class ProjectTypeTest extends TestCase
                         [
                             'node' => [
                                 'name' => $this->projects['public2']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['protected1']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['protected2']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['private1']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
@@ -624,7 +634,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testGetProjectAdministratorsAsAdmin(): void
@@ -646,7 +656,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -672,25 +682,33 @@ class ProjectTypeTest extends TestCase
                         [
                             'node' => [
                                 'name' => $this->projects['public2']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['protected1']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['protected2']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['private1']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
@@ -710,13 +728,15 @@ class ProjectTypeTest extends TestCase
                         [
                             'node' => [
                                 'name' => $this->projects['private3']->name,
-                                'administrators' => [],
+                                'administrators' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testGetProjectUsersAsAdmin(): void
@@ -738,26 +758,32 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
                         [
                             'node' => [
                                 'name' => $this->projects['public1']->name,
-                                'basicUsers' => [],
+                                'basicUsers' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['public2']->name,
-                                'basicUsers' => [],
+                                'basicUsers' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['protected1']->name,
-                                'basicUsers' => [],
+                                'basicUsers' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
@@ -791,19 +817,23 @@ class ProjectTypeTest extends TestCase
                         [
                             'node' => [
                                 'name' => $this->projects['private2']->name,
-                                'basicUsers' => [],
+                                'basicUsers' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                         [
                             'node' => [
                                 'name' => $this->projects['private3']->name,
-                                'basicUsers' => [],
+                                'basicUsers' => [
+                                    'edges' => [],
+                                ],
                             ],
                         ],
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testProjectVisibilityValue(): void
@@ -819,7 +849,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -868,7 +898,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     /**
@@ -930,13 +960,13 @@ class ProjectTypeTest extends TestCase
 
         if ($can_create) {
             $project = Project::where('name', $name)->firstOrFail();
-            $response->assertJson([
+            $response->assertExactJson([
                 'data' => [
                     'createProject' => [
                         'visibility' => $visibility,
                     ],
                 ],
-            ], true);
+            ]);
             $project->delete();
         } else {
             // A final check to ensure this project wasn't created anyway
@@ -1001,13 +1031,13 @@ class ProjectTypeTest extends TestCase
 
         if ($result) {
             $project = Project::where('name', $name)->firstOrFail();
-            $response->assertJson([
+            $response->assertExactJson([
                 'data' => [
                     'createProject' => [
                         'authenticateSubmissions' => $use_authenticated_submits,
                     ],
                 ],
-            ], true);
+            ]);
             $project->delete();
         } else {
             // A final check to ensure this project wasn't created anyway
@@ -1039,7 +1069,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -1056,7 +1086,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testMostRecentBuild(): void
@@ -1091,7 +1121,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -1112,7 +1142,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testBuildCountFieldWithNoFilters(): void
@@ -1156,7 +1186,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -1175,7 +1205,7 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testBuildCountFieldWithFilters(): void
@@ -1223,7 +1253,7 @@ class ProjectTypeTest extends TestCase
                     }
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'projects' => [
                     'edges' => [
@@ -1242,6 +1272,6 @@ class ProjectTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/QueryTypeTest.php
+++ b/tests/Feature/GraphQL/QueryTypeTest.php
@@ -34,13 +34,13 @@ class QueryTypeTest extends TestCase
                     id
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'me' => [
                     'id' => (string) $user->id,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testMeFieldWhenSignedOut(): void
@@ -51,11 +51,11 @@ class QueryTypeTest extends TestCase
                     id
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'me' => null,
             ],
-        ], true);
+        ]);
     }
 
     public function testUserFieldInvalidUser(): void
@@ -68,11 +68,11 @@ class QueryTypeTest extends TestCase
                     id
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'user' => null,
             ],
-        ], true);
+        ]);
     }
 
     public function testUserFieldValidUser(): void
@@ -90,13 +90,13 @@ class QueryTypeTest extends TestCase
             }
         ', [
             'userid' => $user->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'user' => [
                     'id' => (string) $user->id,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testUsersFieldBasicAccess(): void
@@ -132,7 +132,7 @@ class QueryTypeTest extends TestCase
         ', [
             'user1' => $user1->id,
             'user2' => $user2->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'users' => [
                     'edges' => [
@@ -149,6 +149,6 @@ class QueryTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/TargetTypeTest.php
+++ b/tests/Feature/GraphQL/TargetTypeTest.php
@@ -79,7 +79,7 @@ class TargetTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [
@@ -129,7 +129,7 @@ class TargetTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [
@@ -199,7 +199,7 @@ class TargetTypeTest extends TestCase
         ', [
             'id' => $build->id,
             'type' => $type,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [
@@ -271,7 +271,7 @@ class TargetTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'targets' => [

--- a/tests/Feature/GraphQL/TestMeasurementTypeTest.php
+++ b/tests/Feature/GraphQL/TestMeasurementTypeTest.php
@@ -101,7 +101,7 @@ class TestMeasurementTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -142,6 +142,6 @@ class TestMeasurementTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -87,7 +87,7 @@ class TestTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -113,7 +113,7 @@ class TestTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     /**
@@ -164,7 +164,7 @@ class TestTypeTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'project' => [
                     'builds' => [
@@ -188,7 +188,7 @@ class TestTypeTest extends TestCase
                     ],
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testLabelRelationship(): void
@@ -226,7 +226,7 @@ class TestTypeTest extends TestCase
             }
         ', [
             'id' => $build->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'tests' => [
@@ -237,7 +237,7 @@ class TestTypeTest extends TestCase
                                         'edges' => [
                                             [
                                                 'node' => [
-                                                    'id' => $label->id,
+                                                    'id' => (string) $label->id,
                                                     'text' => $label->text,
                                                 ],
                                             ],
@@ -301,7 +301,7 @@ class TestTypeTest extends TestCase
         ', [
             'id' => $build->id,
             'labeltext' => $label1->text,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'build' => [
                     'tests' => [

--- a/tests/Feature/GraphQL/UserTypeTest.php
+++ b/tests/Feature/GraphQL/UserTypeTest.php
@@ -42,7 +42,7 @@ class UserTypeTest extends TestCase
                     admin
                 }
             }
-        ')->assertJson([
+        ')->assertExactJson([
             'data' => [
                 'me' => [
                     'id' => (string) $this->normalUser->id,
@@ -53,7 +53,7 @@ class UserTypeTest extends TestCase
                     'admin' => $this->normalUser->admin,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testCanSeeOwnEmail(): void
@@ -67,14 +67,14 @@ class UserTypeTest extends TestCase
             }
         ', [
             'userid' => $this->normalUser->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'user' => [
                     'id' => (string) $this->normalUser->id,
                     'email' => $this->normalUser->email,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testCannotSeeEmailForOtherUsers(): void
@@ -88,14 +88,14 @@ class UserTypeTest extends TestCase
             }
         ', [
             'userid' => $this->adminUser->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'user' => [
                     'id' => (string) $this->adminUser->id,
                     'email' => null,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testAnonUsersCannotSeeEmails(): void
@@ -109,14 +109,14 @@ class UserTypeTest extends TestCase
             }
         ', [
             'userid' => $this->normalUser->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'user' => [
                     'id' => (string) $this->normalUser->id,
                     'email' => null,
                 ],
             ],
-        ], true);
+        ]);
     }
 
     public function testAdminCanSeeAllEmails(): void
@@ -130,13 +130,13 @@ class UserTypeTest extends TestCase
             }
         ', [
             'userid' => $this->normalUser->id,
-        ])->assertJson([
+        ])->assertExactJson([
             'data' => [
                 'user' => [
                     'id' => (string) $this->normalUser->id,
                     'email' => $this->normalUser->email,
                 ],
             ],
-        ], true);
+        ]);
     }
 }

--- a/tests/Feature/LdapIntegration.php
+++ b/tests/Feature/LdapIntegration.php
@@ -285,19 +285,19 @@ class LdapIntegration extends TestCase
         ]);
 
         if ($should_access) {
-            $result->assertJson([
+            $result->assertExactJson([
                 'data' => [
                     'project' => [
                         'name' => $project->name,
                     ],
                 ],
-            ], true);
+            ]);
         } else {
-            $result->assertJson([
+            $result->assertExactJson([
                 'data' => [
                     'project' => null,
                 ],
-            ], true);
+            ]);
         }
 
         $this->get('/logout')->assertRedirect('/');

--- a/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
+++ b/tests/Feature/Submission/Instrumentation/BuildInstrumentationTest.php
@@ -247,6 +247,6 @@ class BuildInstrumentationTest extends TestCase
             }
         ', [
             'id' => $this->project->id,
-        ])->assertJson($expected_result_json, true);
+        ])->assertExactJson($expected_result_json);
     }
 }


### PR DESCRIPTION
`assertJson()` with strict mode turned on (second parameter = `true`) doesn't actually perform an exact match against the expected array structure.  This has caused problems in the past with tests not catching errors they should have caught.  This PR converts most of our `assertJson()` to `assertExactJson()`, which performs a true exact match between the array structures provided.