### PR TITLE
Convert `coveragefilelog` `log` column to text

### DIFF
--- a/app/cdash/app/Model/CoverageFileLog.php
+++ b/app/cdash/app/Model/CoverageFileLog.php
@@ -126,9 +126,7 @@ class CoverageFileLog
             return false;
         }
 
-        $log = stream_get_contents($row->log);
-
-        $log_entries = explode(';', $log);
+        $log_entries = explode(';', $row->log);
         // Make an initial pass through $log_entries to see what lines
         // it contains.
         $lines_retrieved = [];

--- a/database/migrations/2025_07_24_173132_coveragefilelog_bytea_to_text.php
+++ b/database/migrations/2025_07_24_173132_coveragefilelog_bytea_to_text.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE coveragefilelog RENAME COLUMN log TO old_log');
+        DB::statement('ALTER TABLE coveragefilelog ADD COLUMN IF NOT EXISTS log text');
+
+        // Convert from binary/bytea to UTF-8 text..
+        DB::update("UPDATE coveragefilelog SET log = encode(old_log, 'escape')");
+
+        DB::statement('ALTER TABLE coveragefilelog ALTER COLUMN log SET NOT NULL');
+        DB::statement('ALTER TABLE coveragefilelog DROP COLUMN old_log');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12208,12 +12208,6 @@ parameters:
 			path: app/cdash/app/Model/CoverageFileLog.php
 
 		-
-			message: '#^Parameter \#2 \$string of function explode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/app/Model/CoverageFileLog.php
-
-		-
 			message: '#^Property CDash\\Model\\CoverageFileLog\:\:\$AggregateBuildId has no type specified\.$#'
 			identifier: missingType.property
 			count: 1


### PR DESCRIPTION
The `coveragefilelog` `log` column stores text strings.  Even if it's not immediately human readable, the underlying data is still text.  Storing text data in a binary column type is an over-engineered abuse of Postgres' type system.  This PR changes the underlying column type to `text` for better compatibility with various parts of our PHP application layer.