### PR TITLE
compose: configure containers to restart

### DIFF
--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -20,5 +20,6 @@ services:
       test: "pg_isready -U postgres"
       interval: 1s
       retries: 120
+    restart: unless-stopped
 volumes:
   postgresqldata:

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - "${SSL_CERTIFICATE_FILE}:/var/www/cdash.pem"
       - "${SSL_CERTIFICATE_KEY_FILE}:/var/www/cdash.key"
+    restart: unless-stopped
   worker:
     env_file:
       - ../.env


### PR DESCRIPTION
Update our docker compose configuration files to restart the webservice and database containers except for when they are explicitly shut down.