### PR TITLE
Catch exceptions from Storage facade

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
+use League\Flysystem\UnableToReadFile;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 require_once 'include/api_common.php';
@@ -792,7 +793,12 @@ final class BuildController extends AbstractBuildController
         // 1) Render text and images in browser (as opposed to forcing a download).
         // 2) Download other files to the proper filename (not a numeric identifier).
         // 3) Support downloading files that are larger than the PHP memory_limit.
-        $fp = Storage::readStream("upload/{$file->sha1sum}");
+        try {
+            $fp = Storage::readStream("upload/{$file->sha1sum}");
+        } catch (UnableToReadFile $e) {
+            $fp = null;
+            report($e);
+        }
         if ($fp === null) {
             abort(404, 'File not found');
         }

--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -27,6 +27,7 @@ use CDash\Model\BuildError;
 use CDash\Model\BuildErrorFilter;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToReadFile;
 use stdClass;
 
 class BazelJSONHandler extends AbstractSubmissionHandler
@@ -91,7 +92,13 @@ class BazelJSONHandler extends AbstractSubmissionHandler
      **/
     public function Parse($filename)
     {
-        $handle = Storage::readStream($filename);
+        try {
+            $handle = Storage::readStream($filename);
+        } catch (UnableToReadFile $e) {
+            report($e);
+            return false;
+        }
+
         if ($handle === null) {
             Log::error("Could not open $filename for parsing", [
                 'function' => 'BazelJSONHandler::Parse',

--- a/app/Http/Submission/Handlers/RetryHandler.php
+++ b/app/Http/Submission/Handlers/RetryHandler.php
@@ -18,6 +18,8 @@ namespace App\Http\Submission\Handlers;
 =========================================================================*/
 
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToWriteFile;
 
 /** Because this class uses SimpleXML it is only suitable for use with small
  * XML files that can fit into memory.
@@ -42,7 +44,12 @@ class RetryHandler
             return false;
         }
 
-        $contents = Storage::get($this->FileName);
+        try {
+            $contents = Storage::get($this->FileName);
+        } catch (UnableToReadFile $e) {
+            $contents = null;
+            report($e);
+        }
         if ($contents === null) {
             return false;
         }
@@ -59,6 +66,11 @@ class RetryHandler
         }
         $xml['retries'] = $this->Retries;
 
-        return Storage::put($this->FileName, (string) $xml->asXML());
+        try {
+            return Storage::put($this->FileName, (string) $xml->asXML());
+        } catch (UnableToWriteFile $e) {
+            report($e);
+            return false;
+        }
     }
 }

--- a/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+++ b/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
@@ -20,8 +20,8 @@ namespace App\Http\Submission\Handlers;
 use CDash\Model\Build;
 use CDash\Model\Project;
 use CDash\Model\SubProject;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToReadFile;
 
 class SubProjectDirectoriesHandler extends AbstractSubmissionHandler
 {
@@ -40,11 +40,13 @@ class SubProjectDirectoriesHandler extends AbstractSubmissionHandler
     public function Parse($filename)
     {
         $open_list = [];
-        $fp = Storage::readStream($filename);
+        try {
+            $fp = Storage::readStream($filename);
+        } catch (UnableToReadFile $e) {
+            $fp = null;
+            report($e);
+        }
         if ($fp === null) {
-            Log::error("Could not open $filename for parsing", [
-                'function' => 'SubProjectDirectoriesHandler::Parse',
-            ]);
             return false;
         }
         while (($line = fgets($fp)) !== false) {

--- a/app/Http/Submission/Handlers/UploadHandler.php
+++ b/app/Http/Submission/Handlers/UploadHandler.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToWriteFile;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 /**
@@ -259,8 +260,10 @@ class UploadHandler extends AbstractXmlHandler
                             $this->UploadError = true;
                             return;
                         }
-                        if (Storage::putFileAs('upload', $fileToUpload, (string) $this->UploadFile->sha1sum) === false) {
-                            Log::error("Failed to store {$this->TmpFilename} as {$uploadFilepath}");
+                        try {
+                            Storage::putFileAs('upload', $fileToUpload, (string) $this->UploadFile->sha1sum);
+                        } catch (UnableToWriteFile $e) {
+                            report($e);
                             unlink($this->TmpFilename);
                             $this->UploadError = true;
                             return;


### PR DESCRIPTION
Wrap all calls to `Storage::get()`, `Storage::put()`, and `Storage::delete()`, etc. in try/catch blocks.