### PR TITLE
Fix broken edit project dropdown

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -48,7 +48,8 @@ use Illuminate\Support\Facades\Auth;
  * @property ?string $ldapfilter
  * @property ?string $banner
  *
- * @method Builder<Project> forUser(?User $user = null)
+ * @method Builder<Project> forUser()
+ * @method Builder<Project> administeredByUser()
  *
  * @mixin Builder<Project>
  */
@@ -167,6 +168,24 @@ class Project extends Model
             });
         }
         // Else, this is an admin user, so we shouldn't apply any filters...
+    }
+
+    /**
+     * Get the projects the current user has admin access to.
+     *
+     * @param Builder<self> $query
+     */
+    public function scopeAdministeredByUser(Builder $query): void
+    {
+        $user = Auth::user();
+
+        if ($user !== null && $user->admin) {
+            return;
+        } else {
+            $query->whereHas('administrators', function ($subquery) use ($user): void {
+                $subquery->where('users.id', $user?->id);
+            });
+        }
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1777,23 +1777,8 @@ parameters:
 			path: app/Http/Controllers/OAuthController.php
 
 		-
-			message: '''
-				#^Call to deprecated method getPdo\(\) of class CDash\\Database\:
-				04/22/2023  Use Laravel query builder or Eloquent instead$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 1
-			path: app/Http/Controllers/ProjectController.php
-
-		-
-			message: '#^Method App\\Http\\Controllers\\ProjectController\:\:GetProjectsForUser\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Controllers/ProjectController.php
 


### PR DESCRIPTION
The project switcher dropdown on the edit project page currently shows nothing for non-admin users due to an undefined variable `$id` in `GetProjectsForUser()`.  Interestingly, PHPStan failed to catch this obvious undefined variable--something I plan to look into in more detail.  This PR resolves the issue by replacing the broken code with a modern Laravel equivalent.