### PR TITLE
Add command gantt chart to targets page

### DIFF
--- a/resources/js/vue/components/shared/CommandGanttChart.vue
+++ b/resources/js/vue/components/shared/CommandGanttChart.vue
@@ -1,0 +1,352 @@
+<template>
+  <div
+    id="chart-wrapper"
+    ref="chartWrapperRef"
+    class="card tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200"
+  >
+    <div
+      id="legend-container"
+      class="tw-flex tw-flex-wrap tw-justify-center tw-gap-x-5 tw-gap-y-2.5 tw-p-2.5 tw-text-xs"
+    >
+      <div
+        v-for="(color, type) in colors"
+        :key="type"
+        class="tw-flex tw-items-center"
+      >
+        <span
+          class="tw-w-3 tw-h-3 tw-mr-1.5 tw-rounded-sm"
+          :style="{ backgroundColor: color }"
+        />
+        <span class="tw-text-gray-700">{{ type }}</span>
+      </div>
+    </div>
+    <div
+      ref="chartContainerRef"
+      class="tw-w-full tw-p-0 tw-flex-grow"
+    />
+  </div>
+</template>
+
+<script>
+import { Duration } from 'luxon';
+import * as echarts from 'echarts';
+
+export default {
+  props: {
+    /**
+     * An array of command objects. Each object is expected to have the following properties:
+     * {
+     *     startTime: Object, // A Luxon DateTime object
+     *     duration: Object,  // A Luxon Duration object.
+     *     type: String,
+     *     disabled: Boolean  // Whether to "gray out" the command
+     *     targetName: String
+     *     source: String,
+     *     command: String,
+     *     language: String,
+     *     config: String,
+     * }
+     */
+    commands: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      colors: {
+        // TODO: Use Tailwind for these colors instead.
+        'COMPILE': '#0072B2',
+        'LINK': '#009E73',
+        'CUSTOM': '#D55E00',
+        'CMAKE_BUILD': '#F0E442',
+        'CMAKE_INSTALL': '#CC79A7',
+        'INSTALL': '#56B4E9',
+      },
+      commandBarHeight: 15,
+      commandBarSpacing: 5,
+      processedChartData: {},
+      overallStartTime: 0,
+    };
+  },
+  watch: {
+    commands: {
+      handler(newCommands) {
+        if (newCommands && newCommands.length > 0) {
+          this.renderChart(newCommands);
+        }
+      },
+      deep: true,
+    },
+  },
+  created() {
+    this.chart = null;
+  },
+  mounted() {
+    this.$nextTick(() => {
+      window.addEventListener('resize', this.handleResize);
+      if (this.commands && this.commands.length > 0) {
+        this.renderChart(this.commands);
+      }
+    });
+  },
+  unmounted() {
+    if (this.chart) {
+      this.chart.dispose();
+    }
+    window.removeEventListener('resize', this.handleResize);
+  },
+  methods: {
+    processData(incomingCommands) {
+      const rawCommandData = incomingCommands.map((cmd, index) => {
+        const startTime = cmd.startTime.toMillis();
+        const endTime = startTime + cmd.duration.toMillis();
+        return {
+          ...cmd,
+          startTime,
+          endTime,
+          originalIndex: index,
+        };
+      });
+
+      if (rawCommandData.length > 0) {
+        this.overallStartTime = Math.min(...rawCommandData.map(cmd => cmd.startTime));
+      }
+      else {
+        this.overallStartTime = 0;
+      }
+
+      const trackEndTimes = [];
+      const processedData = [];
+      const sortedData = rawCommandData.slice().sort((a, b) => a.startTime - b.startTime);
+
+      sortedData.forEach(command => {
+        let placed = false;
+        let trackIndex = -1;
+        for (let i = 0; i < trackEndTimes.length; i++) {
+          if (command.startTime >= trackEndTimes[i]) {
+            trackEndTimes[i] = command.endTime;
+            trackIndex = i;
+            placed = true;
+            break;
+          }
+        }
+        if (!placed) {
+          trackIndex = trackEndTimes.length;
+          trackEndTimes.push(command.endTime);
+        }
+
+        const processedCommand = {
+          value: [
+            trackIndex,
+            command.startTime,
+            command.endTime,
+            command.duration.toMillis(),
+            command.originalIndex,
+            command.type,
+            command.disabled,
+            command.targetName,
+            command.source,
+            command.language,
+            command.config,
+          ],
+        };
+        processedData.push(processedCommand);
+      });
+
+      this.processedChartData = {
+        data: processedData,
+        tracks: trackEndTimes.map((_, i) => `Thread ${i + 1}`),
+      };
+    },
+
+    initializeChart() {
+      if (!this.$refs.chartContainerRef || this.chart) {
+        return;
+      }
+      this.chart = echarts.init(this.$refs.chartContainerRef);
+    },
+
+    renderChart(commands) {
+      this.processData(commands);
+
+      const numtracks = this.processedChartData.tracks.length;
+      const overallEndTime = Math.max(...this.processedChartData.data.map(d => d.value[2]));
+      const totalChartHeight = (this.commandBarHeight + this.commandBarSpacing) * numtracks + 60;
+
+      // The container size must be set before initializing the chart.
+      if (this.$refs.chartContainerRef) {
+        this.$refs.chartContainerRef.style.height = `${totalChartHeight}px`;
+      }
+
+      // If the chart instance doesn't exist yet, initialize it now that the container has dimensions.
+      if (!this.chart) {
+        this.initializeChart();
+      }
+
+      // Ensure the chart is resized to fit the newly set container height.
+      this.chart.resize();
+
+      const option = {
+        tooltip: {
+          confine: true,
+          trigger: 'item',
+          extraCssText: 'max-width: 500px; white-space: normal;',
+          formatter: this.getTooltipElement,
+        },
+        grid: {
+          top: '10px',
+          left: '20px',
+          right: '20px',
+          bottom: '50px',
+        },
+        xAxis: {
+          max: overallEndTime,
+          type: 'time',
+          axisLabel: {
+            formatter: val => {
+              const relativeTime = val - this.overallStartTime;
+              return this.formatDuration(relativeTime);
+            },
+          },
+        },
+        yAxis: {
+          show: false,
+          type: 'category',
+          data: this.processedChartData.tracks,
+        },
+        dataZoom: [
+          {
+            type: 'slider',
+            filterMode: 'weakFilter',
+            showDataShadow: false,
+            bottom: 5,
+            height: 15,
+          },
+          {
+            type: 'inside',
+            filterMode: 'weakFilter',
+          },
+        ],
+        series: [{
+          id: 'command-series',
+          type: 'custom',
+          coordinateSystem: 'cartesian2d',
+          data: this.processedChartData.data,
+          large: true,
+          progressive: 400,
+          renderItem: (params, api) => {
+            const trackIndex = api.value(0);
+            const start = api.coord([api.value(1), trackIndex]);
+            const end = api.coord([api.value(2), trackIndex]);
+            if (!start || !end) {
+              return;
+            }
+
+            const height = this.commandBarHeight;
+            const itemType = api.value(5);
+            const isDisabled = api.value(6);
+
+            const style = {
+              fill: this.colors[itemType],
+              opacity: 0.85,
+            };
+
+            if (isDisabled) {
+              Object.assign(style, {
+                fill: '#d1d5db',
+                stroke: '#d1d5db',
+                lineWidth: 0.5,
+                opacity: 0.4,
+              });
+            }
+            return {
+              type: 'rect',
+              shape: {
+                x: start[0],
+                y: start[1] - height / 2,
+                width: end[0] - start[0],
+                height: height,
+              },
+              style: style,
+            };
+          },
+          encode: {
+            x: [1, 2],
+            y: 0,
+          },
+        }],
+      };
+
+      this.chart.setOption(option, true);
+    },
+
+    getTooltipElement(params) {
+      if (!params.data.value || !Array.isArray(params.data.value)) {
+        return '';
+      }
+      const data = params.data.value;
+      const type = data[5];
+      const duration = this.formatDuration(data[3]);
+      const targetName = data[7];
+      const source = data[8];
+      const language = data[9];
+      const config = data[10];
+
+      const container = document.createElement('div');
+
+      const appendLine = (label, value, isBold = false, isCode = false) => {
+        if (value) {
+          if (container.childNodes.length > 0) {
+            container.appendChild(document.createElement('br'));
+          }
+          const labelNode = document.createTextNode(`${label}: `);
+          container.appendChild(labelNode);
+
+          let valueNode;
+          if (isCode) {
+            valueNode = document.createElement('div');
+            valueNode.className = 'tw-font-mono tw-bg-gray-100 tw-p-1 tw-rounded tw-whitespace-pre-wrap tw-break-all !tw-mt-0';
+            valueNode.textContent = value;
+          }
+          else if (isBold) {
+            valueNode = document.createElement('b');
+            valueNode.textContent = value;
+          }
+          else {
+            valueNode = document.createTextNode(value);
+          }
+          container.appendChild(valueNode);
+        }
+      };
+
+      appendLine('Target', targetName, true);
+      appendLine('Type', type);
+      appendLine('Duration', duration);
+      appendLine('Language', language);
+      appendLine('Config', config);
+      appendLine('Source', source, false, true);
+
+      return container;
+    },
+
+    handleResize() {
+      if (this.chart) {
+        this.chart.resize();
+      }
+    },
+
+    formatDuration(ms) {
+      if (ms < 1000) {
+        return `${ms}ms`;
+      }
+      if (ms < 60000) {
+        return `${(ms / 1000).toFixed(2)}s`;
+      }
+      const duration = Duration.fromMillis(ms);
+      // Use Luxon's toFormat which intelligently omits larger units if they are zero.
+      return duration.toFormat("m'm' ss's'");
+    },
+  },
+};
+</script>


### PR DESCRIPTION
The most powerful features in CDash are interactive visualizations which show large amounts of data in a small amount of screen space.  This PR begins an effort to add visualizations for the data collected via the recent CMake [instrumentation](https://cmake.org/cmake/help/latest/manual/cmake-instrumentation.7.html) feature.

The build targets page (`/builds/<id>/targets`) currently displays a filterable table of targets.  This PR adds a Gantt chart of all build commands to the top of the page, with commands associated with filtered targets highlighted.

For example, here's the result of a CMake build with no filters applied:
<img width="2832" height="1754" alt="image" src="https://github.com/user-attachments/assets/021e7504-a558-4b21-9d10-dae622381e19" />

Now, suppose we want to see just the commands run while building `cmliblzma`:
<img width="2828" height="1824" alt="image" src="https://github.com/user-attachments/assets/762dfa84-7a5b-4a3e-84a7-ee06be66f46c" />


Wondering what that long-running command cutting through the other `cmliblzma` commands is?  You can hover over the command to see some more information:
<img width="2832" height="1812" alt="image" src="https://github.com/user-attachments/assets/fcf5ee1b-026e-4889-9e11-d5ee98bd8778" />

The opportunities to explore are endless!