### PR TITLE
Relate test images to tests instead of test outputs

### DIFF
--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -32,10 +32,10 @@ class Image extends Model
     ];
 
     /**
-     * @return HasManyThrough<TestOutput, TestImage, $this>
+     * @return HasManyThrough<Test, TestImage, $this>
      */
-    public function testOutputs(): HasManyThrough
+    public function tests(): HasManyThrough
     {
-        return $this->hasManyThrough(TestOutput::class, TestImage::class, 'imgid', 'id', 'id', 'outputid');
+        return $this->hasManyThrough(Test::class, TestImage::class, 'imgid', 'id', 'id', 'testid');
     }
 }

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 
@@ -105,6 +106,22 @@ class Test extends Model
     public function labels(): BelongsToMany
     {
         return $this->belongsToMany(\App\Models\Label::class, 'label2test', 'testid', 'labelid');
+    }
+
+    /**
+     * @return HasManyThrough<Image, TestImage, $this>
+     */
+    public function images(): HasManyThrough
+    {
+        return $this->hasManyThrough(Image::class, TestImage::class, 'testid', 'id', 'id', 'imgid');
+    }
+
+    /**
+     * @return HasMany<TestImage, $this>
+     */
+    public function testImages(): HasMany
+    {
+        return $this->hasMany(TestImage::class, 'testid');
     }
 
     /**

--- a/app/Models/TestImage.php
+++ b/app/Models/TestImage.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * @property int $id
  * @property int $imgid
- * @property int $outputid
+ * @property int $testid
  * @property string $role
  *
  * @mixin Builder<TestImage>
@@ -22,22 +22,22 @@ class TestImage extends Model
 
     protected $fillable = [
         'imgid',
-        'outputid',
+        'testid',
         'role',
     ];
 
     protected $casts = [
         'id' => 'integer',
         'imgid' => 'integer',
-        'outputid' => 'integer',
+        'testid' => 'integer',
     ];
 
     /**
-     * @return BelongsTo<TestOutput, $this>
+     * @return BelongsTo<Test, $this>
      */
-    public function testOutput(): BelongsTo
+    public function test(): BelongsTo
     {
-        return $this->belongsTo(TestOutput::class, 'outputid');
+        return $this->belongsTo(Test::class, 'testid');
     }
 
     /**

--- a/app/Models/TestOutput.php
+++ b/app/Models/TestOutput.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 /**
  * @property int $id
@@ -40,21 +39,5 @@ class TestOutput extends Model
     public function tests(): HasMany
     {
         return $this->hasMany(Test::class, 'outputid');
-    }
-
-    /**
-     * @return HasManyThrough<Image, TestImage, $this>
-     */
-    public function images(): HasManyThrough
-    {
-        return $this->hasManyThrough(Image::class, TestImage::class, 'outputid', 'id', 'id', 'imgid');
-    }
-
-    /**
-     * @return HasMany<TestImage, $this>
-     */
-    public function testImages(): HasMany
-    {
-        return $this->hasMany(TestImage::class, 'outputid');
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -69,16 +69,10 @@ class AuthServiceProvider extends ServiceProvider
             }
 
             // Make sure the current user has access to a test result with this image
-            foreach (\App\Models\Image::findOrFail((int) $image->Id)->testOutputs as $output) {
-                $buildtests = $output->tests;
-                if ($buildtests === null) {
-                    continue;
-                }
-                foreach ($buildtests as $buildtest) {
-                    $project = $buildtest->build?->project;
-                    if ($project !== null && Gate::allows('view', $project)) {
-                        return true;
-                    }
+            foreach (\App\Models\Image::findOrFail((int) $image->Id)->tests as $test) {
+                $project = $test->build?->project;
+                if ($project !== null && Gate::allows('view', $project)) {
+                    return true;
                 }
             }
 

--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -104,12 +104,12 @@ class TestCreator
         $image->Checksum = crc32($imageVariable);
     }
 
-    public function saveImage(Image $image, $outputid): void
+    private function saveImage(Image $image, int $testid): void
     {
         $image->Save();
         $testImage = new TestImage();
         $testImage->imgid = $image->Id;
-        $testImage->outputid = $outputid;
+        $testImage->testid = $testid;
         $testImage->role = $image->Name;
         $testImage->save();
     }
@@ -122,9 +122,9 @@ class TestCreator
         $crc32_input .= $this->testOutput;
         $crc32_input .= $this->testDetails;
 
+        // TODO: Clean this up.  This implicitly loads images for use in other places.
         foreach ($this->images as $image) {
             $this->loadImage($image);
-            $crc32_input .= "_{$image->Checksum}";
         }
 
         return crc32($crc32_input);
@@ -181,11 +181,6 @@ class TestCreator
                     ':output' => $this->testOutput,
                     ':crc32' => $crc32]);
             $outputid = DB::getPdo()->lastInsertId();
-
-            // test2image
-            foreach ($this->images as $image) {
-                $this->saveImage($image, $outputid);
-            }
         }
 
         // build2test
@@ -216,6 +211,11 @@ class TestCreator
             $label->Test = $buildtest;
             $label->Insert();
             $buildtest->addLabel($label);
+        }
+
+        // test2image
+        foreach ($this->images as $image) {
+            $this->saveImage($image, $buildtest->id);
         }
     }
 }

--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -18,7 +18,7 @@
 namespace CDash\Controller\Api;
 
 use App\Models\Project as EloquentProject;
-use App\Models\TestOutput;
+use App\Models\Test;
 use App\Utils\RepositoryUtils;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
@@ -208,7 +208,7 @@ class TestDetails extends BuildTestApi
 
         // Get any images associated with this test.
         $compareimages_response = [];
-        $test_images = TestOutput::findOrFail((int) $outputid)
+        $test_images = Test::findOrFail((int) $testid)
             ->testImages()
             ->whereIn('role', [
                 'TestImage',
@@ -227,7 +227,7 @@ class TestDetails extends BuildTestApi
         }
 
         $images_response = [];
-        $test_images = TestOutput::findOrFail((int) $outputid)
+        $test_images = Test::findOrFail((int) $testid)
             ->testImages()
             ->whereNotIn('role', [
                 'ValidImage',

--- a/app/cdash/tests/test_imagecomparison.php
+++ b/app/cdash/tests/test_imagecomparison.php
@@ -33,7 +33,7 @@ class ImageComparisonTestCase extends KWWebTestCase
         $stmt = $pdo->query(
             "SELECT b.id AS buildid, i.id AS imgid FROM build b
             JOIN build2test b2t ON (b2t.buildid=b.id)
-            JOIN test2image t2i ON (b2t.outputid=t2i.outputid)
+            JOIN test2image t2i ON (b2t.id=t2i.testid)
             JOIN image i ON (i.id=t2i.imgid)
             WHERE b.name='image_comparison'");
         $imgids = [];

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -475,9 +475,8 @@ class RemoveBuildsTestCase extends KWWebTestCase
             $this->verify_get_rows('dynamicanalysis', 'id', 'buildid', '=', $build->Id, 1);
         $this->verify('dynamicanalysisdefect', 'dynamicanalysisid', '=', $dynamicanalysisid, 1);
 
-        $outputids =
-            $this->verify_get_rows('build2test', 'outputid', 'buildid', '=', $build->Id, 2);
-        $imgids = $this->verify_get_rows('test2image', 'imgid', 'outputid', 'IN', $outputids, 2);
+        $testids = $this->verify_get_rows('build2test', 'id', 'buildid', '=', $build->Id, 2);
+        $imgids = $this->verify_get_rows('test2image', 'imgid', 'testid', 'IN', $testids, 2);
         $this->verify('image', 'id', 'IN', $imgids, 2);
 
         $updateid =
@@ -537,7 +536,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('note', 'id', 'IN', $noteids, 1, $extra_msg);
         $this->verify('summaryemail', 'buildid', '=', $build->Id, 0, $extra_msg);
         $this->verify('subproject2build', 'buildid', '=', $build->Id, 0, $extra_msg);
-        $this->verify('test2image', 'outputid', 'IN', $outputids, 1, $extra_msg);
+        $this->verify('test2image', 'testid', 'IN', $testids, 0, $extra_msg);
         $this->verify('testdiff', 'buildid', '=', $build->Id, 0, $extra_msg);
         $this->verify('updatefile', 'updateid', '=', $updateid, 1, $extra_msg);
         $this->verify('uploadfile', 'id', 'IN', $uploadfileids, 1, $extra_msg);
@@ -580,7 +579,7 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('note', 'id', 'IN', $noteids, 0, $extra_msg);
         $this->verify('summaryemail', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
         $this->verify('subproject2build', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
-        $this->verify('test2image', 'outputid', 'IN', $outputids, 0, $extra_msg);
+        $this->verify('test2image', 'testid', 'IN', $testids, 0, $extra_msg);
         $this->verify('testdiff', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
         $this->verify('updatefile', 'updateid', '=', $updateid, 0, $extra_msg);
         $this->verify('uploadfile', 'id', 'IN', $uploadfileids, 0, $extra_msg);

--- a/app/cdash/tests/test_testimages.php
+++ b/app/cdash/tests/test_testimages.php
@@ -43,21 +43,21 @@ class TestImagesTestCase extends KWWebTestCase
             }
         }
 
-        // Verify two separate testoutput rows.
+        // Verify two separate test rows.
         $results = DB::select('
-            SELECT outputid
+            SELECT build2test.id
             FROM build2test
             JOIN build on (build2test.buildid = build.id)
             WHERE build.projectid = ?
         ', [(int) $this->project->Id]);
 
         $this->assertTrue(2 === count($results));
-        $outputid1 = $results[0]->outputid;
-        $outputid2 = $results[1]->outputid;
-        $this->assertTrue($outputid1 != $outputid2);
+        $testid1 = $results[0]->id;
+        $testid2 = $results[1]->id;
+        $this->assertTrue($testid1 != $testid2);
 
         // Verify that these testoutputs have separate images.
-        $image_results = TestImage::whereIn('outputid', [$outputid1, $outputid2])->get();
+        $image_results = TestImage::whereIn('testid', [$testid1, $testid2])->get();
         $this->assertTrue(2 === count($image_results));
         $image_id1 = $image_results[0]?->id;
         $image_id2 = $image_results[1]?->id;

--- a/database/migrations/2025_08_07_181941_test2image_test_relationship.php
+++ b/database/migrations/2025_08_07_181941_test2image_test_relationship.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE test2image ALTER COLUMN outputid DROP NOT NULL');
+
+        DB::statement('ALTER TABLE test2image ADD COLUMN testid bigint');
+        DB::statement('ALTER TABLE test2image ADD FOREIGN KEY (testid) REFERENCES build2test(id) ON DELETE CASCADE');
+
+        DB::insert('
+            INSERT INTO test2image (testid, imgid, role) (
+                SELECT
+                    build2test.id AS testid,
+                    test2image.imgid,
+                    test2image.role
+                FROM test2image
+                INNER JOIN build2test ON (test2image.outputid = build2test.outputid)
+            )
+        ');
+
+        // Delete the old rows
+        DB::delete('DELETE FROM test2image WHERE testid IS NULL');
+        DB::statement('ALTER TABLE test2image ALTER COLUMN testid SET NOT NULL');
+
+        DB::statement('CREATE INDEX ON test2image (testid)');
+
+        DB::statement('ALTER TABLE test2image DROP COLUMN outputid');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7381,12 +7381,6 @@ parameters:
 			path: app/Utils/TestCreator.php
 
 		-
-			message: '#^Method App\\Utils\\TestCreator\:\:saveImage\(\) has parameter \$outputid with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Utils/TestCreator.php
-
-		-
 			message: '#^Parameter \#1 \$image of function imagegif expects GdImage, GdImage\|false given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
Test images are currently related to test outputs instead of tests.  This approach theoretically saves disk space, but means that data integrity and test output deduplication is a persistent challenge.  By changing test images to instead relate images to tests directly, we can change test output to be unique within a single table.  This PR contains the changes to the `test2image` table; a future PR will update the test output table's constraints.