### PR TITLE
Move submission file pruning to scheduled job

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Jobs\NotifyExpiringAuthTokens;
 use App\Jobs\PruneAuthTokens;
 use App\Jobs\PruneJobs;
+use App\Jobs\PruneSubmissionFiles;
 use App\Jobs\PruneUploads;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -25,6 +26,10 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping();
 
         $schedule->job(new PruneUploads())
+            ->hourly()
+            ->withoutOverlapping();
+
+        $schedule->job(new PruneSubmissionFiles())
             ->hourly()
             ->withoutOverlapping();
 

--- a/app/Jobs/PruneSubmissionFiles.php
+++ b/app/Jobs/PruneSubmissionFiles.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToRetrieveMetadata;
+
+/**
+ * Deletes submission files older than the configured BACKUP_TIMEFRAME.
+ */
+class PruneSubmissionFiles implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(): void
+    {
+        $deletion_time_threshold = time() - (int) config('cdash.backup_timeframe') * 3600;
+        $dirs_to_clean = ['parsed', 'failed', 'inprogress'];
+        foreach ($dirs_to_clean as $dir_to_clean) {
+            $files = Storage::allFiles($dir_to_clean);
+            foreach ($files as $file) {
+                try {
+                    $last_modified = Storage::lastModified($file);
+                } catch (UnableToRetrieveMetadata) {
+                    continue;
+                }
+                if ($last_modified < $deletion_time_threshold) {
+                    try {
+                        Storage::delete($file);
+                    } catch (UnableToDeleteFile) {
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/cdash/include/dailyupdates.php
+++ b/app/cdash/include/dailyupdates.php
@@ -27,9 +27,6 @@ use CDash\Model\BuildGroupRule;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Support\Facades\Storage;
-use League\Flysystem\UnableToDeleteFile;
-use League\Flysystem\UnableToRetrieveMetadata;
 
 @set_time_limit(0);
 
@@ -298,27 +295,6 @@ function addDailyChanges(int $projectid): void
                 projectid=?
                 AND date=?
         ', [$projectid, $date]);
-
-        // Clean the backup directories.
-        $deletion_time_threshold = time() - (int) config('cdash.backup_timeframe') * 3600;
-        $dirs_to_clean = ['parsed', 'failed', 'inprogress'];
-        foreach ($dirs_to_clean as $dir_to_clean) {
-            $files = Storage::allFiles($dir_to_clean);
-            foreach ($files as $file) {
-                try {
-                    $last_modified = Storage::lastModified($file);
-                } catch (UnableToRetrieveMetadata $e) {
-                    continue;
-                }
-                if ($last_modified < $deletion_time_threshold) {
-                    try {
-                        Storage::delete($file);
-                    } catch (UnableToDeleteFile $e) {
-                        continue;
-                    }
-                }
-            }
-        }
 
         // Delete expired buildgroups and rules.
         $current_date = gmdate(FMT_DATETIME);


### PR DESCRIPTION
This PR moves the submission file pruning process from the legacy "daily updates" script to a new scheduled job which runs hourly.