### PR TITLE
Add test history calendar view

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,7 @@ module.exports = {
     '^.+\\.js$': 'babel-jest',
     '^.+\\.vue$': '@vue/vue3-jest',
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!echarts|zrender)/',
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "bootstrap": "^4.6.2",
         "d3": "^3.5.17",
         "daisyui": "^4.12.23",
+        "echarts": "^6.0.0",
         "eslint": "^8.57.0",
         "eslint-plugin-vue": "^10.4.0",
         "flot": "^4.2.6",
@@ -7110,6 +7111,22 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/editorconfig": {
       "version": "1.0.4",
@@ -17564,6 +17581,21 @@
       "dependencies": {
         "zen-observable": "0.8.15"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bootstrap": "^4.6.2",
     "d3": "^3.5.17",
     "daisyui": "^4.12.23",
+    "echarts": "^6.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^10.4.0",
     "flot": "^4.2.6",

--- a/resources/js/vue/components/shared/TestHistoryPlot.vue
+++ b/resources/js/vue/components/shared/TestHistoryPlot.vue
@@ -1,0 +1,533 @@
+<template>
+  <div class="chart-container">
+    <div class="year-navigation">
+      <button
+        :disabled="!canGoToPreviousYear"
+        aria-label="Previous year"
+        @click="previousYear"
+      >
+        ‹
+      </button>
+      <span class="year-label">{{ currentYear }}</span>
+      <button
+        :disabled="!canGoToNextYear"
+        aria-label="Next year"
+        @click="nextYear"
+      >
+        ›
+      </button>
+    </div>
+    <loading-indicator :is-loading="!testStatuses" />
+    <div
+      ref="chart"
+      class="chart"
+    />
+  </div>
+</template>
+
+<script>
+import {DateTime} from 'luxon';
+import * as echarts from 'echarts/core';
+import {CanvasRenderer} from 'echarts/renderers';
+import {
+  CalendarComponent,
+  LegendComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent,
+} from 'echarts/components';
+import {CustomChart, ScatterChart} from 'echarts/charts';
+import gql from 'graphql-tag';
+import LoadingIndicator from './LoadingIndicator.vue';
+
+const decalPattern = {
+  symbol: 'rect',
+  symbolSize: 0.5,
+  symbolKeepAspect: false,
+  color: 'rgba(255, 255, 255, 0.5)',
+  backgroundColor: 'transparent',
+  dashArrayX: [1, 0],
+  dashArrayY: [4, 1.5],
+  rotation: Math.PI / 4,
+};
+
+echarts.use([
+  CanvasRenderer,
+  CalendarComponent,
+  TitleComponent,
+  TooltipComponent,
+  VisualMapComponent,
+  LegendComponent,
+  CustomChart,
+  ScatterChart,
+]);
+
+export default {
+  name: 'TestHistoryPlot',
+  components: {LoadingIndicator},
+
+  props: {
+    baseUrl: {
+      type: String,
+      required: true,
+    },
+    projectId: {
+      type: Number,
+      required: true,
+    },
+    projectName: {
+      type: String,
+      required: true,
+    },
+    testName: {
+      type: String,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      currentYear: null,
+      chart: null,
+    };
+  },
+
+  apollo: {
+    testStatuses: {
+      query: gql`
+        query($projectid: ID, $testname: String!) {
+          testStatuses: project(id: $projectid) {
+            id
+            name
+            buildsWhereTestPassed: builds(filters: {
+              any: [
+                {
+                  has: {
+                    tests: {
+                      all: [
+                        {
+                          eq: {
+                            status: PASSED
+                          }
+                        },
+                        {
+                          eq: {
+                            name: $testname
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }
+                {
+                  has: {
+                    children: {
+                      all: [
+                        {
+                          has: {
+                            tests: {
+                              all: [
+                                {
+                                  eq: {
+                                    status: PASSED
+                                  }
+                                },
+                                {
+                                  eq: {
+                                    name: $testname
+                                  }
+                                },
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }, first: 1000000) {
+              edges {
+                node {
+                  id
+                  startTime
+                }
+              }
+            }
+            buildsWhereTestFailed: builds(filters: {
+              any: [
+                {
+                  has: {
+                    tests: {
+                      all: [
+                        {
+                          eq: {
+                            status: FAILED
+                          }
+                        },
+                        {
+                          eq: {
+                            name: $testname
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }
+                {
+                  has: {
+                    children: {
+                      all: [
+                        {
+                          has: {
+                            tests: {
+                              all: [
+                                {
+                                  eq: {
+                                    status: FAILED
+                                  }
+                                },
+                                {
+                                  eq: {
+                                    name: $testname
+                                  }
+                                },
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }, first: 1000000) {
+              edges {
+                node {
+                  id
+                  startTime
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables() {
+        return {
+          projectid: this.projectId,
+          testname: this.testName,
+        };
+      },
+    },
+  },
+
+  computed: {
+    history() {
+      if (!this.testStatuses) {
+        return [];
+      }
+
+      const passed = this.testStatuses.buildsWhereTestPassed.edges.map(edge => ({
+        date: edge.node.startTime,
+        status: 'passed',
+      }));
+
+      const failed = this.testStatuses.buildsWhereTestFailed.edges.map(edge => ({
+        date: edge.node.startTime,
+        status: 'failed',
+      }));
+
+      return [...passed, ...failed];
+    },
+
+    yearsWithData() {
+      if (!this.history || this.history.length === 0) {
+        return [];
+      }
+      const years = new Set(this.history.map(item => parseInt(item.date.substring(0, 4), 10)));
+      return Array.from(years).sort();
+    },
+
+    canGoToPreviousYear() {
+      const currentIndex = this.yearsWithData.indexOf(this.currentYear);
+      return currentIndex > 0;
+    },
+
+    canGoToNextYear() {
+      const currentIndex = this.yearsWithData.indexOf(this.currentYear);
+      return currentIndex < this.yearsWithData.length - 1;
+    },
+
+    chartData() {
+      if (!this.currentYear) {
+        return [];
+      }
+
+      const dailyBins = this.history
+        .filter(item => parseInt(item.date.substring(0, 4), 10) === this.currentYear)
+        .reduce((acc, item) => {
+          const dateStr = item.date.substring(0, 10);
+          if (!acc[dateStr]) {
+            acc[dateStr] = { numpassing: 0, numfailing: 0 };
+          }
+          if (item.status === 'passed') {
+            acc[dateStr].numpassing++;
+          }
+          else if (item.status === 'failed') {
+            acc[dateStr].numfailing++;
+          }
+          return acc;
+        }, {});
+
+      const yearData = [];
+      let currentDate = DateTime.fromObject({ year: this.currentYear });
+      while (currentDate.year === this.currentYear) {
+        const dateStr = currentDate.toISODate();
+        const bin = dailyBins[dateStr];
+
+        yearData.push([
+          dateStr,
+          bin ? bin.numpassing : 0,
+          bin ? bin.numfailing : 0,
+        ]);
+        currentDate = currentDate.plus({ days: 1 });
+      }
+      return yearData;
+    },
+
+    chartRange() {
+      return this.currentYear ? this.currentYear.toString() : DateTime.now().year.toString();
+    },
+
+    chartOptions() {
+      return {
+        tooltip: {
+          formatter: function (p) {
+            if (p.seriesType === 'custom') {
+              const num_passing = p.data[1];
+              const num_failing = p.data[2];
+
+              if (num_passing === 0 && num_failing === 0) {
+                return `Date: ${p.data[0]}<br/>No tests`;
+              }
+
+              let status_text = '';
+              if (num_passing > 0) {
+                status_text += `${num_passing} passing`;
+              }
+              if (num_failing > 0) {
+                if (status_text.length > 0) {
+                  status_text += ', ';
+                }
+                status_text += `${num_failing} failing`;
+              }
+              const date = p.data[0];
+              return `Date: ${date}<br/>${status_text}`;
+            }
+            return null;
+          },
+        },
+        calendar: {
+          top: 30,
+          left: 30,
+          right: 30,
+          height: 'auto',
+          cellSize: 13,
+          range: this.chartRange,
+          itemStyle: {
+            borderWidth: 0.5,
+            borderColor: '#fff',
+          },
+          yearLabel: { show: false },
+          dayLabel: {
+            firstDay: 1,
+            nameMap: 'en',
+          },
+          monthLabel: { nameMap: 'en' },
+          splitLine: {
+            show: true,
+            lineStyle: {
+              color: '#ddd',
+              width: 1,
+              type: 'solid',
+            },
+          },
+        },
+        series: [
+          {
+            type: 'custom',
+            coordinateSystem: 'calendar',
+            data: this.chartData,
+            renderItem: function (params, api) {
+              const cellPoint = api.coord(api.value(0));
+              const cellWidth = params.coordSys.cellWidth;
+              const cellHeight = params.coordSys.cellHeight;
+              const num_passing = api.value(1);
+              const num_failing = api.value(2);
+
+              if (isNaN(cellPoint[0]) || isNaN(cellPoint[1])) {
+                return;
+              }
+
+              let value = 0;
+              if (num_passing > 0 && num_failing === 0) {
+                value = 1; // Passing
+              }
+              else if (num_passing === 0 && num_failing > 0) {
+                value = 2; // Failing
+              }
+              else if (num_passing > 0 && num_failing > 0) {
+                value = 3; // Both
+              }
+
+              const gap = 2;
+              const shapeWidth = cellWidth - gap;
+              const shapeHeight = cellHeight - gap;
+              const x = cellPoint[0] - cellWidth / 2 + gap / 2;
+              const y = cellPoint[1] - cellHeight / 2 + gap / 2;
+
+              if (value === 1) { // Passing
+                return {
+                  type: 'rect',
+                  shape: { x, y, width: shapeWidth, height: shapeHeight, r: 3 },
+                  style: { fill: '#52c41a' },
+                };
+              }
+              else if (value === 2) { // Failing
+                return {
+                  type: 'rect',
+                  shape: { x, y, width: shapeWidth, height: shapeHeight, r: 3 },
+                  style: { fill: '#f5222d', decal: decalPattern },
+                };
+              }
+              else if (value === 3) { // Both
+                return {
+                  type: 'group',
+                  clipPath: { type: 'rect', shape: { x, y, width: shapeWidth, height: shapeHeight, r: 3 } },
+                  children: [
+                    { type: 'polygon', shape: { points: [[x, y], [x + shapeWidth, y], [x, y + shapeHeight]] }, style: { fill: '#52c41a' } },
+                    { type: 'polygon', shape: { points: [[x + shapeWidth, y], [x + shapeWidth, y + shapeHeight], [x, y + shapeHeight]] }, style: { fill: '#f5222d', decal: decalPattern } },
+                  ],
+                };
+              }
+              return {
+                type: 'rect',
+                shape: { x, y, width: shapeWidth, height: shapeHeight, r: 3 },
+                style: { fill: '#fff', stroke: '#eee', lineWidth: 1 },
+              };
+            },
+            legendHoverLink: false,
+          },
+        ],
+      };
+    },
+  },
+
+  watch: {
+    currentYear() {
+      if (this.chart) {
+        this.chart.setOption(this.chartOptions);
+      }
+    },
+    yearsWithData(newYears) {
+      if (newYears.length > 0 && !this.currentYear) {
+        this.currentYear = newYears[newYears.length - 1];
+      }
+    },
+  },
+
+  mounted() {
+    this.chart = echarts.init(this.$refs.chart);
+    this.chart.on('click', this.handleChartClick);
+    this.chart.getZr().on('mousemove', params => {
+      const pixel = [params.offsetX, params.offsetY];
+      const seriesIndex = this.chart.convertFromPixel('grid', pixel);
+      if (seriesIndex) {
+        this.chart.getZr().setCursorStyle('pointer');
+      }
+    });
+    this.chart.setOption(this.chartOptions);
+  },
+
+  beforeUnmount() {
+    if (this.chart) {
+      this.chart.dispose();
+    }
+  },
+
+  methods: {
+    previousYear() {
+      const currentIndex = this.yearsWithData.indexOf(this.currentYear);
+      if (currentIndex > 0) {
+        this.currentYear = this.yearsWithData[currentIndex - 1];
+      }
+    },
+
+    nextYear() {
+      const currentIndex = this.yearsWithData.indexOf(this.currentYear);
+      if (currentIndex < this.yearsWithData.length - 1) {
+        this.currentYear = this.yearsWithData[currentIndex + 1];
+      }
+    },
+
+    handleChartClick(params) {
+      if (params.seriesType === 'custom' && params.data) {
+        const date = params.data[0];
+        window.location.href = `${this.baseUrl}/queryTests.php?project=${this.projectName}&date=${date}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${this.testName}`;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.chart-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 940px;
+  background-color: #f0f2f5;
+  padding: 10px 0;
+  box-sizing: border-box;
+}
+.chart {
+  width: 100%;
+  height: 144px;
+}
+.year-navigation {
+  display: flex;
+  align-items: center;
+}
+.year-label {
+  font-weight: bold;
+  margin: 0 12px;
+  font-size: 1.1em;
+  color: #262626;
+}
+.year-navigation button {
+  background-color: #f0f2f5;
+  border: 1px solid #d9d9d9;
+  color: #595959;
+  cursor: pointer;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  transition: all 0.3s;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.015);
+}
+.year-navigation button:hover {
+  border-color: #40a9ff;
+  color: #40a9ff;
+}
+.year-navigation button:disabled {
+  border-color: #d9d9d9;
+  color: rgba(0, 0, 0, 0.25);
+  cursor: not-allowed;
+  background-color: #f5f5f5;
+}
+</style>

--- a/tests/Spec/test-details.spec.js
+++ b/tests/Spec/test-details.spec.js
@@ -19,9 +19,6 @@ global.$ = $;
 import AnsiUp from 'ansi_up';
 global.AnsiUp = AnsiUp;
 
-import d3 from 'd3';
-global.d3 = d3;
-
 let axiosMockAdapter;
 let apiResponse;
 let graphData;

--- a/tests/cypress/e2e/tests.cy.js
+++ b/tests/cypress/e2e/tests.cy.js
@@ -122,10 +122,7 @@ describe('the test page', () => {
     // do the same for the Failing/Passing graph
     cy.get('@dropdown').contains('option', 'Test Time').should('be.selected');
     cy.get('@dropdown').select('Failing/Passing');
-    cy.get('#graph_holder').find('canvas').should('exist');
-    cy.contains('a', 'View Graph Data as JSON')
-      .invoke('attr', 'href')
-      .should('match', /api\/v1\/testGraph.php\?testname=nap&buildid=[0-9]+&type=status/);
+    // Not much we can do to assert that it actually works, but we can check for basic console errors at least...
 
     // toggle back to hide the graph
     cy.get('@dropdown').select('Select...');


### PR DESCRIPTION
When viewing a particular test, it's currently possible to view prior test statuses on a scatter plot.  A scatter plot with binary is not ideal for a multitude of reasons, so this PR re-implements it to instead show the data on a calendar plot.  Days with only passing tests are shown in free, days with only failing tests are shown in red, and days with both passing and failing tests are shown in green/red.  Clicking on a day takes users to the test query page with appropriate filters set for further exploration.  Further refactoring of this plot and similar plots is yet to come, but these changes are sufficient in the short term.  I also intend to add a visual difference test for this component once I implement visual difference testing.

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/64b2e045-85b3-4494-9978-80db0761683b" />


After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/68113d2a-48ee-4e33-a3ed-83a944182c2b" />
