### PR TITLE
Remove measurements from test output crc32 computation

### DIFF
--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -121,11 +121,6 @@ class TestCreator
         $crc32_input .= $this->testCommand;
         $crc32_input .= $this->testOutput;
         $crc32_input .= $this->testDetails;
-        foreach ($this->measurements as $measurement) {
-            $crc32_input .= '_' . $measurement->type;
-            $crc32_input .= '_' . $measurement->name;
-            $crc32_input .= '_' . $measurement->value;
-        }
 
         foreach ($this->images as $image) {
             $this->loadImage($image);


### PR DESCRIPTION
Since https://github.com/Kitware/CDash/pull/2336, test measurements are no longer related to test outputs directly.  Their removal from the test output crc32 was overlooked, meaning that we're now missing opportunities to deduplicate test outputs more efficiently.  This is particularly impactful because some test measurements include variable measurements such as wall clock time, effectively meaning that we're not deduplicating at all.  This PR removes test measurements from the test output hash computation.