### PR TITLE
CSP: Allow inline images

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -25,7 +25,7 @@
         Header set Cache-Control "max-age=31536000"
     </FilesMatch>
 
-    Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:"
+    Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src 'self' data:"
 </IfModule>
 
 <IfModule mod_deflate.c>


### PR DESCRIPTION
#2877 broke the image on the maintenance page because it's rendered inline.  This PR restores the image by changing our content security policy to allow inline images.