### PR TITLE
Make router aware of integer route params

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -47,13 +47,13 @@ final class BuildController extends AbstractBuildController
     }
 
     // Render the build configure page.
-    public function configure($build_id = null): View
+    public function configure(int $build_id): View
     {
         return $this->renderBuildPage($build_id, 'configure');
     }
 
     // Render the build notes page.
-    public function notes($build_id = null): View
+    public function notes(int $build_id): View
     {
         $this->setBuildById($build_id);
 
@@ -63,7 +63,7 @@ final class BuildController extends AbstractBuildController
     }
 
     // Render the build summary page.
-    public function summary($build_id = null): View
+    public function summary(int $build_id): View
     {
         return $this->renderBuildPage($build_id, 'summary', 'Build Summary');
     }

--- a/app/Http/Controllers/EditProjectController.php
+++ b/app/Http/Controllers/EditProjectController.php
@@ -16,9 +16,9 @@ final class EditProjectController extends AbstractProjectController
     }
 
     // Render the edit project form.
-    public function edit($project_id): View
+    public function edit(int $project_id): View
     {
-        $this->setProjectById((int) $project_id);
+        $this->setProjectById($project_id);
         Gate::authorize('edit-project', $this->project);
 
         return $this->vue('edit-project', 'Edit Project', ['projectid' => $this->project->Id], false);

--- a/app/Http/Controllers/ManageMeasurementsController.php
+++ b/app/Http/Controllers/ManageMeasurementsController.php
@@ -12,9 +12,9 @@ use Illuminate\View\View;
 final class ManageMeasurementsController extends AbstractProjectController
 {
     // Render the 'manage measurements' page.
-    public function show($project_id): View
+    public function show(int $project_id): View
     {
-        $this->setProjectById((int) $project_id);
+        $this->setProjectById($project_id);
         Gate::authorize('edit-project', $this->project);
 
         return $this->vue('manage-measurements', 'Test Measurements', ['projectid' => $this->project->Id ?? 0], false);

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -23,9 +23,9 @@ require_once 'include/api_common.php';
 final class TestController extends AbstractProjectController
 {
     // Render the test details page.
-    public function details($buildtest_id = null): View
+    public function details(int $buildtest_id): View
     {
-        $buildtest = Test::findOrFail((int) $buildtest_id);
+        $buildtest = Test::findOrFail($buildtest_id);
         $projectid = $buildtest->build?->projectid;
 
         if ($projectid === null) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -697,24 +697,6 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
-			message: '#^Method App\\Http\\Controllers\\BuildController\:\:configure\(\) has parameter \$build_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\BuildController\:\:notes\(\) has parameter \$build_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\BuildController\:\:summary\(\) has parameter \$build_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Controllers/BuildController.php
-
-		-
 			message: '#^Only booleans are allowed in &&, array\|false given on the left side\.$#'
 			identifier: booleanAnd.leftNotBoolean
 			count: 1
@@ -1645,12 +1627,6 @@ parameters:
 			path: app/Http/Controllers/DynamicAnalysisController.php
 
 		-
-			message: '#^Method App\\Http\\Controllers\\EditProjectController\:\:edit\(\) has parameter \$project_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Controllers/EditProjectController.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 3
@@ -1768,12 +1744,6 @@ parameters:
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 4
-			path: app/Http/Controllers/ManageMeasurementsController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\ManageMeasurementsController\:\:show\(\) has parameter \$project_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
 			path: app/Http/Controllers/ManageMeasurementsController.php
 
 		-
@@ -2578,12 +2548,6 @@ parameters:
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 2
-			path: app/Http/Controllers/TestController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\TestController\:\:details\(\) has parameter \$buildtest_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
 			path: app/Http/Controllers/TestController.php
 
 		-

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,36 +60,42 @@ Route::get('/', 'IndexController@showIndexPage');
 
 Route::any('/submit.php', 'SubmissionController@submit');
 
-Route::get('/image/{image}', 'ImageController@image');
+Route::get('/image/{image}', 'ImageController@image')
+    ->whereNumber('image');
 Route::get('/displayImage.php', function (Request $request) {
     $imgid = $request->query('imgid');
     return redirect("/image/{$imgid}", 301);
 });
 
-Route::get('/builds/{id}', 'BuildController@summary');
+Route::get('/builds/{id}', 'BuildController@summary')
+    ->whereNumber('id');
 Route::permanentRedirect('/build/{id}', url('/builds/{id}'));
 Route::get('/buildSummary.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}", 301);
 });
 
-Route::get('/builds/{id}/configure', 'BuildController@configure');
+Route::get('/builds/{id}/configure', 'BuildController@configure')
+    ->whereNumber('id');
 Route::permanentRedirect('/build/{id}/configure', url('/builds/{id}/configure'));
 Route::get('/viewConfigure.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/configure", 301);
 });
 
-Route::get('/builds/{build_id}/tests', 'BuildController@tests');
+Route::get('/builds/{build_id}/tests', 'BuildController@tests')
+    ->whereNumber('build_id');
 
-Route::get('/builds/{id}/update', 'BuildController@update');
+Route::get('/builds/{id}/update', 'BuildController@update')
+    ->whereNumber('id');
 Route::permanentRedirect('/build/{id}/update', url('/builds/{id}/update'));
 Route::get('/viewUpdate.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/builds/{$buildid}/update", 301);
 });
 
-Route::get('/builds/{id}/notes', 'BuildController@notes');
+Route::get('/builds/{id}/notes', 'BuildController@notes')
+    ->whereNumber('id');
 Route::permanentRedirect('/build/{id}/notes', url('/builds/{id}/notes'));
 Route::get('/viewNotes.php', function (Request $request) {
     $buildid = $request->query('buildid');
@@ -104,23 +110,29 @@ Route::get('/viewDynamicAnalysis.php', function (Request $request) {
     return redirect("/builds/{$buildid}/dynamic_analysis", 301);
 });
 
-Route::get('/builds/{build_id}/targets', 'BuildController@targets')->whereNumber('build_id');
+Route::get('/builds/{build_id}/targets', 'BuildController@targets')
+    ->whereNumber('build_id');
 
-Route::get('/build/{build_id}/files', 'BuildController@files')->whereNumber('build_id');
+Route::get('/build/{build_id}/files', 'BuildController@files')
+    ->whereNumber('build_id');
 Route::get('/viewFiles.php', function (Request $request) {
     $buildid = $request->query('buildid');
     return redirect("/build/{$buildid}/files", 301);
 });
 
-Route::get('/build/{build_id}/file/{file_id}', 'BuildController@build_file')->whereNumber('build_id')->whereNumber('file_id');
+Route::get('/build/{build_id}/file/{file_id}', 'BuildController@build_file')
+    ->whereNumber('build_id')
+    ->whereNumber('file_id');
 
-Route::get('/projects/{id}/edit', 'EditProjectController@edit');
+Route::get('/projects/{id}/edit', 'EditProjectController@edit')
+    ->whereNumber('id');
 Route::permanentRedirect('/project/{id}/edit', url('/projects/{id}/edit'));
 
 Route::get('/projects/new', 'EditProjectController@create');
 Route::permanentRedirect('/project/new', url('/projects/new'));
 
-Route::get('/projects/{id}/testmeasurements', 'ManageMeasurementsController@show');
+Route::get('/projects/{id}/testmeasurements', 'ManageMeasurementsController@show')
+    ->whereNumber('id');
 Route::permanentRedirect('/project/{id}/testmeasurements', url('/projects/{id}/testmeasurements'));
 
 Route::get('/projects/{id}/ctest_configuration', 'CTestConfigurationController@get')
@@ -134,7 +146,8 @@ Route::get('/generateCTestConfig.php', function (Request $request) {
     return redirect("/projects/{$projectid}/ctest_configuration", 301);
 });
 
-Route::get('/projects/{project_id}/sites', 'ProjectController@sites')->whereNumber('project_id');
+Route::get('/projects/{project_id}/sites', 'ProjectController@sites')
+    ->whereNumber('project_id');
 Route::get('/viewMap.php', function (Request $request) {
     $project = Project::where('name', $request->query('project'))->first();
     if ($project === null || Gate::denies('view', $project)) {
@@ -143,7 +156,8 @@ Route::get('/viewMap.php', function (Request $request) {
     return redirect("/projects/{$project->id}/sites", 301);
 });
 
-Route::get('/tests/{id}', 'TestController@details');
+Route::get('/tests/{id}', 'TestController@details')
+    ->whereNumber('id');
 Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
@@ -217,7 +231,8 @@ Route::get('/manageBuildGroup.php', 'BuildController@manageBuildGroup');
 
 Route::get('/users', 'UsersController@users');
 
-Route::get('/projects/{project_id}/members', 'ProjectMembersController@members')->whereNumber('project_id');
+Route::get('/projects/{project_id}/members', 'ProjectMembersController@members')
+    ->whereNumber('project_id');
 
 Route::get('/invitations/{invitationId}', GlobalInvitationController::class)
     ->whereNumber('invitationId')


### PR DESCRIPTION
Public-facing CDash instances subject to web scrapers currently experience stack traces in the log due to type incompatibility issues when calling functions which expect integer parameters.  This PR fixes the issue by allowing the router to reject requests which do not use integer parameters where expected.