### PR TITLE
Update join project homepage link

### DIFF
--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Project;
 use App\Models\User;
 use CDash\Database;
 use Illuminate\Http\RedirectResponse;
@@ -119,18 +120,11 @@ final class SubscribeProjectController extends AbstractProjectController
 
         $xml .= '</project>';
 
-        $sql = 'SELECT id, name FROM project';
-        $params = [];
-        if (!$user->admin) {
-            $sql .= ' WHERE public=1 OR id IN (SELECT projectid AS id FROM user2project WHERE userid=? AND role>0)';
-            $params[] = $user->id;
-        }
-        $projects = $db->executePrepared($sql, $params);
-        foreach ($projects as $project_array) {
+        foreach (Project::whereRelation('users', 'id', $user->id)->orderBy('name')->get() as $project) {
             $xml .= '<availableproject>';
-            $xml .= add_XML_value('id', $project_array['id']);
-            $xml .= add_XML_value('name', $project_array['name']);
-            if (intval($project_array['id']) === $this->project->Id) {
+            $xml .= add_XML_value('id', $project->id);
+            $xml .= add_XML_value('name', $project->name);
+            if (intval($project->id) === $this->project->Id) {
                 $xml .= add_XML_value('selected', '1');
             }
             $xml .= '</availableproject>';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2419,18 +2419,12 @@ parameters:
 			path: app/Http/Controllers/SubmissionController.php
 
 		-
-			message: '#^Argument of an invalid type array\|false supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/Http/Controllers/SubscribeProjectController.php
-
-		-
 			message: '''
 				#^Call to deprecated method executePrepared\(\) of class CDash\\Database\:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			'''
 			identifier: method.deprecated
-			count: 2
+			count: 1
 			path: app/Http/Controllers/SubscribeProjectController.php
 
 		-

--- a/resources/js/vue/components/UserHomepage.vue
+++ b/resources/js/vue/components/UserHomepage.vue
@@ -392,9 +392,9 @@
             <td>
               <a
                 class="cdash-link"
-                :href="$baseURL + '/subscribeProject.php?projectid=' + project.id"
+                :href="$baseURL + '/projects/' + project.id + '/members'"
               >
-                Subscribe to this project
+                Join Project
               </a>
             </td>
           </tr>


### PR DESCRIPTION
Since the merge of https://github.com/Kitware/CDash/pull/2898, user management is separate from project notification settings.  This PR updates the homepage link to take you to the new project members page instead of the project notifications page when attempting to join a project.