### PR TITLE
Add project name to hash mismatch error log

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -96,7 +96,7 @@ final class SubmissionController extends AbstractProjectController
         $expected_md5 = isset($_GET['MD5']) ? htmlspecialchars($_GET['MD5']) : '';
 
         if ($expected_md5 !== '' && !preg_match('/^[a-f0-9]{32}$/i', $expected_md5)) {
-            Log::info("Rejected submission with invalid hash: $expected_md5");
+            Log::info("Rejected submission with invalid hash '$expected_md5' for project $projectname");
             $this->failProcessing(null, Response::HTTP_BAD_REQUEST, "Provided md5 hash '{$expected_md5}' is improperly formatted.");
         }
 


### PR DESCRIPTION
Invalid hashes are probably associated with configuration issues for a small handful of projects, so it's helpful to have the project name in the log message.