### PR TITLE
Restrict allowable Bazel test statuses

### DIFF
--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -605,19 +605,22 @@ class BazelJSONHandler extends AbstractSubmissionHandler
                         }
                         $testdata->status =
                             strtolower($json_array['testSummary']['overallStatus']);
-                        if ($testdata->status === 'failed') {
-                            $this->NumTestsFailed[$subproject_name]++;
-                            $testdata->details = 'Completed (Failed)';
+                        if ($testdata->status === 'passed' || $testdata->status === 'flaky') {
+                            $this->NumTestsPassed[$subproject_name]++;
+                            $testdata->status = 'passed';
+                            $testdata->details = 'Completed';
                         } elseif ($testdata->status === 'timeout') {
-                            $testdata->status = 'failed';
                             $this->NumTestsFailed[$subproject_name]++;
+                            $testdata->status = 'failed';
                             $testdata->details = 'Completed (Timeout)';
                             // "TIMEOUT" message is only in stderr, not stdout
                             // Make sure that it is displayed.
                             $this->TestsOutput[$testdata->name] = "TIMEOUT\n\n";
                         } elseif (!empty($testdata->status)) {
-                            $this->NumTestsPassed[$subproject_name]++;
-                            $testdata->details = 'Completed';
+                            // "failed", "flaky", etc...  See here for the set of possible values:
+                            // https://github.com/bazelbuild/bazel/blob/5b2baea3d70e2e1381bc6dbfb0327130d00d98ee/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L676
+                            $this->NumTestsFailed[$subproject_name]++;
+                            $testdata->details = 'Completed (Failed)';
                         }
                         break;
                     }
@@ -716,19 +719,22 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         $testdata->time = $test_time;
         $testdata->details = '';
 
-        if ($testdata->status === 'failed') {
-            $this->NumTestsFailed[$subproject_name]++;
-            $testdata->details = 'Completed (Failed)';
+        if ($testdata->status === 'passed' || $testdata->status === 'flaky') {
+            $this->NumTestsPassed[$subproject_name]++;
+            $testdata->status = 'passed';
+            $testdata->details = 'Completed';
         } elseif ($testdata->status === 'timeout') {
-            $testdata->status = 'failed';
             $this->NumTestsFailed[$subproject_name]++;
+            $testdata->status = 'failed';
             $testdata->details = 'Completed (Timeout)';
             // "TIMEOUT" message is only in stderr, not stdout
             // Make sure that it is displayed.
             $this->TestsOutput[$testdata->name] = "TIMEOUT\n\n";
         } elseif (!empty($testdata->status)) {
-            $this->NumTestsPassed[$subproject_name]++;
-            $testdata->details = 'Completed';
+            // "failed", "flaky", etc...  See here for the set of possible values:
+            // https://github.com/bazelbuild/bazel/blob/5b2baea3d70e2e1381bc6dbfb0327130d00d98ee/src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto#L676
+            $this->NumTestsFailed[$subproject_name]++;
+            $testdata->details = 'Completed (Failed)';
         }
 
         $this->Tests[] = $testdata;


### PR DESCRIPTION
Some types of Bazel submissions have test statuses other than "passed", "failed", or "notrun", which breaks CDash logic which only expects one of these three valid CTest statuses in a number of different locations throughout the site.  This PR changes the Bazel JSON handler to convert all Bazel test statuses to one of these three valid statuses.  I intend to make a follow-up PR to enforce this constraint at the database level.