### PR TITLE
Update test status in place

### DIFF
--- a/database/migrations/2025_07_30_131713_test_status_enum.php
+++ b/database/migrations/2025_07_30_131713_test_status_enum.php
@@ -9,13 +9,19 @@ return new class extends Migration {
         // We drop the type first in case the database has been truncated previously.
         DB::statement('DROP TYPE IF EXISTS teststatus');
         DB::statement("CREATE TYPE teststatus AS ENUM ('failed', 'notrun', 'passed')");
-        DB::statement('ALTER TABLE build2test RENAME COLUMN status TO old_status');
-        DB::statement('ALTER TABLE build2test ADD COLUMN status teststatus');
-        DB::update("UPDATE build2test SET status = old_status::teststatus WHERE old_status IN ('failed', 'notrun', 'passed')");
-        DB::update("UPDATE build2test SET status = 'passed' WHERE status IS NULL");
+        DB::statement('ALTER TABLE build2test ALTER COLUMN status DROP DEFAULT');
+        DB::statement("
+            ALTER TABLE build2test
+            ALTER COLUMN status
+            TYPE teststatus USING
+                CASE
+                    WHEN status = 'failed' THEN 'failed'::teststatus
+                    WHEN status = 'notrun' THEN 'notrun'::teststatus
+                    WHEN status = 'passed' THEN 'passed'::teststatus
+                    ELSE 'passed'::teststatus
+                END
+        ");
         DB::statement('ALTER TABLE build2test ALTER COLUMN status SET NOT NULL');
-        DB::statement('ALTER TABLE build2test DROP COLUMN old_status');
-        DB::statement('CREATE INDEX ON build2test (buildid, status)');
     }
 
     public function down(): void


### PR DESCRIPTION
#3012 added a migration which proved to be exceedingly slow on large systems.  This PR attempts to speed up the migration by updating the status column in-place, thus preventing a table rewrite.