### PR TITLE
Make `lotsofsubprojects` test run independently

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -389,6 +389,9 @@ set_tests_properties(junithandler PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHan
 add_php_test(configurewarnings)
 set_tests_properties(configurewarnings PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 
+add_php_test(lotsofsubprojects)
+set_tests_properties(lotsofsubprojects PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
+
 add_feature_test(/Feature/AutoRemoveBuildsCommand)
 
 # Must run serially since it can delete builds other than the ones it creates.
@@ -430,6 +433,7 @@ set_property(TEST install_2 APPEND PROPERTY DEPENDS
   issuecreation
   junithandler
   configurewarnings
+  lotsofsubprojects
 )
 
 
@@ -688,11 +692,8 @@ set_tests_properties(starttimefromupload PROPERTIES DEPENDS starttimefromnotes)
 add_php_test(querytestsfilterlabels)
 set_tests_properties(querytestsfilterlabels PROPERTIES DEPENDS starttimefromupload)
 
-add_php_test(lotsofsubprojects)
-set_tests_properties(lotsofsubprojects PROPERTIES DEPENDS querytestsfilterlabels)
-
 add_php_test(querytestsrevisionfilter)
-set_tests_properties(querytestsrevisionfilter PROPERTIES DEPENDS lotsofsubprojects)
+set_tests_properties(querytestsrevisionfilter PROPERTIES DEPENDS querytestsfilterlabels)
 
 add_php_test(redundanttests)
 set_tests_properties(redundanttests PROPERTIES DEPENDS querytestsrevisionfilter)

--- a/app/cdash/tests/test_lotsofsubprojects.php
+++ b/app/cdash/tests/test_lotsofsubprojects.php
@@ -4,16 +4,18 @@ require_once dirname(__FILE__) . '/cdash_test_case.php';
 
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;
+use Tests\Traits\CreatesProjects;
 
 class LotsOfSubProjectsTestCase extends KWWebTestCase
 {
+    use CreatesProjects;
+
     private $project;
 
     public function __construct()
     {
         parent::__construct();
         $this->project = null;
-        $this->deleteLog($this->logfilename);
     }
 
     public function __destruct()
@@ -34,11 +36,8 @@ class LotsOfSubProjectsTestCase extends KWWebTestCase
     public function testLotsOfSubProjects(): void
     {
         // Create test project.
-        $this->login();
         $this->project = new Project();
-        $this->project->Id = $this->createProject([
-            'Name' => 'LotsOfSubProjects',
-        ]);
+        $this->project->Id = $this->makePublicProject('LotsOfSubProjects')->id;
         $this->project->Fill();
 
         // Generate our testing data.
@@ -58,9 +57,6 @@ class LotsOfSubProjectsTestCase extends KWWebTestCase
         if (!$this->submission('LotsOfSubProjects', $test_filename)) {
             $this->fail("Failed to submit $test_filename");
         }
-
-        // No errors in the log.
-        $this->assertTrue($this->checkLog($this->logfilename) !== false);
 
         // Verify 101 builds (1 parent + 100 children).
         $results = DB::select('SELECT id FROM build WHERE projectid = ?', [(int) $this->project->Id]);


### PR DESCRIPTION
Incremental progress towards our goal of making each test run as an individual atomic unit.  This change is expected to save 3-4 seconds in CI.