### PR TITLE
Fix coverage percent display bug when no executable lines

### DIFF
--- a/resources/js/vue/components/CoverageFilePage.vue
+++ b/resources/js/vue/components/CoverageFilePage.vue
@@ -9,7 +9,10 @@
         </div>
         <div class="tw-flex-grow" />
         <div>
-          {{ coverage.linesOfCodeTested }} / {{ totalLines }} lines covered ({{ percentLinesCovered }}%)
+          {{ coverage.linesOfCodeTested }} / {{ totalLines }} lines covered
+          <template v-if="!isNaN(percentLinesCovered)">
+            ({{ percentLinesCovered }}%)
+          </template>
         </div>
       </div>
 


### PR DESCRIPTION
The coverage file UI currently shows "NaN" when there are no executable lines of code in the file.  Since the behavior in such a case is undefined, it's better to just hide the percent display unless there are lines to calculate a percentage from.