### PR TITLE
Index `coveragefilelog(buildid,fileid)`

### DIFF
--- a/database/migrations/2025_09_11_174937_coveragefilelog_buildid_fileid_index.php
+++ b/database/migrations/2025_09_11_174937_coveragefilelog_buildid_fileid_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON coveragefilelog (buildid, fileid)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
the `coveragefilelog` currently has a multi-valued primary key `(buildid,fileid)`, but no index.  As a result Postgres has to do a BitmapAnd on the results from two indexes.  Adding an index containing these two columns should improve performance for pages using this table.