### PR TITLE
Use `ng-href` for AngularJS links

### DIFF
--- a/resources/js/angular/views/viewBuildError.html
+++ b/resources/js/angular/views/viewBuildError.html
@@ -2,7 +2,7 @@
         <tr>
           <td align="left">
             <b>Site: </b>
-            <a class="cdash-link" href="sites/{{cdash.build.siteid}}">
+            <a class="cdash-link" ng-href="sites/{{cdash.build.siteid}}">
               {{cdash.build.site}}
             </a>
           </td>
@@ -38,7 +38,7 @@
         </tr>
         <tr>
           <td align="left">
-            <a class="cdash-link" href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
+            <a class="cdash-link" ng-href="viewBuildError.php?type={{cdash.nonerrortype}}&buildid={{cdash.build.buildid}}">
               {{cdash.nonerrortypename}}s are here.
             </a>
           </td>
@@ -64,7 +64,7 @@
           <tr ng-repeat="error in pagination.buildErrors">
             <td style="vertical-align:top">{{error.subprojectname}}</td>
             <td>
-              <a class="cdash-link" href="#" ng-click="showErrors = !showErrors">
+              <a class="cdash-link" ng-href="#" ng-click="showErrors = !showErrors">
                 Error building {{error.outputfile}}
               </a>
               <div ng-hide="!showErrors">


### PR DESCRIPTION
Using `href` attributes in AngularJS is discouraged because links will still have placeholders in them if users (or, more likely, web scrapers) attempt to click them before AngularJS has finished rendering.  Instead, it's preferable to use `ng-href`, which gets transformed into `href` by AngularJS.  This PR addresses various stack traces and logs associated with URLs containing AngularJS placeholders in a production system.