### PR TITLE
Attach log to failing CDash submissions

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ function(add_laravel_test TestName)
       -c ${CDash_SOURCE_DIR}/phpunit.xml
       ${laravel_testing_dir}/${TestName}.php
   )
+  set_property(TEST ${TestName} APPEND PROPERTY ATTACHED_FILES "${CDash_SOURCE_DIR}/storage/logs/cdash.log")
 endfunction()
 
 # Tests with no dependencies whatsoever


### PR DESCRIPTION
Test failures sometimes don't contain enough information to properly track down the issue.  To assist with that, this PR attaches the CDash test log to submissions with failing tests.