### PR TITLE
Refactor misc. database queries

### DIFF
--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -197,11 +197,11 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                             $existing_config_results = $existing_config->GetConfigureForBuild();
                             if ($existing_config_results) {
                                 // Combine these with the data we just parsed out of the XML.
-                                $this->Configure->Log = $existing_config_results['log'] . "\n" . $this->Configure->Log;
-                                $this->Configure->Status = intval($existing_config_results['status']) + intval($this->Configure->Status);
+                                $this->Configure->Log = $existing_config_results->log . "\n" . $this->Configure->Log;
+                                $this->Configure->Status = intval($existing_config_results->status) + intval($this->Configure->Status);
 
                                 // Also reuse the prior start time for this configure step.
-                                $existing_start_timestamp = strtotime($existing_config_results['starttime'] . ' UTC');
+                                $existing_start_timestamp = strtotime($existing_config_results->starttime . ' UTC');
                                 if ($existing_start_timestamp) {
                                     $this->StartTimeStamp = $existing_start_timestamp;
                                 }

--- a/app/Models/TestDiff.php
+++ b/app/Models/TestDiff.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $buildid
+ * @property int $type
+ * @property int $difference_positive
+ * @property int $difference_negative
+ *
+ * @mixin Builder<TestDiff>
+ */
 class TestDiff extends Model
 {
     protected $table = 'testdiff';
-    protected $fillable = ['buildid', 'type', 'difference_positive', 'difference_negative'];
+
     public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'type',
+        'difference_positive',
+        'difference_negative',
+    ];
 }

--- a/app/Utils/DatabaseCleanupUtils.php
+++ b/app/Utils/DatabaseCleanupUtils.php
@@ -13,10 +13,12 @@ use App\Models\Image;
 use App\Models\Note;
 use App\Models\RichBuildAlertDetails;
 use App\Models\Test;
+use App\Models\UploadFile;
 use CDash\Database;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use InvalidArgumentException;
 
 class DatabaseCleanupUtils
@@ -231,7 +233,9 @@ class DatabaseCleanupUtils
         foreach ($build2uploadfiles as $build2uploadfile_array) {
             $fileid = intval($build2uploadfile_array->fileid);
             $fileids[] = $fileid;
-            unlink_uploaded_file($fileid);
+
+            $sha1sum = UploadFile::findOrFail($fileid)->sha1sum;
+            Storage::delete("upload/{$sha1sum}");
         }
 
         if (count($fileids) > 0) {

--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -667,7 +667,6 @@ class RepositoryUtils
                         ORDER BY name
                         LIMIT $maxitems
                     ", [$buildid]);
-            add_last_sql_error('sendmail');
             $numrows = count($da_query);
 
             if ($numrows > 0) {

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -143,7 +143,6 @@ class BuildFailure
                          SELECT id FROM buildfailureargument WHERE argument=?
                      ', [$argumentescaped]);
             if ($query === false) {
-                add_last_sql_error('BuildFailure Insert', 0, $this->BuildId);
                 return false;
             }
 
@@ -169,7 +168,6 @@ class BuildFailure
         }
         $query = rtrim($query, ',');
         if (count($params) > 0 && $db->executePrepared($query, $params) === false) {
-            add_last_sql_error('BuildFailure Insert', 0, $this->BuildId);
             return false;
         }
 

--- a/app/cdash/app/Model/CoverageSummary.php
+++ b/app/cdash/app/Model/CoverageSummary.php
@@ -296,7 +296,6 @@ class CoverageSummary
                         WHERE buildid=?
                     ', [intval($this->BuildId)]);
         if (empty($coverage)) {
-            add_last_sql_error('CoverageSummary:ComputeDifference');
             return false;
         }
         $loctested = intval($coverage['loctested']);

--- a/app/cdash/app/Model/SubProject.php
+++ b/app/cdash/app/Model/SubProject.php
@@ -368,7 +368,6 @@ class SubProject
         $project = $db->executePrepared($query, $params);
 
         if ($project === false) {
-            add_last_sql_error('SubProject CommonBuildQuery');
             return false;
         }
         if ($allSubProjects) {

--- a/app/cdash/public/api/v1/manageBuildGroup.php
+++ b/app/cdash/public/api/v1/manageBuildGroup.php
@@ -225,10 +225,6 @@ $wildcards = $db->executePrepared("
                      AND bg.projectid=?
                      AND b2gr.endtime = '1980-01-01 00:00:00'
              ", [intval($projectid)]);
-$err = pdo_error();
-if (!empty($err)) {
-    $response['error'] = $err;
-}
 
 $wildcards_response = [];
 foreach ($wildcards as $wildcard_array) {

--- a/app/cdash/public/api/v1/subproject.php
+++ b/app/cdash/public/api/v1/subproject.php
@@ -99,7 +99,6 @@ function rest_get($projectid): bool
              ", [$projectid]);
 
     if ($query === false) {
-        add_last_sql_error('getSubProject Select');
         return false;
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2929,24 +2929,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: '''
-				Call to deprecated function pdo_execute():
-				v2.5.0 01/22/2018
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method getPdo() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
 			rawMessage: Cannot access offset 'command' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -2962,18 +2944,6 @@ parameters:
 			rawMessage: Cannot access offset 'label' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Cannot access offset 'name' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Cannot access offset 'path' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
@@ -3031,12 +3001,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: 'Cannot call method fetch() on PDOStatement|false.'
-			identifier: method.nonObject
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
 			identifier: empty.notAllowed
 			count: 12
@@ -3081,12 +3045,6 @@ parameters:
 		-
 			rawMessage: 'Method App\Http\Submission\Handlers\BazelJSONHandler::CreateNewTest() has parameter $test_time with no type specified.'
 			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: 'Method App\Http\Submission\Handlers\BazelJSONHandler::GetSubProjectForPath() should return string but returns mixed.'
-			identifier: return.type
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
@@ -3169,12 +3127,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: 'Only booleans are allowed in a while condition, mixed given.'
-			identifier: while.condNotBoolean
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
 			rawMessage: 'Only booleans are allowed in an if condition, int|false given.'
 			identifier: if.condNotBoolean
 			count: 1
@@ -3193,12 +3145,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: 'Parameter #1 $stmt of function pdo_execute expects PDOStatement, (PDOStatement|false) given.'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
 			rawMessage: 'Parameter #1 $string of function strtolower expects string, mixed given.'
 			identifier: argument.type
 			count: 1
@@ -3214,12 +3160,6 @@ parameters:
 			rawMessage: 'Parameter #2 $array of function array_key_exists expects array, mixed given.'
 			identifier: argument.type
 			count: 8
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: 'Parameter #2 $needle of function str_contains expects string, mixed given.'
-			identifier: argument.type
-			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
@@ -3272,12 +3212,6 @@ parameters:
 
 		-
 			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsPassed has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$PDO has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -3553,18 +3487,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildPropertiesJSONHandler.php
 
 		-
-			rawMessage: Binary operation "." between mixed and "\n" results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Binary operation "." between mixed and ' UTC' results in an error.
-			identifier: binaryOp.invalid
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
 			rawMessage: 'Call to an undefined method CDash\Messaging\Preferences\NotificationPreferencesInterface::get().'
 			identifier: method.notFound
 			count: 1
@@ -3583,20 +3505,20 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Cannot access offset 'log' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
+			rawMessage: Cannot access property $log on mixed.
+			identifier: property.nonObject
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Cannot access offset 'starttime' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
+			rawMessage: Cannot access property $starttime on mixed.
+			identifier: property.nonObject
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Cannot access offset 'status' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
+			rawMessage: Cannot access property $status on mixed.
+			identifier: property.nonObject
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
@@ -3686,12 +3608,6 @@ parameters:
 
 		-
 			rawMessage: 'Parameter #1 $duration of method CDash\Model\Build::SetConfigureDuration() expects int, (float|int) given.'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: 'Parameter #1 $value of function intval expects array|bool|float|int|resource|string|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
@@ -6410,15 +6326,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to deprecated function add_last_sql_error():
-				04/22/2023
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: app/Utils/RepositoryUtils.php
-
-		-
-			rawMessage: '''
 				Call to deprecated method executePrepared() of class CDash\Database:
 				04/22/2023  Use Laravel query builder or Eloquent instead
 			'''
@@ -7011,7 +6918,7 @@ parameters:
 				v2.5.0 01/22/2018
 			'''
 			identifier: function.deprecated
-			count: 9
+			count: 6
 			path: app/Utils/SubmissionUtils.php
 
 		-
@@ -7036,39 +6943,21 @@ parameters:
 			path: app/Utils/SubmissionUtils.php
 
 		-
-			rawMessage: Cannot access offset 'difference_negative' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Utils/SubmissionUtils.php
-
-		-
-			rawMessage: Cannot access offset 'difference_positive' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Utils/SubmissionUtils.php
-
-		-
 			rawMessage: Cannot access offset 0 on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
 			path: app/Utils/SubmissionUtils.php
 
 		-
-			rawMessage: 'Cannot call method bindParam() on PDOStatement|false.'
-			identifier: method.nonObject
-			count: 2
-			path: app/Utils/SubmissionUtils.php
-
-		-
 			rawMessage: 'Cannot call method bindValue() on PDOStatement|false.'
 			identifier: method.nonObject
-			count: 20
+			count: 13
 			path: app/Utils/SubmissionUtils.php
 
 		-
 			rawMessage: 'Cannot call method fetch() on PDOStatement|false.'
 			identifier: method.nonObject
-			count: 6
+			count: 5
 			path: app/Utils/SubmissionUtils.php
 
 		-
@@ -7132,12 +7021,6 @@ parameters:
 			path: app/Utils/SubmissionUtils.php
 
 		-
-			rawMessage: 'Only booleans are allowed in an if condition, mixed given.'
-			identifier: if.condNotBoolean
-			count: 2
-			path: app/Utils/SubmissionUtils.php
-
-		-
 			rawMessage: 'Only numeric types are allowed in +, int<0, max>|false given on the left side.'
 			identifier: plus.leftNonNumeric
 			count: 1
@@ -7146,7 +7029,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $stmt of function pdo_execute expects PDOStatement, (PDOStatement|false) given.'
 			identifier: argument.type
-			count: 9
+			count: 6
 			path: app/Utils/SubmissionUtils.php
 
 		-
@@ -7329,7 +7212,7 @@ parameters:
 		-
 			rawMessage: 'Only booleans are allowed in an if condition, object|null given.'
 			identifier: if.condNotBoolean
-			count: 2
+			count: 1
 			path: app/Utils/TestDiffUtil.php
 
 		-
@@ -9393,7 +9276,7 @@ parameters:
 				v2.5.0 01/22/2018
 			'''
 			identifier: function.deprecated
-			count: 21
+			count: 15
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -9921,7 +9804,7 @@ parameters:
 				v2.5.0 01/22/2018
 			'''
 			identifier: function.deprecated
-			count: 2
+			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
@@ -9943,6 +9826,12 @@ parameters:
 			rawMessage: 'Cannot call method Insert() on mixed.'
 			identifier: method.nonObject
 			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
+			rawMessage: 'Cannot call method bindParam() on PDOStatement|false.'
+			identifier: method.nonObject
+			count: 2
 			path: app/cdash/app/Model/BuildConfigure.php
 
 		-
@@ -9990,6 +9879,12 @@ parameters:
 		-
 			rawMessage: 'Method CDash\Model\BuildConfigure::marshal() has parameter $data with no type specified.'
 			identifier: missingType.parameter
+			count: 1
+			path: app/cdash/app/Model/BuildConfigure.php
+
+		-
+			rawMessage: 'Parameter #1 $stmt of function pdo_execute expects PDOStatement, (PDOStatement|false) given.'
+			identifier: argument.type
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
 
@@ -10043,12 +9938,6 @@ parameters:
 
 		-
 			rawMessage: Property CDash\Model\BuildConfigure::$NumberOfWarnings has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/BuildConfigure.php
-
-		-
-			rawMessage: Property CDash\Model\BuildConfigure::$PDO has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/BuildConfigure.php
@@ -10328,15 +10217,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/BuildErrorFilter.php
-
-		-
-			rawMessage: '''
-				Call to deprecated function add_last_sql_error():
-				04/22/2023
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: app/cdash/app/Model/BuildFailure.php
 
 		-
 			rawMessage: '''
@@ -11198,15 +11078,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to deprecated function add_last_sql_error():
-				04/22/2023
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: app/cdash/app/Model/CoverageSummary.php
-
-		-
-			rawMessage: '''
 				Call to deprecated method coverageResults() of class App\Models\Build:
 				07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
 			'''
@@ -11327,24 +11198,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: app/cdash/app/Model/CoverageSummary.php
-
-		-
-			rawMessage: '''
-				Call to deprecated function pdo_execute():
-				v2.5.0 01/22/2018
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: app/cdash/app/Model/DynamicAnalysis.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method getPdo() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/app/Model/DynamicAnalysis.php
 
 		-
 			rawMessage: 'Call to function base64_decode() requires parameter #2 to be set.'
@@ -11492,12 +11345,6 @@ parameters:
 
 		-
 			rawMessage: Property CDash\Model\DynamicAnalysis::$Name has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/DynamicAnalysis.php
-
-		-
-			rawMessage: Property CDash\Model\DynamicAnalysis::$PDO has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/DynamicAnalysis.php
@@ -12191,15 +12038,6 @@ parameters:
 			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: app/cdash/app/Model/Repository.php
-
-		-
-			rawMessage: '''
-				Call to deprecated function add_last_sql_error():
-				04/22/2023
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: app/cdash/app/Model/SubProject.php
 
 		-
 			rawMessage: '''
@@ -14507,15 +14345,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to deprecated function pdo_execute():
-				v2.5.0 01/22/2018
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: '''
 				Call to deprecated function pdo_real_escape_string():
 				04/01/2023
 			'''
@@ -14542,29 +14371,8 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			rawMessage: '''
-				Call to deprecated method getPdo() of class CDash\Database:
-				04/22/2023  Use Laravel query builder or Eloquent instead
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			rawMessage: 'Call to function in_array() requires parameter #3 to be set.'
 			identifier: function.strict
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: Cannot access offset 'filesize' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: Cannot access offset 'sha1sum' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -14577,24 +14385,6 @@ parameters:
 		-
 			rawMessage: Cannot access property $admin on App\Models\User|null.
 			identifier: property.nonObject
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Cannot call method bindParam() on PDOStatement|false.'
-			identifier: method.nonObject
-			count: 2
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Cannot call method fetch() on PDOStatement|false.'
-			identifier: method.nonObject
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Cannot call method fetchColumn() on PDOStatement|false.'
-			identifier: method.nonObject
 			count: 1
 			path: app/cdash/include/common.php
 
@@ -14654,24 +14444,6 @@ parameters:
 
 		-
 			rawMessage: 'Function add_XML_value() has parameter $value with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Function add_last_sql_error() has parameter $buildid with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Function add_last_sql_error() has parameter $functionname with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Function add_last_sql_error() has parameter $projectid with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/include/common.php
@@ -14899,18 +14671,6 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
-			rawMessage: 'Function unlink_uploaded_file() has no return type specified.'
-			identifier: missingType.return
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Function unlink_uploaded_file() has parameter $fileid with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: app/cdash/include/common.php
-
-		-
 			rawMessage: 'Function xml_replace_callback() has parameter $matches with no type specified.'
 			identifier: missingType.parameter
 			count: 1
@@ -14961,7 +14721,7 @@ parameters:
 		-
 			rawMessage: 'Loose comparison via "==" is not allowed.'
 			identifier: equal.notAllowed
-			count: 4
+			count: 3
 			path: app/cdash/include/common.php
 
 		-
@@ -14973,7 +14733,7 @@ parameters:
 		-
 			rawMessage: 'Only booleans are allowed in a negated boolean, mixed given.'
 			identifier: booleanNot.exprNotBoolean
-			count: 2
+			count: 1
 			path: app/cdash/include/common.php
 
 		-
@@ -15040,12 +14800,6 @@ parameters:
 			rawMessage: 'Parameter #1 $source of method DOMDocument::loadXML() expects string, string|false given.'
 			identifier: argument.type
 			count: 1
-			path: app/cdash/include/common.php
-
-		-
-			rawMessage: 'Parameter #1 $stmt of function pdo_execute expects PDOStatement, (PDOStatement|false) given.'
-			identifier: argument.type
-			count: 2
 			path: app/cdash/include/common.php
 
 		-
@@ -16121,15 +15875,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to deprecated function pdo_error():
-				04/01/2023
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: app/cdash/public/api/v1/manageBuildGroup.php
-
-		-
-			rawMessage: '''
 				Call to deprecated method execute() of class CDash\Database:
 				04/22/2023  Use Laravel query builder or Eloquent instead
 			'''
@@ -16197,7 +15942,7 @@ parameters:
 		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
 			identifier: empty.notAllowed
-			count: 5
+			count: 4
 			path: app/cdash/public/api/v1/manageBuildGroup.php
 
 		-
@@ -16563,15 +16308,6 @@ parameters:
 		-
 			rawMessage: 'Argument of an invalid type mixed supplied for foreach, only iterables are supported.'
 			identifier: foreach.nonIterable
-			count: 1
-			path: app/cdash/public/api/v1/subproject.php
-
-		-
-			rawMessage: '''
-				Call to deprecated function add_last_sql_error():
-				04/22/2023
-			'''
-			identifier: function.deprecated
 			count: 1
 			path: app/cdash/public/api/v1/subproject.php
 


### PR DESCRIPTION
Database queries executed through PDO bypass Laravel's transaction wrapper and query monitoring features.  This PR updates a miscellaneous assortment of easily refactorable queries to either use the recently created Eloquent models or Laravel's DB facade.  There's more refactoring to be done, but I'll do it in separate PRs to spread out the changes some.