### PR TITLE
Run `/CDash/ConfigUseCase` test serially

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -146,6 +146,7 @@ set_tests_properties(/CDash/BuildUseCase PROPERTIES DEPENDS /CDash/XmlHandler/Up
 
 add_legacy_unit_test(/CDash/ConfigUseCase)
 set_tests_properties(/CDash/ConfigUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+set_property(TEST /CDash/ConfigUseCase APPEND PROPERTY RUN_SERIAL TRUE)
 
 add_legacy_unit_test(/CDash/UpdateUseCase)
 set_tests_properties(/CDash/UpdateUseCase PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)


### PR DESCRIPTION
`/CDash/ConfigUseCase` was found to conflict with other tests in rare occasions.  It's not clear to me what exactly causes the conflict, but running this test serially resolved the issue in every configuration I tried locally.