### PR TITLE
Add subproject to new `/builds/<id>/tests` page

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -510,6 +510,8 @@ type Build {
   urls: [UploadedUrl!]! @hasMany(relation: "uploadedFiles", type: CONNECTION, scopes: ["urls"]) @orderBy(column: "id", direction: ASC)
 
   files: [UploadedFile!]! @hasMany(relation: "uploadedFiles", type: CONNECTION, scopes: ["files"]) @orderBy(column: "id", direction: ASC)
+
+  subProject: SubProject! @belongsTo
 }
 
 
@@ -890,4 +892,13 @@ type UploadedFile @model(class: "App\\Models\\UploadFile") {
 
   "File size in bytes."
   size: Int! @rename(attribute: "filesize")
+}
+
+
+# TODO: add the rest of the fields once types and relationships are solidified.
+type SubProject {
+  "Unique primary key."
+  id: ID!
+
+  name: String!
 }

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -12,6 +12,10 @@
     <loading-indicator :is-loading="!tests">
       <data-table
         :columns="[
+          ...(hasSubProjects ? [{
+            name: 'subProject',
+            displayName: 'SubProject',
+          }] : []),
           {
             name: 'name',
             displayName: 'Name',
@@ -101,6 +105,10 @@ export default {
                       }
                     }
                   }
+                  subProject {
+                    id
+                    name
+                  }
                 }
               }
             }
@@ -109,7 +117,14 @@ export default {
       `,
       update: (data) => {
         let tests = [...data.build.tests.edges];
-        data.build.children.edges.forEach((child) => tests = tests.concat(child.node.tests.edges));
+        data.build.children.edges.forEach((child) => {
+          tests = tests.concat(
+            child.node.tests.edges.map((test) => ({
+              ...test,
+              subProject: child.node.subProject.name,
+            })),
+          );
+        });
         return tests;
       },
       variables() {
@@ -128,6 +143,10 @@ export default {
   },
 
   computed: {
+    hasSubProjects() {
+      return this.tests?.some((element) => element.subProject) ?? false;
+    },
+
     executeQueryLink() {
       return `${window.location.origin}${window.location.pathname}?filters=${encodeURIComponent(JSON.stringify(this.changedFilters))}`;
     },
@@ -152,6 +171,7 @@ export default {
             href: `${this.$baseURL}/tests/${edge.node.id}`,
             classes: [this.testStatusToColorClass(edge.node.status)],
           },
+          subProject: edge.subProject ?? '',
         };
       });
     },

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -7,6 +7,7 @@ use App\Models\Build;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Models\SubProject;
 use App\Models\Test;
 use App\Models\TestOutput;
 use Illuminate\Support\Str;
@@ -71,6 +72,18 @@ class BuildTestsPageTest extends BrowserTestCase
 
     public function testFiltersByParentAndChildBuildTests(): void
     {
+        /** @var SubProject $subproject1 */
+        $subproject1 = $this->project->subprojects()->create([
+            'groupid' => -1,
+            'name' => Str::uuid()->toString(),
+        ]);
+
+        /** @var SubProject $subproject2 */
+        $subproject2 = $this->project->subprojects()->create([
+            'groupid' => -1,
+            'name' => Str::uuid()->toString(),
+        ]);
+
         /** @var Build $parent_build */
         $parent_build = $this->project->builds()->create([
             'siteid' => $this->site->id,
@@ -91,6 +104,7 @@ class BuildTestsPageTest extends BrowserTestCase
             'siteid' => $this->site->id,
             'name' => Str::uuid()->toString(),
             'uuid' => Str::uuid()->toString(),
+            'subprojectid' => $subproject1->id,
         ])->tests()->create([
             'testname' => Str::uuid()->toString(),
             'status' => 'failed',
@@ -103,6 +117,7 @@ class BuildTestsPageTest extends BrowserTestCase
             'siteid' => $this->site->id,
             'name' => Str::uuid()->toString(),
             'uuid' => Str::uuid()->toString(),
+            'subprojectid' => $subproject2->id,
         ])->tests()->create([
             'testname' => Str::uuid()->toString(),
             'status' => 'passed',
@@ -136,6 +151,68 @@ class BuildTestsPageTest extends BrowserTestCase
                 ->assertDontSeeIn('@tests-table', $parent_build_test->testname)
                 ->assertDontSeeIn('@tests-table', $child_build_1_test->testname)
                 ->assertSeeIn('@tests-table', $child_build_2_test->testname)
+            ;
+        });
+    }
+
+    public function testHidesSubProjectColumnWhenNoChildBuilds(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Test $test */
+        $test = $build->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($test, $build): void {
+            $browser->visit("/builds/{$build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertDontSeeIn('@tests-table', 'SubProject')
+                ->assertSeeIn('@tests-table', $test->testname)
+            ;
+        });
+    }
+
+    public function testShowsSubProjectColumnWhenHasChildBuilds(): void
+    {
+        /** @var SubProject $subproject */
+        $subproject = $this->project->subprojects()->create([
+            'groupid' => -1,
+            'name' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Build $parent_build */
+        $parent_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Test $child_build_test */
+        $child_build_test = $parent_build->children()->create([
+            'projectid' => $this->project->id,
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'subprojectid' => $subproject->id,
+        ])->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($child_build_test, $parent_build): void {
+            $browser->visit("/builds/{$parent_build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table', 'SubProject')
+                ->assertSeeIn('@tests-table', $child_build_test->testname)
             ;
         });
     }


### PR DESCRIPTION
The last missing piece of the replacement page for `viewTest.php` is a subproject column.  This PR adds that column and exposes the most minimal amount of SubProject data necessary to support it via the GraphQL API.  A follow-up PR will switch all `viewTest.php` references to use this new page instead.