### PR TITLE
Add URI to all log messages

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ define('FMT_DATETIMEDISPLAY', 'M d, Y - H:i T');  // date and time standard
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -28,6 +29,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Log::shareContext([
+            // Limit the size of the string to prevent users from (un)intentionally filling
+            // up the logs with a very long query string.
+            'uri' => substr(request()->uri(), 0, 1000),
+        ]);
+
         Validator::extendImplicit('complexity', 'App\Validators\Password@complexity');
 
         URL::forceRootUrl(Config::get('app.url'));

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -119,7 +119,7 @@ class EmailTestCase extends KWWebTestCase
         $url = url('/');
 
         $expected = [
-            'testing.INFO: Sent email titled \'PASSED (w=6): EmailProjectExample - Win32-MSVC2009 - Nightly\' to user1@kw {"projectid":3,"subject":"PASSED (w=6): EmailProjectExample - Win32-MSVC2009 - Nightly","body":"Congratulations. A submission to CDash for the project EmailProjectExample has fixed warnings. You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.',
+            'testing.INFO: Sent email titled \'PASSED (w=6): EmailProjectExample - Win32-MSVC2009 - Nightly\' to user1@kw {"uri":"http://localhost:8080/submit.php?project=EmailProjectExample","projectid":3,"subject":"PASSED (w=6): EmailProjectExample - Win32-MSVC2009 - Nightly","body":"Congratulations. A submission to CDash for the project EmailProjectExample has fixed warnings. You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.',
             "{$url}/build/",
             'Project: EmailProjectExample',
             'Site: Dash20.kitware',
@@ -145,7 +145,7 @@ class EmailTestCase extends KWWebTestCase
         }
         $url = url('/');
         $expected = [
-            'testing.INFO: Sent email titled \'PASSED (t=2): EmailProjectExample - Win32-MSVC2009 - Nightly\' to user1@kw {"projectid":3,"subject":"PASSED (t=2): EmailProjectExample - Win32-MSVC2009 - Nightly","body":"Congratulations. A submission to CDash for the project EmailProjectExample has fixed failing tests. You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.',
+            'testing.INFO: Sent email titled \'PASSED (t=2): EmailProjectExample - Win32-MSVC2009 - Nightly\' to user1@kw {"uri":"http://localhost:8080/submit.php?project=EmailProjectExample","projectid":3,"subject":"PASSED (t=2): EmailProjectExample - Win32-MSVC2009 - Nightly","body":"Congratulations. A submission to CDash for the project EmailProjectExample has fixed failing tests. You have been identified as one of the authors who have checked in changes that are part of this submission or you are listed in the default contact list.',
             "{$url}/build/",
             'Project: EmailProjectExample',
             'Site: Dash20.kitware',


### PR DESCRIPTION
It's often difficult to tell which project is generating log messages in a multi-project CDash instance.  While we do add context if the project or build is known, it's useful to just have the entire URI.  This PR adds the full URI to all log messages.  If this approach turns out to be too "spammy", we can adjust the settings to only log the URI in a more target subset of cases, such as only when stack traces are logged.