### PR TITLE
Remove trivial Blade templates

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -56,13 +56,13 @@ final class BuildController extends AbstractBuildController
         ]);
     }
 
-    // Render the build configure page.
     public function configure(int $build_id): View
     {
-        return $this->renderBuildPage($build_id, 'configure');
+        $this->setBuildById($build_id);
+
+        return $this->vue('build-configure', 'Configure', [], false);
     }
 
-    // Render the build notes page.
     public function notes(int $build_id): View
     {
         $this->setBuildById($build_id);
@@ -72,15 +72,18 @@ final class BuildController extends AbstractBuildController
         ]);
     }
 
-    // Render the build summary page.
     public function summary(int $build_id): View
     {
-        return $this->renderBuildPage($build_id, 'summary', 'Build Summary');
+        $this->setBuildById($build_id);
+
+        return $this->vue('build-summary', 'Build Summary', [], false);
     }
 
     public function update(int $build_id): View
     {
-        return $this->renderBuildPage($build_id, 'update', 'Files Updated');
+        $this->setBuildById($build_id);
+
+        return $this->vue('build-update', 'Files Updated', [], false);
     }
 
     public function tests(int $build_id): View
@@ -93,15 +96,6 @@ final class BuildController extends AbstractBuildController
             'build-id' => $this->build->Id,
             'initial-filters' => $filters,
         ]);
-    }
-
-    protected function renderBuildPage(int $build_id, string $page_name, string $page_title = ''): View
-    {
-        $this->setBuildById($build_id);
-        if ($page_title === '') {
-            $page_title = ucfirst($page_name);
-        }
-        return $this->view("build.{$page_name}", $page_title);
     }
 
     public function apiBuildSummary(): JsonResponse

--- a/app/Http/Controllers/ViewProjectsController.php
+++ b/app/Http/Controllers/ViewProjectsController.php
@@ -31,7 +31,8 @@ final class ViewProjectsController extends AbstractController
             return $this->redirectToLogin();
         }
 
-        return $this->view('project.view-all-projects', 'Projects')
-            ->with('show_all', $all);
+        return $this->vue('all-projects', 'Projects', [
+            'show-all' => $all,
+        ], false);
     }
 }

--- a/resources/views/build/configure.blade.php
+++ b/resources/views/build/configure.blade.php
@@ -1,7 +1,0 @@
-@extends('cdash', [
-    'vue' => true
-])
-
-@section('main_content')
-    <build-configure></build-configure>
-@endsection

--- a/resources/views/build/summary.blade.php
+++ b/resources/views/build/summary.blade.php
@@ -1,7 +1,0 @@
-@extends('cdash', [
-    'vue' => true
-])
-
-@section('main_content')
-    <build-summary></build-summary>
-@endsection

--- a/resources/views/build/update.blade.php
+++ b/resources/views/build/update.blade.php
@@ -1,7 +1,0 @@
-@extends('cdash', [
-    'vue' => true,
-])
-
-@section('main_content')
-    <build-update></build-update>
-@endsection

--- a/resources/views/project/view-all-projects.blade.php
+++ b/resources/views/project/view-all-projects.blade.php
@@ -1,8 +1,0 @@
-@extends('cdash', [
-    'vue' => true,
-    'title' => 'Projects',
-])
-
-@section('main_content')
-    <all-projects :show-all="@json($show_all)"></all-projects>
-@endsection

--- a/tests/Feature/CDashTest.php
+++ b/tests/Feature/CDashTest.php
@@ -98,7 +98,7 @@ class CDashTest extends TestCase
         $this->get('/projects')->assertRedirect('/login');
 
         $normal_user = $this->makeNormalUser();
-        $this->actingAs($normal_user)->get('/projects')->assertOk()->assertViewIs('project.view-all-projects');
+        $this->actingAs($normal_user)->get('/projects')->assertOk();
         $normal_user->delete();
     }
 }


### PR DESCRIPTION
Now that there's a `vue()` helper which renders Vue components directly, there's no need to have trivial Blade templates which render a single Vue component.