### PR TITLE
Clean up BuildError model

### DIFF
--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -17,6 +17,7 @@
 
 namespace CDash\Model;
 
+use App\Models\BasicBuildAlert;
 use App\Models\Build as EloquentBuild;
 use App\Models\Site;
 use App\Models\Test;
@@ -589,9 +590,10 @@ class Build
             if ($this->IsParentBuild()) {
                 $errors = $this->GetErrorsForChildren($fetchStyle);
             } else {
-                $buildErrors = new BuildError();
-                $buildErrors->BuildId = $this->Id;
-                $errors = $buildErrors->GetErrorsForBuild($fetchStyle);
+                $result = BasicBuildAlert::where('buildid', $this->Id)
+                    ->orderBy('logline')
+                    ->get();
+                $errors = $fetchStyle === PDO::FETCH_ASSOC ? $result->toArray() : $result->all();
             }
 
             if ($errors !== false) {

--- a/app/cdash/tests/test_buildproperties.php
+++ b/app/cdash/tests/test_buildproperties.php
@@ -94,11 +94,11 @@ class BuildPropertiesTestCase extends KWWebTestCase
         $error->SourceLine = 1;
         $error->PreContext = 'this is precontext';
         $error->PostContext = 'this is postcontext';
-        $error->RepeatCount = '0';
+        $error->RepeatCount = 0;
 
-        $error->BuildId = $this->Builds['error1']->Id;
+        $error->BuildId = (int) $this->Builds['error1']->Id;
         $error->Insert();
-        $error->BuildId = $this->Builds['error2']->Id;
+        $error->BuildId = (int) $this->Builds['error2']->Id;
         $error->Insert();
 
         $warning = new BuildFailure();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -739,6 +739,12 @@ parameters:
 			path: app/Http/Controllers/BuildController.php
 
 		-
+			rawMessage: 'Parameter #1 $data of static method CDash\Model\BuildError::marshal() expects array, mixed given.'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Controllers/BuildController.php
+
+		-
 			rawMessage: 'Parameter #1 $haystack of function strrpos expects string, (array<string>|string) given.'
 			identifier: argument.type
 			count: 2
@@ -10168,20 +10174,14 @@ parameters:
 			path: app/cdash/app/Model/BuildError.php
 
 		-
-			rawMessage: 'Method CDash\Model\BuildError::GetErrorsForBuild() return type has no value type specified in iterable type array.'
+			rawMessage: 'Method CDash\Model\BuildError::GetSourceFile() has parameter $data with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 
 		-
-			rawMessage: 'Method CDash\Model\BuildError::GetSourceFile() has parameter $data with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/app/Model/BuildError.php
-
-		-
-			rawMessage: 'Method CDash\Model\BuildError::marshal() has parameter $data with no type specified.'
-			identifier: missingType.parameter
+			rawMessage: 'Method CDash\Model\BuildError::marshal() has parameter $data with no value type specified in iterable type array.'
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/cdash/app/Model/BuildError.php
 


### PR DESCRIPTION
This PR contains the remnants of an attempt to add type annotations to the properties in the legacy `BuildError` class.  Doing so is virtually impossible for a variety of reasons, so I've backed out all of the type changes in favor of only the light refactor in this PR.