### PR TITLE
Remove ID fields from filters UI

### DIFF
--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -13,7 +13,7 @@
         class="tw-select tw-select-xs tw-select-bordered tw-shrink"
       >
         <option
-          v-for="field in result.typeInformation.inputFields"
+          v-for="field in result.typeInformation.inputFields.filter((x) => x.name !== 'id')"
           :value="field.name"
         >
           {{ humanReadableField(field.name) }}
@@ -175,7 +175,7 @@ export default {
           return;
         }
 
-        this.selectedField = this.initialField ?? result.typeInformation.inputFields[0].name;
+        this.selectedField = this.initialField ?? result.typeInformation.inputFields.filter((x) => x.name !== 'id')[0].name;
 
         this.selectedOperator = this.initialOperator ?? 'eq';
       },


### PR DESCRIPTION
There are almost no good reasons to allow users to filter by ID via the UI.  This PR removes the ID field from the filter builder UI in preparation for the rollout of the first page with the "new" filters UI in https://github.com/Kitware/CDash/pull/2997.