### PR TITLE
Fix mock object type annotations

### DIFF
--- a/app/cdash/include/Test/BuildDiffForTesting.php
+++ b/app/cdash/include/Test/BuildDiffForTesting.php
@@ -18,7 +18,7 @@
 namespace CDash\Test;
 
 use CDash\Model\Build;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 trait BuildDiffForTesting
 {
@@ -73,11 +73,11 @@ trait BuildDiffForTesting
     }
 
     /**
-     * @return Build|PHPUnit_Framework_MockObject_MockObject
+     * @return Build|MockObject
      */
     protected function createMockBuildWithDiff($diff)
     {
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
+        /** @var Build|MockObject $build */
         $build = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
             ->getMock();

--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -19,7 +19,7 @@ use CDash\Database;
 use CDash\Model\Build;
 use CDash\ServiceContainer;
 use PDOStatement;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 require_once 'include/common.php';
@@ -89,7 +89,7 @@ class CDashTestCase extends TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Build
+     * @return MockObject|Build
      */
     protected function getMockBuild()
     {

--- a/app/cdash/tests/case/CDash/DatabaseTest.php
+++ b/app/cdash/tests/case/CDash/DatabaseTest.php
@@ -3,6 +3,7 @@
 use CDash\Database;
 use CDash\Singleton;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class DatabaseTest extends CDashTestCase
 {
@@ -56,7 +57,7 @@ class DatabaseTest extends CDashTestCase
     public function testExecute()
     {
         $input_params = ['param1', 'param2'];
-        /** @var PDOStatement|PHPUnit_Framework_MockObject_MockObject $stmt */
+        /** @var PDOStatement|MockObject $stmt */
         $stmt = $this->getMockBuilder('\PDOStatement')
             ->getMock();
         $stmt

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
@@ -26,6 +26,7 @@ use CDash\Model\Build;
 use CDash\Model\BuildGroup;
 use CDash\Model\Project;
 use CDash\Test\BuildDiffForTesting;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 class CommitAuthorSubscriptionBuilderTest extends TestCase
@@ -105,7 +106,7 @@ class CommitAuthorSubscriptionBuilderTest extends TestCase
     }
 
     /**
-     * @return ActionableBuildInterface|PHPUnit_Framework_MockObject_MockObject
+     * @return ActionableBuildInterface|MockObject
      */
     public function getMockSubmission($key, $handler_class)
     {
@@ -115,12 +116,12 @@ class CommitAuthorSubscriptionBuilderTest extends TestCase
 
         $mock_site = Mockery::mock(Site::class);
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $mock_build */
+        /** @var Build|MockObject $mock_build */
         $mock_build = $this->createMockBuildWithDiff(
             $this->createNew($key)
         );
 
-        /** @var BuildGroup|PHPUnit_Framework_MockObject_MockObject $mock_group */
+        /** @var BuildGroup|MockObject $mock_group */
         $mock_group = $this->getMockBuilder(BuildGroup::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['isNotifyingCommitters'])
@@ -130,7 +131,7 @@ class CommitAuthorSubscriptionBuilderTest extends TestCase
             ->method('isNotifyingCommitters')
             ->willReturn(true);
 
-        /** @var ActionableBuildInterface|PHPUnit_Framework_MockObject_MockObject $mock_handler */
+        /** @var ActionableBuildInterface|MockObject $mock_handler */
         $mock_handler = $this->getMockBuilder($handler_class)
             ->disableOriginalConstructor()
             ->onlyMethods(['GetProject', 'GetSite', 'GetBuildCollection', 'GetCommitAuthors', 'GetBuildGroup', 'GetTopicCollectionForSubscriber'])

--- a/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
@@ -28,6 +28,7 @@ use CDash\Model\BuildGroup;
 use CDash\Model\Project;
 use CDash\Model\Subscriber;
 use CDash\Test\BuildDiffForTesting;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 class UserSubscriptionBuilderTest extends TestCase
@@ -46,7 +47,7 @@ class UserSubscriptionBuilderTest extends TestCase
             ->add($buildA)
             ->add($buildB);
 
-        /** @var BuildHandler|PHPUnit_Framework_MockObject_MockObject $mock_build_submission */
+        /** @var BuildHandler|MockObject $mock_build_submission */
         $mock_build_submission = $this->getMockHandler($buildCollection);
 
         // Insted of using mocked method return this allows us to use the actual logic

--- a/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
@@ -21,6 +21,7 @@ use CDash\Messaging\Topic\Topic;
 use CDash\Model\Build;
 use CDash\Model\Subscriber;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class AuthoredTopicTest extends CDashTestCase
 {
@@ -34,7 +35,7 @@ class AuthoredTopicTest extends CDashTestCase
             ->method('subscribesToBuild')
             ->willReturn(true);
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
+        /** @var Build|MockObject $build */
         $build = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetCommitAuthors'])
             ->getMock();

--- a/app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
@@ -24,6 +24,7 @@ use CDash\Model\BuildError;
 use CDash\Model\Subscriber;
 use CDash\Test\BuildDiffForTesting;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class BuildErrorTopicTest extends CDashTestCase
 {
@@ -173,7 +174,7 @@ class BuildErrorTopicTest extends CDashTestCase
         $sut = new BuildErrorTopic();
         $sut->setType(Build::TYPE_ERROR);
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build */
+        /** @var Build|MockObject $build */
         $build = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetErrorDifferences'])
             ->getMock();

--- a/app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
@@ -24,10 +24,11 @@ use CDash\Model\BuildConfigure;
 use CDash\Model\Label;
 use CDash\Model\Subscriber;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ConfigureTopicTest extends CDashTestCase
 {
-    /** @var Topic|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Topic|MockObject */
     private $parent;
 
     public function setUp(): void

--- a/app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
@@ -19,6 +19,7 @@ use CDash\Messaging\Topic\MissingTestTopic;
 use CDash\Messaging\Topic\Topic;
 use CDash\Model\Build;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 class MissingTestTopicTest extends TestCase
@@ -27,7 +28,7 @@ class MissingTestTopicTest extends TestCase
     {
         $sut = new MissingTestTopic();
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build1 */
+        /** @var Build|MockObject $build1 */
         $build1 = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetMissingTests'])
             ->getMock();
@@ -39,7 +40,7 @@ class MissingTestTopicTest extends TestCase
 
         $this->assertFalse($sut->subscribesToBuild($build1));
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build2 */
+        /** @var Build|MockObject $build2 */
         $build2 = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetMissingTests'])
             ->getMock();
@@ -86,7 +87,7 @@ class MissingTestTopicTest extends TestCase
 
         $this->assertEquals(0, $sut->getTopicCount());
 
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $build2 */
+        /** @var Build|MockObject $build2 */
         $build2 = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetMissingTests'])
             ->getMock();

--- a/app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
+++ b/app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
@@ -29,6 +29,7 @@ use CDash\Messaging\Topic\Topic;
 use CDash\Messaging\Topic\TopicCollection;
 use CDash\Messaging\Topic\TopicDecorator;
 use CDash\Messaging\Topic\TopicInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 abstract class MockTopic extends Topic implements Decoratable
@@ -45,7 +46,7 @@ class TopicDecoratorTest extends TestCase
 {
     public function testDecorateGivenFixesEmailPreference()
     {
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopic('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);
@@ -70,7 +71,7 @@ class TopicDecoratorTest extends TestCase
 
     public function testDecorateGivenEmailRedundantPreference()
     {
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopic('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);
@@ -83,7 +84,7 @@ class TopicDecoratorTest extends TestCase
 
     public function testDecorateGivenGroupFilterableEmailPreference()
     {
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopic('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);
@@ -101,7 +102,7 @@ class TopicDecoratorTest extends TestCase
 
     public function testDecorateGivenLabelsEmailPreference()
     {
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopic('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);
@@ -115,7 +116,7 @@ class TopicDecoratorTest extends TestCase
 
         $this->assertNotInstanceOf(LabeledTopic::class, $collection->get('MockTopic'));
 
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopicLabelable('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);
@@ -127,7 +128,7 @@ class TopicDecoratorTest extends TestCase
 
     public function testDecorateGivenAuthoredEmailPreference()
     {
-        /** @var TopicInterface|PHPUnit_Framework_MockObject_MockObject $mock_topic */
+        /** @var TopicInterface|MockObject $mock_topic */
         $mock_topic = $this->getMockTopic('MockTopic');
         $collection = new TopicCollection();
         $collection->add($mock_topic);

--- a/app/cdash/tests/case/CDash/Model/BuildTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildTest.php
@@ -18,6 +18,7 @@
 use CDash\Collection\BuildEmailCollection;
 use CDash\Model\Build;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class BuildTest extends CDashTestCase
 {
@@ -40,7 +41,7 @@ class BuildTest extends CDashTestCase
     {
         // This is a bad idea, don't do this
         // TODO: refactor asap
-        /** @var Build|PHPUnit_Framework_MockObject_MockObject $sut */
+        /** @var Build|MockObject $sut */
         $sut = $this->getMockBuilder(Build::class)
             ->onlyMethods(['GetErrorDifferences', 'GetPreviousBuildId'])
             ->getMock();

--- a/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
+++ b/app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
@@ -31,6 +31,7 @@ use CDash\Test\UseCase\UseCase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
 {
@@ -39,7 +40,7 @@ class MultipleSubprojectsEmailTest extends CDashUseCaseTestCase
 
     private static int $projectid = -1;
 
-    /** @var Database|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Database|MockObject */
     private $db;
 
     /** @var ActionableBuildInterface */

--- a/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
+++ b/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
@@ -20,11 +20,12 @@ use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
 use CDash\Service\RepositoryService;
 use CDash\Test\CDashTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use Ramsey\Uuid\Uuid;
 
 class RepositoryServiceTest extends CDashTestCase
 {
-    /** @var RepositoryInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var RepositoryInterface|MockObject */
     private $repository;
 
     public function setUp(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15586,12 +15586,6 @@ parameters:
 			path: app/cdash/include/Test/CDashTestCase.php
 
 		-
-			message: '#^Method CDash\\Test\\CDashTestCase\:\:getMockBuild\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/include/Test/CDashTestCase.php
-
-		-
 			message: '#^Method CDash\\Test\\CDashTestCase\:\:setDatabaseMocked\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -19111,12 +19105,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/DatabaseTest.php
 
 		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/DatabaseTest.php
-
-		-
 			message: '#^Cannot access offset ''CDash\\\\Database'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -19167,18 +19155,6 @@ parameters:
 		-
 			message: '#^Method DatabaseTest\:\:testInstance\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/tests/case/CDash/DatabaseTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$stmt contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/DatabaseTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type PDOStatement&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
 			count: 1
 			path: app/cdash/tests/case/CDash/DatabaseTest.php
 
@@ -19243,21 +19219,9 @@ parameters:
 			path: app/cdash/tests/case/CDash/LinkifyCompilerOutputTest.php
 
 		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
 			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 11
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
@@ -19303,12 +19267,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
-			message: '#^Method CommitAuthorSubscriptionBuilderTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
 			message: '#^Method CommitAuthorSubscriptionBuilderTest\:\:createMockBuildWithDiff\(\) has parameter \$diff with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -19341,12 +19299,6 @@ parameters:
 		-
 			message: '#^Method CommitAuthorSubscriptionBuilderTest\:\:getDiff\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^Method CommitAuthorSubscriptionBuilderTest\:\:getMockSubmission\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
@@ -19417,48 +19369,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$mock_build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$mock_group contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$mock_handler contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type App\\Http\\Submission\\Handlers\\ActionableBuildInterface&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\BuildGroup&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
-
-		-
 			message: '#^PHPDoc tag @var with type CDash\\Model\\Project is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
 			identifier: varTag.nativeType
 			count: 1
@@ -19477,33 +19387,21 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
+			message: '#^Trying to mock an undefined method GetCommitAuthors\(\) on class App\\Http\\Submission\\Handlers\\ActionableBuildInterface\.$#'
+			identifier: phpunit.mockMethod
+			count: 1
+			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
+
+		-
 			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:getMockBuilder\(\)$#'
 			identifier: argument.templateType
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/CommitAuthorSubscriptionBuilderTest.php
 
 		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^Access to property \$Name on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 4
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
 			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 3
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
@@ -19533,12 +19431,6 @@ parameters:
 		-
 			message: '#^Method UserSubscriptionBuilderTest\:\:createFixed\(\) should return array but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^Method UserSubscriptionBuilderTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
@@ -19591,24 +19483,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$mock_build_submission contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
 			message: '#^Property UserSubscriptionBuilderTest\:\:\$diff has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -19619,12 +19493,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Subscription/UserSubscriptionBuilderTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
 
 		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertFalse\(\)\.$#'
@@ -19645,33 +19513,9 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/AuthoredTopicTest.php
-
-		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 4
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
 			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 7
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
 		-
@@ -19719,12 +19563,6 @@ parameters:
 		-
 			message: '#^Method BuildErrorTopicTest\:\:createFixed\(\) should return array but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
-			message: '#^Method BuildErrorTopicTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
@@ -19831,18 +19669,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
 			message: '#^Property BuildErrorTopicTest\:\:\$diff has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -19859,12 +19685,6 @@ parameters:
 			identifier: phpunit.assertEquals
 			count: 6
 			path: app/cdash/tests/case/CDash/Messaging/Topic/BuildErrorTopicTest.php
-
-		-
-			message: '#^Call to method method\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
 
 		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertCount\(\)\.$#'
@@ -19965,18 +19785,6 @@ parameters:
 		-
 			message: '#^Method ConfigureTopicTest\:\:testSubscribesToBuild\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
-
-		-
-			message: '#^Property ConfigureTopicTest\:\:\$parent \(CDash\\Messaging\\Topic\\Topic&PHPUnit_Framework_MockObject_MockObject\) does not accept CDash\\Messaging\\Topic\\Topic&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
-
-		-
-			message: '#^Property ConfigureTopicTest\:\:\$parent has unknown class PHPUnit_Framework_MockObject_MockObject as its type\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/ConfigureTopicTest.php
 
@@ -20089,20 +19897,8 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/EmailSentTopicTest.php
 
 		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
 
@@ -20133,12 +19929,6 @@ parameters:
 		-
 			message: '#^Method FixedTopicTest\:\:createFixed\(\) should return array but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
-			message: '#^Method FixedTopicTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
 
@@ -20203,18 +19993,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
 			message: '#^Property FixedTopicTest\:\:\$diff has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -20225,18 +20003,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/FixedTopicTest.php
-
-		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 6
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 3
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
 
 		-
 			message: '#^Call to method get\(\) on an unknown class CDash\\Messaging\\Topic\\Illuminate\\Support\\Collection\.$#'
@@ -20305,34 +20071,10 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build1 contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$build2 contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 3
-			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
 			message: '#^You should use assertSame\(\) instead of assertEquals\(\), because both values are scalars of the same type$#'
 			identifier: phpunit.assertEquals
 			count: 4
 			path: app/cdash/tests/case/CDash/Messaging/Topic/MissingTestTopicTest.php
-
-		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
 		-
 			message: '''
@@ -20346,12 +20088,6 @@ parameters:
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
@@ -20400,12 +20136,6 @@ parameters:
 		-
 			message: '#^Method TestFailureTopicTest\:\:createFixed\(\) should return array but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
-
-		-
-			message: '#^Method TestFailureTopicTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
@@ -20506,18 +20236,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TestFailureTopicTest.php
-
-		-
 			message: '#^Property TestFailureTopicTest\:\:\$diff has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -20614,32 +20332,8 @@ parameters:
 			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
 
 		-
-			message: '#^PHPDoc tag @var for variable \$mock_topic contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 6
-			path: app/cdash/tests/case/CDash/Messaging/Topic/TopicDecoratorTest.php
-
-		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 2
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
-			message: '#^Call to method GetDiffWithPreviousBuild\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 4
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 2
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
 
@@ -20682,12 +20376,6 @@ parameters:
 		-
 			message: '#^Method UpdateErrorTopicTest\:\:createFixed\(\) should return array but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
-			message: '#^Method UpdateErrorTopicTest\:\:createMockBuildWithDiff\(\) has invalid return type PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
 
@@ -20766,18 +20454,6 @@ parameters:
 		-
 			message: '#^Method UpdateErrorTopicTest\:\:testSubscribesToBuild\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$build contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
 			count: 1
 			path: app/cdash/tests/case/CDash/Messaging/Topic/UpdateErrorTopicTest.php
 
@@ -21010,27 +20686,9 @@ parameters:
 			path: app/cdash/tests/case/CDash/Model/BuildRelationshipTest.php
 
 		-
-			message: '#^Access to property \$Id on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
-			message: '#^Call to method GetDiffWithPreviousBuild\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CDash\\\\Collection\\\\BuildEmailCollection'' and CDash\\Collection\\BuildEmailCollection will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 2
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 
 		-
@@ -21084,18 +20742,6 @@ parameters:
 		-
 			message: '#^Missing call to parent\:\:setUp\(\) method\.$#'
 			identifier: phpunit.callParent
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
-			message: '#^PHPDoc tag @var for variable \$sut contains unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Model/BuildTest.php
-
-		-
-			message: '#^PHPDoc tag @var with type CDash\\Model\\Build&PHPUnit_Framework_MockObject_MockObject is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: varTag.nativeType
 			count: 1
 			path: app/cdash/tests/case/CDash/Model/BuildTest.php
 
@@ -21271,18 +20917,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
 
 		-
-			message: '#^Property MultipleSubprojectsEmailTest\:\:\$db \(CDash\\Database&PHPUnit_Framework_MockObject_MockObject\) does not accept CDash\\Database&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
-
-		-
-			message: '#^Property MultipleSubprojectsEmailTest\:\:\$db has unknown class PHPUnit_Framework_MockObject_MockObject as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/MultipleSubprojectsEmailTest.php
-
-		-
 			message: '#^Property MultipleSubprojectsEmailTest\:\:\$submission \(App\\Http\\Submission\\Handlers\\ActionableBuildInterface\) does not accept App\\Http\\Submission\\Handlers\\AbstractXmlHandler\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -21361,12 +20995,6 @@ parameters:
 			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
 
 		-
-			message: '#^Call to method expects\(\) on an unknown class PHPUnit_Framework_MockObject_MockObject\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
-
-		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 1
@@ -21381,18 +21009,6 @@ parameters:
 		-
 			message: '#^Method RepositoryServiceTest\:\:testSetStatusOnStart\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
-
-		-
-			message: '#^Property RepositoryServiceTest\:\:\$repository \(CDash\\Lib\\Repository\\RepositoryInterface&PHPUnit_Framework_MockObject_MockObject\) does not accept CDash\\Lib\\Repository\\RepositoryInterface&PHPUnit\\Framework\\MockObject\\MockObject\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
-
-		-
-			message: '#^Property RepositoryServiceTest\:\:\$repository has unknown class PHPUnit_Framework_MockObject_MockObject as its type\.$#'
-			identifier: class.notFound
 			count: 1
 			path: app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
 


### PR DESCRIPTION
PHPUnit now uses namespaces to define their class hierarchy, instead of building the namespace into class names.  Changing our type annotations to reflect the actual class being used allows PHPStan to perform a more thorough analysis of our code.