### PR TITLE
Remove `git-revision-webpack-plugin` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "eslint": "^8.57.0",
         "eslint-plugin-vue": "^10.5.0",
         "flot": "^4.2.6",
-        "git-revision-webpack-plugin": "^5.0.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
         "jquery": "^3.7",
@@ -8821,17 +8820,6 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/git-revision-webpack-plugin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz",
-      "integrity": "sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^10.5.0",
     "flot": "^4.2.6",
-    "git-revision-webpack-plugin": "^5.0.0",
     "graphql": "^16.11.0",
     "graphql-tag": "^2.12.6",
     "jquery": "^3.7",


### PR DESCRIPTION
I forgot to remove `git-revision-webpack-plugin` from our `package.json` in https://github.com/Kitware/CDash/pull/3171.