### PR TITLE
Use Laravel DB facade for all transactions

### DIFF
--- a/app/Utils/SubmissionUtils.php
+++ b/app/Utils/SubmissionUtils.php
@@ -21,6 +21,7 @@ use App\Http\Submission\Handlers\UploadHandler;
 use CDash\Database;
 use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
+use Illuminate\Support\Facades\DB;
 
 class SubmissionUtils
 {
@@ -251,7 +252,7 @@ class SubmissionUtils
         }
 
         // Check if a diff already exists for this build.
-        $pdo->beginTransaction();
+        DB::beginTransaction();
         $stmt = $pdo->prepare(
             'SELECT * FROM builderrordiff WHERE buildid=:buildid AND type=:type FOR UPDATE');
         $stmt->bindParam(':buildid', $buildid);
@@ -267,7 +268,7 @@ class SubmissionUtils
 
         // Only log if there's a diff since last build or an existing diff record.
         if ($npositives == 0 && $nnegatives == 0 && $existing_npositives == 0 && $existing_nnegatives == 0) {
-            $pdo->commit();
+            DB::commit();
             return;
         }
 
@@ -289,10 +290,10 @@ class SubmissionUtils
         $stmt->bindValue(':npositives', $npositives);
         $stmt->bindValue(':nnegatives', $nnegatives);
         if (!pdo_execute($stmt)) {
-            $pdo->rollBack();
+            DB::rollBack();
             return;
         }
-        $pdo->commit();
+        DB::commit();
     }
 
     /** Return the hash of an open file handle */

--- a/app/cdash/app/Model/BuildConfigure.php
+++ b/app/cdash/app/Model/BuildConfigure.php
@@ -202,7 +202,7 @@ class BuildConfigure
             return false;
         }
 
-        $this->PDO->beginTransaction();
+        DB::beginTransaction();
         $new_configure_inserted = false;
         if (!$this->ExistsByCrc32()) {
             // No such configure exists yet, insert a new row.
@@ -226,7 +226,7 @@ class BuildConfigure
                 // This error might be due to a unique constraint violation.
                 // Query again to see if this configure was created since
                 // the last time we checked.
-                $this->PDO->rollBack();
+                DB::rollBack();
                 if ($this->ExistsByCrc32()) {
                     return true;
                 } else {
@@ -245,11 +245,11 @@ class BuildConfigure
         $stmt->bindParam(':starttime', $this->StartTime);
         $stmt->bindParam(':endtime', $this->EndTime);
         if (!pdo_execute($stmt)) {
-            $this->PDO->rollBack();
+            DB::rollBack();
             return false;
         }
 
-        $this->PDO->commit();
+        DB::commit();
         $this->InsertLabelAssociations();
         return $new_configure_inserted;
     }

--- a/app/cdash/app/Model/DynamicAnalysisSummary.php
+++ b/app/cdash/app/Model/DynamicAnalysisSummary.php
@@ -79,7 +79,7 @@ class DynamicAnalysisSummary
             return false;
         }
 
-        $this->PDO->beginTransaction();
+        DB::beginTransaction();
 
         $stmt = $this->PDO->prepare('
                 INSERT INTO dynamicanalysissummary
@@ -95,7 +95,7 @@ class DynamicAnalysisSummary
                 pdo_execute($stmt, [$this->BuildId]);
                 $row = $stmt->fetch();
                 if (!$row) {
-                    $this->PDO->rollBack();
+                    DB::rollBack();
                     return false;
                 }
                 $this->Checker = $row['checker'];
@@ -118,10 +118,10 @@ class DynamicAnalysisSummary
         $stmt->bindParam(':checker', $this->Checker);
         $stmt->bindParam(':numdefects', $this->NumDefects);
         if (!pdo_execute($stmt)) {
-            $this->PDO->rollBack();
+            DB::rollBack();
             return false;
         }
-        $this->PDO->commit();
+        DB::commit();
         return true;
     }
 }

--- a/app/cdash/app/Model/PendingSubmissions.php
+++ b/app/cdash/app/Model/PendingSubmissions.php
@@ -19,6 +19,7 @@ namespace CDash\Model;
 
 use CDash\Database;
 use Exception;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 /** PendingSubmission class */
@@ -66,7 +67,7 @@ class PendingSubmissions
             return false;
         }
 
-        $this->PDO->beginTransaction();
+        DB::beginTransaction();
         if ($this->Exists()) {
             $stmt = $this->PDO->prepare(
                 'UPDATE pending_submissions
@@ -84,10 +85,10 @@ class PendingSubmissions
         $stmt->bindParam(':numfiles', $this->NumFiles);
         $stmt->bindParam(':recheck', $this->Recheck);
         if (!pdo_execute($stmt)) {
-            $this->PDO->rollBack();
+            DB::rollBack();
             return false;
         }
-        $this->PDO->commit();
+        DB::commit();
         return true;
     }
 
@@ -164,9 +165,9 @@ class PendingSubmissions
             return false;
         }
 
-        $this->PDO->beginTransaction();
+        DB::beginTransaction();
         if (!$this->Exists()) {
-            $this->PDO->commit();
+            DB::commit();
             return false;
         }
 
@@ -176,7 +177,7 @@ class PendingSubmissions
             WHERE buildid = ?");
         try {
             if ($stmt->execute([$this->Build->Id])) {
-                $this->PDO->commit();
+                DB::commit();
             } else {
                 // The UPDATE statement didn't execute cleanly.
                 $error_info = $stmt->errorInfo();
@@ -184,7 +185,7 @@ class PendingSubmissions
                 throw new Exception($error);
             }
         } catch (Exception $e) {
-            $this->PDO->rollBack();
+            DB::rollBack();
             // Ignore any 'Numeric value out of range' SQL errors.
             if ($this->GetNumFiles() > 0) {
                 // Otherwise log the error and return false.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11953,6 +11953,12 @@ parameters:
 			path: app/cdash/app/Model/PendingSubmissions.php
 
 		-
+			rawMessage: 'Method CDash\Model\PendingSubmissions::AtomicUpdate() throws checked exception Error but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/cdash/app/Model/PendingSubmissions.php
+
+		-
 			rawMessage: 'Method CDash\Model\PendingSubmissions::Fill() has no return type specified.'
 			identifier: missingType.return
 			count: 1


### PR DESCRIPTION
Using PDO directly interferes with Laravel's internal transaction representation state, and causes issues when multiple transaction blocks are nested.