### PR TITLE
Demote subproject creation log message to debug

### DIFF
--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -213,7 +213,7 @@ class Build
         $Label->Text = $subProject->GetName();
         $Label->Insert();
 
-        Log::info('New subproject detected: ' . $subproject, [
+        Log::debug('New subproject detected: ' . $subproject, [
             'projectid' => $this->ProjectId,
             'buildid' => $this->Id,
         ]);


### PR DESCRIPTION
Subproject creation is more similar to our debug logging than it is to our info level logging.