### PR TITLE
Move submission handlers to PSR-4-compliant paths

### DIFF
--- a/app/Http/Controllers/RemoteProcessingController.php
+++ b/app/Http/Controllers/RemoteProcessingController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Submission\Handlers\RetryHandler;
 use App\Jobs\ProcessSubmission;
 use CDash\Model\PendingSubmissions;
 use Exception;
 use Illuminate\Support\Facades\Storage;
-use RetryHandler;
 use Symfony\Component\HttpFoundation\Response;
 
 final class RemoteProcessingController extends AbstractController

--- a/app/Http/Submission/Handlers/AbstractSubmissionHandler.php
+++ b/app/Http/Submission/Handlers/AbstractSubmissionHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 use CDash\Model\Build;
 use CDash\Model\Project;
 

--- a/app/Http/Submission/Handlers/AbstractXmlHandler.php
+++ b/app/Http/Submission/Handlers/AbstractXmlHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -20,6 +22,7 @@ use App\Utils\Stack;
 use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\ServiceContainer;
+use DOMDocument;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\UnableToReadFile;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;

--- a/app/Http/Submission/Handlers/ActionableBuildInterface.php
+++ b/app/Http/Submission/Handlers/ActionableBuildInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 use App\Models\Site;
 use CDash\Collection\BuildCollection;
 use CDash\Collection\SubscriptionBuilderCollection;

--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -25,6 +27,7 @@ use CDash\Model\BuildError;
 use CDash\Model\BuildErrorFilter;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use stdClass;
 
 class BazelJSONHandler extends AbstractSubmissionHandler
 {

--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -44,6 +46,7 @@ use CDash\Model\Project;
 use CDash\Model\SubscriberInterface;
 use CDash\Submission\CommitAuthorHandlerInterface;
 use CDash\Submission\CommitAuthorHandlerTrait;
+use Exception;
 
 class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {

--- a/app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
+++ b/app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -18,6 +20,7 @@
 use CDash\Model\Build;
 use CDash\Model\BuildProperties;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 
 class BuildPropertiesJSONHandler extends AbstractSubmissionHandler
 {

--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/CoverageHandler.php
+++ b/app/Http/Submission/Handlers/CoverageHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/CoverageJUnitHandler.php
+++ b/app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/DoneHandler.php
+++ b/app/Http/Submission/Handlers/DoneHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+++ b/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/GcovTarHandler.php
+++ b/app/Http/Submission/Handlers/GcovTarHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -24,6 +26,10 @@ use CDash\Model\CoverageSummary;
 use CDash\Model\Label;
 use CDash\Model\SubProject;
 use League\Flysystem\UnableToReadFile;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileObject;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class GcovTarHandler extends AbstractSubmissionHandler

--- a/app/Http/Submission/Handlers/JSCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/JSCoverTarHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -22,6 +24,9 @@ use CDash\Model\CoverageFileLog;
 use CDash\Model\CoverageSummary;
 use Illuminate\Support\Facades\DB;
 use League\Flysystem\UnableToReadFile;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class JSCoverTarHandler extends AbstractSubmissionHandler

--- a/app/Http/Submission/Handlers/JavaJSONTarHandler.php
+++ b/app/Http/Submission/Handlers/JavaJSONTarHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -22,6 +24,9 @@ use CDash\Model\CoverageFileLog;
 use CDash\Model\CoverageSummary;
 use Illuminate\Support\Facades\DB;
 use League\Flysystem\UnableToReadFile;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class JavaJSONTarHandler extends AbstractSubmissionHandler

--- a/app/Http/Submission/Handlers/NoteHandler.php
+++ b/app/Http/Submission/Handlers/NoteHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -21,6 +23,7 @@ use App\Models\SiteInformation;
 use App\Utils\NoteCreator;
 use App\Utils\SubmissionUtils;
 use CDash\Model\Project;
+use Illuminate\Support\Facades\Log;
 
 class NoteHandler extends AbstractXmlHandler
 {

--- a/app/Http/Submission/Handlers/OpenCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/OpenCoverTarHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -21,6 +23,9 @@ use CDash\Model\CoverageFile;
 use CDash\Model\CoverageFileLog;
 use CDash\Model\CoverageSummary;
 use League\Flysystem\UnableToReadFile;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class OpenCoverTarHandler extends AbstractXmlHandler

--- a/app/Http/Submission/Handlers/ProjectHandler.php
+++ b/app/Http/Submission/Handlers/ProjectHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/RetryHandler.php
+++ b/app/Http/Submission/Handlers/RetryHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -14,6 +16,8 @@
   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
+
+use Illuminate\Support\Facades\Storage;
 
 /** Because this class uses SimpleXML it is only suitable for use with small
  * XML files that can fit into memory.

--- a/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+++ b/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -19,6 +21,7 @@ use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\Model\SubProject;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 
 class SubProjectDirectoriesHandler extends AbstractSubmissionHandler
 {

--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;

--- a/app/Http/Submission/Handlers/TestingJUnitHandler.php
+++ b/app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Http/Submission/Handlers/UpdateHandler.php
+++ b/app/Http/Submission/Handlers/UpdateHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$
@@ -32,6 +34,7 @@ use CDash\Model\Project;
 use CDash\Model\Repository;
 use CDash\Model\SubscriberInterface;
 use CDash\Submission\CommitAuthorHandlerInterface;
+use Exception;
 
 /** Write the updates in one block
  *  In case of a lot of updates this might take up some memory */

--- a/app/Http/Submission/Handlers/UploadHandler.php
+++ b/app/Http/Submission/Handlers/UploadHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Http\Submission\Handlers;
+
 /*=========================================================================
   Program:   CDash - Cross-Platform Dashboard System
   Module:    $Id$

--- a/app/Utils/SubmissionUtils.php
+++ b/app/Utils/SubmissionUtils.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace App\Utils;
 
 use App\Exceptions\BadSubmissionException;
-use BuildHandler;
+use App\Http\Submission\Handlers\BuildHandler;
+use App\Http\Submission\Handlers\ConfigureHandler;
+use App\Http\Submission\Handlers\CoverageHandler;
+use App\Http\Submission\Handlers\CoverageJUnitHandler;
+use App\Http\Submission\Handlers\CoverageLogHandler;
+use App\Http\Submission\Handlers\DoneHandler;
+use App\Http\Submission\Handlers\DynamicAnalysisHandler;
+use App\Http\Submission\Handlers\NoteHandler;
+use App\Http\Submission\Handlers\ProjectHandler;
+use App\Http\Submission\Handlers\TestingHandler;
+use App\Http\Submission\Handlers\TestingJUnitHandler;
+use App\Http\Submission\Handlers\UpdateHandler;
+use App\Http\Submission\Handlers\UploadHandler;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
-use ConfigureHandler;
-use CoverageHandler;
-use CoverageJUnitHandler;
-use CoverageLogHandler;
-use DoneHandler;
-use DynamicAnalysisHandler;
-use NoteHandler;
-use ProjectHandler;
-use TestingHandler;
-use TestingJUnitHandler;
-use UpdateHandler;
-use UploadHandler;
 
 class SubmissionUtils
 {
@@ -29,7 +29,7 @@ class SubmissionUtils
      *
      * @return array{
      *     file_handle: mixed,
-     *     xml_handler: 'BuildHandler'|'ConfigureHandler'|'CoverageHandler'|'CoverageJUnitHandler'|'CoverageLogHandler'|'DoneHandler'|'DynamicAnalysisHandler'|'NoteHandler'|'ProjectHandler'|'TestingHandler'|'TestingJUnitHandler'|'UpdateHandler'|'UploadHandler',
+     *     xml_handler: 'App\Http\Submission\Handlers\BuildHandler'|'App\Http\Submission\Handlers\ConfigureHandler'|'App\Http\Submission\Handlers\CoverageHandler'|'App\Http\Submission\Handlers\CoverageJUnitHandler'|'App\Http\Submission\Handlers\CoverageLogHandler'|'App\Http\Submission\Handlers\DoneHandler'|'App\Http\Submission\Handlers\DynamicAnalysisHandler'|'App\Http\Submission\Handlers\NoteHandler'|'App\Http\Submission\Handlers\ProjectHandler'|'App\Http\Submission\Handlers\TestingHandler'|'App\Http\Submission\Handlers\TestingJUnitHandler'|'App\Http\Submission\Handlers\UpdateHandler'|'App\Http\Submission\Handlers\UploadHandler',
      *     xml_type: 'Build'|'Configure'|'Coverage'|'CoverageJUnit'|'CoverageLog'|'Done'|'DynamicAnalysis'|'Notes'|'Project'|'Test'|'TestJUnit'|'Update'|'Upload',
      * }
      *

--- a/app/cdash/app/Model/Repository.php
+++ b/app/cdash/app/Model/Repository.php
@@ -17,7 +17,9 @@ namespace CDash\Model;
 
 use CDash\Database;
 use CDash\Lib\Repository\GitHub;
+use CDash\Lib\Repository\RepositoryInterface;
 use CDash\Service\RepositoryService;
+use Exception;
 use ReflectionClass;
 
 class Repository
@@ -99,7 +101,7 @@ class Repository
     {
         try {
             $repositoryInterface = self::getRepositoryInterface($project);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             report($e);
             return null;
         }
@@ -120,7 +122,7 @@ class Repository
             default:
                 $msg =
                     "No repository interface defined for $project->CvsViewerType";
-                throw new \Exception($msg);
+                throw new Exception($msg);
                 return;
         }
         return $service;

--- a/app/cdash/app/Model/Subscriber.php
+++ b/app/cdash/app/Model/Subscriber.php
@@ -17,7 +17,7 @@
 
 namespace CDash\Model;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\NotificationPreferences;
 use CDash\Messaging\Topic\Topic;

--- a/app/cdash/app/Model/SubscriberInterface.php
+++ b/app/cdash/app/Model/SubscriberInterface.php
@@ -17,7 +17,7 @@
 
 namespace CDash\Model;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 use CDash\Messaging\Preferences\NotificationPreferences;
 use CDash\Messaging\Preferences\NotificationPreferencesInterface;
 use CDash\Messaging\Topic\TopicCollection;

--- a/app/cdash/bootstrap/cdash_autoload.php
+++ b/app/cdash/bootstrap/cdash_autoload.php
@@ -6,7 +6,6 @@ function cdash_autoload($className)
     $inc_dir = "{$cdash_root}/include";
     $app_dir = "{$cdash_root}/app";
     $model_dir = "{$cdash_root}/models";
-    $xml_dir = "{$cdash_root}/xml_handlers";
     $filenames = null;
 
     if (str_contains($className, 'CDash\\')) {
@@ -16,9 +15,6 @@ function cdash_autoload($className)
         $loc2 = "{$app_dir}/{$loc2}.php";
 
         $filenames = [realpath($loc1), realpath($loc2)];
-    } elseif (str_ends_with($className, 'Handler') || str_contains($className, 'ActionableBuildInterface')) {
-        $name_parts = preg_split('/(?=[A-Z])/', $className);
-        $filenames = "{$xml_dir}/" . strtolower(implode('_', array_slice($name_parts, 1))) . '.php';
     } else {
         if (str_contains($className, '\\')) {
             $filenames = preg_replace('/\\\/', '/', $className);

--- a/app/cdash/include/Messaging/Subscription/CommitAuthorSubscriptionBuilder.php
+++ b/app/cdash/include/Messaging/Subscription/CommitAuthorSubscriptionBuilder.php
@@ -17,7 +17,7 @@
 
 namespace CDash\Messaging\Subscription;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Model\Subscriber;

--- a/app/cdash/include/Messaging/Subscription/SubscriptionBuilderInterface.php
+++ b/app/cdash/include/Messaging/Subscription/SubscriptionBuilderInterface.php
@@ -17,7 +17,7 @@
 
 namespace CDash\Messaging\Subscription;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 
 interface SubscriptionBuilderInterface
 {

--- a/app/cdash/include/Messaging/Subscription/UserSubscriptionBuilder.php
+++ b/app/cdash/include/Messaging/Subscription/UserSubscriptionBuilder.php
@@ -2,7 +2,7 @@
 
 namespace CDash\Messaging\Subscription;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 use CDash\Model\SubscriberInterface;
 
 class UserSubscriptionBuilder implements SubscriptionBuilderInterface

--- a/app/cdash/include/Submission/CommitAuthorHandlerInterface.php
+++ b/app/cdash/include/Submission/CommitAuthorHandlerInterface.php
@@ -2,7 +2,7 @@
 
 namespace CDash\Submission;
 
-use ActionableBuildInterface;
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 
 interface CommitAuthorHandlerInterface extends ActionableBuildInterface
 {

--- a/app/cdash/include/Test/UseCase/BuildUseCase.php
+++ b/app/cdash/include/Test/UseCase/BuildUseCase.php
@@ -2,8 +2,8 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
-use BuildHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
+use App\Http\Submission\Handlers\BuildHandler;
 use CDash\Model\Project;
 use DOMDocument;
 use DOMElement;

--- a/app/cdash/include/Test/UseCase/ConfigUseCase.php
+++ b/app/cdash/include/Test/UseCase/ConfigUseCase.php
@@ -2,9 +2,9 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
+use App\Http\Submission\Handlers\ConfigureHandler;
 use CDash\Model\Project;
-use ConfigureHandler;
 use DOMDocument;
 use DOMElement;
 use DOMText;

--- a/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
+++ b/app/cdash/include/Test/UseCase/DynamicAnalysisUseCase.php
@@ -17,13 +17,13 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
+use App\Http\Submission\Handlers\DynamicAnalysisHandler;
 use CDash\Model\Project;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
 use DOMText;
-use DynamicAnalysisHandler;
 use Exception;
 
 class DynamicAnalysisUseCase extends UseCase

--- a/app/cdash/include/Test/UseCase/TestUseCase.php
+++ b/app/cdash/include/Test/UseCase/TestUseCase.php
@@ -2,13 +2,13 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
+use App\Http\Submission\Handlers\TestingHandler;
 use CDash\Model\Project;
 use DOMDocument;
 use DOMElement;
 use DOMText;
 use Exception;
-use TestingHandler;
 
 class TestUseCase extends UseCase
 {

--- a/app/cdash/include/Test/UseCase/UpdateUseCase.php
+++ b/app/cdash/include/Test/UseCase/UpdateUseCase.php
@@ -2,13 +2,13 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
+use App\Http\Submission\Handlers\UpdateHandler;
 use CDash\Model\Project;
 use DOMDocument;
 use DOMElement;
 use DOMText;
 use Exception;
-use UpdateHandler;
 
 class UpdateUseCase extends UseCase
 {

--- a/app/cdash/include/Test/UseCase/UseCase.php
+++ b/app/cdash/include/Test/UseCase/UseCase.php
@@ -2,7 +2,7 @@
 
 namespace CDash\Test\UseCase;
 
-use AbstractXmlHandler;
+use App\Http\Submission\Handlers\AbstractXmlHandler;
 use CDash\Test\CDashUseCaseTestCase;
 use DOMDocument;
 use DOMElement;

--- a/app/cdash/tests/bootstrap.php
+++ b/app/cdash/tests/bootstrap.php
@@ -5,5 +5,4 @@ $cdash_root = str_replace('\\', '/', $cdash_root);
 set_include_path(get_include_path() . PATH_SEPARATOR . $cdash_root);
 
 // Require files that do not adhere to any naming convention below...
-require_once 'xml_handlers/actionable_build_interface.php';
 include_once dirname(__FILE__) . '/../bootstrap/cdash_autoload.php';

--- a/app/cdash/tests/case/CDash/BuildUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/BuildUseCaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Handlers\BuildHandler;
 use CDash\Collection\BuildCollection;
 use CDash\Model\Build;
 use CDash\Test\CDashUseCaseTestCase;

--- a/app/cdash/tests/case/CDash/ConfigUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/ConfigUseCaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Handlers\ConfigureHandler;
 use CDash\Model\BuildConfigure;
 use CDash\Test\CDashUseCaseTestCase;
 use CDash\Test\UseCase\ConfigUseCase;

--- a/app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/DynamicAnalysisUseCaseTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\DynamicAnalysisHandler;
 use CDash\Model\Build;
 use CDash\Model\DynamicAnalysis;
 use CDash\Test\CDashUseCaseTestCase;

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
@@ -15,6 +15,9 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\ActionableBuildInterface;
+use App\Http\Submission\Handlers\BuildHandler;
+use App\Http\Submission\Handlers\TestingHandler;
 use App\Models\Site;
 use CDash\Collection\BuildCollection;
 use CDash\Messaging\Subscription\CommitAuthorSubscriptionBuilder;

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -15,6 +15,8 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\ActionableBuildInterface;
+use App\Http\Submission\Handlers\BuildHandler;
 use App\Models\Site;
 use CDash\Collection\BuildCollection;
 use CDash\Collection\SubscriberCollection;

--- a/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+++ b/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\ActionableBuildInterface;
 use CDash\Collection\SubscriberCollection;
 use CDash\Database;
 use CDash\Messaging\Notification\Email\EmailBuilder;

--- a/app/cdash/tests/case/CDash/TestUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Handlers\TestingHandler;
 use CDash\Collection\BuildCollection;
 use CDash\Model\Build;
 use CDash\Test\CDashUseCaseTestCase;

--- a/app/cdash/tests/case/CDash/UpdateUseCaseTest.php
+++ b/app/cdash/tests/case/CDash/UpdateUseCaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Handlers\UpdateHandler;
 use CDash\Test\CDashUseCaseTestCase;
 use CDash\Test\UseCase\UpdateUseCase;
 use CDash\Test\UseCase\UseCase;

--- a/app/cdash/tests/case/CDash/XmlHandler/BuildHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/BuildHandlerTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\BuildHandler;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Messaging\Subscription\CommitAuthorSubscriptionBuilder;

--- a/app/cdash/tests/case/CDash/XmlHandler/ConfigureHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/ConfigureHandlerTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\ConfigureHandler;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Messaging\Subscription\UserSubscriptionBuilder;

--- a/app/cdash/tests/case/CDash/XmlHandler/DynamicAnalysisHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/DynamicAnalysisHandlerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Submission\Handlers\DynamicAnalysisHandler;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Messaging\Subscription\UserSubscriptionBuilder;

--- a/app/cdash/tests/case/CDash/XmlHandler/TestingHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/TestingHandlerTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\TestingHandler;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Messaging\Subscription\CommitAuthorSubscriptionBuilder;

--- a/app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
+++ b/app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
@@ -15,6 +15,7 @@
  * =========================================================================
  */
 
+use App\Http\Submission\Handlers\UpdateHandler;
 use CDash\Messaging\Notification\NotifyOn;
 use CDash\Messaging\Preferences\BitmaskNotificationPreferences;
 use CDash\Messaging\Subscription\CommitAuthorSubscriptionBuilder;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3115,31 +3115,3259 @@ parameters:
 			path: app/Http/Middleware/VerifyCsrfToken.php
 
 		-
-			message: '#^Access to an undefined property AbstractSubmissionHandler\|App\\Utils\\UnparsedSubmissionProcessor\:\:\$backupFileName\.$#'
+			message: '#^Class App\\Http\\Submission\\Handlers\\AbstractXmlHandler has an uninitialized property \$Site\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:getBuildName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:getElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:\$ModelFactory has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:\$SubProjectName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$details\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Binary operation "\.\=" between ''bazel '' and mixed results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Call to an undefined method App\\Models\\Project\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Project\>\:\:subprojects\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '''
+				#^Call to deprecated function pdo_execute\(\)\:
+				v2\.5\.0 01/22/2018$#
+			'''
+			identifier: function.deprecated
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '''
+				#^Call to deprecated method getPdo\(\) of class CDash\\Database\:
+				04/22/2023  Use Laravel query builder or Eloquent instead$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''command'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''id'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 9
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''label'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''name'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''path'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''pattern'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''progress'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''started'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''status'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''stdout'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''testResult'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset ''testSummary'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset 0 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot access offset int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Cannot call method fetch\(\) on PDOStatement\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 12
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Foreach overwrites \$line with its value variable\.$#'
+			identifier: foreach.valueOverwrite
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$buildid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$subproject_name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_status with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_time with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:GetSubProjectForPath\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:InitializeConfigure\(\) has parameter \$build with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:InitializeConfigure\(\) has parameter \$subproject_name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:InitializeSubProjectBuild\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:InitializeSubProjectBuild\(\) has parameter \$subproject_name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:IsTestName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:IsTestName\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:Parse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:ParseLine\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:ParseLine\(\) has parameter \$line with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:RecordError\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:RecordError\(\) has parameter \$build_error with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:RecordError\(\) has parameter \$subproject_name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:RecordError\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Only booleans are allowed in a negated boolean, int\|string given\.$#'
+			identifier: booleanNot.exprNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Only booleans are allowed in a while condition, mixed given\.$#'
+			identifier: while.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
+			identifier: if.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#1 \$filepath of static method App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:GetSubProjectForPath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#1 \$stmt of function pdo_execute expects PDOStatement, \(PDOStatement\|false\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strtolower expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 8
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#2 \$needle of function str_contains expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 7
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$BuildErrors has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$Builds has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$CommandLine has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$Configures type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$NumTestsFailed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$NumTestsNotRun has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$NumTestsPassed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$PDO has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$ParentBuild has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$ParseConfigure has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$RecordingTestOutput has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$RecordingTestSummary has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$TestName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$Tests has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BazelJSONHandler\:\:\$TestsOutput has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Variable \$source_file might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Variable \$type might not be defined\.$#'
+			identifier: variable.undefined
+			count: 4
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			message: '#^Binary operation "/" between mixed and 2 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Call to an undefined method object\:\:AddLabel\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Cannot access offset '''' on 0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\BuildHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 8
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 18
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:getBuildName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:removeSuppressedWarnings\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:removeSuppressedWarnings\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Parameter \#2 \$offset of function substr expects int, \(float\|int\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Parameter \#3 \$length of function substr expects int\|null, \(float\|int\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Part \$threshold \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildCommand has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildGroup has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildGroup is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$BuildStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$Builds has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$Error has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$ErrorSubProjectName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$Generator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$Labels has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$PullRequest has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\BuildHandler\:\:\$SubProjects has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Variable property access on mixed\.$#'
+			identifier: property.dynamicName
+			count: 12
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildPropertiesJSONHandler\:\:Parse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\BuildPropertiesJSONHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
+
+		-
+			message: '#^Property CDash\\Model\\BuildProperties\:\:\$Properties \(array\<mixed\>\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
+
+		-
+			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Cannot access an offset on array\|float\|int\|string\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\ConfigureHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 6
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 7
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:CreateBuild\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:getBuildName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
+			identifier: if.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$BuildName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$BuildStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$Builds has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$Configure has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$Generator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$Notified has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$PullRequest has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ConfigureHandler\:\:\$SubProjects has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Variable \$build might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 10
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$Coverage has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$CoverageFile has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$CoverageSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$Coverages has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 12
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:\$Coverage has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:\$CoverageFile has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$Id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Call to an undefined method object\:\:TrimLastNewline\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Call to an undefined method object\:\:Update\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Cannot access an offset on array\|float\|int\|string\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 4
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 6
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$CoverageFiles has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$CurrentCoverageFile has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$CurrentCoverageFileLog has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$CurrentLine has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\CoverageLogHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			message: '#^Cannot access property \$name on App\\Models\\Site\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 3
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:shouldRequeue\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DoneHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DoneHandler\:\:\$FinalAttempt has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DoneHandler\:\:\$PendingSubmissions has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DoneHandler\:\:\$Requeue has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DoneHandler\:\:\$backupFileName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$BuildName\.$#'
+			identifier: property.notFound
+			count: 5
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$BuildStamp\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$Generator\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$PullRequest\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Cannot access offset mixed on 0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler has an uninitialized property \$DynamicAnalysis\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 7
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 18
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:createBuild\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:createBuild\(\) has parameter \$subprojectName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:getBuildName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$Builds has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$Checker has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$DynamicAnalysisDefect has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$DynamicAnalysisSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$SubProjects has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\:\:\$TestSubProjectName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Cannot call method getPath\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Cannot call method isFile\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 5
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 3
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
+			identifier: missingType.checkedException
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseGcovFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseGcovFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseLabelsFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseLabelsFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, array\|string\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, array\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, array\|string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$offset of function substr expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, array\|string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$AggregateBuildId has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$BinaryDirectory has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$CoverageSummary has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$Labels has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$PreviousAggregateParentId has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$SourceDirectory has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\GcovTarHandler\:\:\$SubProjectSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/GcovTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:\$CoverageFileLogs\.$#'
+			identifier: property.notFound
+			count: 5
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:\$CoverageFiles\.$#'
+			identifier: property.notFound
+			count: 4
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:\$Coverages\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Foreach overwrites \$coverageSummary with its value variable\.$#'
+			identifier: foreach.valueOverwrite
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:ParseJSCoverFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:ParseJSCoverFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\JSCoverTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:ParseJavaJSONFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:ParseJavaJSONFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:ParsePackageMap\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:ParsePackageMap\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, \(list\<string\>\|string\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\NoteHandler\:\:\$Timestamp\.$#'
+			identifier: property.notFound
+			count: 6
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 4
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:getTimestampFromDateTimeElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:getTimestampFromDateTimeElement\(\) has parameter \$stamp with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:getTimestampFromDateTimeElement\(\) has parameter \$str with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\NoteHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, int given\.$#'
+			identifier: if.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Only numeric types are allowed in \-, int\|false given on the left side\.$#'
+			identifier: minus.leftNonNumeric
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Parameter \#1 \$datetime of function strtotime expects string, list\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, list\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, list\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, list\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, list\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 5
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\NoteHandler\:\:\$AdjustStartTime has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\NoteHandler\:\:\$NoteCreator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/NoteHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$CoverageFileLogs\.$#'
+			identifier: property.notFound
+			count: 5
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$CoverageFiles\.$#'
+			identifier: property.notFound
+			count: 4
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$Coverages\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$ParseCSFiles\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$coverageFile\.$#'
+			identifier: property.notFound
+			count: 4
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$coverageFileLog\.$#'
+			identifier: property.notFound
+			count: 5
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$currentModule\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$tarDir\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Binary operation "\." between non\-falsy\-string and list\<string\>\|string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Cannot call method getPath\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Foreach overwrites \$coverageSummary with its value variable\.$#'
+			identifier: foreach.valueOverwrite
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 6
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has parameter \$buildid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:getCoverageObjects\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:getCoverageObjects\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:parseFullName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:parseFullName\(\) has parameter \$string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:readSourceFile\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:readSourceFile\(\) has parameter \$buildid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:readSourceFile\(\) has parameter \$fileinfo with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Only booleans are allowed in &&, int\<0, max\> given on the right side\.$#'
+			identifier: booleanAnd.rightNotBoolean
+			count: 2
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
+			identifier: if.condNotBoolean
+			count: 3
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Only booleans are allowed in or, int\|false given on the left side\.$#'
+			identifier: logicalOr.leftNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Only booleans are allowed in or, int\|false given on the right side\.$#'
+			identifier: logicalOr.rightNotBoolean
+			count: 7
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Parameter \#2 \$data of function xml_parse expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 8
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\ProjectHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
+			identifier: if.condNotBoolean
+			count: 2
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$CurrentDependencies has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$Dependencies has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$ProjectNameMatches has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$SubProject has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$SubProjectPosition has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\ProjectHandler\:\:\$SubProjects has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			message: '#^SimpleXMLElement does not accept int\.$#'
+			identifier: offsetAssign.valueType
+			count: 1
+			path: app/Http/Submission/Handlers/RetryHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:Parse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has parameter \$closed_list with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has parameter \$open_list with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:\$SubProjectOrder has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+
+		-
+			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\TestingHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 5
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 25
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:createBuild\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:getBuildName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Only numeric types are allowed in \+, int\|false given on the right side\.$#'
+			identifier: plus.rightNonNumeric
+			count: 3
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$BuildName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$BuildStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$Generator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$Labels has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$NumberTestsFailed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$NumberTestsNotRun has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$NumberTestsPassed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$PullRequest has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$SubProjects has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$TestCreator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$TestMeasurement has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingHandler\:\:\$TestSubProjectName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$TestCreator\.$#'
+			identifier: property.notFound
+			count: 8
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 4
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 20
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:createBuild\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Only numeric types are allowed in \+, int\|false given on the left side\.$#'
+			identifier: plus.leftNonNumeric
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Only numeric types are allowed in \+, int\|false given on the right side\.$#'
+			identifier: plus.rightNonNumeric
+			count: 3
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Parameter \#1 \$hour of function mktime expects int, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Parameter \#2 \$minute of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Parameter \#5 \$day of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$BuildAdded has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$Group has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$HasSiteTag has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$NumberTestsFailed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$NumberTestsNotRun has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$NumberTestsPassed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$TestProperties has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$TotalTestDuration has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\TestingJUnitHandler\:\:\$UpdateEndTime has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 9
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 22
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UpdateHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UpdateHandler\:\:\$EndTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UpdateHandler\:\:\$StartTimeStamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UpdateHandler\:\:\$Update has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UpdateHandler\:\:\$UpdateFile has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			message: '#^Call to function base64_decode\(\) requires parameter \#2 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Class App\\Http\\Submission\\Handlers\\UploadHandler has an uninitialized property \$UploadFile\. Give it default value or assign it in the constructor\.$#'
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:text\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Method App\\Http\\Submission\\Handlers\\UploadHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Offset ''extension'' might not exist on array\{dirname\?\: string, basename\: string, extension\?\: string, filename\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Only booleans are allowed in a negated boolean, resource\|false given\.$#'
+			identifier: booleanNot.exprNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function feof expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fread expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fwrite expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#2 \$data of function fwrite expects string, \(list\<string\>\|string\) given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Parameter \#2 \$use_include_path of function file_get_contents expects bool, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$Base64TmpFileWriteHandle has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$Base64TmpFilename has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$Label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$TmpFilename has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$UploadError has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Models\\UploadFile\:\:\$filesize \(int\) does not accept int\<0, max\>\|false\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Property App\\Models\\UploadFile\:\:\$sha1sum \(string\) does not accept string\|false\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\AbstractSubmissionHandler\|App\\Utils\\UnparsedSubmissionProcessor\:\:\$backupFileName\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\BazelJSONHandler\|App\\Http\\Submission\\Handlers\\BuildPropertiesJSONHandler\|App\\Http\\Submission\\Handlers\\GcovTarHandler\|App\\Http\\Submission\\Handlers\\JavaJSONTarHandler\|App\\Http\\Submission\\Handlers\\JSCoverTarHandler\|App\\Http\\Submission\\Handlers\\OpenCoverTarHandler\|App\\Http\\Submission\\Handlers\\SubProjectDirectoriesHandler\:\:\$backupFileName\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\BuildHandler\|App\\Http\\Submission\\Handlers\\ConfigureHandler\|App\\Http\\Submission\\Handlers\\CoverageHandler\|App\\Http\\Submission\\Handlers\\CoverageJUnitHandler\|App\\Http\\Submission\\Handlers\\CoverageLogHandler\|App\\Http\\Submission\\Handlers\\DoneHandler\|App\\Http\\Submission\\Handlers\\DynamicAnalysisHandler\|App\\Http\\Submission\\Handlers\\NoteHandler\|App\\Http\\Submission\\Handlers\\ProjectHandler\|App\\Http\\Submission\\Handlers\\TestingHandler\|App\\Http\\Submission\\Handlers\\TestingJUnitHandler\|App\\Http\\Submission\\Handlers\\UpdateHandler\|App\\Http\\Submission\\Handlers\\UploadHandler\:\:\$backupFileName\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Jobs/ProcessSubmission.php
+
+		-
+			message: '#^Access to an undefined property App\\Http\\Submission\\Handlers\\UpdateHandler\:\:\$BuildId\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
 		-
 			message: '#^Access to an undefined property App\\Utils\\UnparsedSubmissionProcessor\:\:\$backupFileName\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			message: '#^Access to an undefined property BazelJSONHandler\|BuildPropertiesJSONHandler\|GcovTarHandler\|JavaJSONTarHandler\|JSCoverTarHandler\|OpenCoverTarHandler\|SubProjectDirectoriesHandler\:\:\$backupFileName\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			message: '#^Access to an undefined property BuildHandler\|ConfigureHandler\|CoverageHandler\|CoverageJUnitHandler\|CoverageLogHandler\|DoneHandler\|DynamicAnalysisHandler\|NoteHandler\|ProjectHandler\|TestingHandler\|TestingJUnitHandler\|UpdateHandler\|UploadHandler\:\:\$backupFileName\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			message: '#^Access to an undefined property UpdateHandler\:\:\$BuildId\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
@@ -10438,6 +13666,18 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
+			message: '#^Call to an undefined method CDash\\Lib\\Repository\\RepositoryInterface\:\:compareCommits\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/cdash/app/Model/Repository.php
+
+		-
+			message: '#^Call to an undefined method CDash\\Lib\\Repository\\RepositoryInterface\:\:createCheck\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/cdash/app/Model/Repository.php
+
+		-
 			message: '''
 				#^Call to deprecated method execute\(\) of class CDash\\Database\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
@@ -10465,18 +13705,6 @@ parameters:
 			path: app/cdash/app/Model/Repository.php
 
 		-
-			message: '#^Call to method compareCommits\(\) on an unknown class CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Call to method createCheck\(\) on an unknown class CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
 			message: '#^Cannot call method fetchColumn\(\) on PDOStatement\|false\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -10485,12 +13713,6 @@ parameters:
 		-
 			message: '#^Method CDash\\Model\\Repository\:\:compareCommits\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Method CDash\\Model\\Repository\:\:compareCommits\(\) throws checked exception CDash\\Model\\Exception but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
 			count: 1
 			path: app/cdash/app/Model/Repository.php
 
@@ -10507,32 +13729,8 @@ parameters:
 			path: app/cdash/app/Model/Repository.php
 
 		-
-			message: '#^Method CDash\\Model\\Repository\:\:createOrUpdateCheck\(\) throws checked exception CDash\\Model\\Exception but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Method CDash\\Model\\Repository\:\:getRepositoryInterface\(\) has invalid return type CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Method CDash\\Model\\Repository\:\:getRepositoryInterface\(\) should return CDash\\Model\\RepositoryInterface but returns CDash\\Lib\\Repository\\GitHub\.$#'
-			identifier: return.type
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
 			message: '#^Method CDash\\Model\\Repository\:\:getRepositoryService\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Method CDash\\Model\\Repository\:\:getRepositoryService\(\) throws checked exception CDash\\Model\\Exception but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
 			count: 1
 			path: app/cdash/app/Model/Repository.php
 
@@ -10551,18 +13749,6 @@ parameters:
 		-
 			message: '#^Method CDash\\Model\\Repository\:\:setStatus\(\) has parameter \$complete with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^PHPDoc tag @throws with type CDash\\Model\\Exception is not subtype of Throwable$#'
-			identifier: throws.notThrowable
-			count: 1
-			path: app/cdash/app/Model/Repository.php
-
-		-
-			message: '#^Parameter \#1 \$repository of class CDash\\Service\\RepositoryService constructor expects CDash\\Lib\\Repository\\RepositoryInterface, CDash\\Model\\RepositoryInterface given\.$#'
-			identifier: argument.type
 			count: 1
 			path: app/cdash/app/Model/Repository.php
 
@@ -11025,12 +14211,6 @@ parameters:
 		-
 			message: '#^Function cdash_autoload\(\) has parameter \$className with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/bootstrap/cdash_autoload.php
-
-		-
-			message: '#^Parameter \#1 \$array of function array_slice expects array, list\<string\>\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: app/cdash/bootstrap/cdash_autoload.php
 
@@ -11527,7 +14707,7 @@ parameters:
 			path: app/cdash/include/Messaging/Preferences/PreferencesInterface.php
 
 		-
-			message: '#^Call to an undefined method ActionableBuildInterface\:\:GetCommitAuthors\(\)\.$#'
+			message: '#^Call to an undefined method App\\Http\\Submission\\Handlers\\ActionableBuildInterface\:\:GetCommitAuthors\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/cdash/include/Messaging/Subscription/CommitAuthorSubscriptionBuilder.php
@@ -16261,7 +19441,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
-			message: '#^PHPDoc tag @var with type ActionableBuildInterface&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
+			message: '#^PHPDoc tag @var with type App\\Http\\Submission\\Handlers\\ActionableBuildInterface&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
@@ -17950,24 +21130,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/PendingSubmissionsTest.php
 
 		-
-			message: '#^Call to method getInstallationId\(\) on an unknown class CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
-
-		-
-			message: '#^Call to method getOwner\(\) on an unknown class CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
-
-		-
-			message: '#^Call to method getRepository\(\) on an unknown class CDash\\Model\\RepositoryInterface\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
-
-		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertEquals\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 3
@@ -17982,12 +21144,6 @@ parameters:
 		-
 			message: '#^Method RepositoryTest\:\:testGetRepositoryInterfaceReturnsGitHubService\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
-
-		-
-			message: '#^Method RepositoryTest\:\:testGetRepositoryInterfaceReturnsGitHubService\(\) throws checked exception CDash\\Model\\Exception but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/RepositoryTest.php
 
@@ -18097,7 +21253,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
 
 		-
-			message: '#^Parameter \#1 \$submission of class CDash\\Messaging\\Subscription\\UserSubscriptionBuilder constructor expects ActionableBuildInterface, AbstractXmlHandler given\.$#'
+			message: '#^Parameter \#1 \$submission of class CDash\\Messaging\\Subscription\\UserSubscriptionBuilder constructor expects App\\Http\\Submission\\Handlers\\ActionableBuildInterface, App\\Http\\Submission\\Handlers\\AbstractXmlHandler given\.$#'
 			identifier: argument.type
 			count: 1
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -18127,7 +21283,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
 
 		-
-			message: '#^Property MultipleSubprojectsEmailTest\:\:\$submission \(ActionableBuildInterface\) does not accept AbstractXmlHandler\.$#'
+			message: '#^Property MultipleSubprojectsEmailTest\:\:\$submission \(App\\Http\\Submission\\Handlers\\ActionableBuildInterface\) does not accept App\\Http\\Submission\\Handlers\\AbstractXmlHandler\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -18301,7 +21457,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
 
 		-
-			message: '#^Call to an undefined method AbstractXmlHandler\:\:GetBuildCollection\(\)\.$#'
+			message: '#^Call to an undefined method App\\Http\\Submission\\Handlers\\AbstractXmlHandler\:\:GetBuildCollection\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/TestUseCaseTest.php
@@ -18541,7 +21697,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/UpdateUseCaseTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and BuildHandler will always evaluate to true\.$#'
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and App\\Http\\Submission\\Handlers\\BuildHandler will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: app/cdash/tests/case/CDash/XmlHandler/BuildHandlerTest.php
@@ -18619,7 +21775,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/XmlHandler/DynamicAnalysisHandlerTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and TestingHandler will always evaluate to true\.$#'
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and App\\Http\\Submission\\Handlers\\TestingHandler will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: app/cdash/tests/case/CDash/XmlHandler/TestingHandlerTest.php
@@ -18655,7 +21811,7 @@ parameters:
 			path: app/cdash/tests/case/CDash/XmlHandler/TestingHandlerTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and UpdateHandler will always evaluate to true\.$#'
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Submission\\\\CommitAuthorHandlerInterface'' and App\\Http\\Submission\\Handlers\\UpdateHandler will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: app/cdash/tests/case/CDash/XmlHandler/UpdateHandlerTest.php
@@ -29933,3234 +33089,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: app/cdash/tests/trilinos_submission_test.php
-
-		-
-			message: '#^Access to an undefined property object\:\:\$details\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Binary operation "\.\=" between ''bazel '' and mixed results in an error\.$#'
-			identifier: assignOp.invalid
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Call to an undefined method App\\Models\\Project\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Project\>\:\:subprojects\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '''
-				#^Call to deprecated function pdo_execute\(\)\:
-				v2\.5\.0 01/22/2018$#
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '''
-				#^Call to deprecated method getPdo\(\) of class CDash\\Database\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''command'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''id'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 9
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''label'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''name'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''path'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''pattern'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''progress'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''started'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''status'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''stdout'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''testResult'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset ''testSummary'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot access offset int\<min, \-1\>\|int\<1, max\>\|non\-falsy\-string on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Cannot call method fetch\(\) on PDOStatement\|false\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 12
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Foreach overwrites \$line with its value variable\.$#'
-			identifier: foreach.valueOverwrite
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$buildid with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$subproject_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_status with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:CreateNewTest\(\) has parameter \$test_time with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:GetSubProjectForPath\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:InitializeConfigure\(\) has parameter \$build with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:InitializeConfigure\(\) has parameter \$subproject_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:InitializeSubProjectBuild\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:InitializeSubProjectBuild\(\) has parameter \$subproject_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:IsTestName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:IsTestName\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:Parse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:ParseLine\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:ParseLine\(\) has parameter \$line with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:RecordError\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:RecordError\(\) has parameter \$build_error with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:RecordError\(\) has parameter \$subproject_name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BazelJSONHandler\:\:RecordError\(\) has parameter \$type with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Only booleans are allowed in a negated boolean, int\|string given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Only booleans are allowed in a while condition, mixed given\.$#'
-			identifier: while.condNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#1 \$filepath of static method BazelJSONHandler\:\:GetSubProjectForPath\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#1 \$stmt of function pdo_execute expects PDOStatement, \(PDOStatement\|false\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function strtolower expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 8
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#2 \$needle of function str_contains expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 7
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$BuildErrors has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$Builds has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$CommandLine has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$Configures type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$NumTestsFailed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$NumTestsNotRun has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$NumTestsPassed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$PDO has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$ParentBuild has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$ParseConfigure has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$RecordingTestOutput has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$RecordingTestSummary has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$TestName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$Tests has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Property BazelJSONHandler\:\:\$TestsOutput has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Variable \$source_file might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Variable \$type might not be defined\.$#'
-			identifier: variable.undefined
-			count: 4
-			path: app/cdash/xml_handlers/BazelJSON_handler.php
-
-		-
-			message: '#^Method BuildPropertiesJSONHandler\:\:Parse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
-
-		-
-			message: '#^Method BuildPropertiesJSONHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
-
-		-
-			message: '#^Property CDash\\Model\\BuildProperties\:\:\$Properties \(array\<mixed\>\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/xml_handlers/BuildPropertiesJSON_handler.php
-
-		-
-			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Cannot call method getPath\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Cannot call method isFile\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
-			identifier: greater.alwaysTrue
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 5
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 3
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseGcovFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseGcovFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseLabelsFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseLabelsFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Method GcovTarHandler\:\:ParseUncoveredSourceFile\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$haystack of function str_contains expects string, array\|string\|false given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$haystack of function strpos expects string, array\|string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, array\|string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$offset of function substr expects int, int\<0, max\>\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, array\|string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$AggregateBuildId has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$BinaryDirectory has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$CoverageSummary has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$Labels has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$PreviousAggregateParentId has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$SourceDirectory has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Property GcovTarHandler\:\:\$SubProjectSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/GcovTar_handler.php
-
-		-
-			message: '#^Access to an undefined property JSCoverTarHandler\:\:\$CoverageFileLogs\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property JSCoverTarHandler\:\:\$CoverageFiles\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property JSCoverTarHandler\:\:\$Coverages\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Foreach overwrites \$coverageSummary with its value variable\.$#'
-			identifier: foreach.valueOverwrite
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Method JSCoverTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Method JSCoverTarHandler\:\:ParseJSCoverFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Method JSCoverTarHandler\:\:ParseJSCoverFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function trim expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Property JSCoverTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/JSCoverTar_handler.php
-
-		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Method JavaJSONTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Method JavaJSONTarHandler\:\:ParseJavaJSONFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Method JavaJSONTarHandler\:\:ParseJavaJSONFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Method JavaJSONTarHandler\:\:ParsePackageMap\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Method JavaJSONTarHandler\:\:ParsePackageMap\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, \(list\<string\>\|string\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Property JavaJSONTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/JavaJSONTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$CoverageFileLogs\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$CoverageFiles\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$Coverages\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$ParseCSFiles\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$coverageFile\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$coverageFileLog\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$currentModule\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Access to an undefined property OpenCoverTarHandler\:\:\$tarDir\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Binary operation "\." between non\-falsy\-string and list\<string\>\|string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Cannot call method getFilename\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Cannot call method getPath\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Foreach overwrites \$coverageSummary with its value variable\.$#'
-			identifier: foreach.valueOverwrite
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 6
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:Parse\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has parameter \$buildid with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:ParseOpenCoverFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:getCoverageObjects\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:getCoverageObjects\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:parseFullName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:parseFullName\(\) has parameter \$string with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:readSourceFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:readSourceFile\(\) has parameter \$buildid with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:readSourceFile\(\) has parameter \$fileinfo with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Method OpenCoverTarHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Only booleans are allowed in &&, int\<0, max\> given on the right side\.$#'
-			identifier: booleanAnd.rightNotBoolean
-			count: 2
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
-			identifier: if.condNotBoolean
-			count: 3
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Only booleans are allowed in or, int\|false given on the left side\.$#'
-			identifier: logicalOr.leftNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Only booleans are allowed in or, int\|false given on the right side\.$#'
-			identifier: logicalOr.rightNotBoolean
-			count: 7
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Parameter \#2 \$data of function xml_parse expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Property OpenCoverTarHandler\:\:\$CoverageSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/OpenCoverTar_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Method SubProjectDirectoriesHandler\:\:Parse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Method SubProjectDirectoriesHandler\:\:Parse\(\) has parameter \$filename with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Method SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Method SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has parameter \$closed_list with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Method SubProjectDirectoriesHandler\:\:ParseSubProjects\(\) has parameter \$open_list with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Property SubProjectDirectoriesHandler\:\:\$SubProjectOrder has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/SubProjectDirectories_handler.php
-
-		-
-			message: '#^Class AbstractXmlHandler has an uninitialized property \$Site\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:getBuildName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:getElement\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Method AbstractXmlHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Property AbstractXmlHandler\:\:\$ModelFactory has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Property AbstractXmlHandler\:\:\$SubProjectName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/abstract_xml_handler.php
-
-		-
-			message: '#^Binary operation "/" between mixed and 2 results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Call to an undefined method object\:\:AddLabel\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Cannot access offset '''' on 0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Class BuildHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 8
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 18
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:getBuildName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:removeSuppressedWarnings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:removeSuppressedWarnings\(\) has parameter \$input with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Method BuildHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Parameter \#2 \$offset of function substr expects int, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Parameter \#3 \$length of function substr expects int\|null, \(float\|int\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Part \$threshold \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildCommand has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildGroup has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildGroup is unused\.$#'
-			identifier: property.unused
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$BuildStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$Builds has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$Error has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$ErrorSubProjectName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$Generator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$Labels has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$PullRequest has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Property BuildHandler\:\:\$SubProjects has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Variable property access on mixed\.$#'
-			identifier: property.dynamicName
-			count: 12
-			path: app/cdash/xml_handlers/build_handler.php
-
-		-
-			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Cannot access an offset on array\|float\|int\|string\|false\|null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Class ConfigureHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 6
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 7
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:CreateBuild\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:getBuildName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Method ConfigureHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int\|false given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$BuildName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$BuildStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$Builds has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$Configure has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$Generator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$Notified has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$PullRequest has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Property ConfigureHandler\:\:\$SubProjects has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Variable \$build might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: app/cdash/xml_handlers/configure_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 10
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Method CoverageHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$Coverage has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$CoverageFile has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$CoverageSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$Coverages has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Property CoverageHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 12
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Method CoverageJUnitHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Property CoverageJUnitHandler\:\:\$Coverage has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Property CoverageJUnitHandler\:\:\$CoverageFile has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Property CoverageJUnitHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Property CoverageJUnitHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Property CoverageJUnitHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_junit_handler.php
-
-		-
-			message: '#^Access to an undefined property object\:\:\$Id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Call to an undefined method object\:\:TrimLastNewline\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Call to an undefined method object\:\:Update\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Cannot access an offset on array\|float\|int\|string\|false\|null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 4
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 6
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Method CoverageLogHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$CoverageFiles has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$CurrentCoverageFile has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$CurrentCoverageFileLog has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$CurrentLine has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Property CoverageLogHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/coverage_log_handler.php
-
-		-
-			message: '#^Cannot access property \$name on App\\Models\\Site\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 3
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:shouldRequeue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Method DoneHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Property DoneHandler\:\:\$FinalAttempt has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Property DoneHandler\:\:\$PendingSubmissions has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Property DoneHandler\:\:\$Requeue has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Property DoneHandler\:\:\$backupFileName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/done_handler.php
-
-		-
-			message: '#^Access to an undefined property DynamicAnalysisHandler\:\:\$BuildName\.$#'
-			identifier: property.notFound
-			count: 5
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Access to an undefined property DynamicAnalysisHandler\:\:\$BuildStamp\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Access to an undefined property DynamicAnalysisHandler\:\:\$Generator\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Access to an undefined property DynamicAnalysisHandler\:\:\$PullRequest\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Cannot access offset mixed on 0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Class DynamicAnalysisHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Class DynamicAnalysisHandler has an uninitialized property \$DynamicAnalysis\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 7
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 18
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:createBuild\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:createBuild\(\) has parameter \$subprojectName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:getBuildName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Method DynamicAnalysisHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$Builds has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$Checker has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$DynamicAnalysisDefect has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$DynamicAnalysisSummaries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$SubProjects has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Property DynamicAnalysisHandler\:\:\$TestSubProjectName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/dynamic_analysis_handler.php
-
-		-
-			message: '#^Access to an undefined property NoteHandler\:\:\$Timestamp\.$#'
-			identifier: property.notFound
-			count: 6
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 4
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:getTimestampFromDateTimeElement\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:getTimestampFromDateTimeElement\(\) has parameter \$stamp with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:getTimestampFromDateTimeElement\(\) has parameter \$str with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Method NoteHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, int given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Only numeric types are allowed in \-, int\|false given on the left side\.$#'
-			identifier: minus.leftNonNumeric
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Parameter \#1 \$datetime of function strtotime expects string, list\<string\>\|string given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Parameter \#1 \$haystack of function str_contains expects string, list\<string\>\|string given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Parameter \#1 \$haystack of function strpos expects string, list\<string\>\|string given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function strlen expects string, list\<string\>\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, list\<string\>\|string given\.$#'
-			identifier: argument.type
-			count: 5
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Property NoteHandler\:\:\$AdjustStartTime has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Property NoteHandler\:\:\$NoteCreator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/note_handler.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 8
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Method ProjectHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
-			identifier: if.condNotBoolean
-			count: 2
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$CurrentDependencies has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$Dependencies has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$ProjectNameMatches has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$SubProject has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$SubProjectPosition has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^Property ProjectHandler\:\:\$SubProjects has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/project_handler.php
-
-		-
-			message: '#^SimpleXMLElement does not accept int\.$#'
-			identifier: offsetAssign.valueType
-			count: 1
-			path: app/cdash/xml_handlers/retry_handler.php
-
-		-
-			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Class TestingHandler has an uninitialized property \$BuildInformation\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 5
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 25
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:createBuild\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:getBuildName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:getBuildStamp\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:getSubProjectName\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Method TestingHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Only numeric types are allowed in \+, int\|false given on the right side\.$#'
-			identifier: plus.rightNonNumeric
-			count: 3
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$BuildInformation type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$BuildName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$BuildStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$Generator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$Labels has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$NumberTestsFailed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$NumberTestsNotRun has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$NumberTestsPassed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$PullRequest has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$SubProjects has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$TestCreator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$TestMeasurement has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Property TestingHandler\:\:\$TestSubProjectName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_handler.php
-
-		-
-			message: '#^Access to an undefined property TestingJUnitHandler\:\:\$TestCreator\.$#'
-			identifier: property.notFound
-			count: 8
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 4
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 20
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:createBuild\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Method TestingJUnitHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Only numeric types are allowed in \+, int\|false given on the left side\.$#'
-			identifier: plus.leftNonNumeric
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Only numeric types are allowed in \+, int\|false given on the right side\.$#'
-			identifier: plus.rightNonNumeric
-			count: 3
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Parameter \#1 \$hour of function mktime expects int, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Parameter \#2 \$minute of function mktime expects int\|null, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Parameter \#4 \$month of function mktime expects int\|null, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Parameter \#5 \$day of function mktime expects int\|null, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Parameter \#6 \$year of function mktime expects int\|null, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$BuildAdded has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$Group has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$HasSiteTag has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$NumberTestsFailed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$NumberTestsNotRun has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$NumberTestsPassed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$TestProperties has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$TotalTestDuration has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Property TestingJUnitHandler\:\:\$UpdateEndTime has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/testing_j_unit_handler.php
-
-		-
-			message: '#^Call to an undefined method CDash\\Messaging\\Preferences\\NotificationPreferencesInterface\:\:get\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 9
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 22
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Method UpdateHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Property UpdateHandler\:\:\$EndTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Property UpdateHandler\:\:\$StartTimeStamp has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Property UpdateHandler\:\:\$Update has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Property UpdateHandler\:\:\$UpdateFile has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/update_handler.php
-
-		-
-			message: '#^Call to function base64_decode\(\) requires parameter \#2 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Class UploadHandler has an uninitialized property \$UploadFile\. Give it default value or assign it in the constructor\.$#'
-			identifier: property.uninitialized
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 2
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:endElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:endElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:startElement\(\) has parameter \$attributes with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:startElement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:startElement\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:text\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:text\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Method UploadHandler\:\:text\(\) has parameter \$parser with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Offset ''extension'' might not exist on array\{dirname\?\: string, basename\: string, extension\?\: string, filename\: string\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Only booleans are allowed in a negated boolean, resource\|false given\.$#'
-			identifier: booleanNot.exprNotBoolean
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$stream of function feof expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$stream of function fread expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$stream of function fwrite expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function base64_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#2 \$data of function fwrite expects string, \(list\<string\>\|string\) given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Parameter \#2 \$use_include_path of function file_get_contents expects bool, null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property App\\Models\\UploadFile\:\:\$filesize \(int\) does not accept int\<0, max\>\|false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property App\\Models\\UploadFile\:\:\$sha1sum \(string\) does not accept string\|false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property UploadHandler\:\:\$Base64TmpFileWriteHandle has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property UploadHandler\:\:\$Base64TmpFilename has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property UploadHandler\:\:\$Label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property UploadHandler\:\:\$TmpFilename has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
-
-		-
-			message: '#^Property UploadHandler\:\:\$UploadError has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/xml_handlers/upload_handler.php
 
 		-
 			message: '#^Parameter \#1 \$basePath of class Illuminate\\Foundation\\Application constructor expects string\|null, mixed given\.$#'


### PR DESCRIPTION
CDash currently uses a custom autoloader to integrate Laravel with the legacy portion of the codebase.  This means that Composer cannot generate classmaps for a significant portion of the codebase.  This PR moves all of the XML handlers to a PSR-4-compliant namespace and corresponding directory structure for better organization and performance.