### PR TITLE
Index `build(projectid, name, siteid)`

### DIFF
--- a/database/migrations/2025_09_11_133820_build_project_name_site_index.php
+++ b/database/migrations/2025_09_11_133820_build_project_name_site_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build (projectid, name, siteid)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Several of the mot frequently accessed pages search for builds by project, build name, and optionally site.  The most selective index for these queries is on `build(name)`.  This PR adds an index which allows these types of queries to be answered much more efficiently.  This PR also adds a separate index on `build(projectid,siteid)` to improve the performance of queries which fetch the sites for a project.