### PR TITLE
Index builds by project

### DIFF
--- a/database/migrations/2025_09_11_141806_build_project_indexes.php
+++ b/database/migrations/2025_09_11_141806_build_project_indexes.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build (projectid,name)');
+        DB::statement('CREATE INDEX ON build (projectid,siteid)');
+        DB::statement('CREATE INDEX ON build (projectid,starttime)');
+        DB::statement('CREATE INDEX ON build (projectid,endtime)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Supersedes https://github.com/Kitware/CDash/pull/3114.  Most queries involving the build table which aren't able to use the primary key index include the project ID.  This PR adds indexes on `build(projectid,...)` for each of the columns most likely to be used for filtering builds.  In the future, we may want to expand upon these indexes by adding aggregate summary information.