### PR TITLE
Add build->targets UI

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -34,6 +34,18 @@ require_once 'include/api_common.php';
 
 final class BuildController extends AbstractBuildController
 {
+    public function targets(int $build_id): View
+    {
+        $this->setBuildById($build_id);
+
+        $filters = json_decode(request()->get('filters')) ?? ['all' => []];
+
+        return $this->vue('build-targets-page', 'Targets', [
+            'build-id' => $this->build->Id,
+            'initial-filters' => $filters,
+        ]);
+    }
+
     // Render the build configure page.
     public function configure($build_id = null)
     {

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -332,6 +332,8 @@ add_browser_test(/Browser/Pages/BuildFilesPageTest)
 
 add_browser_test(/Browser/Pages/BuildNotesPageTest)
 
+add_browser_test(/Browser/Pages/BuildTargetsPageTest)
+
 add_php_test(changeid)
 set_tests_properties(changeid PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -861,7 +861,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: app/Http/Controllers/BuildController.php
 
 		-

--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -34,6 +34,7 @@ const SitesIdPage = Vue.defineAsyncComponent(() => import('./components/SitesIdP
 const ProjectMembersPage = Vue.defineAsyncComponent(() => import('./components/ProjectMembersPage.vue'));
 const UsersPage = Vue.defineAsyncComponent(() => import('./components/UsersPage.vue'));
 const BuildFilesPage = Vue.defineAsyncComponent(() => import('./components/BuildFilesPage.vue'));
+const BuildTargetsPage = Vue.defineAsyncComponent(() => import('./components/BuildTargetsPage.vue'));
 
 const cdash_components = {
   BuildConfigure,
@@ -56,6 +57,7 @@ const cdash_components = {
   ProjectMembersPage,
   UsersPage,
   BuildFilesPage,
+  BuildTargetsPage,
 };
 
 /**
@@ -107,6 +109,7 @@ const apolloClient = new ApolloClient({
           files: relayStylePagination(),
           urls: relayStylePagination(),
           notes: relayStylePagination(),
+          targets: relayStylePagination(),
         },
       },
       Site: {

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+    <BuildSummaryCard :build-id="buildId" />
+
+    <FilterBuilder
+      filter-type="BuildTargetsFiltersMultiFilterInput"
+      primary-record-name="targets"
+      :initial-filters="initialFilters"
+      :execute-query-link="executeQueryLink"
+      @change-filters="filters => changedFilters = filters"
+    />
+
+    <LoadingIndicator :is-loading="!targets">
+      <DataTable
+        v-if="targets.edges.length > 0"
+        :column-groups="[
+          {
+            displayName: 'Targets',
+            width: 100,
+          }
+        ]"
+        :columns="[
+          {
+            name: 'name',
+            displayName: 'Name',
+          },
+          {
+            name: 'type',
+            displayName: 'Type',
+          },
+        ]"
+        :rows="formattedTargetRows"
+        :full-width="true"
+        test-id="targets-table"
+      />
+    </LoadingIndicator>
+  </div>
+</template>
+
+<script>
+import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import DataTable from './shared/DataTable.vue';
+import LoadingIndicator from './shared/LoadingIndicator.vue';
+import gql from 'graphql-tag';
+import FilterBuilder from './shared/FilterBuilder.vue';
+
+export default {
+  components: {FilterBuilder, LoadingIndicator, DataTable, BuildSummaryCard},
+
+  props: {
+    buildId: {
+      type: Number,
+      required: true,
+    },
+
+    initialFilters: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      changedFilters: JSON.parse(JSON.stringify(this.initialFilters)),
+    };
+  },
+
+  apollo: {
+    targets: {
+      query: gql`
+        query($buildId: ID!, $filters: BuildTargetsFiltersMultiFilterInput, $after: String) {
+          build(id: $buildId) {
+            id
+            targets(filters: $filters, after: $after) {
+              edges {
+                node {
+                  id
+                  name
+                  type
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+      `,
+      update: data => data?.build?.targets,
+      variables() {
+        return {
+          buildId: this.buildId,
+          filters: this.initialFilters,
+        };
+      },
+      result({data}) {
+        if (data && data.build.targets.pageInfo.hasNextPage) {
+          this.$apollo.queries.targets.fetchMore({
+            variables: {
+              buildId: this.buildId,
+              filters: this.initialFilters,
+              after: data.build.targets.pageInfo.endCursor,
+            },
+          });
+        }
+      },
+    },
+  },
+
+  computed: {
+    executeQueryLink() {
+      return `${window.location.origin}${window.location.pathname}?filters=${encodeURIComponent(JSON.stringify(this.changedFilters))}`;
+    },
+
+    formattedTargetRows() {
+      return this.targets.edges?.map(edge => {
+        return {
+          name: {
+            value: edge.node.name,
+            text: edge.node.name,
+            href: `${this.$baseURL}/targets/${edge.node.id}`,
+          },
+          type: {
+            value: edge.node.type,
+            text: this.humanReadableTargetType(edge.node.type),
+          },
+        };
+      });
+    },
+  },
+
+  methods: {
+    humanReadableTargetType(type) {
+      switch (type) {
+      case 'UNKNOWN':
+        return 'Unknown';
+      case 'STATIC_LIBRARY':
+        return 'Static Library';
+      case 'MODULE_LIBRARY':
+        return 'Module Library';
+      case 'SHARED_LIBRARY':
+        return 'Shared Library';
+      case 'OBJECT_LIBRARY':
+        return 'Object Library';
+      case 'INTERFACE_LIBRARY':
+        return 'Interface Library';
+      case 'EXECUTABLE':
+        return 'Executable';
+      default:
+        return type;
+      }
+    },
+  },
+};
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,6 +104,8 @@ Route::get('/viewDynamicAnalysis.php', function (Request $request) {
     return redirect("/builds/{$buildid}/dynamic_analysis", 301);
 });
 
+Route::get('/builds/{build_id}/targets', 'BuildController@targets')->whereNumber('build_id');
+
 Route::get('/build/{build_id}/files', 'BuildController@files')->whereNumber('build_id');
 Route::get('/viewFiles.php', function (Request $request) {
     $buildid = $request->query('buildid');

--- a/tests/Browser/Pages/BuildTargetsPageTest.php
+++ b/tests/Browser/Pages/BuildTargetsPageTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use App\Enums\TargetType;
+use App\Http\Submission\Traits\UpdatesSiteInformation;
+use App\Models\Build;
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\SiteInformation;
+use App\Models\Target;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\BrowserTestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+
+class BuildTargetsPageTest extends BrowserTestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use UpdatesSiteInformation;
+
+    private Project $project;
+
+    private Build $build;
+
+    private Site $site;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        $this->site = $this->makeSite();
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+        $this->build = $build;
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->project->delete();
+        $this->site->delete();
+    }
+
+    private function addTarget(TargetType $type = TargetType::UNKNOWN): Target
+    {
+        return $this->build->targets()->create([
+            'name' => Str::uuid()->toString(),
+            'type' => $type,
+        ]);
+    }
+
+    public function testShowsBuildName(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit("/builds/{$this->build->id}/targets")
+                ->waitForText($this->build->name)
+                ->assertSee($this->build->name)
+            ;
+        });
+    }
+
+    public function testTargetName(): void
+    {
+        $target = $this->addTarget();
+
+        $this->browse(function (Browser $browser) use ($target) {
+            $browser->visit("/builds/{$this->build->id}/targets")
+                ->waitForText($target->name)
+                ->assertSee($target->name)
+            ;
+        });
+    }
+
+    /**
+     * We arbitrarily choose a random target type to verify that it gets rendered in a human-friendly format.
+     */
+    public function testTargetType(): void
+    {
+        $this->addTarget(TargetType::SHARED_LIBRARY);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit("/builds/{$this->build->id}/targets")
+                ->waitFor('@targets-table')
+                ->assertSee('Shared Library')
+            ;
+        });
+    }
+
+    public function testFilters(): void
+    {
+        $this->addTarget(TargetType::STATIC_LIBRARY);
+        $this->addTarget(TargetType::SHARED_LIBRARY);
+
+        $this->browse(function (Browser $browser) {
+            $browser->visit("/builds/{$this->build->id}/targets")
+                ->waitFor('@targets-table')
+                ->assertSee('Shared Library')
+                ->assertSee('Static Library')
+            ;
+
+            // Now, filter by targets of type SHARED_LIBRARY...
+            $browser->visit("/builds/{$this->build->id}/targets?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22type%22%3A%22SHARED_LIBRARY%22%7D%7D%5D%7D")
+                ->waitFor('@targets-table')
+                ->assertSee('Shared Library')
+                ->assertDontSee('Static Library')
+            ;
+
+            // Now, filter by targets of type STATIC_LIBRARY...
+            $browser->visit("/builds/{$this->build->id}/targets?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22type%22%3A%22STATIC_LIBRARY%22%7D%7D%5D%7D")
+                ->waitFor('@targets-table')
+                ->assertSee('Static Library')
+                ->assertDontSee('Shared Library')
+            ;
+        });
+    }
+
+    public function testTargetTablePagination(): void
+    {
+        $targets = collect();
+        for ($i = 0; $i < 120; $i++) {
+            $targets[] = $this->addTarget();
+        }
+
+        $targets = $targets->sortByDesc('name');
+
+        self::assertCount(120, $targets);
+
+        $this->browse(function (Browser $browser) use ($targets) {
+            $browser->visit("/builds/{$this->build->id}/targets")
+                ->waitFor('@targets-table')
+                // Wait for min and max names to ensure multiple pages of data have loaded properly.
+                ->waitForTextIn('@targets-table', $targets->first()->name ?? '')
+                ->waitForTextIn('@targets-table', $targets->last()->name ?? '')
+                ->assertCount('@targets-table-row', 120)
+            ;
+        });
+    }
+}


### PR DESCRIPTION
Building on top of https://github.com/Kitware/CDash/pull/2612, this PR adds a new "build targets" page which displays a table of targets for a build if instrumentation data was submitted.  See https://github.com/Kitware/CDash/issues/2827 for more details about the outline for our new instrumentation-related pages.  I have a number of future improvements in mind for this page, including better support when viewing parent builds, correlation to errors & warnings with associated color highlighting, customizable timing or other measurement columns, a trace-style view of the targets or other at the top of the page.

<img width="2834" height="944" alt="image" src="https://github.com/user-attachments/assets/1a84ad9d-1197-4c38-a696-8c935c3116ef" />
