### PR TITLE
Change test status column to enum

### DIFF
--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -169,6 +169,13 @@ class BazelJSONHandler extends AbstractSubmissionHandler
 
         // Save testing information.
         foreach ($this->Tests as $testdata) {
+            if (!in_array($testdata->status, ['passed', 'failed', 'notrun'], true)) {
+                // The test summary logic inserts a second test which is meant to replace a placeholder
+                // test created by the test result logic.  We don't want to save and then overwrite
+                // that test, so we just skip the placeholders here.
+                continue;
+            }
+
             $testCreator = new TestCreator();
 
             $testCreator->buildTestTime = $testdata->time;

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Config;
  * @property int $id
  * @property int $buildid
  * @property int $outputid
- * @property string $status
+ * @property string $status 'failed' | 'passed' | 'notrun'  TODO: Turn this into a proper enum.
  * @property float $time
  * @property float $timemean
  * @property float $timestd

--- a/database/migrations/2025_07_30_131713_test_status_enum.php
+++ b/database/migrations/2025_07_30_131713_test_status_enum.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // We drop the type first in case the database has been truncated previously.
+        DB::statement('DROP TYPE IF EXISTS teststatus');
+        DB::statement("CREATE TYPE teststatus AS ENUM ('failed', 'notrun', 'passed')");
+        DB::statement('ALTER TABLE build2test RENAME COLUMN status TO old_status');
+        DB::statement('ALTER TABLE build2test ADD COLUMN status teststatus');
+        DB::update("UPDATE build2test SET status = old_status::teststatus WHERE old_status IN ('failed', 'notrun', 'passed')");
+        DB::update("UPDATE build2test SET status = 'passed' WHERE status IS NULL");
+        DB::statement('ALTER TABLE build2test ALTER COLUMN status SET NOT NULL');
+        DB::statement('ALTER TABLE build2test DROP COLUMN old_status');
+        DB::statement('CREATE INDEX ON build2test (buildid, status)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -529,11 +529,7 @@ enum TestStatus {
 
   FAILED @enum(value: "failed")
 
-  TIMEOUT @enum(value: "Timeout")
-
   NOT_RUN @enum(value: "notrun")
-
-  DISABLED @enum(value: "Disabled")
 }
 
 

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -158,10 +158,6 @@ export default {
         return 'error';
       case 'NOT_RUN':
         return 'warning';
-      case 'TIMEOUT':
-        return 'error';
-      case 'DISABLED':
-        return '';
       default:
         return '';
       }
@@ -175,10 +171,6 @@ export default {
         return 'Failed';
       case 'NOT_RUN':
         return 'Not Run';
-      case 'TIMEOUT':
-        return 'Timeout';
-      case 'DISABLED':
-        return 'Disabled';
       default:
         return status;
       }

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -124,9 +124,7 @@ class TestTypeTest extends TestCase
         return [
             ['passed', 'PASSED'],
             ['failed', 'FAILED'],
-            ['Timeout', 'TIMEOUT'],
             ['notrun', 'NOT_RUN'],
-            ['Disabled', 'DISABLED'],
         ];
     }
 
@@ -201,6 +199,7 @@ class TestTypeTest extends TestCase
         $label = $build->tests()->create([
             'testname' => Str::uuid()->toString(),
             'outputid' => $this->test_output->id,
+            'status' => 'passed',
         ])->labels()->create([
             'text' => Str::uuid()->toString(),
         ]);
@@ -264,6 +263,7 @@ class TestTypeTest extends TestCase
         $test = $build->tests()->create([
             'testname' => Str::uuid()->toString(),
             'outputid' => $this->test_output->id,
+            'status' => 'passed',
         ]);
 
         $label1 = $test->labels()->create([


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/2991 fixed an issue with the Bazel test handler where unexpected test statuses could be inserted into the database.  This PR follows up on that work by changing the test status column to an enum type to ensure that any preexisting invalid values are eliminated (changed to `passed`) and no new invalid values can be inserted.  I also added an index which may improve performance for some users.