### PR TITLE
Allow links in global banner

### DIFF
--- a/config/cdash.php
+++ b/config/cdash.php
@@ -86,7 +86,7 @@ return [
     'require_full_email_when_adding_user' => env('REQUIRE_FULL_EMAIL_WHEN_ADDING_USER', false),
     // Whether or not project administrators can invite users
     'project_admin_registration_form_enabled' => env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true),
-    // Text displayed at the top of all pages.  Limited to 40 characters.
+    // Text displayed at the top of all pages.  Accepts inline markdown (links, bold, italics).
     'global_banner' => env('GLOBAL_BANNER'),
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -20,6 +20,16 @@ body {
   flex-direction: column;
 }
 
+#global-banner {
+  color: #2ee84a;
+}
+
+#global-banner > a {
+  color: #2ee84a;
+  text-decoration: underline;
+  font-weight: bold;
+}
+
 .argument {
  background-color: #eeeeee;
  font-family: Courier;
@@ -352,20 +362,24 @@ div#datetime {
 }
 
 div#topmenu {
+  display: flex;
+  justify-content: space-between;
   width: 100%;
   line-height: 25px;
 }
 
-div#topmenu a {
+div#topmenu .cdash-link {
   padding: 5px;
-  color: #CCCCCC !important;
+  color: #CCCCCC;
   cursor: pointer;
-  text-decoration: none !important;
+  text-decoration: none;
+  font-size: 12px;
 }
 
-div#topmenu a:hover {
+div#topmenu .cdash-link:hover {
   background-color: #5A5A5A;
-  text-decoration: none !important;
+  text-decoration: none;
+  font-size: 12px;
 }
 
 div#banner {
@@ -652,10 +666,6 @@ div#headertop {
   min-height:25px;
   padding:0 2em;
   width:100%;
-}
-
-#headertop #topmenu a {
-  font-size:12px !important;
 }
 
 #headerbottom {

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -14,7 +14,7 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
 
 <div id="header">
     <div id="headertop">
-        <div id="topmenu" style="display: flex; justify-content: space-between;">
+        <div id="topmenu">
             <span>
                 <a class="cdash-link" href="{{ url('/projects') }}">All Dashboards</a>
                 @if(Auth::check())
@@ -23,8 +23,8 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
             </span>
 
             @if(config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0)
-                <span id="global-banner" style="color: #2ee84a;">
-                    {{ Str::limit(config('cdash.global_banner'), 40) }}
+                <span id="global-banner">
+                    {!! Str::inlineMarkdown(config('cdash.global_banner'), ['allow_unsafe_links' => false, 'html_input' => 'escape']) !!}
                 </span>
             @endif
 

--- a/tests/Feature/GlobalBannerTest.php
+++ b/tests/Feature/GlobalBannerTest.php
@@ -18,12 +18,21 @@ class GlobalBannerTest extends TestCase
         $this->get('/login')->assertSee($bannerText);
     }
 
-    public function testLongGlobalBannerGetsTruncated(): void
+    public function testMarkdownLinkGetsConvertedToHtml(): void
     {
-        $bannerText = 'AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMM';
+        $bannerText = 'link [here](https://example.com)';
 
         config(['cdash.global_banner' => $bannerText]);
 
-        $this->get('/login')->assertSee('AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJ...');
+        $this->get('/login')->assertSeeHtml('link <a href="https://example.com">here</a>');
+    }
+
+    public function testHtmlTagsAreEncoded(): void
+    {
+        $bannerText = "text here <script>alert('xss')</script>";
+
+        config(['cdash.global_banner' => $bannerText]);
+
+        $this->get('/login')->assertSeeHtml("text here &lt;script&gt;alert('xss')&lt;/script&gt;");
     }
 }


### PR DESCRIPTION
CDash users may want to link to policies, status pages, or other outside resources in the global banner.  This PR adds support for that by accepting markdown via the `GLOBAL_BANNER` environment variable.

The string `text [link](http://example.com) <script>alert('xss')</script>` now gets rendered like this:
<img width="400" height="60" alt="image" src="https://github.com/user-attachments/assets/8d4c2cb5-2ade-482a-ad65-1818a99f789a" />
