### PR TITLE
Increase `build2test` primary key to `bigint` type

### DIFF
--- a/database/migrations/2025_08_12_182732_test_id_column_type.php
+++ b/database/migrations/2025_08_12_182732_test_id_column_type.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE build2test ALTER COLUMN id TYPE bigint');
+        DB::statement('ALTER SEQUENCE build2test_id_seq AS bigint');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
The `build2test` primary key column currently uses an integer type.  Bigints are recommended for primary keys in Postgres since they are effectively impossible to overflow.  This PR changes the type from int to bigint to avoid a sequence overflow observed on one of our large production systems.