### PR TITLE
Expose path-based coverage percentage aggregate

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -486,6 +486,15 @@ type Build {
     filters: _ @filter
   ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
+  """
+  Get the percentage of lines covered in all files starting with the provided path.
+  Automatically trims leading slashes and dots.  Returns null if the directory does
+  not exist or contains no lines of executable code.
+  """
+  percentCoverageForPath(
+    path: String!
+  ): Float @method
+
   labels(
     filters: _ @filter
   ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28056,6 +28056,15 @@ parameters:
 				07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
 			'''
 			identifier: method.deprecated
+			count: 2
+			path: tests/Feature/GraphQL/BuildTypeTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method coverageResults() of class App\Models\Build:
+				07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
+			'''
+			identifier: method.deprecated
 			count: 5
 			path: tests/Feature/GraphQL/CoverageTypeTest.php
 


### PR DESCRIPTION
This PR adds a new `percentCoverageForPath` field to the `Build` type, which allows relatively efficient querying of the percentage of lines covered in the directory structure below a provided point.  This will help with a future refactor of the coverage file browser page.