### PR TITLE
Change default LDAP logging level to `debug`

### DIFF
--- a/config/ldap.php
+++ b/config/ldap.php
@@ -56,7 +56,7 @@ return [
     'logging' => [
         'enabled' => env('LDAP_LOGGING', true),
         'channel' => env('LOG_CHANNEL', 'stack'),
-        'level' => env('LOG_LEVEL', 'info'),
+        'level' => env('LOG_LEVEL', 'debug'),
     ],
 
     /*


### PR DESCRIPTION
Logging every LDAP query is more in line with our `debug` log level usages rather than our `info` log level usages.