### PR TITLE
Move version computation out of Mix build

### DIFF
--- a/app/Console/Commands/GenerateVersion.php
+++ b/app/Console/Commands/GenerateVersion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+class GenerateVersion extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'generate-version';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Use `git describe` to compute the version if git is installed.';
+
+    public function handle(): int
+    {
+        // Use --tags to capture all tags, including lightweight tags.
+        $describe_result = Process::run('git describe --tags');
+
+        $version = $describe_result->successful() ? $describe_result->output() : 'v' . config('cdash.version');
+
+        $result = file_put_contents(public_path('VERSION'), $version);
+
+        return $result === false ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,9 @@ else
     npm run prod --stats-children
 fi
 
+echo "Generating version files..."
+php artisan generate-version
+
 echo "Bringing CDash back online..."
 php artisan up
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -10,28 +10,8 @@ mix.sourceMaps(true, 'source-map');
 // Hash the built files to create a version identifier.  Use the mix() helper in PHP to automatically append the identifier to a path.
 mix.version();
 
-// Webpack plugins.
-const webpack_plugins = [];
-
-// Write a VERSION file to be reported in the page footer
-fs = require('fs');
-let version;
-if (fs.existsSync('.git')) {
-  // If this is a git clone, we will use the `git describe` to generate a version
-  // to report in the footer.
-  const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
-  webpack_plugins.push(new GitRevisionPlugin({
-    lightweightTags: true,
-  }));
-}
-else {
-  // Otherwise if this is a release download, use the version from package.json.
-  const config = require('./package.json');
-  version = config.version;
-  fs.writeFileSync('public/VERSION', `v${version}`);
-}
-
 // Write out version file for angular.js
+fs = require('fs');
 const dir = 'public/assets/js/angular';
 if (!fs.existsSync(dir)) {
   fs.mkdirSync(dir, { recursive: true });
@@ -108,7 +88,6 @@ mix.copy('resources/js/angular/jquery.dataTables.min.js', 'public/assets/js/jque
 mix.js('resources/js/vue/app.js', 'public/assets/js').vue();
 
 mix.webpackConfig({
-  plugins: webpack_plugins,
   stats: {
     children: true,
   },


### PR DESCRIPTION
The `VERSION` file is currently generated during the Mix build, which hinders our ability to migrate to Vite in the future.  This PR creates a new Laravel command which performs the same actions.