### PR TITLE
Move global banner text to top bar

### DIFF
--- a/app/Http/Controllers/SubProjectController.php
+++ b/app/Http/Controllers/SubProjectController.php
@@ -141,9 +141,6 @@ final class SubProjectController extends AbstractProjectController
         $response['showcalendar'] = 1;
 
         $banners = [];
-        if (config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0) {
-            $banners[] = config('cdash.global_banner');
-        }
         if ($this->project->Banner !== null && strlen($this->project->Banner) > 0) {
             $banners[] = $this->project->Banner;
         }

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -51,9 +51,6 @@ $response['title'] = $Project->Name;
 $response['showcalendar'] = 1;
 
 $banners = [];
-if (config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0) {
-    $banners[] = config('cdash.global_banner');
-}
 if ($Project->Banner !== null && strlen($Project->Banner) > 0) {
     $banners[] = $Project->Banner;
 }

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -156,6 +156,8 @@ add_feature_test(/Feature/SlowPageTest)
 
 add_feature_test(/Feature/GitHubWebhook)
 
+add_feature_test(/Feature/GlobalBannerTest)
+
 add_legacy_unit_test(/CDash/Lib/Repository/GitHub)
 set_tests_properties(/CDash/Lib/Repository/GitHub PROPERTIES
     DEPENDS /CDash/XmlHandler/UpdateHandler

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -86,6 +86,7 @@ return [
     'require_full_email_when_adding_user' => env('REQUIRE_FULL_EMAIL_WHEN_ADDING_USER', false),
     // Whether or not project administrators can invite users
     'project_admin_registration_form_enabled' => env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true),
+    // Text displayed at the top of all pages.  Limited to 40 characters.
     'global_banner' => env('GLOBAL_BANNER'),
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2401,12 +2401,6 @@ parameters:
 			path: app/Http/Controllers/SubProjectController.php
 
 		-
-			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Controllers/SubProjectController.php
-
-		-
 			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 2
@@ -17293,12 +17287,6 @@ parameters:
 			message: '#^Only numeric types are allowed in \-, int\|false given on the right side\.$#'
 			identifier: minus.rightNonNumeric
 			count: 6
-			path: app/cdash/public/api/v1/index.php
-
-		-
-			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: app/cdash/public/api/v1/index.php
 
 		-

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,4 +1,6 @@
 @php
+use Illuminate\Support\Str;
+
 if (isset($project)) {
     $logoid = $project->ImageId;
 }
@@ -22,7 +24,7 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
 
             @if(config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0)
                 <span id="global-banner" style="color: #2ee84a;">
-                    {{ config('cdash.global_banner') }}
+                    {{ Str::limit(config('cdash.global_banner'), 40) }}
                 </span>
             @endif
 

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -12,13 +12,21 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
 
 <div id="header">
     <div id="headertop">
-        <div id="topmenu">
-            <a class="cdash-link" href="{{ url('/projects') }}">All Dashboards</a>
-            @if(Auth::check())
-                <a class="cdash-link" href="{{ url('/user') }}">My CDash</a>
+        <div id="topmenu" style="display: flex; justify-content: space-between;">
+            <span>
+                <a class="cdash-link" href="{{ url('/projects') }}">All Dashboards</a>
+                @if(Auth::check())
+                    <a class="cdash-link" href="{{ url('/user') }}">My CDash</a>
+                @endif
+            </span>
+
+            @if(config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0)
+                <span id="global-banner" style="color: #2ee84a;">
+                    {{ config('cdash.global_banner') }}
+                </span>
             @endif
 
-            <span style="float: right;">
+            <span>
                 @if(Auth::check())
                     <a class="cdash-link" href="{{ url('/logout') }}">Logout</a>
                 @else

--- a/tests/Feature/GlobalBannerTest.php
+++ b/tests/Feature/GlobalBannerTest.php
@@ -17,4 +17,13 @@ class GlobalBannerTest extends TestCase
 
         $this->get('/login')->assertSee($bannerText);
     }
+
+    public function testLongGlobalBannerGetsTruncated(): void
+    {
+        $bannerText = 'AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMM';
+
+        config(['cdash.global_banner' => $bannerText]);
+
+        $this->get('/login')->assertSee('AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJ...');
+    }
 }

--- a/tests/Feature/GlobalBannerTest.php
+++ b/tests/Feature/GlobalBannerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GlobalBannerTest extends TestCase
+{
+    public function testGlobalBannerAppearsWhenSet(): void
+    {
+        $bannerText = Str::uuid()->toString();
+
+        $this->get('/login')->assertDontSee($bannerText);
+
+        config(['cdash.global_banner' => $bannerText]);
+
+        $this->get('/login')->assertSee($bannerText);
+    }
+}


### PR DESCRIPTION
The current banner isn't shown on all pages, and it's currently impossible to view the global banner and project-specific banners at the same time.  This PR moves the global banner to the middle of the top bar, leaving the original banner as a project-specific feature.  A future PR will extend the project-specific banner to all project pages.

<img width="2834" height="194" alt="image" src="https://github.com/user-attachments/assets/5719b342-5474-4829-ae76-1e5bd4be6658" />
