### PR TITLE
Add memory chart to build commands page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "tailwindcss": "^3.4.17",
         "tiny-emitter": "^2.1.0",
         "vue": "^3.5.22",
+        "vue-echarts": "^8.0.1",
         "vue-loader": "^17.4.2",
         "vuedraggable": "^4.1.0",
         "webpack": "^5.102.0"
@@ -16649,6 +16650,16 @@
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.7.tgz",
       "integrity": "sha512-7e12Evdll7JcTIocojgnCgwocX4WzIYStGClBQ+QuWPinZo/vQolv2EMq4a3lg16TKfwWafLimG77bxb56UauA==",
       "dev": true
+    },
+    "node_modules/vue-echarts": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
+      "integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "echarts": "^6.0.0",
+        "vue": "^3.3.0"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "tailwindcss": "^3.4.17",
     "tiny-emitter": "^2.1.0",
     "vue": "^3.5.22",
+    "vue-echarts": "^8.0.1",
     "vue-loader": "^17.4.2",
     "vuedraggable": "^4.1.0",
     "webpack": "^5.102.0"

--- a/resources/js/vue/components/BuildCommandsPage.vue
+++ b/resources/js/vue/components/BuildCommandsPage.vue
@@ -2,17 +2,30 @@
   <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
     <BuildSummaryCard :build-id="buildId" />
 
-    <FilterBuilder
-      filter-type="BuildCommandsFiltersMultiFilterInput"
-      primary-record-name="commands"
-      :initial-filters="initialFilters"
-      :execute-query-link="executeQueryLink"
-      @change-filters="filters => changedFilters = filters"
-    />
+    <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+      <FilterBuilder
+        filter-type="BuildCommandsFiltersMultiFilterInput"
+        primary-record-name="commands"
+        :initial-filters="initialFilters"
+        :execute-query-link="executeQueryLink"
+        @change-filters="filters => changedFilters = filters"
+      />
 
-    <loading-indicator :is-loading="!formattedChartCommands">
-      <CommandGanttChart :commands="formattedChartCommands" />
-    </loading-indicator>
+      <loading-indicator :is-loading="!formattedChartCommands">
+        <CommandGanttChart :commands="formattedChartCommands" />
+      </loading-indicator>
+    </div>
+
+    <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+      <h3 class="tw-text-xl tw-font-bold tw-mb-2">
+        Memory
+      </h3>
+
+      <LineChart
+        y-label="Memory (GB)"
+        :data="memoryChartData"
+      />
+    </div>
   </div>
 </template>
 
@@ -23,9 +36,11 @@ import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import CommandGanttChart from './shared/CommandGanttChart.vue';
 import { DateTime, Duration } from 'luxon';
+import LineChart from './shared/LineChart.vue';
 
 export default {
   components: {
+    LineChart,
     CommandGanttChart,
     FilterBuilder,
     LoadingIndicator,
@@ -70,6 +85,14 @@ export default {
                     id
                     name
                   }
+                  measurements(first: 100000) {
+                    edges {
+                      node {
+                        name
+                        value
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -90,6 +113,14 @@ export default {
                         target {
                           id
                           name
+                        }
+                        measurements(first: 100000) {
+                          edges {
+                            node {
+                              name
+                              value
+                            }
+                          }
                         }
                       }
                     }
@@ -204,6 +235,32 @@ export default {
           disabled: !this.visibleCommandIds.has(edge.node.id),
         };
       });
+    },
+
+    memoryChartData() {
+      if (!this.allCommands) {
+        return [];
+      }
+
+      const memoryData = [];
+      this.allCommands.forEach(edge => {
+        const command = edge.node;
+        if (command.measurements.edges && command.measurements.edges.length > 0) {
+          const memoryMeasurement = command.measurements.edges.find(
+            m => m.node.name === 'BeforeHostMemoryUsed' || m.node.name === 'AfterHostMemoryUsed',
+          );
+
+          if (memoryMeasurement) {
+            memoryData.push({
+              x: DateTime.fromISO(command.startTime),
+              y: parseFloat(memoryMeasurement.node.value) / (1024 * 1024), // Convert KB to GB
+            });
+          }
+        }
+      });
+
+      // Sort the data by time to ensure the line is drawn correctly.
+      return memoryData.sort((a, b) => a.x - b.x);
     },
   },
 };

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -11,7 +11,9 @@
     />
 
     <loading-indicator :is-loading="!build || !targets">
-      <CommandGanttChart :commands="formattedCommands" />
+      <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+        <CommandGanttChart :commands="formattedCommands" />
+      </div>
     </loading-indicator>
 
     <LoadingIndicator :is-loading="!targets">

--- a/resources/js/vue/components/shared/CommandGanttChart.vue
+++ b/resources/js/vue/components/shared/CommandGanttChart.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    id="chart-wrapper"
-    ref="chartWrapperRef"
-    class="card tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200"
-  >
+  <div>
     <div
       id="legend-container"
       class="tw-flex tw-flex-wrap tw-justify-center tw-gap-x-5 tw-gap-y-2.5 tw-p-2.5 tw-text-xs"
@@ -195,9 +191,9 @@ export default {
           formatter: this.getTooltipElement,
         },
         grid: {
-          top: '10px',
-          left: '20px',
-          right: '20px',
+          top: '0px',
+          left: '10px',
+          right: '10px',
           bottom: '50px',
         },
         xAxis: {

--- a/resources/js/vue/components/shared/LineChart.vue
+++ b/resources/js/vue/components/shared/LineChart.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-chart
+    class="tw-w-full tw-h-60"
+    :option="chartOption"
+    autoresize
+  />
+</template>
+
+<script>
+import { Duration } from 'luxon';
+import VChart from 'vue-echarts';
+
+export default {
+  name: 'LineChart',
+  components: {
+    VChart,
+  },
+
+  props: {
+    /**
+     * The label for the y-axis. Optional.
+     */
+    yLabel: {
+      type: String,
+      default: '',
+    },
+
+    /**
+     * An array of data points to plot.
+     *
+     * @type {Array<{x: import('luxon').DateTime, y: number}>}
+     */
+    data: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  computed: {
+    chartOption() {
+      const hasData = this.data && this.data.length > 0;
+      let chartData = [];
+
+      const baseOption = {
+        grid: {
+          left: '30px',
+          right: '20px',
+          top: '10px', // Don't cut off the top of the y-axis ticks
+          bottom: '60px', // Give the slider some room
+          containLabel: true,
+        },
+        yAxis: {
+          type: 'value',
+          name: this.yLabel,
+          nameLocation: 'middle',
+          nameGap: 30,
+        },
+        series: [],
+      };
+
+      if (hasData) {
+        const overallStartTime = Math.min(...this.data.map(p => p.x.toMillis()));
+
+        chartData = this.data.map(point => [point.x.toMillis() - overallStartTime, point.y]);
+
+        return {
+          ...baseOption,
+          xAxis: {
+            ...baseOption.xAxis,
+            axisLabel: {
+              formatter: (value) => {
+                return this.formatDuration(value);
+              },
+            },
+          },
+          tooltip: {
+            trigger: 'axis',
+            formatter: (params) => {
+              if (!params || params.length === 0 || !params[0] || !params[0].value) {
+                return '';
+              }
+
+              // We assume this is only ever being used with fixed axis values and floating point
+              // numbers, so we don't have any XSS concerns.
+              const point = params[0];
+              const value = point.value[1].toFixed(2);
+              let tooltipText = `<b>${value}</b>`;
+              if (this.yLabel) {
+                tooltipText += ` ${this.yLabel}`;
+              }
+              return tooltipText;
+            },
+          },
+          dataZoom: [
+            {
+              type: 'slider',
+              start: 0,
+              end: 100,
+              xAxisIndex: 0,
+            },
+            {
+              type: 'inside',
+              start: 0,
+              end: 100,
+              xAxisIndex: 0,
+            },
+          ],
+          series: [
+            {
+              data: chartData,
+              type: 'line',
+              symbol: 'none',
+            },
+          ],
+        };
+      }
+
+      return baseOption;
+    },
+  },
+
+  methods: {
+    formatDuration(ms) {
+      if (ms < 1000) {
+        return `${ms}ms`;
+      }
+      if (ms < 60000) {
+        return `${(ms / 1000).toFixed(2)}s`;
+      }
+      const duration = Duration.fromMillis(ms);
+      return duration.toFormat("m'm' ss's'");
+    },
+  },
+};
+</script>


### PR DESCRIPTION
This PR adds a plot of the `BeforeHostMemoryUsed` and `AfterHostMemoryUsed` memory measurements to the build commands page.  I also added [`vue-echarts`](https://vue-echarts.dev) to reduce the pain of adding new charts, which are tricky to set up reactively.

<img width="2796" height="1658" alt="image" src="https://github.com/user-attachments/assets/59f017e7-dd70-48e1-9bf5-215a26eed4c9" />
