### PR TITLE
Pin Postgres 17

### DIFF
--- a/docker/docker-compose.postgres.yml
+++ b/docker/docker-compose.postgres.yml
@@ -4,7 +4,7 @@ services:
       DB_LOGIN: postgres
       DB_PORT: 5432
   database:
-    image: postgres
+    image: postgres:17
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE}


### PR DESCRIPTION
The Postgres 18 docker image contains changes to make it easier to upgrade which break our existing setup.  See https://github.com/docker-library/postgres/issues/37 for a long discussion of the issues being addressed.

This PR pins our default Postgres version to 17.  I plan to make a separate PR to upgrade to Postgres 18 in the near future.