### PR TITLE
Remove formatting from coverage files in database

### DIFF
--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -11,6 +11,7 @@ use CDash\Model\Build;
 use CDash\Model\CoverageFile;
 use CDash\Model\CoverageFileLog;
 use CDash\Model\Project;
+use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -482,8 +483,11 @@ final class CoverageController extends AbstractBuildController
         $coverageFile->Id = $fileid;
         $coverageFile->Load();
 
-        // Generating the html file
-        $file_array = explode('<br>', $coverageFile->File);
+        // Split on all forms of line breaks
+        $file_array = preg_split('/\R/', rtrim($coverageFile->File));
+        if ($file_array === false) {
+            throw new Exception('Error parsing coverage file.');
+        }
         $i = 0;
 
         // Load the coverage info.

--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -108,7 +108,6 @@ class CoverageLogHandler extends AbstractXmlHandler
                     continue;
                 }
                 $coverageFileLog = $coverageInfo[1];
-                $coverageFile->TrimLastNewline();
 
                 $buildid = $this->Build->Id;
                 if ($has_subprojects) {
@@ -142,9 +141,7 @@ class CoverageLogHandler extends AbstractXmlHandler
                 $coverageFileLog->Insert(true);
             }
         } elseif ($name == 'LINE') {
-            $this->CurrentCoverageFile->File .= rtrim($this->CurrentLine);
-            // Cannot be <br/> for backward compatibility.
-            $this->CurrentCoverageFile->File .= '<br>';
+            $this->CurrentCoverageFile->File .= $this->CurrentLine . PHP_EOL;
         } elseif ($name == 'FILE') {
             // Store these objects to be inserted after we're guaranteed
             // to have a valid buildid.

--- a/app/Http/Submission/Handlers/GcovTarHandler.php
+++ b/app/Http/Submission/Handlers/GcovTarHandler.php
@@ -293,7 +293,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
                 // Separate out delimited values from this line.
                 $timesHit = trim($fields[0]);
                 $lineNumber = (int) trim($fields[1]);
-                $sourceLine = rtrim($fields[2]);
+                $sourceLine = $fields[2];
 
                 // check for duplicate line output
                 if ($lineNumber <= $last_lineNumber) {
@@ -303,8 +303,6 @@ class GcovTarHandler extends AbstractSubmissionHandler
 
                 if ($lineNumber > 0) {
                     $coverageFile->File .= $sourceLine;
-                    // cannot be <br/> for backward compatibility.
-                    $coverageFile->File .= '<br>';
                 }
 
                 // This is how gcov indicates a line of unexecutable code.
@@ -368,7 +366,6 @@ class GcovTarHandler extends AbstractSubmissionHandler
         }
 
         // Save these models to the database.
-        $coverageFile->TrimLastNewline();
         $coverageFile->Update($buildid);
         $coverageFileLog->BuildId = $buildid;
         $coverageFileLog->FileId = $coverageFile->Id;
@@ -464,15 +461,12 @@ class GcovTarHandler extends AbstractSubmissionHandler
         $lines = file($fileinfo);
         $lineNumber = 0;
         foreach ($lines as $line) {
-            $sourceLine = rtrim($line);
-            $coverageFile->File .= $sourceLine;
-            $coverageFile->File .= '<br>';
+            $coverageFile->File .= $line;
             $coverageFileLog->AddLine($lineNumber, 0);
             $lineNumber++;
         }
 
         // Save this source file to the database.
-        $coverageFile->TrimLastNewline();
         $coverageFile->Update($this->Build->Id);
 
         // Check if this build already has coverage for this file.

--- a/app/Http/Submission/Handlers/JSCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/JSCoverTarHandler.php
@@ -89,7 +89,6 @@ class JSCoverTarHandler extends AbstractSubmissionHandler
             }
 
             // Save these models to the database.
-            $coverageFile->TrimLastNewline();
             $coverageFile->Update($this->Build->Id);
             $coverageFileLog->BuildId = $this->Build->Id;
             $coverageFileLog->FileId = $coverageFile->Id;
@@ -183,8 +182,7 @@ class JSCoverTarHandler extends AbstractSubmissionHandler
                     // Record this line of code if this is the first time that
                     // this file has been encountered.
                     $sourceLine = $coverageEntry['source'][$i - 1];
-                    $coverageFile->File .= rtrim($sourceLine);
-                    $coverageFile->File .= '<br>';
+                    $coverageFile->File .= $sourceLine;
                 }
 
                 $timesHit = $coverageLines[$i];

--- a/app/Http/Submission/Handlers/JavaJSONTarHandler.php
+++ b/app/Http/Submission/Handlers/JavaJSONTarHandler.php
@@ -174,9 +174,7 @@ class JavaJSONTarHandler extends AbstractSubmissionHandler
         $lineNumber = 0;
 
         foreach ($coverageLines as $coverageLine) {
-            $sourceLine = $coverageLine['source'];
-            $coverageFile->File .= rtrim($sourceLine);
-            $coverageFile->File .= '<br>';
+            $coverageFile->File .= $coverageLine['source'];
 
             $timesHit = $coverageLine['covered'];
 
@@ -201,7 +199,6 @@ class JavaJSONTarHandler extends AbstractSubmissionHandler
         }
 
         // Save these models to the database.
-        $coverageFile->TrimLastNewline();
         $coverageFile->Update($buildid);
         $coverageFileLog->BuildId = $buildid;
         $coverageFileLog->FileId = $coverageFile->Id;

--- a/app/Http/Submission/Handlers/OpenCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/OpenCoverTarHandler.php
@@ -200,7 +200,6 @@ class OpenCoverTarHandler extends AbstractXmlHandler
             }
 
             // Save these models to the database.
-            $coverageFile->TrimLastNewline();
             $coverageFile->Update($this->Build->Id);
             $coverageFileLog->BuildId = $this->Build->Id;
             $coverageFileLog->FileId = $coverageFile->Id;
@@ -246,13 +245,12 @@ class OpenCoverTarHandler extends AbstractXmlHandler
         if ($this->coverageFile) {
             foreach ($fileContents as $key => $line) {
                 $trimmedLine = trim($line);
-                $displayLine = rtrim($line);
                 // Matches the beginning of a comment block
                 if (preg_match("/\/[*]+/", $trimmedLine)) {
                     $inlongComment = true;
                 }
 
-                $this->coverageFile->File .= $displayLine . '<br>';
+                $this->coverageFile->File .= $line;
                 if (!(preg_match("/^\/\//", $trimmedLine)
                    or preg_match('/using /', $trimmedLine)
                    or preg_match('/^namespace/', $trimmedLine)

--- a/app/cdash/app/Model/CoverageFile.php
+++ b/app/cdash/app/Model/CoverageFile.php
@@ -147,14 +147,4 @@ class CoverageFile
 
         return true;
     }
-
-    // Remove the extra <br> tag that is added to the end of the file
-    // by some of our XML handlers.
-    public function TrimLastNewline()
-    {
-        // Remove trailing <br> tag.
-        if (substr($this->File, -4) === '<br>') {
-            $this->File = substr($this->File, 0, strlen($this->File) - 4);
-        }
-    }
 }

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -168,8 +168,8 @@ class RemoveBuildsTestCase extends KWWebTestCase
         // Coverage
         $file1 = new CoverageFile();
         $file1->FullPath = '/path/to/unshared.php';
-        $file1->File .= 'this unshared line gets covered<br>';
-        $file1->File .= 'this unshared line does not<br>';
+        $file1->File .= 'this unshared line gets covered' . PHP_EOL;
+        $file1->File .= 'this unshared line does not' . PHP_EOL;
 
         $coverage1 = new Coverage();
         $coverage1->Covered = 1;
@@ -180,8 +180,8 @@ class RemoveBuildsTestCase extends KWWebTestCase
 
         $file2 = new CoverageFile();
         $file2->FullPath = '/path/to/shared.php';
-        $file2->File .= 'this shared line gets covered<br>';
-        $file2->File .= 'this shared line does not<br>';
+        $file2->File .= 'this shared line gets covered' . PHP_EOL;
+        $file2->File .= 'this shared line does not' . PHP_EOL;
 
         $coverage2 = new Coverage();
         $coverage2->Covered = 1;
@@ -196,7 +196,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $summary->AddCoverage($coverage2);
         $summary->Insert(true);
 
-        $file1->TrimLastNewline();
         $file1->Update($build->Id);
         $log1 = new CoverageFileLog();
         $log1->AddLine(1, 1);
@@ -204,7 +203,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $log1->FileId = $file1->Id;
         $log1->Insert(true);
 
-        $file2->TrimLastNewline();
         $file2->Update($build->Id);
         $log2 = new CoverageFileLog();
         $log2->AddLine(1, 1);

--- a/database/migrations/2025_07_27_214956_coverage_file_newlines.php
+++ b/database/migrations/2025_07_27_214956_coverage_file_newlines.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::update("UPDATE coveragefile SET file = replace(file, '<br>', E'\n')");
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4309,12 +4309,6 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
 		-
-			message: '#^Call to an undefined method object\:\:TrimLastNewline\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
 			message: '#^Call to an undefined method object\:\:Update\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -12020,12 +12014,6 @@ parameters:
 
 		-
 			message: '#^Method CDash\\Model\\CoverageFile\:\:Load\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/app/Model/CoverageFile.php
-
-		-
-			message: '#^Method CDash\\Model\\CoverageFile\:\:TrimLastNewline\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/app/Model/CoverageFile.php


### PR DESCRIPTION
Coverage files are currently stored in the database with artificial line separators.  This attempt at pre-rendering the files is problematic for a variety of reasons, all stemming from the fact that what's stored in the database is not actually what we want to be displayed.  This PR adds a migration to remove these artificial separators and prevent them from being added to new records.