### PR TITLE
Expose time status via GraphQL

### DIFF
--- a/app/Enums/TestTimeStatusCategory.php
+++ b/app/Enums/TestTimeStatusCategory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum TestTimeStatusCategory: string
+{
+    case PASSED = 'PASSED';
+    case FAILED = 'FAILED';
+}

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\TestTimeStatusCategory;
 use CDash\Model\Label;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -26,6 +27,7 @@ use Illuminate\Support\Facades\Config;
  * @property int $newstatus
  * @property string $details
  * @property string $testname
+ * @property TestTimeStatusCategory $timestatuscategory
  *
  * @mixin Builder<Test>
  */
@@ -74,6 +76,7 @@ class Test extends Model
         'timestd' => 'float',
         'timestatus' => 'integer',
         'newstatus' => 'integer',
+        'timestatuscategory' => TestTimeStatusCategory::class,
     ];
 
     /**

--- a/app/Providers/GraphQLServiceProvider.php
+++ b/app/Providers/GraphQLServiceProvider.php
@@ -6,6 +6,7 @@ use App\Enums\BuildCommandType;
 use App\Enums\GlobalRole;
 use App\Enums\ProjectRole;
 use App\Enums\TargetType;
+use App\Enums\TestTimeStatusCategory;
 use GraphQL\Type\Definition\PhpEnumType;
 use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
@@ -18,5 +19,6 @@ final class GraphQLServiceProvider extends ServiceProvider
         $typeRegistry->register(new PhpEnumType(ProjectRole::class));
         $typeRegistry->register(new PhpEnumType(TargetType::class));
         $typeRegistry->register(new PhpEnumType(BuildCommandType::class));
+        $typeRegistry->register(new PhpEnumType(TestTimeStatusCategory::class));
     }
 }

--- a/database/migrations/2025_10_28_135523_test_time_status_category.php
+++ b/database/migrations/2025_10_28_135523_test_time_status_category.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // We drop the type first in case the database has been truncated previously.
+        DB::statement('DROP TYPE IF EXISTS testtimestatuscategory');
+        DB::statement("CREATE TYPE testtimestatuscategory AS ENUM ('PASSED', 'FAILED')");
+
+        // VIRTUAL columns aren't supported in postgres <18, and don't support user-defined types in 18+ anyway.
+        DB::statement("
+            ALTER TABLE build2test
+            ADD COLUMN timestatuscategory testtimestatuscategory
+            GENERATED ALWAYS AS (
+                CASE
+                    WHEN timestatus = 0 THEN 'PASSED'::testtimestatuscategory
+                    ELSE 'FAILED'::testtimestatuscategory
+                END
+            ) STORED NOT NULl
+        ");
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -524,6 +524,8 @@ type Test {
 
   status: TestStatus! @filterable
 
+  timeStatusCategory: TestTimeStatusCategory! @rename(attribute: "timestatuscategory") @filterable
+
   runningTime: NonNegativeSeconds! @rename(attribute: "time") @filterable
 
   details: String! @filterable


### PR DESCRIPTION
The `build2test.timestatus` column currently encodes information about both the binary "did this test instance pass the time check" and an aggregate across previous test instances indicating "does this chunk of tests represent a change in test time".  This PR exposes just the former portion, returning a binary passed/failed value corresponding to the exact test record being retrieved.  The rest of the information about aggregate test timing will be exposed via a separate field in the future.