### PR TITLE
Remove unused site geolocation logic

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -434,63 +434,6 @@ function get_project_name($projectid): string
 }
 
 /**
- * Get the geolocation from IP address
- */
-function get_geolocation($ip): array
-{
-    $location = [];
-
-    $lat = '';
-    $long = '';
-
-    if (config('cdash.geolocate_ip_addresses')) {
-        // Ask hostip.info for geolocation
-        $url = 'http://api.hostip.info/get_html.php?ip=' . $ip . '&position=true';
-
-        if (function_exists('curl_init')) {
-            $curl = curl_init();
-            curl_setopt($curl, CURLOPT_URL, $url);
-            curl_setopt($curl, CURLOPT_TIMEOUT, 5); // if we cannot get the geolocation in 5 seconds we quit
-            ob_start();
-            curl_exec($curl);
-            $httpReply = ob_get_contents();
-            ob_end_clean();
-            curl_close($curl);
-        } elseif (ini_get('allow_url_fopen')) {
-            $options = ['http' => ['timeout' => 5.0]];
-            $context = stream_context_create($options);
-            $httpReply = file_get_contents($url, false, $context);
-        } else {
-            $httpReply = '';
-        }
-
-        $pos = strpos($httpReply, 'Latitude: ');
-        if ($pos !== false) {
-            $pos2 = strpos($httpReply, "\n", $pos);
-            $lat = substr($httpReply, $pos + 10, $pos2 - $pos - 10);
-        }
-
-        $pos = strpos($httpReply, 'Longitude: ');
-        if ($pos !== false) {
-            $pos2 = strpos($httpReply, "\n", $pos);
-            $long = substr($httpReply, $pos + 11, $pos2 - $pos - 11);
-        }
-    }
-
-    $location['latitude'] = '';
-    $location['longitude'] = '';
-
-    // Sanity check
-    if (strlen($lat) > 0 && strlen($long) > 0
-        && $lat[0] != ' ' && $long[0] != ' '
-    ) {
-        $location['latitude'] = $lat;
-        $location['longitude'] = $long;
-    }
-    return $location;
-}
-
-/**
  * remove all builds for a project
  */
 function remove_project_builds($projectid): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6217,18 +6217,6 @@ parameters:
 			path: app/Models/ProjectInvitation.php
 
 		-
-			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
-			identifier: empty.notAllowed
-			count: 1
-			path: app/Models/Site.php
-
-		-
-			rawMessage: 'Property App\Models\Site::$ip (string) does not accept mixed.'
-			identifier: assign.propertyType
-			count: 1
-			path: app/Models/Site.php
-
-		-
 			rawMessage: 'Method App\Models\Test::getLabels() return type with generic class Illuminate\Support\Collection does not specify its types: TKey, TValue'
 			identifier: missingType.generics
 			count: 1
@@ -15229,18 +15217,6 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			rawMessage: 'Function get_geolocation() has parameter $ip with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Function get_geolocation() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			rawMessage: 'Function get_labels_JSON_from_query_results() has parameter $query_params with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -15393,7 +15369,7 @@ parameters:
 		-
 			rawMessage: 'Loose comparison via "!=" is not allowed.'
 			identifier: notEqual.notAllowed
-			count: 3
+			count: 1
 			path: app/cdash/include/common.php
 
 		-
@@ -15415,19 +15391,7 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			rawMessage: 'Only booleans are allowed in an elseif condition, string|false given.'
-			identifier: elseif.condNotBoolean
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			rawMessage: 'Only booleans are allowed in an if condition, (int|false) given.'
-			identifier: if.condNotBoolean
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Only booleans are allowed in an if condition, bool|string given.'
 			identifier: if.condNotBoolean
 			count: 1
 			path: app/cdash/include/common.php
@@ -15441,12 +15405,6 @@ parameters:
 		-
 			rawMessage: 'Only numeric types are allowed in +, int|false given on the left side.'
 			identifier: plus.leftNonNumeric
-			count: 2
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Only numeric types are allowed in -, int<0, max>|false given on the left side.'
-			identifier: minus.leftNonNumeric
 			count: 2
 			path: app/cdash/include/common.php
 
@@ -15475,33 +15433,9 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			rawMessage: 'Parameter #1 $handle of function curl_close expects CurlHandle, (CurlHandle|false) given.'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Parameter #1 $handle of function curl_exec expects CurlHandle, (CurlHandle|false) given.'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Parameter #1 $handle of function curl_setopt expects CurlHandle, (CurlHandle|false) given.'
-			identifier: argument.type
-			count: 2
-			path: app/cdash/include/common.php
-
-		-
 			rawMessage: 'Parameter #1 $haystack of function stripos expects string, float|int|string given.'
 			identifier: argument.type
 			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Parameter #1 $haystack of function strpos expects string, string|false given.'
-			identifier: argument.type
-			count: 4
 			path: app/cdash/include/common.php
 
 		-
@@ -15544,12 +15478,6 @@ parameters:
 			rawMessage: 'Parameter #1 $string of function substr expects string, (string|false) given.'
 			identifier: argument.type
 			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Parameter #1 $string of function substr expects string, string|false given.'
-			identifier: argument.type
-			count: 2
 			path: app/cdash/include/common.php
 
 		-


### PR DESCRIPTION
This logic was preserved with the idea that it could be reused in the future if we ever decide to bring back site geolocation.  In reality, this isn't a lot of logic and it needs a refactor anyway, so this PR just removes it entirely.