### PR TITLE
Sort testSummary rows deterministically in e2e test

### DIFF
--- a/tests/cypress/e2e/test-summary.cy.js
+++ b/tests/cypress/e2e/test-summary.cy.js
@@ -30,6 +30,9 @@ describe('testSummary', () => {
     const stats_text = '40% passed, 3 failed out of 5.';
     cy.get('[data-cy="summary-stats"]').should('contain', stats_text);
 
+    // Sort by build stamp deterministically.
+    cy.get('[data-cy="summary-table"]').contains('Build Stamp').click();
+
     // the table in this page should be of size 6x6
     cy.get('[data-cy="summary-table"]').find('tr').should('have.length', 6);
     cy.get('[data-cy="summary-table"]').find('tr').each((row) => {
@@ -48,23 +51,23 @@ describe('testSummary', () => {
     get_cell(0, 4).should('contain', 'Time (s)');
     get_cell(0, 5).should('contain', 'Build Revision');
 
-    get_cell(1, 0).should('not.be.empty');
-    get_cell(1, 1).should('contain', 'TestHistory');
-    get_cell(1, 2).should('contain', '20151116-1904-Experimental');
-    get_cell(1, 3).should('contain', 'Failed').and('have.class', 'error');
-    get_cell(1, 4).should('contain', '0');
-
-    get_cell(2, 0).should('not.be.empty');
-    get_cell(2, 1).should('contain', 'TestHistory');
-    get_cell(2, 2).should('contain', '20151116-1906-Experimental');
-    get_cell(2, 3).should('contain', 'Failed').and('have.class', 'error');
-    get_cell(2, 4).should('contain', '0');
+    get_cell(3, 0).should('not.be.empty');
+    get_cell(3, 1).should('contain', 'TestHistory');
+    get_cell(3, 2).should('contain', '20151116-1906-Experimental');
+    get_cell(3, 3).should('contain', 'Failed').and('have.class', 'error');
+    get_cell(3, 4).should('contain', '0');
 
     get_cell(4, 0).should('not.be.empty');
     get_cell(4, 1).should('contain', 'TestHistory');
     get_cell(4, 2).should('contain', '20151116-1905-Experimental');
     get_cell(4, 3).should('contain', 'Passed').and('have.class', 'normal');
     get_cell(4, 4).should('contain', '1');
+
+    get_cell(5, 0).should('not.be.empty');
+    get_cell(5, 1).should('contain', 'TestHistory');
+    get_cell(5, 2).should('contain', '20151116-1904-Experimental');
+    get_cell(5, 3).should('contain', 'Failed').and('have.class', 'error');
+    get_cell(5, 4).should('contain', '0');
   });
 
 

--- a/tests/cypress/e2e/tests.cy.js
+++ b/tests/cypress/e2e/tests.cy.js
@@ -30,7 +30,12 @@ describe('the test page', () => {
 
   it('loads the right navigation links', () => {
     cy.visit('testSummary.php?project=21&name=nap&date=2018-01-25');
+
+    // Sort by build stamp deterministically.
+    cy.get('[data-cy="summary-table"]').contains('Build Stamp').click();
+
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).as('test_td');
+
     cy.get('@test_td').find('a').invoke('attr', 'href').then(test_url => {
       const test_id = test_url.match(/tests?\/([0-9]+)/)[1];
       // visit a test page
@@ -56,6 +61,10 @@ describe('the test page', () => {
 
   it('displays information about the test', () => {
     cy.visit('testSummary.php?project=21&name=nap&date=2018-01-25');
+
+    // Sort by build stamp deterministically.
+    cy.get('[data-cy="summary-table"]').contains('Build Stamp').click();
+
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     // verify information for the test we clicked on
@@ -96,6 +105,10 @@ describe('the test page', () => {
 
   it('loads the "Test Time" and "Failing/Passing" graphs', () => {
     cy.visit('testSummary.php?project=21&name=nap&date=2018-01-25');
+
+    // Sort by build stamp deterministically.
+    cy.get('[data-cy="summary-table"]').contains('Build Stamp').click();
+
     cy.get('#testSummaryTable').find('tbody').find('tr').eq(2).find('td').eq(3).click();
 
     cy.on('uncaught:exception', (err, runnable) => {


### PR DESCRIPTION
`test-summary.cy.js` has been flaky for years and is quite a nuisance when unrelated changes modify the test timing subtly and upset this delicate test.  See the trouble merging https://github.com/Kitware/CDash/pull/3132 for an example.  My hypothesis is that somehow the rows in the table are not rendered deterministically.  This PR attempts to resolve that by sorting by build stamp.  I intend to run the tests 10 times before opening this for review to ensure that this fix actually does something.