### PR TITLE
Use strict equality for string constant comparisons

### DIFF
--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -46,14 +46,14 @@ class AutoRemoveBuilds extends Command
         $sql = 'SELECT id, autoremovetimeframe, autoremovemaxbuilds
                 FROM project';
         $args = [];
-        if ($projectname != 'all') {
+        if ($projectname !== 'all') {
             $sql .= ' WHERE name = ?';
             $args = [$projectname];
         }
         $stmt = $db->prepare($sql);
 
         if ($this->option('all-builds')) {
-            if ($projectname == 'all') {
+            if ($projectname === 'all') {
                 echo "Removing all builds for all projects is not supported.\n";
                 return;
             }

--- a/app/Console/Commands/SaveUser.php
+++ b/app/Console/Commands/SaveUser.php
@@ -58,7 +58,7 @@ class SaveUser extends Command
         foreach ($options as $option_name) {
             $option_value = $this->option($option_name);
             if (!is_null($option_value)) {
-                if ($option_name == 'password') {
+                if ($option_name === 'password') {
                     $option_value = password_hash($option_value, PASSWORD_DEFAULT);
                 }
                 $user->$option_name = $option_value;

--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -712,13 +712,13 @@ final class BuildController extends AbstractBuildController
             // This field is redundant because of the way our data is organized.
             unset($file['status']);
 
-            if ($status == 'UPDATED') {
+            if ($status === 'UPDATED') {
                 $diff_url = RepositoryUtils::get_diff_url($this->project->Id, $this->project->CvsUrl, $directory, $filename, $revision);
                 $diff_url = XMLStrFormat($diff_url);
                 $file['diffurl'] = $diff_url;
                 $this->add_file($file, $directory, $updated_files);
                 $num_updated_files++;
-            } elseif ($status == 'MODIFIED') {
+            } elseif ($status === 'MODIFIED') {
                 $diff_url = RepositoryUtils::get_diff_url($this->project->Id, $this->project->CvsUrl, $directory, $filename);
                 $diff_url = XMLStrFormat($diff_url);
                 $file['diffurl'] = $diff_url;

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -897,7 +897,7 @@ final class CoverageController extends AbstractBuildController
             }
 
             // For display branch purposes
-            if ($coveragetype == 'gcov') {
+            if ($coveragetype === 'gcov') {
                 $roundedpercentage2 = round($covfile['branchpercentcoverage']);
                 if ($roundedpercentage2 > 98) {
                     $roundedpercentage2 = 98;
@@ -1000,7 +1000,7 @@ final class CoverageController extends AbstractBuildController
 
             // Fourth column (Line not covered)
             $fourthcolumn = '';
-            if ($coveragetype == 'gcov') {
+            if ($coveragetype === 'gcov') {
                 $fourthcolumn = '<span';
                 if ($covfile['covered'] == 0) {
                     $fourthcolumn .= ' class="error">' . $covfile['locuntested'] . '</span>';

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -184,42 +184,42 @@ final class SubscribeProjectController extends AbstractProjectController
     private static function check_email_category(string $name, int $emailcategory): bool
     {
         if ($emailcategory >= 64) {
-            if ($name == 'dynamicanalysis') {
+            if ($name === 'dynamicanalysis') {
                 return true;
             }
             $emailcategory -= 64;
         }
 
         if ($emailcategory >= 32) {
-            if ($name == 'test') {
+            if ($name === 'test') {
                 return true;
             }
             $emailcategory -= 32;
         }
 
         if ($emailcategory >= 16) {
-            if ($name == 'error') {
+            if ($name === 'error') {
                 return true;
             }
             $emailcategory -= 16;
         }
 
         if ($emailcategory >= 8) {
-            if ($name == 'warning') {
+            if ($name === 'warning') {
                 return true;
             }
             $emailcategory -= 8;
         }
 
         if ($emailcategory >= 4) {
-            if ($name == 'configure') {
+            if ($name === 'configure') {
                 return true;
             }
             $emailcategory -= 4;
         }
 
         if ($emailcategory >= 2) {
-            if ($name == 'update') {
+            if ($name === 'update') {
                 return true;
             }
         }

--- a/app/Http/Submission/Handlers/AbstractXmlHandler.php
+++ b/app/Http/Submission/Handlers/AbstractXmlHandler.php
@@ -148,7 +148,7 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
     {
         $this->stack->push($name);
 
-        if ($name == 'SUBPROJECT') {
+        if ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
         }
 

--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -183,7 +183,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
             }
 
             $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {
                 $this->SubProjects[$this->SubProjectName] = [];
@@ -205,7 +205,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                 $build->CompilerVersion = $this->BuildInformation['compilerversion'] ?? null;
                 $this->Builds[$this->SubProjectName] = $build;
             }
-        } elseif ($name == 'BUILD') {
+        } elseif ($name === 'BUILD') {
             if (empty($this->Builds)) {
                 // No subprojects
                 $build = $factory->create(Build::class);
@@ -224,20 +224,20 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                 $build->CompilerVersion = $this->BuildInformation['compilerversion'] ?? null;
                 $this->Builds[''] = $build;
             }
-        } elseif ($name == 'WARNING') {
+        } elseif ($name === 'WARNING') {
             $this->Error = $factory->create(BuildError::class);
             $this->Error->Type = 1;
             $this->ErrorSubProjectName = '';
-        } elseif ($name == 'ERROR') {
+        } elseif ($name === 'ERROR') {
             $this->Error = $factory->create(BuildError::class);
             $this->Error->Type = 0;
             $this->ErrorSubProjectName = '';
-        } elseif ($name == 'FAILURE') {
+        } elseif ($name === 'FAILURE') {
             $this->Error = $factory->create(BuildFailure::class);
             $this->Error->Type = 0;
-            if ($attributes['TYPE'] == 'Error') {
+            if ($attributes['TYPE'] === 'Error') {
                 $this->Error->Type = 0;
-            } elseif ($attributes['TYPE'] == 'Warning') {
+            } elseif ($attributes['TYPE'] === 'Warning') {
                 $this->Error->Type = 1;
             }
             $this->ErrorSubProjectName = '';
@@ -333,7 +333,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
     {
         $factory = $this->getModelFactory();
 
-        if ($name == 'BUILD') {
+        if ($name === 'BUILD') {
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
             $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp);
             $submit_time = gmdate(FMT_DATETIME);
@@ -431,7 +431,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                     }
                 }
             }
-        } elseif ($name == 'WARNING' || $name == 'ERROR' || $name == 'FAILURE') {
+        } elseif ($name === 'WARNING' || $name === 'ERROR' || $name === 'FAILURE') {
             $skip_error = false;
             foreach (['StdOutput', 'StdError', 'Text'] as $field) {
                 if (isset($this->Error->$field)) {
@@ -610,19 +610,19 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                     $this->Error->ExitCondition .= $data;
                     break;
             }
-        } elseif ($element == 'BUILDLOGLINE') {
+        } elseif ($element === 'BUILDLOGLINE') {
             $this->Error->LogLine .= $data;
-        } elseif ($element == 'TEXT') {
+        } elseif ($element === 'TEXT') {
             $this->Error->Text .= $data;
-        } elseif ($element == 'SOURCEFILE') {
+        } elseif ($element === 'SOURCEFILE') {
             $this->Error->SourceFile .= $data;
-        } elseif ($element == 'SOURCELINENUMBER') {
+        } elseif ($element === 'SOURCELINENUMBER') {
             $this->Error->SourceLine .= $data;
-        } elseif ($element == 'PRECONTEXT') {
+        } elseif ($element === 'PRECONTEXT') {
             $this->Error->PreContext .= $data;
-        } elseif ($element == 'POSTCONTEXT') {
+        } elseif ($element === 'POSTCONTEXT') {
             $this->Error->PostContext .= $data;
-        } elseif ($this->getParent() === 'SUBPROJECT' && $element == 'LABEL') {
+        } elseif ($this->getParent() === 'SUBPROJECT' && $element === 'LABEL') {
             $this->SubProjects[$this->SubProjectName][] = $data;
         } elseif ($this->currentPathMatches('site.build.targets.target.labels.label')) {
             if ($this->MostRecentCommand === null || !array_key_exists('targetname', $this->MostRecentCommand)) {

--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -123,7 +123,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
             }
 
             $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {
                 $this->SubProjects[$this->SubProjectName] = [];
@@ -139,7 +139,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                 // No subprojects
                 $this->Builds[] = $this->CreateBuild();
             }
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             $this->Label = $this->getModelFactory()->create(Label::class);
         }
     }
@@ -294,13 +294,13 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                     $this->Configure->NumberOfErrors = $data;
                     break;
             }
-        } elseif ($parent == 'SUBPROJECT' && $element == 'LABEL') {
+        } elseif ($parent === 'SUBPROJECT' && $element === 'LABEL') {
             $this->SubProjects[$this->SubProjectName][] = $data;
             $build = $this->Builds[$this->SubProjectName];
             $label = $this->getModelFactory()->create(Label::class);
             $label->Text = $data;
             $build->AddLabel($label);
-        } elseif ($parent == 'LABELS' && $element == 'LABEL') {
+        } elseif ($parent === 'LABELS' && $element === 'LABEL') {
             // First, check if this label belongs to a SubProject
             $subproject_name = '';
             foreach ($this->SubProjects as $subproject => $labels) {

--- a/app/Http/Submission/Handlers/CoverageHandler.php
+++ b/app/Http/Submission/Handlers/CoverageHandler.php
@@ -96,7 +96,7 @@ class CoverageHandler extends AbstractXmlHandler
             }
             $this->Build->SetStamp($attributes['BUILDSTAMP']);
             $this->Build->Generator = $attributes['GENERATOR'];
-        } elseif ($name == 'FILE') {
+        } elseif ($name === 'FILE') {
             $this->CoverageFile = new CoverageFile();
             $this->Coverage = new Coverage();
             $this->CoverageFile->FullPath = trim($attributes['FULLPATH']);
@@ -106,7 +106,7 @@ class CoverageHandler extends AbstractXmlHandler
                 $this->Coverage->Covered = 0;
             }
             $this->Coverage->CoverageFile = $this->CoverageFile;
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             $this->Label = new Label();
         }
     } // start element
@@ -180,11 +180,11 @@ class CoverageHandler extends AbstractXmlHandler
                 $coverageSummary->Insert(true);
                 $coverageSummary->ComputeDifference();
             }
-        } elseif ($name == 'FILE') {
+        } elseif ($name === 'FILE') {
             // Store this data.
             // We will insert it once we're done parsing the whole file.
             $this->Coverages[] = [$this->Coverage, $this->CoverageFile];
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             if (isset($this->Coverage)) {
                 $this->Coverage->AddLabel($this->Label);
             }
@@ -198,7 +198,7 @@ class CoverageHandler extends AbstractXmlHandler
         $parent = $this->getParent();
         $element = $this->getElement();
 
-        if ($parent == 'COVERAGE') {
+        if ($parent === 'COVERAGE') {
             switch ($element) {
                 case 'STARTTIME':
                     $this->StartTimeStamp = $data;
@@ -207,7 +207,7 @@ class CoverageHandler extends AbstractXmlHandler
                     $this->EndTimeStamp = $data;
                     break;
             }
-        } elseif ($parent == 'FILE') {
+        } elseif ($parent === 'FILE') {
             switch ($element) {
                 case 'LOCTESTED':
                     $this->Coverage->LocTested .= $data;
@@ -228,7 +228,7 @@ class CoverageHandler extends AbstractXmlHandler
                     $this->Coverage->FunctionsUntested .= $data;
                     break;
             }
-        } elseif ($element == 'LABEL') {
+        } elseif ($element === 'LABEL') {
             $this->Label->SetText($data);
         }
     }

--- a/app/Http/Submission/Handlers/CoverageJUnitHandler.php
+++ b/app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -92,19 +92,19 @@ class CoverageJUnitHandler extends AbstractXmlHandler
             }
             $this->Build->SetStamp($attributes['BUILDSTAMP']);
             $this->Build->Generator = $attributes['GENERATOR'];
-        } elseif ($name == 'SOURCEFILE') {
+        } elseif ($name === 'SOURCEFILE') {
             $this->CoverageFile = new CoverageFile();
             $this->Coverage = new Coverage();
             $this->CoverageFile->FullPath = trim($attributes['NAME']);
             $this->Coverage->Covered = 1;
             $this->Coverage->CoverageFile = $this->CoverageFile;
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             $this->Label = new Label();
-        } elseif ($parent == 'REPORT' && $name == 'SESSIONINFO') {
+        } elseif ($parent === 'REPORT' && $name === 'SESSIONINFO') {
             // timestamp are in miliseconds
             $this->StartTimeStamp = substr($attributes['START'], 0, -3);
             $this->EndTimeStamp = substr($attributes['DUMP'], 0, -3);
-        } elseif ($parent == 'REPORT' && $name == 'COUNTER') {
+        } elseif ($parent === 'REPORT' && $name === 'COUNTER') {
             switch ($attributes['TYPE']) {
                 case 'COMPLEXITY':
                     $this->CoverageSummary->BranchesTested = intval($attributes['COVERED']);
@@ -115,7 +115,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
                     $this->CoverageSummary->FunctionsUntested = intval($attributes['MISSED']);
                     break;
             }
-        } elseif ($parent == 'SOURCEFILE' && $name == 'COUNTER') {
+        } elseif ($parent === 'SOURCEFILE' && $name === 'COUNTER') {
             switch ($attributes['TYPE']) {
                 case 'LINE':
                     $this->Coverage->LocTested = intval($attributes['COVERED']);
@@ -167,9 +167,9 @@ class CoverageJUnitHandler extends AbstractXmlHandler
             // Insert coverage summary
             $this->CoverageSummary->Insert();
             $this->CoverageSummary->ComputeDifference();
-        } elseif ($name == 'SOURCEFILE') {
+        } elseif ($name === 'SOURCEFILE') {
             $this->CoverageSummary->AddCoverage($this->Coverage);
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             if (isset($this->Coverage)) {
                 $this->Coverage->AddLabel($this->Label);
             }
@@ -182,7 +182,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
     public function text($parser, $data): void
     {
         $element = $this->getElement();
-        if ($element == 'LABEL') {
+        if ($element === 'LABEL') {
             $this->Label->SetText($data);
         }
     }

--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -62,11 +62,11 @@ class CoverageLogHandler extends AbstractXmlHandler
             }
             $this->Build->SetStamp($attributes['BUILDSTAMP']);
             $this->Build->Generator = $attributes['GENERATOR'];
-        } elseif ($name == 'FILE') {
+        } elseif ($name === 'FILE') {
             $this->CurrentCoverageFile = new CoverageFile();
             $this->CurrentCoverageFileLog = new CoverageFileLog();
             $this->CurrentCoverageFile->FullPath = trim($attributes['FULLPATH']);
-        } elseif ($name == 'LINE') {
+        } elseif ($name === 'LINE') {
             if ($attributes['COUNT'] >= 0) {
                 $this->CurrentCoverageFileLog->AddLine($attributes['NUMBER'], $attributes['COUNT']);
             }
@@ -140,14 +140,14 @@ class CoverageLogHandler extends AbstractXmlHandler
                 $coverageFileLog->FileId = $coverageFile->Id;
                 $coverageFileLog->Insert(true);
             }
-        } elseif ($name == 'LINE') {
+        } elseif ($name === 'LINE') {
             $this->CurrentCoverageFile->File .= $this->CurrentLine . PHP_EOL;
-        } elseif ($name == 'FILE') {
+        } elseif ($name === 'FILE') {
             // Store these objects to be inserted after we're guaranteed
             // to have a valid buildid.
             $this->CoverageFiles[] = [$this->CurrentCoverageFile,
                 $this->CurrentCoverageFileLog];
-        } elseif ($name == 'COVERAGELOG') {
+        } elseif ($name === 'COVERAGELOG') {
             if (empty($this->CoverageFiles)) {
                 // Store these objects to be inserted after we're guaranteed
                 // to have a valid buildid.

--- a/app/Http/Submission/Handlers/DoneHandler.php
+++ b/app/Http/Submission/Handlers/DoneHandler.php
@@ -41,7 +41,7 @@ class DoneHandler extends AbstractXmlHandler
     public function startElement($parser, $name, $attributes): void
     {
         parent::startElement($parser, $name, $attributes);
-        if ($name == 'DONE' && array_key_exists('RETRIES', $attributes)
+        if ($name === 'DONE' && array_key_exists('RETRIES', $attributes)
                 && $attributes['RETRIES'] > 4) {
             // Too many retries, stop trying to parse this file.
             $this->FinalAttempt = true;
@@ -51,7 +51,7 @@ class DoneHandler extends AbstractXmlHandler
     public function endElement($parser, $name): void
     {
         parent::endElement($parser, $name);
-        if ($name == 'DONE') {
+        if ($name === 'DONE') {
             // Check pending submissions and requeue this file if necessary.
             $this->PendingSubmissions->Build = $this->Build;
             if ($this->PendingSubmissions->GetNumFiles() > 1) {
@@ -89,7 +89,7 @@ class DoneHandler extends AbstractXmlHandler
     {
         $parent = $this->getParent();
         $element = $this->getElement();
-        if ($parent == 'DONE') {
+        if ($parent === 'DONE') {
             switch ($element) {
                 case 'BUILDID':
                     $this->Build->Id = $data;

--- a/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+++ b/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -118,12 +118,12 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                 $this->BuildName = '(empty)';
             }
             $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {
                 $this->SubProjects[$this->SubProjectName] = [];
             }
-        } elseif ($name == 'DYNAMICANALYSIS') {
+        } elseif ($name === 'DYNAMICANALYSIS') {
             $this->Checker = $attributes['CHECKER'];
             if (empty($this->DynamicAnalysisSummaries)) {
                 $summary = $factory->create(DynamicAnalysisSummary::class);
@@ -135,17 +135,17 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                     $summary->Checker = $this->Checker;
                 }
             }
-        } elseif ($name == 'TEST' && isset($attributes['STATUS'])) {
+        } elseif ($name === 'TEST' && isset($attributes['STATUS'])) {
             $this->DynamicAnalysis = $factory->create(DynamicAnalysis::class);
             $this->DynamicAnalysis->Checker = $this->Checker;
             $this->DynamicAnalysis->Status = $attributes['STATUS'];
             $this->TestSubProjectName = '';
-        } elseif ($name == 'DEFECT') {
+        } elseif ($name === 'DEFECT') {
             $this->DynamicAnalysisDefect = $factory->create(DynamicAnalysisDefect::class);
             $this->DynamicAnalysisDefect->Type = $attributes['TYPE'];
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             $this->Label = $factory->create(Label::class);
-        } elseif ($name == 'LOG') {
+        } elseif ($name === 'LOG') {
             $this->DynamicAnalysis->LogCompression = $attributes['COMPRESSION'] ?? '';
             $this->DynamicAnalysis->LogEncoding = $attributes['ENCODING'] ?? '';
         }
@@ -165,7 +165,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                     $this->createBuild($subproject);
                 }
             }
-        } elseif ($name === 'TEST' && $this->getParent() == 'DYNAMICANALYSIS') {
+        } elseif ($name === 'TEST' && $this->getParent() === 'DYNAMICANALYSIS') {
             /** @var Build $build */
             $build = $this->Builds[$this->SubProjectName];
             $GLOBALS['PHP_ERROR_BUILD_ID'] = $build->Id;
@@ -178,16 +178,16 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
             $this->DynamicAnalysis->Insert();
             $analysis = clone $this->DynamicAnalysis;
             $build->AddDynamicAnalysis($analysis);
-        } elseif ($name == 'DEFECT') {
+        } elseif ($name === 'DEFECT') {
             $this->DynamicAnalysis->AddDefect($this->DynamicAnalysisDefect);
             unset($this->DynamicAnalysisDefect);
-        } elseif ($name == 'LABEL') {
+        } elseif ($name === 'LABEL') {
             if (!empty($this->TestSubProjectName)) {
                 $this->SubProjectName = $this->TestSubProjectName;
             } elseif (isset($this->DynamicAnalysis)) {
                 $this->DynamicAnalysis->AddLabel($this->Label);
             }
-        } elseif ($name == 'DYNAMICANALYSIS') {
+        } elseif ($name === 'DYNAMICANALYSIS') {
             foreach ($this->Builds as $subprojectName => $build) {
                 // Update this build's end time if necessary.
                 $build->EndTime = gmdate(FMT_DATETIME, $this->EndTimeStamp);
@@ -223,7 +223,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
         $parent = $this->getParent();
         $element = $this->getElement();
 
-        if ($parent == 'DYNAMICANALYSIS') {
+        if ($parent === 'DYNAMICANALYSIS') {
             switch ($element) {
                 case 'STARTTESTTIME':
                     $this->StartTimeStamp = $data;
@@ -232,7 +232,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                     $this->EndTimeStamp = $data;
                     break;
             }
-        } elseif ($parent == 'TEST') {
+        } elseif ($parent === 'TEST') {
             switch ($element) {
                 case 'NAME':
                     $this->DynamicAnalysis->Name .= $data;
@@ -247,13 +247,13 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
                     $this->DynamicAnalysis->Log .= $data;
                     break;
             }
-        } elseif ($parent == 'RESULTS') {
-            if ($element == 'DEFECT') {
+        } elseif ($parent === 'RESULTS') {
+            if ($element === 'DEFECT') {
                 $this->DynamicAnalysisDefect->Value .= $data;
             }
-        } elseif ($parent == 'SUBPROJECT' && $element == 'LABEL') {
+        } elseif ($parent === 'SUBPROJECT' && $element === 'LABEL') {
             $this->SubProjects[$this->SubProjectName][] = $data;
-        } elseif ($element == 'LABEL') {
+        } elseif ($element === 'LABEL') {
             // Check if this label belongs to a SubProject.
             foreach ($this->SubProjects as $subproject => $labels) {
                 if (in_array($data, $labels)) {

--- a/app/Http/Submission/Handlers/GcovTarHandler.php
+++ b/app/Http/Submission/Handlers/GcovTarHandler.php
@@ -74,7 +74,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
             new RecursiveDirectoryIterator($dirName),
             RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $fileinfo) {
-            if ($fileinfo->getFilename() == 'data.json') {
+            if ($fileinfo->getFilename() === 'data.json') {
                 $jsonContents = file_get_contents($fileinfo->getPath() . DIRECTORY_SEPARATOR . $fileinfo->getFilename());
                 $jsonDecoded = json_decode($jsonContents, true);
                 if (is_null($jsonDecoded) || !array_key_exists('Source', $jsonDecoded)
@@ -97,7 +97,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
         // Check if any Labels.json files were included
         $iterator->rewind();
         foreach ($iterator as $fileinfo) {
-            if ($fileinfo->getFilename() == 'Labels.json') {
+            if ($fileinfo->getFilename() === 'Labels.json') {
                 $this->ParseLabelsFile($fileinfo);
             }
         }
@@ -120,7 +120,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
         // Recursively search for .gcov files and parse them.
         $iterator->rewind();
         foreach ($iterator as $fileinfo) {
-            if (pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION) == 'gcov') {
+            if (pathinfo($fileinfo->getFilename(), PATHINFO_EXTENSION) === 'gcov') {
                 $this->ParseGcovFile($fileinfo);
             }
         }

--- a/app/Http/Submission/Handlers/JavaJSONTarHandler.php
+++ b/app/Http/Submission/Handlers/JavaJSONTarHandler.php
@@ -62,7 +62,7 @@ class JavaJSONTarHandler extends AbstractSubmissionHandler
             new RecursiveDirectoryIterator($dirName),
             RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $fileinfo) {
-            if ($fileinfo->getFilename() == 'package_map.json') {
+            if ($fileinfo->getFilename() === 'package_map.json') {
                 $this->ParsePackageMap($fileinfo);
             }
         }

--- a/app/Http/Submission/Handlers/NoteHandler.php
+++ b/app/Http/Submission/Handlers/NoteHandler.php
@@ -87,7 +87,7 @@ class NoteHandler extends AbstractXmlHandler
             }
             $this->Build->SetStamp($attributes['BUILDSTAMP']);
             $this->Build->Generator = $attributes['GENERATOR'];
-        } elseif ($name == 'NOTE') {
+        } elseif ($name === 'NOTE') {
             $this->NoteCreator = new NoteCreator();
             $this->NoteCreator->name =
                 $attributes['NAME'] ?? '';
@@ -99,7 +99,7 @@ class NoteHandler extends AbstractXmlHandler
     public function endElement($parser, $name): void
     {
         parent::endElement($parser, $name);
-        if ($name == 'NOTE') {
+        if ($name === 'NOTE') {
             $this->Build->ProjectId = $this->GetProject()->Id;
             $this->Build->GetIdFromName($this->SubProjectName);
             $this->Build->RemoveIfDone();
@@ -147,7 +147,7 @@ class NoteHandler extends AbstractXmlHandler
     {
         $parent = $this->getParent();
         $element = $this->getElement();
-        if ($parent == 'NOTE') {
+        if ($parent === 'NOTE') {
             switch ($element) {
                 case 'DATETIME':
                     // Only use the <DateTime> element when <Time> is unsuitable.

--- a/app/Http/Submission/Handlers/OpenCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/OpenCoverTarHandler.php
@@ -58,7 +58,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
          *  VC -> Visit Count
          *  EL -> Line offset, reduced by one to start the file at line 0
          */
-        if (($name == 'SEQUENCEPOINT') && $this->coverageFileLog) {
+        if (($name === 'SEQUENCEPOINT') && $this->coverageFileLog) {
             $this->coverageFileLog->AddLine($attributes['EL'] - 1, $attributes['VC']);
         }
     }
@@ -123,7 +123,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
         $element = $this->getElement();
         $data = trim($data);
         // FULLNAME refers to the "namespace" of the individual file
-        if ($element == 'FULLNAME' && strlen($data)) {
+        if ($element === 'FULLNAME' && strlen($data)) {
             $path = $this->parseFullName($data);
             // Lookup our models & create them if they don't exist yet.
             if ($path) {
@@ -134,7 +134,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
             }
         }
         // MODULENAME gives the folder structure that the .cs file belongs in
-        if ($element == 'MODULENAME' && strlen($data)) {
+        if ($element === 'MODULENAME' && strlen($data)) {
             $this->currentModule = [$data, strtolower($data)];
         }
     }
@@ -156,7 +156,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
             new RecursiveDirectoryIterator($this->tarDir),
             RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($iterator as $fileinfo) {
-            if ($fileinfo->getFilename() == 'data.json') {
+            if ($fileinfo->getFilename() === 'data.json') {
                 $jsonContents = file_get_contents($fileinfo->getPath() . DIRECTORY_SEPARATOR . $fileinfo->getFilename());
                 $jsonDecoded = json_decode($jsonContents, true);
                 if (array_key_exists('parseCSFiles', $jsonDecoded)) {

--- a/app/Http/Submission/Handlers/ProjectHandler.php
+++ b/app/Http/Submission/Handlers/ProjectHandler.php
@@ -53,7 +53,7 @@ class ProjectHandler extends AbstractXmlHandler
         parent::startElement($parser, $name, $attributes);
 
         // Check that the project name matches
-        if ($name == 'PROJECT') {
+        if ($name === 'PROJECT') {
             if (get_project_id($attributes['NAME']) != $this->GetProject()->Id) {
                 Log::error('Wrong project name: ' . $attributes['NAME'], [
                     'function' => 'ProjectHandler::startElement',
@@ -67,10 +67,10 @@ class ProjectHandler extends AbstractXmlHandler
             return;
         }
 
-        if ($name == 'PROJECT') {
+        if ($name === 'PROJECT') {
             $this->SubProjects = [];
             $this->Dependencies = [];
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             $this->CurrentDependencies = [];
             $this->SubProject = new SubProject();
             $this->SubProject->SetProjectId($this->GetProject()->Id);
@@ -78,7 +78,7 @@ class ProjectHandler extends AbstractXmlHandler
             if (array_key_exists('GROUP', $attributes)) {
                 $this->SubProject->SetGroup($attributes['GROUP']);
             }
-        } elseif ($name == 'DEPENDENCY') {
+        } elseif ($name === 'DEPENDENCY') {
             // A DEPENDENCY is expected to be:
             //
             //  - another subproject that already exists
@@ -102,7 +102,7 @@ class ProjectHandler extends AbstractXmlHandler
             return;
         }
 
-        if ($name == 'PROJECT') {
+        if ($name === 'PROJECT') {
             foreach ($this->SubProjects as $subproject) {
                 if (config('cdash.delete_old_subprojects')) {
                     // Remove dependencies that do not exist anymore,
@@ -164,7 +164,7 @@ class ProjectHandler extends AbstractXmlHandler
                     }
                 }
             }
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             // Insert the SubProject.
             $this->SubProject->SetPosition($this->SubProjectPosition);
             $this->SubProject->Save();
@@ -203,7 +203,7 @@ class ProjectHandler extends AbstractXmlHandler
     public function text($parser, $data): void
     {
         $element = $this->getElement();
-        if ($element == 'PATH') {
+        if ($element === 'PATH') {
             $this->SubProject->SetPath($data);
         }
     }

--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -130,29 +130,29 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                 $this->BuildName = '(empty)';
             }
             $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
-        } elseif ($name == 'SUBPROJECT') {
+        } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {
                 $this->SubProjects[$this->SubProjectName] = [];
                 $this->createBuild();
             }
-        } elseif ($name == 'TEST' && count($attributes) > 0) {
+        } elseif ($name === 'TEST' && count($attributes) > 0) {
             $this->TestCreator = new TestCreator();
             $this->TestCreator->projectid = $this->GetProject()->Id;
             $this->TestCreator->testStatus = $attributes['STATUS'];
             $this->TestSubProjectName = '';
             $this->Labels = [];
-        } elseif ($name == 'NAMEDMEASUREMENT' && array_key_exists('TYPE', $attributes)) {
+        } elseif ($name === 'NAMEDMEASUREMENT' && array_key_exists('TYPE', $attributes)) {
             $this->TestMeasurement = $factory->create(TestMeasurement::class);
 
-            if ($attributes['TYPE'] == 'file') {
+            if ($attributes['TYPE'] === 'file') {
                 $this->TestMeasurement->name = $attributes['FILENAME'];
             } else {
                 $this->TestMeasurement->name = $attributes['NAME'];
             }
             $this->TestMeasurement->type = $attributes['TYPE'];
         } elseif ($name === 'VALUE' && $this->getParent() === 'MEASUREMENT') {
-            if (isset($attributes['COMPRESSION']) && $attributes['COMPRESSION'] == 'gzip') {
+            if (isset($attributes['COMPRESSION']) && $attributes['COMPRESSION'] === 'gzip') {
                 $this->TestCreator->alreadyCompressed = true;
             }
         } elseif ($name === 'LABEL' && $this->getParent() === 'LABELS') {
@@ -177,11 +177,11 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
 
             $GLOBALS['PHP_ERROR_BUILD_ID'] = $build->Id;
 
-            if ($this->TestCreator->testStatus == 'passed') {
+            if ($this->TestCreator->testStatus === 'passed') {
                 $this->NumberTestsPassed[$this->SubProjectName]++;
-            } elseif ($this->TestCreator->testStatus == 'failed') {
+            } elseif ($this->TestCreator->testStatus === 'failed') {
                 $this->NumberTestsFailed[$this->SubProjectName]++;
-            } elseif ($this->TestCreator->testStatus == 'notrun') {
+            } elseif ($this->TestCreator->testStatus === 'notrun') {
                 $this->NumberTestsNotRun[$this->SubProjectName]++;
             }
             if ($this->Labels) {
@@ -189,26 +189,26 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
             }
             $this->TestCreator->projectid = $this->GetProject()->Id;
             $this->TestCreator->create($build);
-        } elseif ($name === 'LABEL' && $this->getParent() == 'LABELS') {
+        } elseif ($name === 'LABEL' && $this->getParent() === 'LABELS') {
             if (!empty($this->TestSubProjectName)) {
                 $this->SubProjectName = $this->TestSubProjectName;
             }
-        } elseif ($name == 'NAMEDMEASUREMENT') {
-            if ($this->TestMeasurement->name == 'Execution Time') {
+        } elseif ($name === 'NAMEDMEASUREMENT') {
+            if ($this->TestMeasurement->name === 'Execution Time') {
                 $this->TestCreator->buildTestTime = $this->TestMeasurement->value;
-            } elseif ($this->TestMeasurement->name == 'Exit Code') {
+            } elseif ($this->TestMeasurement->name === 'Exit Code') {
                 if (strlen($this->TestCreator->testDetails) > 0 && $this->TestMeasurement->value) {
                     $this->TestCreator->testDetails .= ' (' . $this->TestMeasurement->value . ')';
                 } elseif ($this->TestMeasurement->value) {
                     $this->TestCreator->testDetails = $this->TestMeasurement->value;
                 }
-            } elseif ($this->TestMeasurement->name == 'Completion Status') {
+            } elseif ($this->TestMeasurement->name === 'Completion Status') {
                 if (strlen($this->TestCreator->testDetails) > 0) {
                     $this->TestCreator->testDetails = $this->TestMeasurement->value . ' (' . $this->TestCreator->testDetails . ')';
                 } else {
                     $this->TestCreator->testDetails = $this->TestMeasurement->value;
                 }
-            } elseif ($this->TestMeasurement->name == 'Command Line') {
+            } elseif ($this->TestMeasurement->name === 'Command Line') {
                 // don't do anything since it should already be in the FullCommandLine
             } else {
                 // explicit measurement
@@ -273,7 +273,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
         $parent = $this->getParent();
         $element = $this->getElement();
 
-        if ($parent == 'TESTING') {
+        if ($parent === 'TESTING') {
             switch ($element) {
                 case 'STARTTESTTIME':
                     $this->StartTimeStamp = $data;
@@ -282,7 +282,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                     $this->EndTimeStamp = $data;
                     break;
             }
-        } elseif ($parent == 'TEST') {
+        } elseif ($parent === 'TEST') {
             switch ($element) {
                 case 'NAME':
                     $this->TestCreator->testName .= $data;
@@ -294,17 +294,17 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                     $this->TestCreator->testCommand .= $data;
                     break;
             }
-        } elseif ($parent == 'NAMEDMEASUREMENT' && $element == 'VALUE') {
+        } elseif ($parent === 'NAMEDMEASUREMENT' && $element === 'VALUE') {
             if (!isset($this->TestMeasurement->value)) {
                 $this->TestMeasurement->value = $data;
             } else {
                 $this->TestMeasurement->value .= $data;
             }
-        } elseif ($parent == 'MEASUREMENT' && $element == 'VALUE') {
+        } elseif ($parent === 'MEASUREMENT' && $element === 'VALUE') {
             $this->TestCreator->testOutput .= $data;
-        } elseif ($parent == 'SUBPROJECT' && $element == 'LABEL') {
+        } elseif ($parent === 'SUBPROJECT' && $element === 'LABEL') {
             $this->SubProjects[$this->SubProjectName][] = $data;
-        } elseif ($parent == 'LABELS' && $element == 'LABEL') {
+        } elseif ($parent === 'LABELS' && $element === 'LABEL') {
             // Check if this label belongs to a SubProject.
             foreach ($this->SubProjects as $subproject => $labels) {
                 if (in_array($data, $labels)) {

--- a/app/Http/Submission/Handlers/TestingJUnitHandler.php
+++ b/app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -114,9 +114,9 @@ class TestingJUnitHandler extends AbstractXmlHandler
 
             $this->Build->SetStamp($attributes['BUILDSTAMP']);
             $this->Build->Generator = $attributes['GENERATOR'];
-        } elseif ($name == 'FAILURE' || $name == 'ERROR') {
+        } elseif ($name === 'FAILURE' || $name === 'ERROR') {
             $this->TestCreator->testDetails = $attributes['TYPE'];
-        } elseif ($name == 'PROPERTY' && $parent == 'PROPERTIES') {
+        } elseif ($name === 'PROPERTY' && $parent === 'PROPERTIES') {
             $this->TestProperties .= $attributes['NAME'] . '=' . $attributes['VALUE'] . "\n";
             if ($this->HasSiteTag == false) {
                 switch ($attributes['NAME']) {
@@ -144,7 +144,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
                         break;
                 }
             }
-        } elseif ($name == 'TESTCASE' && count($attributes) > 0) {
+        } elseif ($name === 'TESTCASE' && count($attributes) > 0) {
             $this->TestCreator = new TestCreator();
             $this->TestCreator->testCommand = $this->TestProperties;
             $this->TestCreator->projectid = $this->GetProject()->Id;
@@ -167,7 +167,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
 
             $this->TestCreator->testName = $attributes['NAME'];
             $this->TestCreator->testPath = $attributes['CLASSNAME'];
-        } elseif ($name == 'TESTSUITE') {
+        } elseif ($name === 'TESTSUITE') {
             // If the XML file doesn't have a <Site> tag then we use the information
             // provided by the testsuite.
             // buildname is 'name'
@@ -207,26 +207,26 @@ class TestingJUnitHandler extends AbstractXmlHandler
     public function endElement($parser, $name): void
     {
         parent::endElement($parser, $name);
-        if ($name == 'FAILURE' || $name == 'ERROR') {
+        if ($name === 'FAILURE' || $name === 'ERROR') {
             // Mark this test as failed if it has a <failure> or <error> tag.
             $this->TestCreator->testStatus = 'failed';
-        } elseif ($name == 'TESTCASE') {
+        } elseif ($name === 'TESTCASE') {
             // At this point we should have enough information
             // to create a build if we haven't done so already.
             $this->createBuild();
 
             // Update our tally of passing/failing/notrun tests.
-            if ($this->TestCreator->testStatus == 'passed') {
+            if ($this->TestCreator->testStatus === 'passed') {
                 $this->NumberTestsPassed++;
-            } elseif ($this->TestCreator->testStatus == 'failed') {
+            } elseif ($this->TestCreator->testStatus === 'failed') {
                 $this->NumberTestsFailed++;
-            } elseif ($this->TestCreator->testStatus == 'notrun') {
+            } elseif ($this->TestCreator->testStatus === 'notrun') {
                 $this->NumberTestsNotRun++;
             }
 
             // Record this test in the database.
             $this->TestCreator->create($this->Build);
-        } elseif ($name == 'SITE' || ($this->HasSiteTag == false && $name == 'TESTSUITE')) {
+        } elseif ($name === 'SITE' || ($this->HasSiteTag == false && $name === 'TESTSUITE')) {
             if (strlen($this->EndTimeStamp) > 0 && $this->UpdateEndTime) {
                 $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp); // The EndTimeStamp
                 $this->Build->UpdateEndTime($end_time);
@@ -246,7 +246,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
     public function text($parser, $data): void
     {
         $element = $this->getElement();
-        if ($element == 'FAILURE') {
+        if ($element === 'FAILURE') {
             $this->TestCreator->testOutput .= $data;
         }
     }

--- a/app/Http/Submission/Handlers/UpdateHandler.php
+++ b/app/Http/Submission/Handlers/UpdateHandler.php
@@ -57,7 +57,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
     {
         parent::startElement($parser, $name, $attributes);
         $factory = $this->getModelFactory();
-        if ($name == 'UPDATE') {
+        if ($name === 'UPDATE') {
             $this->Build = new Build();
             $this->Update = $factory->create(BuildUpdate::class);
 
@@ -65,10 +65,10 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
                 $this->Build->Generator = $attributes['GENERATOR'];
             }
             $this->Update->Append = $this->Append;
-        } elseif ($name == 'UPDATED' || $name == 'CONFLICTING' || $name == 'MODIFIED') {
+        } elseif ($name === 'UPDATED' || $name === 'CONFLICTING' || $name === 'MODIFIED') {
             $this->UpdateFile = $factory->create(BuildUpdateFile::class);
             $this->UpdateFile->Status = $name;
-        } elseif ($name == 'UPDATERETURNSTATUS') {
+        } elseif ($name === 'UPDATERETURNSTATUS') {
             $this->Update->Status = '';
         }
     }
@@ -82,7 +82,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
             } else {
                 $this->Site->save();
             }
-        } elseif ($name == 'UPDATE') {
+        } elseif ($name === 'UPDATE') {
             $this->Build->SiteId = $this->Site->id;
 
             $start_time = gmdate(FMT_DATETIME, $this->StartTimeStamp);
@@ -140,7 +140,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
 
             // Compute the update statistics
             $this->Build->ComputeUpdateStatistics();
-        } elseif ($name == 'UPDATED' || $name == 'CONFLICTING' || $name == 'MODIFIED') {
+        } elseif ($name === 'UPDATED' || $name === 'CONFLICTING' || $name === 'MODIFIED') {
             $this->Update->AddFile($this->UpdateFile);
             unset($this->UpdateFile);
         }
@@ -153,7 +153,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
     {
         $parent = $this->getParent();
         $element = $this->getElement();
-        if ($parent == 'UPDATE') {
+        if ($parent === 'UPDATE') {
             switch ($element) {
                 case 'BUILDNAME':
                     $this->Build->Name = $data;
@@ -196,27 +196,27 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
                     $this->Update->Type = $data;
                     break;
             }
-        } elseif ($parent != 'REVISIONS' && $element == 'FULLNAME') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'FULLNAME') {
             $this->UpdateFile->Filename = $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'CHECKINDATE') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'CHECKINDATE') {
             $this->UpdateFile->CheckinDate = $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'AUTHOR') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'AUTHOR') {
             $this->UpdateFile->Author .= $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'EMAIL') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'EMAIL') {
             $this->UpdateFile->Email .= $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'COMMITTER') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'COMMITTER') {
             $this->UpdateFile->Committer .= $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'COMMITTEREMAIL') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'COMMITTEREMAIL') {
             $this->UpdateFile->CommitterEmail .= $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'LOG') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'LOG') {
             $this->UpdateFile->Log .= $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'REVISION') {
-            if ($data == 'Unknown') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'REVISION') {
+            if ($data === 'Unknown') {
                 $data = -1;
             }
             $this->UpdateFile->Revision = $data;
-        } elseif ($parent != 'REVISIONS' && $element == 'PRIORREVISION') {
-            if ($data == 'Unknown') {
+        } elseif ($parent !== 'REVISIONS' && $element === 'PRIORREVISION') {
+            if ($data === 'Unknown') {
                 $data = -1;
             }
             $this->UpdateFile->PriorRevision = $data;

--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -344,7 +344,7 @@ class ProcessSubmission implements ShouldQueue
         $file = pathinfo($fileNameWithExt, PATHINFO_FILENAME);
 
         $filename = $projectname_escaped . '_';
-        if ($file != 'Project') {
+        if ($file !== 'Project') {
             // Project.xml files aren't associated with a particular build, so we
             // only record the site and buildname for other types of submissions.
             $filename .= $subprojectname_escaped . '_' . $sitename_escaped . '_' . $buildname_escaped . '_' . $stamp . '_';
@@ -490,7 +490,7 @@ class ProcessSubmission implements ShouldQueue
         $buildname = '';
         $subprojectname = '';
         $stamp = '';
-        if ($file != 'Project') {
+        if ($file !== 'Project') {
             // projects don't have some of these fields.
 
             $sitename = $handler->getSiteName();

--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -181,7 +181,7 @@ class RepositoryUtils
 
         // remove base dir from other (binary) paths
         $base_dir = dirname($source_dir) . '/';
-        if ($base_dir != '//') {
+        if ($base_dir !== '//') {
             return str_replace($base_dir, '', $compiler_output);
         }
         return $compiler_output;
@@ -404,13 +404,13 @@ class RepositoryUtils
 
         $i = 0;
         foreach ($emailtext['category'] as $key => $value) {
-            if ($key != 'update_errors'
-                && $key != 'configure_errors'
-                && $key != 'build_warnings'
-                && $key != 'build_errors'
-                && $key != 'test_errors'
-                && $key != 'dynamicanalysis_errors'
-                && $key != 'missing_tests'
+            if ($key !== 'update_errors'
+                && $key !== 'configure_errors'
+                && $key !== 'build_warnings'
+                && $key !== 'build_errors'
+                && $key !== 'test_errors'
+                && $key !== 'dynamicanalysis_errors'
+                && $key !== 'missing_tests'
             ) {
                 continue;
             }
@@ -562,7 +562,7 @@ class RepositoryUtils
             $information .= 'Command: ';
             $information .= substr($update->command, 0, $maxchars);
             $information .= "\n";
-        } elseif ($errorkey == 'configure_errors') {
+        } elseif ($errorkey === 'configure_errors') {
             // Configure information
 
             $information = "\n\n*Configure*\n";

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -52,11 +52,11 @@ class QueryTests extends ResultsApi
     {
         $filters = $this->flattenFilters();
         foreach ($filters as $filter) {
-            if ($filter['field'] == 'groupname') {
+            if ($filter['field'] === 'groupname') {
                 $this->filterOnBuildGroup = true;
-            } elseif ($filter['field'] == 'revision') {
+            } elseif ($filter['field'] === 'revision') {
                 $this->filterOnRevision = true;
-            } elseif ($filter['field'] == 'testoutput') {
+            } elseif ($filter['field'] === 'testoutput') {
                 $this->filterOnTestOutput = true;
                 if ($filter['compare'] == 94) {
                     $this->testOutputExclude[] = $filter['value'];

--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -259,7 +259,7 @@ class TestDetails extends BuildTestApi
             if ($row['name'] === 'Environment' && $row['type'] === 'text/string') {
                 $test_response['environment'] = $row['value'];
                 continue;
-            } elseif ($row['type'] == 'text/preformatted') {
+            } elseif ($row['type'] === 'text/preformatted') {
                 $preformatted_measurement = ['name' => $row['name'], 'value' => $row['value']];
                 $preformatted_measurements[] = $preformatted_measurement;
                 continue;
@@ -271,20 +271,20 @@ class TestDetails extends BuildTestApi
 
             // CTest base64-encodes the type text/plain...
             $value = $row['value'];
-            if ($row['type'] == 'text/plain') {
-                if (substr($value, strlen($value) - 2) == '==') {
+            if ($row['type'] === 'text/plain') {
+                if (substr($value, strlen($value) - 2) === '==') {
                     $value = base64_decode($value);
                 }
-            } elseif ($row['type'] == 'file') {
+            } elseif ($row['type'] === 'file') {
                 $measurement_response['fileid'] = $fileid++;
             }
             // Add nl2br for type text/plain and text/string
-            if ($row['type'] == 'text/plain' || $row['type'] == 'text/string') {
+            if ($row['type'] === 'text/plain' || $row['type'] === 'text/string') {
                 $value = nl2br($value);
             }
 
             // If the type is a file we just don't pass the text (too big) to the output
-            if ($row['type'] == 'file') {
+            if ($row['type'] === 'file') {
                 $value = '';
             }
 

--- a/app/cdash/app/Controller/Api/TestGraph.php
+++ b/app/cdash/app/Controller/Api/TestGraph.php
@@ -114,7 +114,7 @@ class TestGraph extends BuildTestApi
                     if ($status != 'passed' && $status != 'failed') {
                         break;
                     }
-                    if ($status == 'passed') {
+                    if ($status === 'passed') {
                         $data_point['y'] = 1;
                         $chart_data[0]['data'][] = $data_point;
                     } else {

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -205,7 +205,7 @@ class Timeline extends Index
         ];
 
         $group_type = $buildgroup->GetType();
-        if ($group_type == 'Daily') {
+        if ($group_type === 'Daily') {
             // Query for defects on builds from this group.
             $stmt = $this->db->prepare('
                     SELECT b.configureerrors, b.builderrors, b.testfailed,
@@ -243,7 +243,7 @@ class Timeline extends Index
             $response = $this->getTimelineChartData($builds);
             $response['colors'] = $colors;
             return $response;
-        } elseif ($group_type == 'Latest') {
+        } elseif ($group_type === 'Latest') {
             $this->filterOnBuildGroup($groupname);
 
             // Save endDate before changing it.

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -319,7 +319,7 @@ class ViewTest extends BuildApi
             $this->db->execute($etestquery, $params);
         }
 
-        if (@$_GET['export'] == 'csv') {
+        if (@$_GET['export'] === 'csv') {
             $this->JSONEncodeResponse = false;
             return $this->exportAsCsv($etestquery, null, $stmt, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus);
         }
@@ -362,11 +362,11 @@ class ViewTest extends BuildApi
         while ($row = $stmt->fetch()) {
             $marshaledTest = self::marshal($row, $row['buildid'], $this->build->ProjectId, $this->project->ShowTestTime, $this->project->TestTimeMaxStatus, $testdate);
 
-            if ($marshaledTest['status'] == 'Passed') {
+            if ($marshaledTest['status'] === 'Passed') {
                 $numPassed++;
-            } elseif ($marshaledTest['status'] == 'Failed') {
+            } elseif ($marshaledTest['status'] === 'Failed') {
                 $numFailed++;
-            } elseif ($marshaledTest['status'] == 'Not Run') {
+            } elseif ($marshaledTest['status'] === 'Not Run') {
                 $numNotRun++;
             }
 

--- a/app/cdash/app/Model/DynamicAnalysis.php
+++ b/app/cdash/app/Model/DynamicAnalysis.php
@@ -128,11 +128,11 @@ class DynamicAnalysis
         $max_log_length = 1024 * 1024;
 
         // Handle log decoding/decompression
-        if (strtolower($this->LogEncoding ?? '') == 'base64') {
+        if (strtolower($this->LogEncoding ?? '') === 'base64') {
             $this->Log = str_replace(["\r\n", "\n", "\r"], '', $this->Log);
             $this->Log = base64_decode($this->Log);
         }
-        if (strtolower($this->LogCompression ?? '') == 'gzip') {
+        if (strtolower($this->LogCompression ?? '') === 'gzip') {
             // Avoid memory exhaustion errors by buffering data as we
             // decompress the gzipped log.
             $uncompressed_log = '';

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -865,7 +865,7 @@ class Project
         // Set up overview page to initially contain just the "Nightly" group.
         $groups = $this->GetBuildGroups();
         foreach ($groups as $group) {
-            if ($group->GetName() == 'Nightly') {
+            if ($group->GetName() === 'Nightly') {
                 $buildgroupid = (int) $group->GetId();
                 DB::table('overview_components')->insert([
                     'projectid' => $this->Id,

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -129,7 +129,7 @@ function time_difference($duration, bool $compact = false, string $suffix = '', 
 
     // If it's "in the future" -- probably indicates server time syncing is not
     // working well...
-    if (($duration < 0) || ($duration < 30 && $compact == false && $suffix == 'ago')) {
+    if (($duration < 0) || ($duration < 30 && $compact == false && $suffix === 'ago')) {
         if ($duration > -300) {
             // For "close" (less than 5 minutes diff)
             return 'just now';

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -972,14 +972,14 @@ function parse_filter_from_request($field_var, $compare_var, $value_var,
     // The following filter types are considered 'date clauses' so that the
     // default date clause of "builds from today only" is not used...
     //
-    if ($field == 'buildstarttime' || $field == 'buildstamp') {
+    if ($field === 'buildstarttime' || $field === 'buildstamp') {
         $filterdata['hasdateclause'] = 1;
     }
 
     // Revision filter is trickier. It should be considered a 'date clause' in the
     // positive case, ie "revision is X", or "revision starts with X", but not in the
     // negative case (when we're trying to filter OUT builds of specific revisions).
-    if ($field == 'revision'
+    if ($field === 'revision'
         && ($compare == 61 || $compare == 63 || $compare == 65)) {
         $filterdata['hasdateclause'] = 1;
     }
@@ -1029,7 +1029,7 @@ function get_filterdata_from_request($page_id = ''): array
     $limit = intval($_GET['limit'] ?? 0);
 
     $clear = $_GET['clear'] ?? '';
-    if ($clear == 'Clear') {
+    if ($clear === 'Clear') {
         $filtercount = 0;
     }
 
@@ -1151,7 +1151,7 @@ function generate_filterdata_sql($filterdata): string
         return '';
     }
 
-    if (strtolower($filterdata['filtercombine']) == 'or') {
+    if (strtolower($filterdata['filtercombine']) === 'or') {
         $sql_combine = 'OR';
         $sql_other_combine = 'AND';
     } else {
@@ -1202,7 +1202,7 @@ function get_label_ids_from_filterdata($filterdata): array
     $sql_combine = $filterdata['filtercombine'];
 
     foreach ($filterdata['filters'] as $filter) {
-        if ($filter['field'] == 'label') {
+        if ($filter['field'] === 'label') {
             $cv = get_sql_compare_and_value($filter['compare'],
                 $filter['value']);
             $sql_compare = $cv[0];
@@ -1251,10 +1251,10 @@ function build_survives_filters($build_response, $filters, $filtercombine): bool
             // Check this sub-block of filters.
             $othercombine = get_othercombine($filtercombine);
             $retval = build_survives_filters($build_response, $filter['filters'], $othercombine);
-            if ($filtercombine == 'and' && !$retval) {
+            if ($filtercombine === 'and' && !$retval) {
                 return false;
             }
-            if ($filtercombine == 'or' && $retval) {
+            if ($filtercombine === 'or' && $retval) {
                 return true;
             }
             continue;
@@ -1426,7 +1426,7 @@ function build_survives_filters($build_response, $filters, $filtercombine): bool
 
 function get_othercombine($filtercombine): string
 {
-    if (strtolower($filtercombine) == 'or') {
+    if (strtolower($filtercombine) === 'or') {
         return 'and';
     } else {
         return 'or';

--- a/app/cdash/public/api/v1/GitHub/webhook.php
+++ b/app/cdash/public/api/v1/GitHub/webhook.php
@@ -55,8 +55,8 @@ $event = array_key_exists('HTTP_X_GITHUB_EVENT', $_SERVER) ? $_SERVER['HTTP_X_GI
 switch ($event) {
     case 'check_run':
         // Avoid an infinite loop of reacting to our own activity.
-        if ($_REQUEST['check_run']['name'] != 'CDash' ||
-                $_REQUEST['action'] == 'rerequested') {
+        if ($_REQUEST['check_run']['name'] !== 'CDash' ||
+                $_REQUEST['action'] === 'rerequested') {
             $sha = $_REQUEST['check_run']['head_sha'];
             Repository::createOrUpdateCheck($sha);
         }

--- a/app/cdash/public/api/v1/computeClassifier.php
+++ b/app/cdash/public/api/v1/computeClassifier.php
@@ -76,7 +76,7 @@ foreach ($builds as $build) {
 // Compute information gain for each value of each property.
 $classifiers = [];
 foreach ($allProperties as $propertyName => $propertyData) {
-    if ($propertyData['type'] == 'number') {
+    if ($propertyData['type'] === 'number') {
         // Numerical property.
         [$classifierName, $score] =
             find_numerical_classifier($propertyName, $propertyData, $builds);

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -146,7 +146,7 @@ foreach ($buildgroups as $buildgroup) {
 
     $buildgroups_response[] = $buildgroup_response;
 
-    if ($buildgroup->GetType() != 'Daily') {
+    if ($buildgroup->GetType() !== 'Daily') {
         // Get the rules associated with this dynamic group.
         $dynamic_response = $buildgroup_response;
         $rules = $buildgroup->GetRules();

--- a/app/cdash/tests/kwtest/simpletest/browser.php
+++ b/app/cdash/tests/kwtest/simpletest/browser.php
@@ -337,7 +337,7 @@ class SimpleBrowser
     protected function load($url, $parameters)
     {
         $frame = $url->getTarget();
-        if (!$frame || !$this->page->hasFrames() || (strtolower($frame) == '_top')) {
+        if (!$frame || !$this->page->hasFrames() || (strtolower($frame) === '_top')) {
             return $this->loadPage($url, $parameters);
         }
         return $this->loadFrame([$frame], $url, $parameters);

--- a/app/cdash/tests/test_autoremovebuilds_on_submit.php
+++ b/app/cdash/tests/test_autoremovebuilds_on_submit.php
@@ -83,7 +83,7 @@ class AutoRemoveBuildsOnSubmitTestCase extends KWWebTestCase
         }
         $query_array = pdo_fetch_array($stmt);
 
-        if ($query_array[0] != 'Win32-MSVC2009') {
+        if ($query_array[0] !== 'Win32-MSVC2009') {
             echo $query_array[0];
             $this->fail('First build not inserted correctly');
             return 1;

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -102,7 +102,7 @@ class BuildDetailsTestCase extends KWWebTestCase
         $this->assertTrue(count($build_response->errors) == 3);
 
         foreach ($build_response->errors as $error) {
-            $this->assertTrue($error->subprojectname == 'my_subproject');
+            $this->assertTrue($error->subprojectname === 'my_subproject');
         }
     }
 
@@ -147,7 +147,7 @@ class BuildDetailsTestCase extends KWWebTestCase
 
         foreach ($response->tests as $test) {
             $this->assertTrue(property_exists($test, 'subprojectid'));
-            $this->assertTrue($test->subprojectname == 'some-subproject');
+            $this->assertTrue($test->subprojectname === 'some-subproject');
         }
 
         DatabaseCleanupUtils::removeBuild($buildId->id);

--- a/app/cdash/tests/test_buildgrouprule.php
+++ b/app/cdash/tests/test_buildgrouprule.php
@@ -177,7 +177,7 @@ class BuildGroupRuleTestCase extends KWWebTestCase
                       buildtype = 'Experimental'");
         pdo_execute($stmt);
         while ($row = $stmt->fetch()) {
-            if ($row['endtime'] == '1980-01-01 00:00:00') {
+            if ($row['endtime'] === '1980-01-01 00:00:00') {
                 $num_active++;
             } else {
                 $num_finished++;

--- a/app/cdash/tests/test_buildmodel.php
+++ b/app/cdash/tests/test_buildmodel.php
@@ -240,7 +240,7 @@ class BuildModelTestCase extends KWWebTestCase
         $buildFailures = $build->GetFailures(['type' => Build::TYPE_WARN]);
         $this->assertTrue(count($buildFailures) === 1);
 
-        $this->assertTrue($buildFailures[0]['subprojectname'] == 'some-test-subproject');
+        $this->assertTrue($buildFailures[0]['subprojectname'] === 'some-test-subproject');
     }
 
     public function testBuildModelGetsResolvedBuildFailures(): void
@@ -288,7 +288,7 @@ class BuildModelTestCase extends KWWebTestCase
         $buildErrors = $build->GetErrors(['type' => Build::TYPE_ERROR]);
         $this->assertTrue(count($buildErrors) === 1);
 
-        $this->assertTrue($buildErrors[0]['subprojectname'] == 'some-test-subproject');
+        $this->assertTrue($buildErrors[0]['subprojectname'] === 'some-test-subproject');
     }
 
     public function testBuildModelGetsResolvedBuildErrors(): void

--- a/app/cdash/tests/test_committerinfo.php
+++ b/app/cdash/tests/test_committerinfo.php
@@ -24,12 +24,12 @@ class CommitterInfoTestCase extends KWWebTestCase
         $committer = $query[0]['committer'];
         $committerEmail = $query[0]['committeremail'];
 
-        if ($committer != 'Test Committer') {
+        if ($committer !== 'Test Committer') {
             $this->fail("Incorrect update committer value: expected 'Test Committer' but was '$committer'");
             return;
         }
 
-        if ($committerEmail != 'simpleuser@localhost') {
+        if ($committerEmail !== 'simpleuser@localhost') {
             $this->fail("Incorrect update committer email value: expected 'simpleuser@localhost' but was '$committerEmail'");
             return;
         }

--- a/app/cdash/tests/test_compressedtest.php
+++ b/app/cdash/tests/test_compressedtest.php
@@ -44,7 +44,7 @@ class CompressedTestCase extends KWWebTestCase
         $response = json_decode($this->getBrowser()->getContentAsText(), true);
         $buildid = -1;
         foreach ($response['buildgroups'] as $buildgroup) {
-            if ($buildgroup['name'] != 'Experimental') {
+            if ($buildgroup['name'] !== 'Experimental') {
                 continue;
             }
             foreach ($buildgroup['builds'] as $build) {

--- a/app/cdash/tests/test_managemeasurements.php
+++ b/app/cdash/tests/test_managemeasurements.php
@@ -49,18 +49,18 @@ class ManageMeasurementsTestCase extends KWWebTestCase
     {
         // For those special moments when 4.2 does not equal 4.2
         $proc_time = sprintf('%.1f', $proc_time);
-        if ($test_name == 'TestNoProcs') {
+        if ($test_name === 'TestNoProcs') {
             if ($proc_time != 1.4) {
                 $this->fail("Expected 1.4 proc time on $page, found $proc_time");
             }
-        } elseif ($test_name == 'Test3Procs') {
+        } elseif ($test_name === 'Test3Procs') {
             if ($num_procs != 3) {
                 $this->fail("Expected 3 processors on $page, found $num_procs");
             }
             if ($proc_time != 4.2) {
                 $this->fail("Expected 4.2 proc time on $page, found $proc_time");
             }
-        } elseif ($test_name == 'Test5Procs') {
+        } elseif ($test_name === 'Test5Procs') {
             if ($num_procs != 5) {
                 $this->fail("Expected 5 processors on $page, found $num_procs");
             }
@@ -78,7 +78,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
         // For those special moments when 6.6 does not equal 6.6
         $proc_time = sprintf('%.1f', $proc_time);
         $io_wait_time = sprintf('%.1f', $io_wait_time);
-        if ($test_name == 'experimentalFail1') {
+        if ($test_name === 'experimentalFail1') {
             if ($num_procs != 2) {
                 $this->fail("Expected 2 processors on $page, found $num_procs");
             }
@@ -88,7 +88,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             if ($io_wait_time != 4.2) {
                 $this->fail("Expected 4.2 io_wait time on $page, found $io_wait_time");
             }
-        } elseif ($test_name == 'experimentalFail2') {
+        } elseif ($test_name === 'experimentalFail2') {
             if ($num_procs != 3) {
                 $this->fail("Expected 3 processors on $page, found $num_procs");
             }
@@ -98,7 +98,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             if ($io_wait_time != 5.3) {
                 $this->fail("Expected 5.3 io_wait time on $page, found $io_wait_time");
             }
-        } elseif ($test_name == 'production') {
+        } elseif ($test_name === 'production') {
             if ($num_procs != 4) {
                 $this->fail("Expected 4 processors on $page, found $num_procs");
             }
@@ -229,7 +229,7 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             $this->fail("Expected 1 extra column on testSummary.php, found $found");
         }
         $found = $jsonobj['columns'][0];
-        if ($found != 'Processors') {
+        if ($found !== 'Processors') {
             $this->fail("Expected extra column to be called 'Processors', found $found");
         }
         $found = count($jsonobj['builds']);
@@ -301,9 +301,9 @@ class ManageMeasurementsTestCase extends KWWebTestCase
             $label = $build['label'];
             $found = $build['test']['procTimeFull'];
             $expected = null;
-            if ($label == 'MyExperimentalFeature') {
+            if ($label === 'MyExperimentalFeature') {
                 $expected = 8.8;
-            } elseif ($label == 'MyProductionCode') {
+            } elseif ($label === 'MyProductionCode') {
                 $expected = 13.2;
             } else {
                 $this->fail("Unexpected build label $label");

--- a/app/cdash/tests/test_multiplesubprojects.php
+++ b/app/cdash/tests/test_multiplesubprojects.php
@@ -390,13 +390,13 @@ class MultipleSubprojectsTestCase extends KWWebTestCase
         if ($jsonobj['updateduration'] !== false) {
             $this->fail("Expected updateduration to be false, found {$jsonobj['updateduration']}");
         }
-        if ($jsonobj['configureduration'] != '1s') {
+        if ($jsonobj['configureduration'] !== '1s') {
             $this->fail("Expected configureduration to be 1s, found {$jsonobj['configureduration']}");
         }
-        if ($jsonobj['buildduration'] != '5s') {
+        if ($jsonobj['buildduration'] !== '5s') {
             $this->fail("Expected buildduration to be 5s, found {$jsonobj['buildduration']}");
         }
-        if ($jsonobj['testduration'] != '4s') {
+        if ($jsonobj['testduration'] !== '4s') {
             $this->fail("Expected testduration to be 4s, found {$jsonobj['testduration']}");
         }
 

--- a/app/cdash/tests/test_namedmeasurements.php
+++ b/app/cdash/tests/test_namedmeasurements.php
@@ -57,10 +57,10 @@ class NamedMeasurementsTestCase extends KWWebTestCase
         $found_link1 = false;
         $found_link2 = false;
         foreach ($results as $result) {
-            if ($result->value == 'https://example.com/link1.txt') {
+            if ($result->value === 'https://example.com/link1.txt') {
                 $found_link1 = true;
             }
-            if ($result->value == 'https://example.com/link2.txt') {
+            if ($result->value === 'https://example.com/link2.txt') {
                 $found_link2 = true;
             }
         }

--- a/app/cdash/tests/test_redundanttests.php
+++ b/app/cdash/tests/test_redundanttests.php
@@ -78,10 +78,10 @@ class RedundantTestsTestCase extends KWWebTestCase
             $this->get("{$this->url}/api/v1/testDetails.php?buildtestid={$row->id}");
             $content = $this->getBrowser()->getContent();
             $jsonobj = json_decode($content, true);
-            if ($jsonobj['test']['output'] == "this is a test\n") {
+            if ($jsonobj['test']['output'] === "this is a test\n") {
                 $test1found = true;
             }
-            if ($jsonobj['test']['output'] == "this is the same test but with different output\n") {
+            if ($jsonobj['test']['output'] === "this is the same test but with different output\n") {
                 $test2found = true;
             }
         }

--- a/app/cdash/tests/test_sequenceindependence.php
+++ b/app/cdash/tests/test_sequenceindependence.php
@@ -283,7 +283,7 @@ class SequenceIndependenceTestCase extends KWWebTestCase
             $this->fail("Expected note time to be '2009-02-23 12:32:00', found " . $note_row->time);
             return false;
         }
-        if ($note_row->name != '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake') {
+        if ($note_row->name !== '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake') {
             $this->fail("Expected note name to be '/home/ibanez/src/Work/Luis/DashboardScripts/camelot_itk_lesion_sizing_sandbox_debug_gcc41.cmake', found " . $note_row->name);
             return false;
         }

--- a/app/cdash/tests/test_subprojecttestfilters.php
+++ b/app/cdash/tests/test_subprojecttestfilters.php
@@ -68,7 +68,7 @@ class SubProjectTestFiltersTestCase extends KWWebTestCase
         $this->assertEqual(11, $jsonobj['numFailed']);
         $this->assertEqual(0, $jsonobj['numNotRun']);
         foreach ($jsonobj['tests'] as $test) {
-            if ($test['subprojectname'] != 'TrilinosFramework' && $test['subprojectname'] != 'Sacado') {
+            if ($test['subprojectname'] !== 'TrilinosFramework' && $test['subprojectname'] !== 'Sacado') {
                 $this->fail("Unexpected subprojectname on viewTest.php for include case: {$test['subprojectname']}");
             }
         }

--- a/app/cdash/tests/test_testhistory.php
+++ b/app/cdash/tests/test_testhistory.php
@@ -250,27 +250,27 @@ class TestHistoryTestCase extends KWWebTestCase
             $history = $test['history'];
             switch ($test['name']) {
                 case 'fails':
-                    if ($history != 'Broken') {
+                    if ($history !== 'Broken') {
                         $this->fail("Expected history for test 'fails' to be 'Broken', instead found '$history'");
                     }
                     break;
                 case 'notrun':
-                    if ($history != 'Inactive') {
+                    if ($history !== 'Inactive') {
                         $this->fail("Expected history for test 'notrun' to be 'Inactive', instead found '$history'");
                     }
                     break;
                 case 'flaky':
-                    if ($history != 'Unstable') {
+                    if ($history !== 'Unstable') {
                         $this->fail("Expected history for test 'flaky' to be 'Unstable', instead found '$history'");
                     }
                     break;
                 case 'passes':
-                    if ('passes' && $history != 'Stable') {
+                    if ('passes' && $history !== 'Stable') {
                         $this->fail("Expected history for test 'passes' to be 'Stable', instead found '$history'");
                     }
                     break;
                 case 'sporadic':
-                    if ('sporadic' && $history != 'Stable') {
+                    if ('sporadic' && $history !== 'Stable') {
                         $this->fail("Expected history for test 'sporadic' to be 'Stable', instead found '$history'");
                     }
                     break;

--- a/app/cdash/tests/test_timeline.php
+++ b/app/cdash/tests/test_timeline.php
@@ -91,7 +91,7 @@ class TimelineTestCase extends KWWebTestCase
         ];
         foreach ($pages_to_check as $page) {
             $filterdata = json_encode(['pageId' => $page]);
-            $extra_param = $page == 'viewBuildGroup.php' ? '&buildgroup=Experimental' : '';
+            $extra_param = $page === 'viewBuildGroup.php' ? '&buildgroup=Experimental' : '';
             $this->get($this->url . "/api/v1/timeline.php?date=2009-02-23&filterdata=$filterdata&project=InsightExample$extra_param");
             $content = $this->getBrowser()->getContent();
             $jsonobj = json_decode($content, true);

--- a/app/cdash/tests/test_truncateoutput.php
+++ b/app/cdash/tests/test_truncateoutput.php
@@ -66,10 +66,10 @@ class TruncateOutputTestCase extends KWWebTestCase
 
             // Verify that the output was properly truncated.
             $fields = [];
-            if ($file == 'Build_stdout.xml' || $file == 'Build_both.xml') {
+            if ($file === 'Build_stdout.xml' || $file === 'Build_both.xml') {
                 $fields[] = 'stdoutput';
             }
-            if ($file == 'Build_stderr.xml' || $file == 'Build_both.xml') {
+            if ($file === 'Build_stderr.xml' || $file === 'Build_both.xml') {
                 $fields[] = 'stderror';
             }
 

--- a/app/cdash/tests/test_updateappend.php
+++ b/app/cdash/tests/test_updateappend.php
@@ -74,20 +74,20 @@ class UppdateAppendTestCase extends KWWebTestCase
             }
 
             // Note: UpdateType is only read from the first Update
-            if ($buildupdate_array['type'] != 'GIT') {
+            if ($buildupdate_array['type'] !== 'GIT') {
                 throw new Exception('Expected type=GIT, found type= ' . $buildupdate_array['type']);
             }
 
             // Note: Commands from all Updates are concatenated together
-            if ($buildupdate_array['command'] != 'Command 1Command 2Command 3') {
+            if ($buildupdate_array['command'] !== 'Command 1Command 2Command 3') {
                 throw new Exception('Expected command=Command 1Command 2Command 3, found command= ' . $buildupdate_array['command']);
             }
 
             // Note: MDT = GMT - 6
-            if ($buildupdate_array['starttime'] != '2015-08-24 04:04:14') {
+            if ($buildupdate_array['starttime'] !== '2015-08-24 04:04:14') {
                 throw new Exception('Expected starttime=GIT, found starttime= ' . $buildupdate_array['starttime']);
             }
-            if ($buildupdate_array['endtime'] != '2015-08-24 04:20:30') {
+            if ($buildupdate_array['endtime'] !== '2015-08-24 04:20:30') {
                 throw new Exception('Expected endtime=2015-08-24 04:20:30, found endtime= ' . $buildupdate_array['endtime']);
             }
 
@@ -106,7 +106,7 @@ class UppdateAppendTestCase extends KWWebTestCase
             }
 
             // Note: Path is only read from the first Update
-            if ($buildupdate_array['path'] != 'mypath') {
+            if ($buildupdate_array['path'] !== 'mypath') {
                 throw new Exception('Expected path=mypath, found path= ' . $buildupdate_array['path']);
             }
         } catch (Exception $e) {

--- a/app/cdash/tests/trilinos_submission_test.php
+++ b/app/cdash/tests/trilinos_submission_test.php
@@ -118,7 +118,7 @@ class TrilinosSubmissionTestCase extends KWWebTestCase
         $buildgroup = array_pop($jsonobj['buildgroups']);
         $builds = $buildgroup['builds'];
 
-        if ($jsonobj['site'] != 'hut11.kitware') {
+        if ($jsonobj['site'] !== 'hut11.kitware') {
             $this->fail('Expected hut11.kitware, found ' . $jsonobj['site']);
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,18 +49,6 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: app/Console/Commands/AutoRemoveBuilds.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: app/Console/Commands/AutoRemoveBuilds.php
-
-		-
 			message: '#^Only booleans are allowed in a while condition, mixed given\.$#'
 			identifier: while.condNotBoolean
 			count: 1
@@ -131,12 +119,6 @@ parameters:
 			identifier: booleanNot.exprNotBoolean
 			count: 1
 			path: app/Console/Commands/RemoveUser.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: app/Console/Commands/SaveUser.php
 
 		-
 			message: '#^Only booleans are allowed in an if condition, string\|null given\.$#'
@@ -693,7 +675,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 3
+			count: 1
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -1317,7 +1299,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 55
+			count: 53
 			path: app/Http/Controllers/CoverageController.php
 
 		-
@@ -2524,12 +2506,6 @@ parameters:
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 6
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
@@ -3033,7 +3009,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 2
+			count: 1
 			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
 
 		-
@@ -3571,12 +3547,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 18
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
 			message: '#^Method App\\Http\\Submission\\Handlers\\BuildHandler\:\:GetCommitAuthors\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -3807,7 +3777,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 7
+			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
@@ -3957,7 +3927,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 10
+			count: 3
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
@@ -4053,7 +4023,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 12
+			count: 1
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
 
 		-
@@ -4155,7 +4125,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 6
+			count: 1
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
 		-
@@ -4240,12 +4210,6 @@ parameters:
 			message: '#^Cannot access property \$name on App\\Models\\Site\|null\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: app/Http/Submission/Handlers/DoneHandler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 3
 			path: app/Http/Submission/Handlers/DoneHandler.php
 
 		-
@@ -4383,7 +4347,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 18
+			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
@@ -4534,12 +4498,6 @@ parameters:
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 5
-			path: app/Http/Submission/Handlers/GcovTarHandler.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 3
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
 
 		-
@@ -4809,7 +4767,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 2
+			count: 1
 			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
 
 		-
@@ -4881,7 +4839,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 4
+			count: 1
 			path: app/Http/Submission/Handlers/NoteHandler.php
 
 		-
@@ -5085,7 +5043,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 6
+			count: 2
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
 		-
@@ -5247,7 +5205,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 8
+			count: 1
 			path: app/Http/Submission/Handlers/ProjectHandler.php
 
 		-
@@ -5421,7 +5379,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 25
+			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
@@ -5595,7 +5553,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 20
+			count: 5
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
@@ -5761,15 +5719,9 @@ parameters:
 			path: app/Http/Submission/Handlers/UpdateHandler.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 9
-			path: app/Http/Submission/Handlers/UpdateHandler.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 22
+			count: 1
 			path: app/Http/Submission/Handlers/UpdateHandler.php
 
 		-
@@ -6100,12 +6052,6 @@ parameters:
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 5
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 2
 			path: app/Jobs/ProcessSubmission.php
 
 		-
@@ -6706,15 +6652,9 @@ parameters:
 			path: app/Utils/RepositoryUtils.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 8
-			path: app/Utils/RepositoryUtils.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 9
+			count: 8
 			path: app/Utils/RepositoryUtils.php
 
 		-
@@ -8424,7 +8364,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 8
+			count: 5
 			path: app/cdash/app/Controller/Api/QueryTests.php
 
 		-
@@ -8682,7 +8622,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 8
+			count: 1
 			path: app/cdash/app/Controller/Api/TestDetails.php
 
 		-
@@ -8737,12 +8677,6 @@ parameters:
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 2
-			path: app/cdash/app/Controller/Api/TestGraph.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
 			path: app/cdash/app/Controller/Api/TestGraph.php
 
 		-
@@ -8872,12 +8806,6 @@ parameters:
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 1
-			path: app/cdash/app/Controller/Api/Timeline.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
 			path: app/cdash/app/Controller/Api/Timeline.php
 
 		-
@@ -9060,7 +8988,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 10
+			count: 6
 			path: app/cdash/app/Controller/Api/ViewTest.php
 
 		-
@@ -11784,7 +11712,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 5
+			count: 3
 			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
@@ -12415,12 +12343,6 @@ parameters:
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 2
-			path: app/cdash/app/Model/Project.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
@@ -15837,7 +15759,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 5
+			count: 4
 			path: app/cdash/include/common.php
 
 		-
@@ -16428,7 +16350,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 16
+			count: 7
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
@@ -16662,18 +16584,6 @@ parameters:
 		-
 			message: '#^Function handle_error\(\) has parameter \$msg with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/public/api/v1/GitHub/webhook.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: app/cdash/public/api/v1/GitHub/webhook.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
 			count: 1
 			path: app/cdash/public/api/v1/GitHub/webhook.php
 
@@ -16981,12 +16891,6 @@ parameters:
 			path: app/cdash/public/api/v1/computeClassifier.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: app/cdash/public/api/v1/computeClassifier.php
-
-		-
 			message: '#^Only numeric types are allowed in /, \(array\|float\|int\) given on the left side\.$#'
 			identifier: div.leftNonNumeric
 			count: 1
@@ -17277,12 +17181,6 @@ parameters:
 		-
 			message: '#^Foreach overwrites \$buildgroup with its value variable\.$#'
 			identifier: foreach.valueOverwrite
-			count: 1
-			path: app/cdash/public/api/v1/manageBuildGroup.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
 			count: 1
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
@@ -21237,19 +21135,13 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on array\|false\|null\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
 			message: '#^Cannot call method fetchColumn\(\) on PDOStatement\|false\.$#'
 			identifier: method.nonObject
 			count: 4
-			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
 			path: app/cdash/tests/test_autoremovebuilds_on_submit.php
 
 		-
@@ -21825,7 +21717,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 3
+			count: 1
 			path: app/cdash/tests/test_builddetails.php
 
 		-
@@ -21964,12 +21856,6 @@ parameters:
 			path: app/cdash/tests/test_buildgrouprule.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: app/cdash/tests/test_buildgrouprule.php
-
-		-
 			message: '#^Method BuildGroupRuleTestCase\:\:testBuildGroupRule\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -22017,7 +21903,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 4
+			count: 2
 			path: app/cdash/tests/test_buildmodel.php
 
 		-
@@ -22432,12 +22318,6 @@ parameters:
 			path: app/cdash/tests/test_committerinfo.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 2
-			path: app/cdash/tests/test_committerinfo.php
-
-		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 2
@@ -22509,12 +22389,6 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 1
-			path: app/cdash/tests/test_compressedtest.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
 			count: 1
 			path: app/cdash/tests/test_compressedtest.php
 
@@ -25092,13 +24966,13 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 21
+			count: 20
 			path: app/cdash/tests/test_managemeasurements.php
 
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 9
+			count: 1
 			path: app/cdash/tests/test_managemeasurements.php
 
 		-
@@ -25518,7 +25392,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''buildduration'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -25536,7 +25410,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''configureduration'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -25692,7 +25566,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''testduration'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -25764,7 +25638,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 32
+			count: 29
 			path: app/cdash/tests/test_multiplesubprojects.php
 
 		-
@@ -26104,12 +25978,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 1
-			path: app/cdash/tests/test_namedmeasurements.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
 			path: app/cdash/tests/test_namedmeasurements.php
 
 		-
@@ -26997,7 +26865,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''output'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_redundanttests.php
 
 		-
@@ -27016,12 +26884,6 @@ parameters:
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: app/cdash/tests/test_redundanttests.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
 			path: app/cdash/tests/test_redundanttests.php
 
 		-
@@ -27192,7 +27054,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 7
+			count: 6
 			path: app/cdash/tests/test_sequenceindependence.php
 
 		-
@@ -27642,7 +27504,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''subprojectname'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
+			count: 3
 			path: app/cdash/tests/test_subprojecttestfilters.php
 
 		-
@@ -27666,12 +27528,6 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/cdash/tests/test_subprojecttestfilters.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
 			count: 2
 			path: app/cdash/tests/test_subprojecttestfilters.php
 
@@ -27937,12 +27793,6 @@ parameters:
 			path: app/cdash/tests/test_testhistory.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 5
-			path: app/cdash/tests/test_testhistory.php
-
-		-
 			message: '#^Method TestHistoryTestCase\:\:generateXML\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -28158,7 +28008,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 2
+			count: 1
 			path: app/cdash/tests/test_timeline.php
 
 		-
@@ -28534,12 +28384,6 @@ parameters:
 			path: app/cdash/tests/test_truncateoutput.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 4
-			path: app/cdash/tests/test_truncateoutput.php
-
-		-
 			message: '#^Parameter \#1 \$haystack of function str_contains expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -28674,7 +28518,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 11
+			count: 6
 			path: app/cdash/tests/test_updateappend.php
 
 		-
@@ -28983,7 +28827,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''site'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: app/cdash/tests/trilinos_submission_test.php
 
 		-
@@ -28995,7 +28839,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
-			count: 4
+			count: 3
 			path: app/cdash/tests/trilinos_submission_test.php
 
 		-


### PR DESCRIPTION
Changes from non-strict to strict equality which are only tangentially related to a PR are a common cause of conflicts.  PHPStan baseline conflicts are also common.  Changing to strict equality when one operand is a constant string of nonzero length is guaranteed to be safe.  This PR converts all such cases to strict equality purely for the sake of reducing the number of errors of this type in the codebase in the hopes of reducing future conflicts.