### PR TITLE
Switch to bitnamilegacy for Docker

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
 
   # Used for testing LDAP authentication
   ldap:
-    image: bitnami/openldap
+    image: bitnamilegacy/openldap
     ports:
       - 389:389
       - 636:636

--- a/docker/docker-compose.minio.yml
+++ b/docker/docker-compose.minio.yml
@@ -10,7 +10,7 @@ services:
       AWS_URL: http://minio:9000/cdash/
       AWS_ENDPOINT: http://minio:9000
   minio:
-    image: bitnami/minio:2025.4.22
+    image: bitnamilegacy/minio:2025.4.22
     ports:
       - "9000:9000"
     environment:


### PR DESCRIPTION
See https://github.com/bitnami/containers/issues/83267 for the information about the switch on DockerHub from `bitnami` to `bitnamisecure`.

At the moment, the instances we use are not available in secure, so use the `bitnamilegacy` images.