### PR TITLE
Move contents of `subproject2build` table to `build`

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1109,12 +1109,10 @@ final class BuildController extends AbstractBuildController
 
         // Take subproject into account, such that if there is one, then the
         // previous builds must be associated with the same subproject.
-        $subproj_table = '';
         $subproj_criteria = '';
         $query_params = [];
         if ($this->build->SubProjectId > 0) {
-            $subproj_table = 'INNER JOIN subproject2build AS sp2b ON (b.id=sp2b.buildid)';
-            $subproj_criteria = 'AND sp2b.subprojectid = ?';
+            $subproj_criteria = 'AND b.subprojectid = ?';
             $query_params[] = $this->build->SubProjectId;
         }
 
@@ -1135,7 +1133,6 @@ final class BuildController extends AbstractBuildController
                             FROM build AS b
                             LEFT JOIN build2update AS b2u ON (b2u.buildid=b.id)
                             LEFT JOIN buildupdate AS bu ON (b2u.updateid=bu.id)
-                            $subproj_table
                             WHERE
                                 siteid = ?
                                 AND b.type = ?

--- a/app/Http/Controllers/CoverageController.php
+++ b/app/Http/Controllers/CoverageController.php
@@ -1701,8 +1701,7 @@ final class CoverageController extends AbstractBuildController
                       INNER JOIN build2group AS b2g ON (b2g.buildid=b.id)
                       INNER JOIN buildgroup AS g ON (g.id=b2g.groupid)
                       INNER JOIN coveragesummary AS cs ON (cs.buildid = b.id)
-                      LEFT JOIN subproject2build AS sp2b ON (sp2b.buildid = b.id)
-                      LEFT JOIN subproject AS sp ON (sp2b.subprojectid = sp.id)
+                      LEFT JOIN subproject AS sp ON (b.subprojectid = sp.id)
                       WHERE
                           b.projectid=?
                           AND g.type='Daily'

--- a/app/Http/Controllers/ProjectOverviewController.php
+++ b/app/Http/Controllers/ProjectOverviewController.php
@@ -322,8 +322,7 @@ final class ProjectOverviewController extends AbstractProjectController
                                                   sp.groupid AS subprojectgroupid
                                               FROM build AS b
                                               LEFT JOIN coveragesummary AS cs ON (cs.buildid=b.id)
-                                              LEFT JOIN subproject2build AS sp2b ON (sp2b.buildid = b.id)
-                                              LEFT JOIN subproject as sp ON (sp2b.subprojectid = sp.id)
+                                              LEFT JOIN subproject as sp ON (b.subprojectid = sp.id)
                                               WHERE b.parentid=?
                                           ', [intval($build_row->id)]);
                     foreach ($child_builds_array as $child_build_row) {

--- a/app/Http/Submission/Handlers/JavaJSONTarHandler.php
+++ b/app/Http/Submission/Handlers/JavaJSONTarHandler.php
@@ -115,10 +115,9 @@ class JavaJSONTarHandler extends AbstractSubmissionHandler
 
             // get the buildid that corresponds to this subproject.
             $buildid_result = DB::select('
-                                  SELECT buildid
-                                  FROM subproject2build AS sp2b
-                                  INNER JOIN subproject AS sp ON (sp.id = sp2b.subprojectid)
-                                  INNER JOIN build AS b ON (b.id = sp2b.buildid)
+                                  SELECT b.id AS buildid
+                                  FROM subproject AS sp
+                                  INNER JOIN build AS b ON (sp.id = b.subprojectid)
                                   WHERE
                                       sp.name = ?
                                       AND b.parentid=?

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
  * @property int $siteid
  * @property int $projectid
  * @property int $parentid
+ * @property int $subprojectid
  * @property string $stamp
  * @property string $name
  * @property string $type
@@ -64,6 +65,7 @@ class Build extends Model
         'siteid',
         'projectid',
         'parentid',
+        'subprojectid',
         'stamp',
         'name',
         'type',
@@ -100,6 +102,7 @@ class Build extends Model
         'siteid' => 'integer',
         'projectid' => 'integer',
         'parentid' => 'integer',
+        'subprojectid' => 'integer',
         'starttime' => 'datetime',
         'endtime' => 'datetime',
         'submittime' => 'datetime',
@@ -132,6 +135,14 @@ class Build extends Model
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class, 'projectid');
+    }
+
+    /**
+     * @return BelongsTo<SubProject, $this>
+     */
+    public function subProject(): BelongsTo
+    {
+        return $this->belongsTo(SubProject::class, 'subprojectid');
     }
 
     /**

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -155,7 +155,7 @@ class Index extends ResultsApi
 
         // Should we query by subproject?
         if (is_numeric($this->subProjectId)) {
-            $sql .= ' AND sp2b.subprojectid=? ';
+            $sql .= ' AND b.subprojectid=? ';
             $query_params[] = (int) $this->subProjectId;
         }
 
@@ -328,8 +328,7 @@ class Index extends ResultsApi
                 LEFT JOIN testdiff AS tfailed_diff ON (tfailed_diff.buildid=b.id AND tfailed_diff.type=1)
                 LEFT JOIN testdiff AS tpassed_diff ON (tpassed_diff.buildid=b.id AND tpassed_diff.type=2)
                 LEFT JOIN testdiff AS tstatusfailed_diff ON (tstatusfailed_diff.buildid=b.id AND tstatusfailed_diff.type=3)
-                LEFT JOIN subproject2build AS sp2b ON (sp2b.buildid = b.id)
-                LEFT JOIN subproject as sp ON (sp2b.subprojectid = sp.id)';
+                LEFT JOIN subproject as sp ON (b.subprojectid = sp.id)';
     }
 
     public function populateBuildRow(array $build_row): array
@@ -628,8 +627,7 @@ class Index extends ResultsApi
                                           sb.name,
                                           btt.time AS testtime
                                       FROM build AS b
-                                      INNER JOIN subproject2build AS sb2b ON (b.id = sb2b.buildid)
-                                      INNER JOIN subproject AS sb ON (sb2b.subprojectid = sb.id)
+                                      INNER JOIN subproject AS sb ON (b.subprojectid = sb.id)
                                       LEFT JOIN buildtesttime AS btt ON (btt.buildid = b.id)
                                       WHERE
                                           b.parentid=?

--- a/app/cdash/app/Controller/Api/TestOverview.php
+++ b/app/cdash/app/Controller/Api/TestOverview.php
@@ -112,8 +112,7 @@ class TestOverview extends ResultsApi
         if ($has_subprojects) {
             $sp_select = ', sp.name AS subproject';
             $sp_join = '
-                JOIN subproject2build AS sp2b ON (sp2b.buildid=b.id)
-                JOIN subproject AS sp ON (sp2b.subprojectid=sp.id)';
+                JOIN subproject AS sp ON (b.subprojectid=sp.id)';
         }
 
         // Main query: find all the requested tests.

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -214,10 +214,9 @@ class ViewTest extends BuildApi
         }
 
         if ($this->build->GetParentId() == Build::PARENT_BUILD) {
-            $parentBuildFieldSql = ', sp2b.subprojectid, sp.name subprojectname';
+            $parentBuildFieldSql = ', b.subprojectid, sp.name subprojectname';
             $parentBuildJoinSql = 'JOIN build b ON (b.id = bt.buildid)
-                JOIN subproject2build sp2b on (sp2b.buildid = b.id)
-                JOIN subproject sp on (sp.id = sp2b.subprojectid)';
+                JOIN subproject sp on (sp.id = b.subprojectid)';
             $parentBuildWhere = 'b.parentid = :buildid';
         } else {
             $parentBuildFieldSql = '';

--- a/app/cdash/app/Model/CoverageFileLog.php
+++ b/app/cdash/app/Model/CoverageFileLog.php
@@ -230,11 +230,10 @@ class CoverageFileLog
                 $row = $db->executePreparedSingleRow('
                            SELECT id
                            FROM build
-                           INNER JOIN subproject2build AS sp2b ON (build.id=sp2b.buildid)
                            WHERE
                                parentid=?
                                AND projectid=?
-                               AND sp2b.subprojectid=?
+                               AND b.subprojectid=?
                        ', [
                     intval($this->AggregateBuildId),
                     intval($this->Build->ProjectId),

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -814,8 +814,7 @@ function get_aggregate_build(Build $build): Build
     $subproj_where = '';
     $subproj_where_params = [];
     if ($build->SubProjectId) {
-        $subproj_table = 'INNER JOIN subproject2build AS sp2b ON (build.id=sp2b.buildid)';
-        $subproj_where = 'AND sp2b.subprojectid=?';
+        $subproj_where = 'AND subprojectid=?';
         $subproj_where_params[] = intval($build->SubProjectId);
     }
 

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -255,7 +255,7 @@ class IndexPhpFilters extends DefaultFilters
                 break;
 
             case 'subproject':
-                $sql_field = '(SELECT name FROM subproject, subproject2build WHERE subproject2build.subprojectid=subproject.id AND subproject2build.buildid=b.id)';
+                $sql_field = '(SELECT subproject.name FROM subproject WHERE subproject.id=b.subprojectid)';
 
                 break;
 

--- a/app/cdash/tests/test_bazeljson.php
+++ b/app/cdash/tests/test_bazeljson.php
@@ -203,8 +203,7 @@ class BazelJSONTestCase extends KWWebTestCase
                         configureerrors, configurewarnings,
                         sp.name
                 FROM build b
-                JOIN subproject2build sp2b ON sp2b.buildid = b.id
-                JOIN subproject sp ON sp.id = sp2b.subprojectid
+                JOIN subproject sp ON sp.id = b.subprojectid
                 WHERE parentid = $parentid");
         while ($row = $stmt->fetch()) {
             $subproject_name = $row['name'];

--- a/app/cdash/tests/test_crosssubprojectcoverage.php
+++ b/app/cdash/tests/test_crosssubprojectcoverage.php
@@ -221,8 +221,7 @@ class CoverageAcrossSubProjectsTestCase extends KWWebTestCase
                 SELECT cs.loctested, cs.locuntested, spg.name
                 FROM build AS b
                 INNER JOIN coveragesummary AS cs ON (b.id=cs.buildid)
-                INNER JOIN subproject2build AS sp2b ON (b.id=sp2b.buildid)
-                INNER JOIN subproject AS sp ON (sp2b.subprojectid=sp.id)
+                INNER JOIN subproject AS sp ON (b.subprojectid=sp.id)
                 INNER JOIN subprojectgroup AS spg ON (sp.groupid=spg.id)
                 WHERE parentid='$parentid'");
         $num_builds = count($result);

--- a/app/cdash/tests/test_removebuilds.php
+++ b/app/cdash/tests/test_removebuilds.php
@@ -358,10 +358,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
             'date' => $time,
             'groupid' => 1,
         ]);
-        DB::table('subproject2build')->insert([
-            'subprojectid' => 1,
-            'buildid' => $build->Id,
-        ]);
         DB::table('testdiff')->insert([
             'buildid' => $build->Id,
             'type' => 0,
@@ -440,7 +436,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('coveragefilelog', 'buildid', '=', $build->Id, 2);
         $this->verify('dynamicanalysissummary', 'buildid', '=', $build->Id, 1);
         $this->verify('summaryemail', 'buildid', '=', $build->Id, 1);
-        $this->verify('subproject2build', 'buildid', '=', $build->Id, 1);
         $this->verify('testdiff', 'buildid', '=', $build->Id, 1);
 
         [$buildfailureid, $detailsid] =
@@ -526,7 +521,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('label2test', 'labelid', '=', $labelid, 1, $extra_msg);
         $this->verify('note', 'id', 'IN', $noteids, 1, $extra_msg);
         $this->verify('summaryemail', 'buildid', '=', $build->Id, 0, $extra_msg);
-        $this->verify('subproject2build', 'buildid', '=', $build->Id, 0, $extra_msg);
         $this->verify('test2image', 'testid', 'IN', $testids, 0, $extra_msg);
         $this->verify('testdiff', 'buildid', '=', $build->Id, 0, $extra_msg);
         $this->verify('updatefile', 'updateid', '=', $updateid, 1, $extra_msg);
@@ -569,7 +563,6 @@ class RemoveBuildsTestCase extends KWWebTestCase
         $this->verify('label2test', 'labelid', '=', $labelid, 0, $extra_msg);
         $this->verify('note', 'id', 'IN', $noteids, 0, $extra_msg);
         $this->verify('summaryemail', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
-        $this->verify('subproject2build', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
         $this->verify('test2image', 'testid', 'IN', $testids, 0, $extra_msg);
         $this->verify('testdiff', 'buildid', '=', $existing_build->Id, 0, $extra_msg);
         $this->verify('updatefile', 'updateid', '=', $updateid, 0, $extra_msg);

--- a/app/cdash/tests/test_subprojectnextprevious.php
+++ b/app/cdash/tests/test_subprojectnextprevious.php
@@ -42,8 +42,7 @@ class SubProjectNextPreviousTestCase extends KWWebTestCase
         // Get the ids for the three subsequent builds of Didasko.
         $result = DB::select("
                 SELECT b.id FROM build AS b
-                LEFT JOIN subproject2build AS sp2b ON sp2b.buildid=b.id
-                LEFT JOIN subproject AS sp ON sp.id = sp2b.subprojectid
+                LEFT JOIN subproject AS sp ON sp.id = b.subprojectid
                 WHERE sp.name = 'Didasko'
                 ORDER BY b.starttime");
 

--- a/database/migrations/2025_10_23_233437_remove_subproject2build_table.php
+++ b/database/migrations/2025_10_23_233437_remove_subproject2build_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE build ADD COLUMN subprojectid bigint REFERENCES subproject(id) ON DELETE SET NULL');
+
+        DB::update('
+            UPDATE build
+            SET subprojectid = subproject2build.subprojectid
+            FROM subproject2build, subproject
+            WHERE
+                subproject.id = subproject2build.subprojectid
+                AND subproject2build.buildid = build.id
+        ');
+
+        DB::statement('DROP TABLE subproject2build');
+
+        DB::statement('CREATE INDEX ON build (subprojectid)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9393,7 +9393,7 @@ parameters:
 				v2.5.0 01/22/2018
 			'''
 			identifier: function.deprecated
-			count: 23
+			count: 21
 			path: app/cdash/app/Model/Build.php
 
 		-


### PR DESCRIPTION
Builds are associated with at most one subproject, but there is currently a `subproject2build` pivot table in the schema.  This PR removes the pivot table and moves the `subprojectid` column to the `build` table.  In addition to reducing complexity, this change also makes lookups of builds by subproject more efficient.