### PR TITLE
Improve isolation of `buildproperties` test

### DIFF
--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -209,7 +209,7 @@ final class BuildPropertiesController extends AbstractBuildController
         }
 
         $pdo = Database::getInstance()->getPdo();
-        $placeholder_str = Database::getInstance()->createPreparedArray(count($_GET['buildid']));
+        $placeholder_str = Database::getInstance()->createPreparedArray(is_array($_GET['buildid']) ? count($_GET['buildid']) : 1);
 
         $defects_response = [];
         foreach ($_GET['defect'] as $defect) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24775,12 +24775,6 @@ parameters:
 			path: app/cdash/tests/test_buildproperties.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, CDash\\Model\\Project given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: app/cdash/tests/test_buildproperties.php
-
-		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -24819,12 +24813,6 @@ parameters:
 		-
 			message: '#^Property BuildPropertiesTestCase\:\:\$PDO has no type specified\.$#'
 			identifier: missingType.property
-			count: 1
-			path: app/cdash/tests/test_buildproperties.php
-
-		-
-			message: '#^Property BuildPropertiesTestCase\:\:\$Project \(CDash\\Model\\Project\) does not accept null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: app/cdash/tests/test_buildproperties.php
 


### PR DESCRIPTION
The `buildproperties` test currently uses a hardcoded project name and hardcoded login credentials which conflict other tests in rare cases.  This PR resolves the issue by using a unique project name and eliminating the need for credentials.