### PR TITLE
Simplify submission processing DB queries

### DIFF
--- a/app/Models/BuildFile.php
+++ b/app/Models/BuildFile.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property string $type
@@ -27,4 +28,12 @@ class BuildFile extends Model
         'md5',
         'buildid',
     ];
+
+    /**
+     * @return BelongsTo<Build, $this>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5953,12 +5953,6 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			rawMessage: 'Argument of an invalid type array|false supplied for foreach, only iterables are supported.'
-			identifier: foreach.nonIterable
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			rawMessage: 'Binary operation "." between (array<string>|string|null) and ''_'' results in an error.'
 			identifier: binaryOp.invalid
 			count: 2
@@ -5971,39 +5965,15 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			rawMessage: '''
-				Call to deprecated method executePrepared() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method executePreparedSingleRow() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 3
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			rawMessage: 'Cannot call method build() on mixed.'
 			identifier: method.nonObject
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
-			identifier: empty.notAllowed
-			count: 5
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			rawMessage: 'Loose comparison via "==" is not allowed.'
 			identifier: equal.notAllowed
-			count: 6
+			count: 5
 			path: app/Jobs/ProcessSubmission.php
 
 		-
@@ -6043,19 +6013,7 @@ parameters:
 			path: app/Jobs/ProcessSubmission.php
 
 		-
-			rawMessage: 'Method App\Jobs\ProcessSubmission::ctest_parse() has parameter $expected_md5 with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
 			rawMessage: 'Method App\Jobs\ProcessSubmission::ctest_parse() has parameter $filehandle with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			rawMessage: 'Method App\Jobs\ProcessSubmission::ctest_parse() has parameter $projectid with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/Jobs/ProcessSubmission.php
@@ -6080,12 +6038,6 @@ parameters:
 
 		-
 			rawMessage: 'Method App\Jobs\ProcessSubmission::doSubmit() has parameter $filename with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/Jobs/ProcessSubmission.php
-
-		-
-			rawMessage: 'Method App\Jobs\ProcessSubmission::doSubmit() has parameter $projectid with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/Jobs/ProcessSubmission.php


### PR DESCRIPTION
The submission handling process is currently a delicate mess which is difficult to change without breaking unrelated features.  This PR is part one of a cleanup of the submission process, using Eloquent wherever possible and eliminating unnecessary DB queries.  I'll perform a larger cleanup in a separate PR once this preliminary work is merged.