### PR TITLE
Fix unclosed tag on index page

### DIFF
--- a/resources/js/angular/views/partials/build.html
+++ b/resources/js/angular/views/partials/build.html
@@ -149,14 +149,15 @@
               </span>
               <span ng-if="::build.lastSubmission != -1">
                 This build has not submitted since
-                  <b>
-                    <a class="cdash-link" ng-href="index.php?project={{::cdash.projectname}}&date={{::build.lastSubmissionDate}}">
-                      {{::build.lastSubmission}}
-                    </a>
-                (<ng-pluralize count="::build.daysSinceLastBuild"
-                              when="{'1':     '{} day',
-                                     'other': '{} days'}">
-                </ng-pluralize>)
+                <b>
+                  <a class="cdash-link" ng-href="index.php?project={{::cdash.projectname}}&date={{::build.lastSubmissionDate}}">
+                    {{::build.lastSubmission}}
+                  </a>
+                  (<ng-pluralize count="::build.daysSinceLastBuild"
+                                when="{'1':     '{} day',
+                                       'other': '{} days'}">
+                  </ng-pluralize>)
+                </b>
               </span>
             </font>
           </td>


### PR DESCRIPTION
Fixes a minor HTML issue where the `<b>` tag is unclosed in one location on the index page.  Most browsers are smart enough to overlook these types of errors, so no UI difference is anticipated for most browsers.