### PR TITLE
Add timezone to build summary card timestamps

### DIFF
--- a/resources/js/vue/components/shared/BuildSummaryCard.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCard.vue
@@ -468,15 +468,15 @@ export default {
     },
 
     humanReadableOverallStartTime() {
-      return DateTime.fromISO(this.build.startTime).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+      return DateTime.fromISO(this.build.startTime).toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS);
     },
 
     humanReadableOverallEndTime() {
-      return DateTime.fromISO(this.build.endTime).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+      return DateTime.fromISO(this.build.endTime).toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS);
     },
 
     humanReadableSubmissionTime() {
-      return DateTime.fromISO(this.build.submissionTime).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+      return DateTime.fromISO(this.build.submissionTime).toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS);
     },
 
     /**


### PR DESCRIPTION
As discussed in https://github.com/Kitware/CDash/pull/2990#pullrequestreview-3048769019, it's not currently clear that the times referenced in the build summary card refer to times in the user's local timezone.  This PR clarifies the times by adding an explicit timezone.