### PR TITLE
Change `image` primary key to `bigint` type

### DIFF
--- a/database/migrations/2025_08_18_171650_image_id_column_type.php
+++ b/database/migrations/2025_08_18_171650_image_id_column_type.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE image ALTER COLUMN id TYPE bigint');
+        DB::statement('ALTER TABLE project ALTER COLUMN imageid TYPE bigint');
+        DB::statement('ALTER TABLE test2image ALTER COLUMN imgid TYPE bigint');
+        DB::statement('ALTER SEQUENCE image_id_seq AS bigint');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Follows https://github.com/Kitware/CDash/pull/3054.  For systems where many tests have associated images, the `image` table can be close to the size of the `build2test` table.  The goal is to eventually change all ID columns to bigints, but I'd like to let these two roll out first before proceeding with the rest to make sure there are no lingering issues with this change, especially for databases migrated from MySQL in the past.