### PR TITLE
Remove unnecessary `edit` query parameter

### DIFF
--- a/app/cdash/public/subscribeProject.xsl
+++ b/app/cdash/public/subscribeProject.xsl
@@ -68,7 +68,6 @@
             </font></td>
           </tr>
           </xsl:if>
-          <xsl:if test="/cdash/edit=1">
            <tr>
             <td></td>
             <td><b>Email me:</b></td>
@@ -82,11 +81,10 @@
              </input> never (this is not recommended)
            </td>
           </tr>
-            </xsl:if>
            <tr>
             <td></td>
             <td ><input type="radio" onchange="saveChanges();" name="emailtype" value="1">
-             <xsl:if test="/cdash/emailtype=1 or /cdash/edit=0">
+             <xsl:if test="/cdash/emailtype=1">
              <xsl:attribute name="checked"></xsl:attribute>
              </xsl:if>
              </input> when <b>my checkins</b> are causing problems in <b>any sections</b> of the dashboard
@@ -202,7 +200,6 @@
     </div>
  </div>
 
- <xsl:if test="/cdash/edit=1">
   <br/>
   <div style="width:900px;margin-left:auto;margin-right:auto;text-align:right;">
   <table width="100%" border="0">
@@ -212,7 +209,6 @@
    </tr>
   </table>
   </div>
-  </xsl:if>
 
 </form>
 </td>

--- a/resources/js/vue/components/UserHomepage.vue
+++ b/resources/js/vue/components/UserHomepage.vue
@@ -102,7 +102,7 @@
             >
               <a
                 title="Edit subscription"
-                :href="$baseURL + '/subscribeProject.php?projectid=' + project.id + '&edit=1'"
+                :href="$baseURL + '/subscribeProject.php?projectid=' + project.id"
               >
                 <font-awesome-icon :icon="FA.faBell" />
               </a>


### PR DESCRIPTION
Following the discussion in https://github.com/Kitware/CDash/pull/3066#pullrequestreview-3144830290, this PR removes the unnecessary `edit` query parameter from the project notifications page.  A PR which completely overhauls this page is planned for the future, but this temporary improvement is good enough for now.