### PR TITLE
Add common build info card to dynamic analysis page

### DIFF
--- a/app/Http/Controllers/DynamicAnalysisController.php
+++ b/app/Http/Controllers/DynamicAnalysisController.php
@@ -14,7 +14,7 @@ final class DynamicAnalysisController extends AbstractBuildController
     public function viewDynamicAnalysis(int $buildid): View
     {
         $this->setBuildById($buildid);
-        return $this->vue('view-dynamic-analysis', 'Dynamic Analysis', ['buildid' => $this->build->Id], false);
+        return $this->vue('view-dynamic-analysis', 'Dynamic Analysis', ['buildid' => $this->build->Id]);
     }
 
     public function viewDynamicAnalysisFile(): View

--- a/resources/js/vue/components/ViewDynamicAnalysis.vue
+++ b/resources/js/vue/components/ViewDynamicAnalysis.vue
@@ -3,26 +3,9 @@
     <p>{{ cdash.error }}</p>
   </section>
   <section v-else>
+    <BuildSummaryCard :build-id="buildid" />
+
     <loading-indicator :is-loading="loading">
-      <h3>Dynamic analysis started on {{ cdash.build.buildtime }}</h3>
-
-      <table border="0">
-        <tbody>
-          <tr>
-            <td align="right">
-              <b>Site Name:</b>
-            </td>
-            <td>{{ cdash.build.site }}</td>
-          </tr>
-          <tr>
-            <td align="right">
-              <b>Build Name:</b>
-            </td>
-            <td>{{ cdash.build.buildname }}</td>
-          </tr>
-        </tbody>
-      </table>
-
       <div class="buildgroup">
         <table
           cellspacing="0"
@@ -103,9 +86,11 @@
 <script>
 import ApiLoader from './shared/ApiLoader';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+
 export default {
   name: 'ViewDynamicAnalysis',
-  components: {LoadingIndicator},
+  components: {BuildSummaryCard, LoadingIndicator},
 
   props: {
     buildid: {

--- a/resources/js/vue/components/page-header/HeaderNav.vue
+++ b/resources/js/vue/components/page-header/HeaderNav.vue
@@ -183,4 +183,9 @@ export default {
         text-decoration: none;
         width: 100%;
     }
+
+    svg {
+      display: inline-block;
+      vertical-align: middle;
+    }
 </style>


### PR DESCRIPTION
This PR continues our ongoing effort to standardize the build information displayed at the top of many of the build-specific information pages across the site.