### PR TITLE
Bump version to 4.4.0

### DIFF
--- a/config/cdash.php
+++ b/config/cdash.php
@@ -24,7 +24,7 @@ return [
         'min' => env('MINIMUM_PASSWORD_LENGTH', 5),
         'expires' => env('PASSWORD_EXPIRATION', 0),
     ],
-    'version' => '4.3.0',
+    'version' => '4.4.0',
     'registration' => [
         'email' => [
             'verify' => env('REGISTRATION_EMAIL_VERIFY', true),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdash",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdash",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@apollo/client": "^3.13.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdash",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Continuous integration dashboard.",
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/3128 accidentally targeted `master` instead of `releases/4.4`.  This PR brings the version bump to 4.4.  I'll re-release 4.4 once this PR is merged.