### PR TITLE
Add time status and history columns to new tests page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -22,6 +22,7 @@ use CDash\Model\BuildRelationship;
 use CDash\ServiceContainer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -95,6 +96,8 @@ final class BuildController extends AbstractBuildController
         return $this->vue('build-tests-page', 'Tests', [
             'build-id' => $this->build->Id,
             'show-test-time-status' => (bool) $this->project->ShowTestTime,
+            'project-name' => $this->project->Name,
+            'build-time' => Carbon::parse($this->build->StartTime)->toIso8601String(),
             'initial-filters' => $filters,
         ]);
     }

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -37,6 +37,10 @@
             name: 'timeStatus',
             displayName: 'Time Status',
           }] : []),
+          {
+            name: 'history',
+            displayName: 'History',
+          },
         ]"
         :rows="formattedTestRows"
         :full-width="true"
@@ -54,6 +58,7 @@ import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import {DateTime} from 'luxon';
 
 export default {
   name: 'BuildTestsPage',
@@ -73,6 +78,16 @@ export default {
 
     showTestTimeStatus: {
       type: Boolean,
+      required: true,
+    },
+
+    projectName: {
+      type: String,
+      required: true,
+    },
+
+    buildTime: {
+      type: String,
       required: true,
     },
 
@@ -188,6 +203,11 @@ export default {
             text: this.humanReadableTestStatus(edge.node.timeStatusCategory),
             href: `${this.$baseURL}/tests/${edge.node.id}?graph=time`,
             classes: [this.testStatusToColorClass(edge.node.timeStatusCategory)],
+          },
+          history: {
+            value: '',
+            text: 'History',
+            href: `${this.$baseURL}/queryTests.php?project=${this.projectName}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${edge.node.name}&date=${DateTime.fromISO(this.buildTime).toISODate()}`,
           },
         };
       });

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -273,4 +273,39 @@ class BuildTestsPageTest extends BrowserTestCase
             ;
         });
     }
+
+    public function testHistoryColumn(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'starttime' => '2025-01-01 11:22:33',
+        ]);
+
+        /** @var Test $test */
+        $test = $build->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($test, $build): void {
+            $browser->visit("/builds/{$build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table', 'History')
+                ->assertSeeIn('@tests-table', $test->testname)
+                ->clickLink('History')
+                ->assertUrlIs(url('queryTests.php'))
+                ->assertQueryStringHas('project', $this->project->name)
+                ->assertQueryStringHas('filtercount', '1')
+                ->assertQueryStringHas('showfilters', '1')
+                ->assertQueryStringHas('field1', 'testname')
+                ->assertQueryStringHas('compare1', '61')
+                ->assertQueryStringHas('value1', $test->testname)
+                ->assertQueryStringHas('date', '2025-01-01')
+            ;
+        });
+    }
 }

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -7,6 +7,7 @@ use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\Dusk;
 use Laravel\Dusk\TestCase as BaseTestCase;
@@ -20,17 +21,17 @@ abstract class BrowserTestCase extends BaseTestCase
      */
     public function setUp(): void
     {
-        parent::setUp();
-
-        Dusk::selectorHtmlAttribute('data-test');
-
-        $env_contents = file_get_contents(base_path('.env'));
+        // The APP_URL must be set prior to config initialization so we can correctly generate test URLs.
+        $env_contents = file_get_contents('/cdash/.env');
         if ($env_contents === false) {
             throw new Exception('Unable to read .env file.');
         }
-
         $env_after_substitution = str_replace('APP_URL=http://localhost:8080', 'APP_URL=http://website:8080', $env_contents);
-        file_put_contents(base_path('.env'), $env_after_substitution);
+        file_put_contents('/cdash/.env', $env_after_substitution);
+
+        parent::setUp();
+
+        Dusk::selectorHtmlAttribute('data-test');
 
         Browser::$baseUrl = 'http://website:8080';
         Browser::$waitSeconds = 10;


### PR DESCRIPTION
Follows https://github.com/Kitware/CDash/pull/3221 as we work towards an eventual replacement of `viewTest.php`.