### PR TITLE
Remove legacy filter includes

### DIFF
--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -11,8 +11,6 @@ use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 use PDOStatement;
 
-require_once 'include/filterdataFunctions.php';
-
 final class BuildPropertiesController extends AbstractBuildController
 {
     public function buildProperties(): View

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -15,8 +15,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
-require_once 'include/filterdataFunctions.php';
-
 final class CoverageController extends AbstractBuildController
 {
     public function compareCoverage(): View|RedirectResponse

--- a/app/Http/Controllers/FilterController.php
+++ b/app/Http/Controllers/FilterController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 
-require_once 'include/filterdataFunctions.php';
-
 final class FilterController extends AbstractController
 {
     public function getFilterDataArray(): JsonResponse

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 
 require_once 'include/common.php';
+require_once 'include/filterdataFunctions.php';
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/cdash/app/Controller/Api/QueryTests.php
+++ b/app/cdash/app/Controller/Api/QueryTests.php
@@ -25,8 +25,6 @@ use CDash\Model\Build;
 use CDash\Model\Project;
 use Illuminate\Support\Facades\DB;
 
-require_once 'include/filterdataFunctions.php';
-
 class QueryTests extends ResultsApi
 {
     public function __construct(Database $db, Project $project)

--- a/app/cdash/app/Controller/Api/TestOverview.php
+++ b/app/cdash/app/Controller/Api/TestOverview.php
@@ -21,8 +21,6 @@ use CDash\Database;
 use CDash\Model\BuildGroup;
 use CDash\Model\Project;
 
-require_once 'include/filterdataFunctions.php';
-
 class TestOverview extends ResultsApi
 {
     public function __construct(Database $db, Project $project)

--- a/app/cdash/app/Controller/Api/Timeline.php
+++ b/app/cdash/app/Controller/Api/Timeline.php
@@ -29,8 +29,6 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 
-require_once 'include/filterdataFunctions.php';
-
 class Timeline extends Index
 {
     private $defectTypes;

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -23,8 +23,6 @@ use CDash\Database;
 use CDash\Model\Build;
 use Illuminate\Support\Facades\DB;
 
-require_once 'include/filterdataFunctions.php';
-
 class ViewTest extends BuildApi
 {
     public $JSONEncodeResponse;

--- a/app/cdash/include/Test/CDashTestCase.php
+++ b/app/cdash/include/Test/CDashTestCase.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 
 require_once 'include/common.php';
+require_once 'include/filterdataFunctions.php';
 
 class CDashTestCase extends TestCase
 {

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -17,8 +17,6 @@
 
 namespace CDash\Api\v1\Index;
 
-require_once 'include/filterdataFunctions.php';
-
 use CDash\Controller\Api\Index as IndexController;
 use CDash\Database;
 use App\Models\Project as EloquentProject;

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -19,6 +19,7 @@ trait CreatesApplication
         $app->make(Kernel::class)->bootstrap();
 
         require_once 'include/common.php';
+        require_once 'include/filterdataFunctions.php';
 
         return $app;
     }


### PR DESCRIPTION
`common.php` and `filterdataFunctions.php` are now the only two legacy files with functions in the global namespace.  This PR moves the includes of `filterdataFunctions.php` to the same three root locations `common.php` is included in, so all functions are available everywhere.