### PR TITLE
Refactor BuildEmail model

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -6,6 +6,7 @@ use App\Jobs\NotifyExpiringAuthTokens;
 use App\Jobs\PerformLegacyDailyUpdates;
 use App\Jobs\PruneAuthTokens;
 use App\Jobs\PruneBuilds;
+use App\Jobs\PruneEmails;
 use App\Jobs\PruneJobs;
 use App\Jobs\PruneSubmissionFiles;
 use App\Jobs\PruneUploads;
@@ -41,6 +42,10 @@ class Kernel extends ConsoleKernel
         // hourly.
         $schedule->job(new PruneBuilds())
             ->daily()
+            ->withoutOverlapping();
+
+        $schedule->job(new PruneEmails())
+            ->hourly()
             ->withoutOverlapping();
 
         // A wrapper for the legacy "daily updates" process.  Pieces of this should be moved elsewhere.

--- a/app/Jobs/PerformLegacyDailyUpdates.php
+++ b/app/Jobs/PerformLegacyDailyUpdates.php
@@ -173,14 +173,6 @@ class PerformLegacyDailyUpdates implements ShouldQueue
         }
     }
 
-    /** Remove the buildemail that have been there from more than 48h */
-    private function cleanBuildEmail(): void
-    {
-        $now = date(FMT_DATETIME, time() - 3600 * 48);
-
-        DB::delete('DELETE FROM buildemail WHERE time<?', [$now]);
-    }
-
     /** Clean the usertemp table if more than 24hrs */
     private function cleanUserTemp(): void
     {
@@ -201,8 +193,6 @@ class PerformLegacyDailyUpdates implements ShouldQueue
         // Send an email if some expected builds have not been submitting
         $this->sendEmailExpectedBuilds($projectid, $currentstarttime);
 
-        // cleanBuildEmail
-        $this->cleanBuildEmail();
         $this->cleanUserTemp();
 
         // Delete expired buildgroups and rules.

--- a/app/Jobs/PruneEmails.php
+++ b/app/Jobs/PruneEmails.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\BuildEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+/**
+ * Deletes sent email logs older than 48 hours.
+ */
+class PruneEmails implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(): void
+    {
+        BuildEmail::where('time', '<', Carbon::now()->subDays(2))->delete();
+    }
+}

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -298,4 +298,12 @@ class Build extends Model
     {
         return $this->hasMany(DynamicAnalysis::class, 'buildid');
     }
+
+    /**
+     * @return HasMany<BuildEmail, $this>
+     */
+    public function emails(): HasMany
+    {
+        return $this->hasMany(BuildEmail::class, 'buildid');
+    }
 }

--- a/app/Models/BuildEmail.php
+++ b/app/Models/BuildEmail.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $userid
+ * @property int $buildid
+ * @property int $category
+ * @property Carbon $time
+ *
+ * @mixin Builder<BuildEmail>
+ */
+class BuildEmail extends Model
+{
+    protected $table = 'buildemail';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'userid',
+        'buildid',
+        'category',
+        'time',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'userid' => 'integer',
+        'buildid' => 'integer',
+        'category' => 'integer',
+        'time' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Build, $this>
+     */
+    public function build(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'buildid');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'userid');
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -398,6 +398,11 @@ add_feature_test(/Feature/AutoRemoveBuildsCommand)
 add_feature_test(/Feature/Jobs/PruneBuildsTest)
 set_property(TEST /Feature/Jobs/PruneBuildsTest APPEND PROPERTY RUN_SERIAL TRUE)
 
+# Theoretically it's possible for this test to conflict with other tests because this test can
+# delete email history records other than the ones it creates.  The odds of such a conflict
+# occurring are too low to justify running serially.
+add_feature_test(/Feature/Jobs/PruneEmailsTest)
+
 add_feature_test(/Feature/Services/ProjectServiceTest)
 
 ###################################################################################################

--- a/database/migrations/2025_10_12_161109_buildemail_id.php
+++ b/database/migrations/2025_10_12_161109_buildemail_id.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE buildemail ADD COLUMN id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10018,37 +10018,19 @@ parameters:
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
-			rawMessage: '''
-				Call to deprecated method execute() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method prepare() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: 'Cannot call method Save() on mixed.'
-			identifier: method.nonObject
+			rawMessage: Cannot access property $email on App\Models\User|null.
+			identifier: property.nonObject
 			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
-			rawMessage: 'Cannot call method bindParam() on PDOStatement|false.'
-			identifier: method.nonObject
-			count: 5
+			rawMessage: Cannot access property $id on App\Models\User|null.
+			identifier: property.nonObject
+			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
-			rawMessage: 'Cannot call method fetchAll() on PDOStatement|false.'
+			rawMessage: 'Cannot call method Save() on mixed.'
 			identifier: method.nonObject
 			count: 1
 			path: app/cdash/app/Model/BuildEmail.php
@@ -10090,27 +10072,9 @@ parameters:
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
-			rawMessage: 'Method CDash\Model\BuildEmail::SetSent() has parameter $exists with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: 'Method CDash\Model\BuildEmail::SetTime() has parameter $time with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
 			rawMessage: 'Method CDash\Model\BuildEmail::SetUserId() has parameter $userId with no type specified.'
 			identifier: missingType.parameter
 			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: 'Parameter #1 $stmt of method CDash\Database::execute() expects PDOStatement, PDOStatement|false given.'
-			identifier: argument.type
-			count: 2
 			path: app/cdash/app/Model/BuildEmail.php
 
 		-
@@ -10127,24 +10091,6 @@ parameters:
 
 		-
 			rawMessage: Property CDash\Model\BuildEmail::$Email has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: Property CDash\Model\BuildEmail::$RequiredFields has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: Property CDash\Model\BuildEmail::$Sent has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/BuildEmail.php
-
-		-
-			rawMessage: Property CDash\Model\BuildEmail::$Time has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/BuildEmail.php

--- a/tests/Feature/Jobs/PruneEmailsTest.php
+++ b/tests/Feature/Jobs/PruneEmailsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\PruneEmails;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class PruneEmailsTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+
+    protected Project $project;
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+        $this->user = $this->makeNormalUser();
+    }
+
+    public function tearDown(): void
+    {
+        $this->project->delete();
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testDeletesOldEmails(): void
+    {
+        $email_to_keep = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->emails()->create([
+            'userid' => $this->user->id,
+            'category' => 0,
+            'time' => Carbon::now()->subHours(47),
+        ]);
+
+        $email_to_delete = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->emails()->create([
+            'userid' => $this->user->id,
+            'category' => 0,
+            'time' => Carbon::now()->subHours(49),
+        ]);
+
+        self::assertModelExists($email_to_delete);
+        self::assertModelExists($email_to_keep);
+        PruneEmails::dispatch();
+        self::assertModelMissing($email_to_delete);
+        self::assertModelExists($email_to_keep);
+    }
+}


### PR DESCRIPTION
Incremental progress towards our goal of replacing all of the legacy models with Eloquent equivalents.  All direct DB queries now go through the Eloquent model, and the legacy model is simply an adapter.  A future PR will remove the legacy model entirely.