### PR TITLE
Fix flaky `numericupdate` test

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25156,12 +25156,6 @@ parameters:
 			path: app/cdash/tests/test_numericupdate.php
 
 		-
-			rawMessage: Property NumericUpdateTestCase::$project has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/tests/test_numericupdate.php
-
-		-
 			rawMessage: Binary operation "." between 'POST returned ' and mixed results in an error.
 			identifier: binaryOp.invalid
 			count: 2


### PR DESCRIPTION
`numericupdate` is flaky for the same reason as https://github.com/Kitware/CDash/pull/3209.