### PR TITLE
Fix Done handler invalid property access

### DIFF
--- a/app/Http/Submission/Handlers/DoneHandler.php
+++ b/app/Http/Submission/Handlers/DoneHandler.php
@@ -17,9 +17,9 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
+use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
 use CDash\Model\PendingSubmissions;
-use CDash\Model\Project;
 use CDash\Model\Repository;
 
 class DoneHandler extends AbstractXmlHandler
@@ -30,9 +30,9 @@ class DoneHandler extends AbstractXmlHandler
     public $backupFileName;
     protected static ?string $schema_file = '/app/Validators/Schemas/Done.xsd';
 
-    public function __construct(Project $project)
+    public function __construct(Build $build)
     {
-        parent::__construct($project);
+        parent::__construct($build);
         $this->FinalAttempt = false;
         $this->PendingSubmissions = new PendingSubmissions();
         $this->Requeue = false;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5991,7 +5991,7 @@ parameters:
 		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 7
+			count: 6
 			path: app/Jobs/ProcessSubmission.php
 
 		-


### PR DESCRIPTION
Stack traces with the message `Attempt to read property "name" on null` when parsing "Done" submissions have been showing up in the logs for several production sites running recent versions of CDash.  `Done.xml` is special because it contains a build ID instead of information which uniquely identifies a build.  We were previously passing the `DoneHandler` a project and losing the Build ID.