### PR TITLE
Dump invalid responses in excludesubprojects test

### DIFF
--- a/app/cdash/tests/test_excludesubprojects.php
+++ b/app/cdash/tests/test_excludesubprojects.php
@@ -317,6 +317,11 @@ class ExcludeSubProjectsTestCase extends KWWebTestCase
             $this->get($baseurl . $filter_to_test . '&filtercount=2');
             $content = $this->getBrowser()->getContent();
             $jsonobj = json_decode($content, true);
+
+            if ($jsonobj === null) {
+                throw new Exception($content);
+            }
+
             $buildgroup = array_pop($jsonobj['buildgroups']);
             if (!is_array($buildgroup) || !is_array($buildgroup['builds'])) {
                 $numbuilds = 0;


### PR DESCRIPTION
The `excludesubprojects` test has been flaky in CI recently, but the failures are too nonspecific to do much with and I am unable to reproduce locally.  This PR dumps the response if the response is invalid JSON (probably a 500 response containing HTML) to help us debug the issue.

Example failure output:
```
/cdash/app/cdash/tests/test_excludesubprojects.php
All Tests
Exception 1!
Unexpected exception of type [TypeError] with message [array_pop(): Argument #1 ($array) must be of type array, null given] in [/cdash/app/cdash/tests/test_excludesubprojects.php line 320]
	in testExcludeHonorsOtherFilters
	in ExcludeSubProjectsTestCase
	in /cdash/app/cdash/tests/test_excludesubprojects.php
FAILURES!!!
Test cases run: 1/1, Passes: 4, Failures: 0, Exceptions: 1
```