### PR TITLE
Add context to installation ID exception message

### DIFF
--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -111,7 +111,7 @@ class GitHub implements RepositoryInterface
 
         if ($this->installationId === '') {
             if ($required) {
-                throw new Exception('Unable to find installation ID for repository');
+                throw new Exception("Unable to find installation ID for repository {$this->repo}, project {$this->project->Name}");
             }
             return false;
         }


### PR DESCRIPTION
It's currently impossible to tell which project this exception is coming from.  For now, adding this information to the error message is sufficient.  In the future, it may be useful to switch this from an exception to a log message at a lower log level.