### PR TITLE
Index `build2test(buildid,status)`

### DIFF
--- a/database/migrations/2025_09_11_170335_build2test_buildid_status_index.php
+++ b/database/migrations/2025_09_11_170335_build2test_buildid_status_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build2test (buildid, status)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
There's currently no way for Postgres to efficiently query tests by status for a given build.  The best query plan with the current setup is simply for Postgres to scan all of the tests for a given build.  Scanning all tests is reasonably efficient in most cases, but the overhead adds up over time for this extremely common use case.  This PR indexes `build2test(buildid,status)` to allow the database to count the number of passing or failing tests directly.