### PR TITLE
Force-drop database before tests

### DIFF
--- a/app/cdash/tests/kwtest/kw_db.php
+++ b/app/cdash/tests/kwtest/kw_db.php
@@ -174,7 +174,7 @@ class dbo_pgsql extends dbo
 
     public function drop($db)
     {
-        $sql = "DROP DATABASE IF EXISTS $db";
+        $sql = "DROP DATABASE IF EXISTS $db (FORCE)";
         $dsn = "pgsql:{$this->connection}={$this->host}";
         $pdo = new PDO($dsn, $this->user, $this->password);
         $pdo->exec($sql);


### PR DESCRIPTION
It's currently very annoying to run the tests while simultaneously poking around in the database because Postgres doesn't allow databases with other active connections to be dropped.  In my case, I almost always forget to terminate my connection prior to running the tests and have to re-run the test suite as a result multiple times per day.  By adding the `FORCE` option, the test suite can proceed while other connections are active.  Those connections will be terminated and can be restarted once developers want to go back to exploring the database manually.