### PR TITLE
Run Dependabot updates at a fixed time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      time: "02:00"
+      timezone: "America/New_York"
     labels:
       - dependencies
       - "release notes: external dependencies"
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      time: "02:00"
+      timezone: "America/New_York"
     labels:
       - dependencies
       - "release notes: external dependencies"
@@ -20,6 +24,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+      time: "02:00"
+      timezone: "America/New_York"
     labels:
       - dependencies
       - "release notes: external dependencies"


### PR DESCRIPTION
GitHub recently started running Dependabot updates at a random time during the during the day for load balancing purposes as per [this](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#controlling-the-frequency-and-timings-of-dependency-updates) documentation page.

This behavior is annoying because the initial CI runs consume all our CI resources for a few hours.  This PR forces Dependabot to make PRs at 2:00 AM ET so CI is finished by the time developers wake up in the morning.