### PR TITLE
Fix flaky `sub-project-group-order` e2e test

### DIFF
--- a/resources/js/angular/views/manageSubProject.html
+++ b/resources/js/angular/views/manageSubProject.html
@@ -20,7 +20,7 @@
             <a class="cdash-link" href="#add" aria-controls="add" role="tab" data-toggle="tab">Add a SubProject</a>
           </li>
           <li role="presentation">
-            <a class="cdash-link" href="#groups" aria-controls="groups" role="tab" data-toggle="tab">SubProject Groups</a>
+            <a class="cdash-link" href="#groups" aria-controls="groups" role="tab" data-toggle="tab" data-test="subproject-groups">SubProject Groups</a>
           </li>
         </ul>
 

--- a/tests/cypress/e2e/sub-project-group-order.cy.js
+++ b/tests/cypress/e2e/sub-project-group-order.cy.js
@@ -3,10 +3,9 @@ describe('subProjectGroupOrder', () => {
   it('can change the group order', () => {
     cy.login();
     cy.visit('manageSubProject.php?projectid=15');
-    cy.wait(1000);
 
     // navigate to the 'SubProjects Groups' tab
-    cy.get('a').contains('SubProject Groups').click();
+    cy.get('[data-test="subproject-groups"]').click();
 
     // drag and drop the Production group to the top of the list
     // TODO: (sbelsk) cypress can't see the values bounded by Angular in text


### PR DESCRIPTION
The `sub-project-group-order` test has been flaky for years due to a rendering race condition in which Cypress selects the first `<a>` tag available on the page, something which changes depending on the page load speed.  This PR fixes the issue by using a more specific selector to precisely target the tab in question.

Example failure here: https://github.com/Kitware/CDash/actions/runs/17947517456/job/51041305899