### PR TITLE
Delete unused daily updates code

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15555,7 +15555,7 @@ parameters:
 		-
 			message: '#^Argument of an invalid type array\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 4
+			count: 3
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -15573,7 +15573,7 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			'''
 			identifier: method.deprecated
-			count: 5
+			count: 4
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -15582,7 +15582,7 @@ parameters:
 				04/22/2023  Use Laravel query builder or Eloquent instead$#
 			'''
 			identifier: method.deprecated
-			count: 5
+			count: 1
 			path: app/cdash/include/dailyupdates.php
 
 		-
@@ -15597,17 +15597,11 @@ parameters:
 		-
 			message: '#^Cannot access offset ''c'' on array\|false\|null\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: app/cdash/include/dailyupdates.php
-
-		-
-			message: '#^Cannot access offset ''id'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: app/cdash/include/dailyupdates.php
 
 		-
-			message: '#^Cannot access offset ''status'' on array\|false\|null\.$#'
+			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: app/cdash/include/dailyupdates.php


### PR DESCRIPTION
The deleted code does absolutely nothing besides wasting CPU cycles.  It's possible that something meant to use this at one point and is now broken, but we can address that via a separate PR if needed.