### PR TITLE
Remove `testoutput` `crc32` column

### DIFF
--- a/app/Models/TestOutput.php
+++ b/app/Models/TestOutput.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int $id
- * @property int $crc32
  * @property string $path
  * @property string $command
  * @property string $output
@@ -25,12 +24,10 @@ class TestOutput extends Model
         'path',
         'command',
         'output',
-        'crc32',
     ];
 
     protected $casts = [
         'id' => 'integer',
-        'crc32' => 'integer',
     ];
 
     /**

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -415,7 +415,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
             'output' => 'testoutput for test_removebuildds',
             'command' => 'php test_removebuilds.php',
             'path' => '/cdash/tests/test_removebuilds.php',
-            'crc32' => $crc32,
         ]);
         $uploadfile_id = DB::table('uploadfile')->insertGetId([
             'filename' => 'test_removebuilds.php',

--- a/database/migrations/2025_08_19_192208_drop_testoutput_crc32.php
+++ b/database/migrations/2025_08_19_192208_drop_testoutput_crc32.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE testoutput DROP COLUMN IF EXISTS crc32');
+        DB::statement('CREATE INDEX ON testoutput USING HASH (output)');
+        DB::statement('CREATE INDEX ON testoutput USING HASH (command)');
+        DB::statement('CREATE INDEX ON testoutput USING HASH (path)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/tests/Feature/GraphQL/TestMeasurementTypeTest.php
+++ b/tests/Feature/GraphQL/TestMeasurementTypeTest.php
@@ -29,7 +29,6 @@ class TestMeasurementTypeTest extends TestCase
 
         // A common test output to share among all of our tests
         $this->test_output = TestOutput::create([
-            'crc32' => random_int(0, 100000),
             'path' => 'a',
             'command' => 'b',
             'output' => 'c',

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -30,7 +30,6 @@ class TestTypeTest extends TestCase
 
         // A common test output to share among all of our tests
         $this->test_output = TestOutput::create([
-            'crc32' => random_int(0, 100000),
             'path' => 'a',
             'command' => 'b',
             'output' => 'c',


### PR DESCRIPTION
Following the success of #2943, this PR applies the same principle to the `testoutput` table: remove the `crc32` column, add hash indexes, and perform exact matching to deduplicate the table rather than using a messy, low-entropy, application-layer hashing mechanism.