### PR TITLE
Allow coverage file path filtering

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -216,11 +216,21 @@ class Build extends Model
     }
 
     /**
+     * @deprecated 07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
+     *
      * @return HasMany<Coverage, $this>
      */
     public function coverageResults(): HasMany
     {
         return $this->hasMany(Coverage::class, 'buildid');
+    }
+
+    /**
+     * @return HasMany<CoverageView, $this>
+     */
+    public function coverage(): HasMany
+    {
+        return $this->hasMany(CoverageView::class, 'buildid');
     }
 
     /**

--- a/app/Models/CoverageView.php
+++ b/app/Models/CoverageView.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * This class serves as a READ-ONLY logical grouping of all the parts for a single file's coverage
+ * results for a given build.  CoverageFile and CoverageFileLog deduplicate the largest fields in
+ * this logical relation, but one cannot be had without the other.  Under the hood, this is simply
+ * the Coverage model joined with the CoverageFile and CoverageFileLog models.
+ *
+ * @property int $buildid
+ * @property int $covered
+ * @property int $loctested
+ * @property int $locuntested
+ * @property int $branchestested
+ * @property int $branchesuntested
+ * @property int $functionstested
+ * @property int $functionsuntested
+ * @property ?string $fullpath
+ * @property ?string $file
+ * @property ?string $log
+ *
+ * @mixin Builder<CoverageView>
+ */
+class CoverageView extends Model
+{
+    protected $table = 'coverageview';
+
+    public $timestamps = false;
+
+    protected $fillable = [];
+
+    /**
+     * @return BelongsTo<Build, $this>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return BelongsToMany<Label, $this>
+     */
+    public function labels(): BelongsToMany
+    {
+        return $this->belongsToMany(Label::class, 'label2coverage', 'coverageid', 'labelid');
+    }
+}

--- a/database/migrations/2025_07_25_131613_coverage_view.php
+++ b/database/migrations/2025_07_25_131613_coverage_view.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('
+            CREATE VIEW coverageview AS
+                SELECT
+                    coverage.id,
+                    coverage.buildid,
+                    coverage.covered,
+                    coverage.loctested,
+                    coverage.locuntested,
+                    coverage.branchestested,
+                    coverage.branchesuntested,
+                    coverage.functionstested,
+                    coverage.functionsuntested,
+                    coveragefile.fullpath,
+                    coveragefile.file,
+                    coveragefilelog.log
+                FROM
+                    coverage
+                    LEFT JOIN coveragefile ON (
+                        coverage.fileid = coveragefile.id
+                    )
+                    LEFT JOIN coveragefilelog ON (
+                        coverage.buildid = coveragefilelog.buildid
+                        AND coverage.fileid = coveragefilelog.fileid
+                    )
+        ');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -467,7 +467,7 @@ type Build {
   compilerVersion: String @rename(attribute: "compilerversion") @filterable
 
   """
-  Child builds associated wirh this parent build.  Note that CDash only supports one level of
+  Child builds associated with this parent build.  Note that CDash only supports one level of
   subprojects, so no child builds will have children of their own.
   """
   children(
@@ -475,6 +475,10 @@ type Build {
   ): [Build!]! @hasMany(type: CONNECTION) @orderBy(column: "id")
 
   coverageResults(
+    filters: _ @filter
+  ): [Coverage!]! @belongsToMany(type: CONNECTION, relation: "coverage") @orderBy(column: "id", direction: DESC) @deprecated(reason: "Use 'coverage' instead.")
+
+  coverage(
     filters: _ @filter
   ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
@@ -783,11 +787,9 @@ type Note {
 """
 Coverage result for a particular build+file combination.
 """
-type Coverage {
+type Coverage @model(class: "App\\Models\\CoverageView") {
   "Unique primary key."
   id: ID! @filterable
-
-  filePath: String! @with(relation: "file") @method(name: "getFilePath")
 
   linesOfCodeTested: Int! @rename(attribute: "loctested") @filterable
 
@@ -800,6 +802,8 @@ type Coverage {
   functionsTested: Int! @rename(attribute: "functionstested") @filterable
 
   functionsUntested: Int! @rename(attribute: "functionsuntested") @filterable
+
+  filePath: String @rename(attribute: "fullpath") @filterable
 
   labels(
     filters: _ @filter

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12278,6 +12278,15 @@ parameters:
 
 		-
 			message: '''
+				#^Call to deprecated method coverageResults\(\) of class App\\Models\\Build\:
+				07/27/2025 Use this relation only to edit the underlying coverage table\.  Use coverage\(\) instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: app/cdash/app/Model/CoverageSummary.php
+
+		-
+			message: '''
 				#^Call to deprecated method executePrepared\(\) of class CDash\\Database\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			'''
@@ -33008,6 +33017,15 @@ parameters:
 			identifier: phpunit.assertEquals
 			count: 4
 			path: tests/Feature/GlobalInvitationAcceptanceTest.php
+
+		-
+			message: '''
+				#^Call to deprecated method coverageResults\(\) of class App\\Models\\Build\:
+				07/27/2025 Use this relation only to edit the underlying coverage table\.  Use coverage\(\) instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: tests/Feature/GraphQL/CoverageTypeTest.php
 
 		-
 			message: '#^Method Tests\\Feature\\GraphQL\\GlobalInvitationTypeTest\:\:createInvitation\(\) throws checked exception OverflowException but it''s missing from the PHPDoc @throws tag\.$#'

--- a/tests/Feature/GraphQL/CoverageTypeTest.php
+++ b/tests/Feature/GraphQL/CoverageTypeTest.php
@@ -77,16 +77,29 @@ class CoverageTypeTest extends TestCase
                     builds {
                         edges {
                             node {
-                                coverageResults {
+                                coverage {
                                     edges {
                                         node {
-                                            filePath
                                             linesOfCodeTested
                                             linesOfCodeUntested
                                             branchesTested
                                             branchesUntested
                                             functionsTested
                                             functionsUntested
+                                            filePath
+                                        }
+                                    }
+                                }
+                                coverageResults {
+                                    edges {
+                                        node {
+                                            linesOfCodeTested
+                                            linesOfCodeUntested
+                                            branchesTested
+                                            branchesUntested
+                                            functionsTested
+                                            functionsUntested
+                                            filePath
                                         }
                                     }
                                 }
@@ -108,13 +121,28 @@ class CoverageTypeTest extends TestCase
                                         'edges' => [
                                             [
                                                 'node' => [
-                                                    'filePath' => $coverageFile->fullpath,
                                                     'linesOfCodeTested' => 4,
                                                     'linesOfCodeUntested' => 5,
                                                     'branchesTested' => 6,
                                                     'branchesUntested' => 7,
                                                     'functionsTested' => 8,
                                                     'functionsUntested' => 9,
+                                                    'filePath' => $coverageFile->fullpath,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'coverage' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'linesOfCodeTested' => 4,
+                                                    'linesOfCodeUntested' => 5,
+                                                    'branchesTested' => 6,
+                                                    'branchesUntested' => 7,
+                                                    'functionsTested' => 8,
+                                                    'functionsUntested' => 9,
+                                                    'filePath' => $coverageFile->fullpath,
                                                 ],
                                             ],
                                         ],
@@ -153,7 +181,7 @@ class CoverageTypeTest extends TestCase
                     builds {
                         edges {
                             node {
-                                coverageResults {
+                                coverage {
                                     edges {
                                         node {
                                             labels {
@@ -180,7 +208,7 @@ class CoverageTypeTest extends TestCase
                         'edges' => [
                             [
                                 'node' => [
-                                    'coverageResults' => [
+                                    'coverage' => [
                                         'edges' => [
                                             [
                                                 'node' => [


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2926 used a hack to allow file paths to be accessed via the `Coverage` type, despite residing in a separate relation.  This PR re-works that to instead use a Postgres view to access all coverage information in a single place.  Subsequent PRs will increase usage of this view throughout the codebase, with the ultimate goal of managing the underlying tables entirely within Postgres.