### PR TITLE
Expose coverage files via GraphQL

### DIFF
--- a/app/Policies/CoverageViewPolicy.php
+++ b/app/Policies/CoverageViewPolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CoverageView;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class CoverageViewPolicy
+{
+    public function viewCode(?User $user, CoverageView $coverage): bool
+    {
+        $project = $coverage->build?->project;
+        return Gate::allows('view', $project) && (bool) $project?->showcoveragecode;
+    }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -805,6 +805,8 @@ type Coverage @model(class: "App\\Models\\CoverageView") {
 
   filePath: String @rename(attribute: "fullpath") @filterable
 
+  file: String @filterable @canRoot(ability: "viewCode", action: RETURN_VALUE, returnValue: null)
+
   # Note: we deliberately don't use pagination here because the server has to load the entire file
   # in full anyway, and each record is small.
   coveredLines: [CoverageLine]!

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32859,7 +32859,7 @@ parameters:
 				07/27/2025 Use this relation only to edit the underlying coverage table\.  Use coverage\(\) instead\.$#
 			'''
 			identifier: method.deprecated
-			count: 3
+			count: 5
 			path: tests/Feature/GraphQL/CoverageTypeTest.php
 
 		-


### PR DESCRIPTION
This PR completes our effort to expose all coverage information via GraphQL.