### PR TITLE
Store full instrumentation timestamp precision

### DIFF
--- a/app/Database/Query/Grammars/PostgresGrammar.php
+++ b/app/Database/Query/Grammars/PostgresGrammar.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Database\Query\Grammars;
+
+class PostgresGrammar extends \Illuminate\Database\Query\Grammars\PostgresGrammar
+{
+    public function getDateFormat()
+    {
+        return 'Y-m-d H:i:s.u';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,8 +10,10 @@ define('FMT_DATETIMETZ', 'Y-m-d\TH:i:s T');  // date and time with time zone
 define('FMT_DATETIMEMS', 'Y-m-d\TH:i:s.u');  // date and time with milliseconds
 define('FMT_DATETIMEDISPLAY', 'M d, Y - H:i T');  // date and time standard
 
+use App\Database\Query\Grammars\PostgresGrammar;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -26,6 +28,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        DB::connection()->setQueryGrammar(new PostgresGrammar(DB::connection()));
+
         Validator::extendImplicit('complexity', 'App\Validators\Password@complexity');
 
         URL::forceRootUrl(Config::get('app.url'));

--- a/app/cdash/tests/test_deletesubproject.php
+++ b/app/cdash/tests/test_deletesubproject.php
@@ -25,6 +25,9 @@ class DeleteSubProjectTestCase extends KWWebTestCase
             return false;
         }
 
+        // The end date might be rounded to one second in the future, so it's easiest to just wait until then to check.
+        sleep(1);
+
         $this->get($this->url . '/api/v1/viewSubProjects.php?project=Trilinos');
         $this->assertNoText('FEApp');
 

--- a/database/migrations/2025_10_14_195217_instrumentation_timestamp_precision.php
+++ b/database/migrations/2025_10_14_195217_instrumentation_timestamp_precision.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE buildcommands ALTER COLUMN starttime TYPE timestamptz(3)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,10 @@
 "A datetime and timezone string in ISO 8601 format `Y-m-dTH:i:sP`, e.g. `2020-04-20T13:53:12+02:00`."
 scalar DateTimeTz @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTimeTz")
 
+"A datetime string in ISO 8601 format in UTC with nanoseconds `YYYY-MM-DDTHH:mm:ss.SSSSSSZ`, e.g. `2020-04-20T16:20:04.000000Z`."
+scalar DateTimeUtc
+@scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\DateTimeUtc")
+
 # It would be better to replace these with a "Duration" scalar type in the future.
 "A non-negative decimal number of seconds."
 scalar NonNegativeSeconds @scalar(class: "App\\GraphQL\\Scalars\\NonNegativeSeconds")
@@ -569,7 +573,7 @@ type BuildCommand @model(class: "App\\Models\\BuildCommand") {
 
   type: BuildCommandType! @filterable
 
-  startTime: DateTimeTz! @rename(attribute: "starttime") @filterable
+  startTime: DateTimeUtc! @rename(attribute: "starttime") @filterable
 
   duration: NonNegativeIntegerMilliseconds! @filterable
 

--- a/tests/Feature/GraphQL/BuildCommandTypeTest.php
+++ b/tests/Feature/GraphQL/BuildCommandTypeTest.php
@@ -54,6 +54,7 @@ class BuildCommandTypeTest extends TestCase
             'config' => Str::random(10),
             'workingdirectory' => Str::uuid()->toString(),
         ]);
+        $command->refresh();
 
         $this->graphQL('
             query build($id: ID) {
@@ -87,7 +88,7 @@ class BuildCommandTypeTest extends TestCase
                                 'node' => [
                                     'id' => (string) $command->id,
                                     'type' => 'CUSTOM',
-                                    'startTime' => $command->starttime->toIso8601String(),
+                                    'startTime' => $command->starttime->toIso8601ZuluString('microsecond'),
                                     'duration' => $command->duration,
                                     'command' => $command->command,
                                     'result' => $command->result,

--- a/tests/Feature/GraphQL/GlobalInvitationTypeTest.php
+++ b/tests/Feature/GraphQL/GlobalInvitationTypeTest.php
@@ -54,7 +54,7 @@ class GlobalInvitationTypeTest extends TestCase
             'invitation_timestamp' => Carbon::now(),
             'password' => Hash::make(Str::password()),
         ]);
-        $this->invitations[] = $invitation;
+        $this->invitations[] = $invitation->refresh();
 
         return $invitation;
     }

--- a/tests/Feature/GraphQL/ProjectInvitationTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectInvitationTypeTest.php
@@ -46,7 +46,7 @@ class ProjectInvitationTypeTest extends TestCase
             'project_id' => $this->project->id,
             'role' => ProjectRole::USER,
             'invitation_timestamp' => Carbon::now(),
-        ]);
+        ])->refresh();
 
         $this->actingAs($this->adminUser)->graphQL('
             query($id: ID) {

--- a/tests/Feature/Submission/Instrumentation/data/result.json
+++ b/tests/Feature/Submission/Instrumentation/data/result.json
@@ -14,7 +14,7 @@
                   {
                     "node": {
                       "type": "CMAKE_INSTALL",
-                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "startTime": "2025-04-24T15:34:32.617000Z",
                       "duration": 156,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
@@ -62,7 +62,7 @@
                   {
                     "node": {
                       "type": "INSTALL",
-                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "startTime": "2025-04-24T15:34:32.873000Z",
                       "duration": 114,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
@@ -110,7 +110,7 @@
                   {
                     "node": {
                       "type": "CUSTOM",
-                      "startTime": "2025-04-24T15:34:32+00:00",
+                      "startTime": "2025-04-24T15:34:32.560000Z",
                       "duration": 234,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
@@ -165,7 +165,7 @@
                   {
                     "node": {
                       "type": "CUSTOM",
-                      "startTime": "2025-04-24T15:34:31+00:00",
+                      "startTime": "2025-04-24T15:34:31.223000Z",
                       "duration": 138,
                       "command": "\"/my/path/projects/tmp_for_cdash/bin_instrument/MakeTable\" (truncated)",
                       "result": "0",
@@ -220,7 +220,7 @@
                   {
                     "node": {
                       "type": "CMAKE_BUILD",
-                      "startTime": "2025-04-24T15:34:30+00:00",
+                      "startTime": "2025-04-24T15:34:30.653000Z",
                       "duration": 2346,
                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                       "result": "0",
@@ -283,7 +283,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.084000Z",
                                       "duration": 75,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -341,7 +341,7 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-04-24T15:34:30+00:00",
+                                      "startTime": "2025-04-24T15:34:30.720000Z",
                                       "duration": 290,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -421,7 +421,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.084000Z",
                               "duration": 75,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -479,7 +479,7 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-04-24T15:34:30+00:00",
+                              "startTime": "2025-04-24T15:34:30.720000Z",
                               "duration": 290,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -552,7 +552,7 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.459000Z",
                                       "duration": 84,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -610,7 +610,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "startTime": "2025-04-24T15:34:32.257000Z",
                                       "duration": 59,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -692,7 +692,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.971000Z",
                                       "duration": 24,
                                       "command": "\"/usr/bin/ar\" (truncated)",
                                       "result": "0",
@@ -750,7 +750,7 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.459000Z",
                                       "duration": 314,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -808,7 +808,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.848000Z",
                                       "duration": 62,
                                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                                       "result": "0",
@@ -866,7 +866,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "startTime": "2025-04-24T15:34:32.132000Z",
                                       "duration": 57,
                                       "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                                       "result": "0",
@@ -924,7 +924,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "startTime": "2025-04-24T15:34:32.055000Z",
                                       "duration": 20,
                                       "command": "\"/usr/bin/ranlib\" (truncated)",
                                       "result": "0",
@@ -1004,7 +1004,7 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.459000Z",
                               "duration": 84,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -1062,7 +1062,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "startTime": "2025-04-24T15:34:32.257000Z",
                               "duration": 59,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -1120,7 +1120,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.971000Z",
                               "duration": 24,
                               "command": "\"/usr/bin/ar\" (truncated)",
                               "result": "0",
@@ -1178,7 +1178,7 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.459000Z",
                               "duration": 314,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -1236,7 +1236,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.848000Z",
                               "duration": 62,
                               "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                               "result": "0",
@@ -1294,7 +1294,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "startTime": "2025-04-24T15:34:32.132000Z",
                               "duration": 57,
                               "command": "\"/my/path/projects/CMake_bin/bin/cmake\" (truncated)",
                               "result": "0",
@@ -1352,7 +1352,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "startTime": "2025-04-24T15:34:32.055000Z",
                               "duration": 20,
                               "command": "\"/usr/bin/ranlib\" (truncated)",
                               "result": "0",
@@ -1425,7 +1425,7 @@
                                   {
                                     "node": {
                                       "type": "LINK",
-                                      "startTime": "2025-04-24T15:34:32+00:00",
+                                      "startTime": "2025-04-24T15:34:32.439000Z",
                                       "duration": 57,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -1483,7 +1483,7 @@
                                   {
                                     "node": {
                                       "type": "COMPILE",
-                                      "startTime": "2025-04-24T15:34:31+00:00",
+                                      "startTime": "2025-04-24T15:34:31.459000Z",
                                       "duration": 316,
                                       "command": "\"/usr/bin/c++\" (truncated)",
                                       "result": "0",
@@ -1568,7 +1568,7 @@
                           {
                             "node": {
                               "type": "LINK",
-                              "startTime": "2025-04-24T15:34:32+00:00",
+                              "startTime": "2025-04-24T15:34:32.439000Z",
                               "duration": 57,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",
@@ -1626,7 +1626,7 @@
                           {
                             "node": {
                               "type": "COMPILE",
-                              "startTime": "2025-04-24T15:34:31+00:00",
+                              "startTime": "2025-04-24T15:34:31.459000Z",
                               "duration": 316,
                               "command": "\"/usr/bin/c++\" (truncated)",
                               "result": "0",


### PR DESCRIPTION
Laravel stores timestamps with second precision by default and the fluent migration API generates timestamp columns with second precision.  This PR increases the precision of the build command start time column and makes changes to Laravel's timestamp handling to always use full precision if possible.