### PR TITLE
Remove version from `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "cdash",
-  "version": "4.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdash",
-      "version": "4.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@apollo/client": "^3.13.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "cdash",
-  "version": "4.5.0",
   "description": "Continuous integration dashboard.",
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Follows https://github.com/Kitware/CDash/pull/3171.  Now there is only a single place the version needs to be set when releases are created.