### PR TITLE
Enable verbose queue worker output

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -43,7 +43,7 @@ if [ "$1" = "start-website" ] ; then
 # If the start-worker argument was provided, start a worker process instead
 elif [ "$1" = "start-worker" ] ; then
   php artisan storage:mkdirs
-  php -d memory_limit=-1 artisan queue:work --max-time=3600 --memory=${WORKER_MEMORY_LIMIT:-256}
+  php -d memory_limit=-1 artisan queue:work --verbose --max-time=3600 --memory=${WORKER_MEMORY_LIMIT:-256}
 
 # Otherwise, throw an error...
 else


### PR DESCRIPTION
Laravel's "verbose" queue mode increases the information printed when processing a queue job from:

> Processing jobs from the [default] queue.

to:

> 2025-10-19 19:03:10 App\Jobs\ProcessSubmission 8 database default

It's not a lot of extra information, but the job ID is enough to track down the submission if necessary.  Having the timestamp is also nice in many cases.