### PR TITLE
Show tests for child builds on new build tests page

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -347,6 +347,8 @@ add_browser_test(/Browser/Pages/BuildNotesPageTest)
 
 add_browser_test(/Browser/Pages/BuildTargetsPageTest)
 
+add_browser_test(/Browser/Pages/BuildTestsPageTest)
+
 add_php_test(image)
 set_tests_properties(image PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use App\Http\Submission\Traits\UpdatesSiteInformation;
+use App\Models\Build;
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\SiteInformation;
+use App\Models\Test;
+use App\Models\TestOutput;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\BrowserTestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+
+class BuildTestsPageTest extends BrowserTestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use UpdatesSiteInformation;
+
+    private Project $project;
+
+    private TestOutput $testOutput;
+
+    private Site $site;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        $this->testOutput = TestOutput::create([
+            'path' => 'a',
+            'command' => 'b',
+            'output' => 'c',
+        ]);
+
+        $this->site = $this->makeSite();
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->project->delete();
+        $this->testOutput->delete();
+        $this->site->delete();
+    }
+
+    public function testShowsBuildName(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $browser->visit("/builds/{$build->id}/tests")
+                ->waitForText($build->name)
+                ->assertSee($build->name)
+            ;
+        });
+    }
+
+    public function testFiltersByParentAndChildBuildTests(): void
+    {
+        /** @var Build $parent_build */
+        $parent_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Test $parent_build_test */
+        $parent_build_test = $parent_build->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $child_build_1_test */
+        $child_build_1_test = $parent_build->children()->create([
+            'projectid' => $this->project->id,
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $child_build_2_test */
+        $child_build_2_test = $parent_build->children()->create([
+            'projectid' => $this->project->id,
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'passed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($parent_build_test, $child_build_2_test, $child_build_1_test, $parent_build): void {
+            $browser->visit("/builds/{$parent_build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table', $parent_build_test->testname)
+                ->assertSeeIn('@tests-table', $child_build_1_test->testname)
+                ->assertSeeIn('@tests-table', $child_build_2_test->testname)
+            ;
+
+            $browser->visit("/builds/{$parent_build->id}/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22name%22%3A%22{$parent_build_test->testname}%22%7D%7D%5D%7D")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table', $parent_build_test->testname)
+                ->assertDontSeeIn('@tests-table', $child_build_1_test->testname)
+                ->assertDontSeeIn('@tests-table', $child_build_2_test->testname)
+            ;
+
+            $browser->visit("/builds/{$parent_build->id}/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22name%22%3A%22{$child_build_1_test->testname}%22%7D%7D%5D%7D")
+                ->waitFor('@tests-table')
+                ->assertDontSeeIn('@tests-table', $parent_build_test->testname)
+                ->assertSeeIn('@tests-table', $child_build_1_test->testname)
+                ->assertDontSeeIn('@tests-table', $child_build_2_test->testname)
+            ;
+
+            $browser->visit("/builds/{$parent_build->id}/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22name%22%3A%22{$child_build_2_test->testname}%22%7D%7D%5D%7D")
+                ->waitFor('@tests-table')
+                ->assertDontSeeIn('@tests-table', $parent_build_test->testname)
+                ->assertDontSeeIn('@tests-table', $child_build_1_test->testname)
+                ->assertSeeIn('@tests-table', $child_build_2_test->testname)
+            ;
+        });
+    }
+}


### PR DESCRIPTION
The legacy `viewTest.php` page shows all tests for the input build ID, as well as tests associated with children of that build.  This is an important capability for projects with subprojects, and adding this to the "new" build tests page is a critical step before it can replace `viewTest.php`.  To do this, I was forced to get rid of pagination, but load testing showed that the pagination was not particularly useful in the first place.