### PR TITLE
Clean up submission handler undefined fields and types

### DIFF
--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -32,47 +32,36 @@ use stdClass;
 
 class BazelJSONHandler extends AbstractSubmissionHandler
 {
-    private $Builds;
-    private $BuildErrors;
-    private $CommandLine;
+    private $Builds = [];
+    private $BuildErrors = [
+        '' => [],
+    ];
+    private $CommandLine = '';
     private array $Configures = [];
     private ?bool $_HasSubProjects = null;
-    private $NumTestsPassed;
-    private $NumTestsFailed;
-    private $NumTestsNotRun;
+    private $NumTestsPassed = [
+        '' => 0,
+    ];
+    private $NumTestsFailed = [
+        '' => 0,
+    ];
+    private $NumTestsNotRun = [
+        '' => 0,
+    ];
     private $ParentBuild;
-    private $RecordingTestOutput;
-    private $RecordingTestSummary;
-    private $Tests;
-    private $TestsOutput;
-    private $TestName;
-    private $ParseConfigure;
+    private $RecordingTestOutput = false;
+    private $RecordingTestSummary = false;
+    private $Tests = [];
+    private $TestsOutput = [];
+    private $TestName = '';
+    private $ParseConfigure = true;
     private ?BuildErrorFilter $BuildErrorFilter = null;
 
     public function __construct(Build $build)
     {
         parent::__construct($build);
 
-        $this->Builds = [];
         $this->Builds[''] = $this->Build;
-        $this->ParentBuild = null;
-
-        $this->CommandLine = '';
-
-        $this->NumTestsPassed = [];
-        $this->NumTestsFailed = [];
-        $this->NumTestsNotRun = [];
-        $this->NumTestsPassed[''] = 0;
-        $this->NumTestsFailed[''] = 0;
-        $this->NumTestsNotRun[''] = 0;
-
-        $this->BuildErrors = ['' => []];
-        $this->RecordingTestOutput = false;
-        $this->RecordingTestSummary = false;
-        $this->Tests = [];
-        $this->TestsOutput = [];
-        $this->TestName = '';
-        $this->ParseConfigure = true;
     }
 
     protected function HasSubProjects(): bool

--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -57,17 +57,17 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
     private $EndTimeStamp;
     private $Error;
     private $Label;
-    private $Builds;
+    private $Builds = [];
     private array $BuildInformation;
-    private $BuildCommand;
+    private $BuildCommand = '';
     private $BuildGroup;
-    private $Labels;
+    private $Labels = [];
     // Map SubProjects to Labels
-    private $SubProjects;
+    private $SubProjects = [];
     private $ErrorSubProjectName;
-    private $BuildName;
-    private $BuildStamp;
-    private $Generator;
+    private string $BuildName;
+    private string $BuildStamp;
+    private string $Generator;
     private $PullRequest;
     private ?BuildErrorFilter $BuildErrorFilter = null;
     protected static ?string $schema_file = '/app/Validators/Schemas/Build.xsd';
@@ -120,10 +120,6 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
     public function __construct(Project $project)
     {
         parent::__construct($project);
-        $this->Builds = [];
-        $this->BuildCommand = '';
-        $this->Labels = [];
-        $this->SubProjects = [];
     }
 
     public function startElement($parser, $name, $attributes): void

--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -38,18 +38,18 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp;
-    private $EndTimeStamp;
-    private $Builds;
+    private $StartTimeStamp = 0;
+    private $EndTimeStamp = 0;
+    private array $Builds = [];
     private array $BuildInformation;
     // Map SubProjects to Labels
-    private $SubProjects;
+    private array $SubProjects = [];
     private $Configure;
     private $Label;
-    private $Notified;
-    private $BuildName;
-    private $BuildStamp;
-    private $Generator;
+    private bool $Notified = false;
+    private string $BuildName;
+    private string $BuildStamp;
+    private string $Generator;
     private $PullRequest;
     protected static ?string $schema_file = '/app/Validators/Schemas/Configure.xsd';
 
@@ -57,12 +57,6 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
     {
         parent::__construct($project);
 
-        $this->Builds = [];
-        $this->SubProjects = [];
-        $this->StartTimeStamp = 0;
-        $this->EndTimeStamp = 0;
-        // Only complain about errors & warnings once.
-        $this->Notified = false;
         // Instantiate model factory.
         $this->getModelFactory();
     }

--- a/app/Http/Submission/Handlers/CoverageHandler.php
+++ b/app/Http/Submission/Handlers/CoverageHandler.php
@@ -36,11 +36,11 @@ class CoverageHandler extends AbstractXmlHandler
     private $StartTimeStamp;
     private $EndTimeStamp;
 
-    private $Coverage;
-    private $Coverages;
-    private $CoverageFile;
-    private $CoverageSummaries;
-    private $Label;
+    private Coverage $Coverage;
+    private array $Coverages = [];
+    private CoverageFile $CoverageFile;
+    private array $CoverageSummaries = [];
+    private Label $Label;
     protected static ?string $schema_file = '/app/Validators/Schemas/Coverage.xsd';
 
     /** Constructor */
@@ -48,8 +48,6 @@ class CoverageHandler extends AbstractXmlHandler
     {
         parent::__construct($project);
         $this->Site = new Site();
-        $this->Coverages = [];
-        $this->CoverageSummaries = [];
     }
 
     /** startElement */

--- a/app/Http/Submission/Handlers/CoverageJUnitHandler.php
+++ b/app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -34,10 +34,10 @@ class CoverageJUnitHandler extends AbstractXmlHandler
     private $StartTimeStamp;
     private $EndTimeStamp;
 
-    private $Coverage;
-    private $CoverageFile;
+    private Coverage $Coverage;
+    private CoverageFile $CoverageFile;
     private CoverageSummary $CoverageSummary;
-    private $Label;
+    private Label $Label;
 
     /** Constructor */
     public function __construct(Project $project)

--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -30,11 +30,11 @@ class CoverageLogHandler extends AbstractXmlHandler
     private $StartTimeStamp;
     private $EndTimeStamp;
 
-    private $CurrentCoverageFile;
-    private $CurrentCoverageFileLog;
-    private $CoverageFiles;
+    private CoverageFile $CurrentCoverageFile;
+    private CoverageFileLog $CurrentCoverageFileLog;
+    private array $CoverageFiles = [];
 
-    private $CurrentLine;
+    private string $CurrentLine = '';
 
     protected static ?string $schema_file = '/app/Validators/Schemas/CoverageLog.xsd';
 
@@ -43,8 +43,6 @@ class CoverageLogHandler extends AbstractXmlHandler
     {
         parent::__construct($project);
         $this->Site = new Site();
-        $this->CoverageFiles = [];
-        $this->CurrentLine = '';
     }
 
     /** Start element */

--- a/app/Http/Submission/Handlers/DoneHandler.php
+++ b/app/Http/Submission/Handlers/DoneHandler.php
@@ -23,18 +23,16 @@ use CDash\Model\Repository;
 
 class DoneHandler extends AbstractXmlHandler
 {
-    private $FinalAttempt;
-    private $PendingSubmissions;
-    private $Requeue;
-    public $backupFileName;
+    private bool $FinalAttempt = false;
+    private PendingSubmissions $PendingSubmissions;
+    private bool $Requeue = false;
+    public string $backupFileName;
     protected static ?string $schema_file = '/app/Validators/Schemas/Done.xsd';
 
     public function __construct(Build $build)
     {
         parent::__construct($build);
-        $this->FinalAttempt = false;
         $this->PendingSubmissions = new PendingSubmissions();
-        $this->Requeue = false;
     }
 
     public function startElement($parser, $name, $attributes): void

--- a/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+++ b/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -46,25 +46,22 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
 
     private DynamicAnalysis $DynamicAnalysis;
     private DynamicAnalysisDefect $DynamicAnalysisDefect;
-    private $DynamicAnalysisSummaries;
+    private $DynamicAnalysisSummaries = [];
     private $Label;
 
-    private $Builds;
+    private $Builds = [];
     private array $BuildInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/DynamicAnalysis.xsd';
 
     // Map SubProjects to Labels
-    private $SubProjects;
+    private $SubProjects = [];
     private $TestSubProjectName;
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
-        $this->Builds = [];
-        $this->SubProjects = [];
-        $this->DynamicAnalysisSummaries = [];
     }
 
     /** Start element */

--- a/app/Http/Submission/Handlers/GcovTarHandler.php
+++ b/app/Http/Submission/Handlers/GcovTarHandler.php
@@ -34,12 +34,12 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class GcovTarHandler extends AbstractSubmissionHandler
 {
-    private $CoverageSummary;
-    private $SourceDirectory;
-    private $BinaryDirectory;
-    private $Labels;
+    private CoverageSummary $CoverageSummary;
+    private $SourceDirectory = '';
+    private $BinaryDirectory = '';
+    private array $Labels = [];
     private ?string $SubProjectPath = null;
-    private $SubProjectSummaries;
+    private array $SubProjectSummaries = [];
     private $AggregateBuildId;
     private $PreviousAggregateParentId;
 
@@ -49,11 +49,6 @@ class GcovTarHandler extends AbstractSubmissionHandler
 
         $this->CoverageSummary = new CoverageSummary();
         $this->CoverageSummary->BuildId = $this->Build->Id;
-        $this->SourceDirectory = '';
-        $this->BinaryDirectory = '';
-        $this->Labels = [];
-        $this->SubProjectSummaries = [];
-        $this->PreviousAggregateParentId = null;
     }
 
     /**
@@ -161,8 +156,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
     {
         $coverageFileLog = new CoverageFileLog();
         $coverageFileLog->AggregateBuildId = $this->AggregateBuildId;
-        $coverageFileLog->PreviousAggregateParentId =
-            $this->PreviousAggregateParentId;
+        $coverageFileLog->PreviousAggregateParentId = $this->PreviousAggregateParentId ?? null;
         $coverageFile = new CoverageFile();
         $coverage = new Coverage();
         $coverage->CoverageFile = $coverageFile;
@@ -449,8 +443,7 @@ class GcovTarHandler extends AbstractSubmissionHandler
     {
         $coverageFileLog = new CoverageFileLog();
         $coverageFileLog->AggregateBuildId = $this->AggregateBuildId;
-        $coverageFileLog->PreviousAggregateParentId =
-            $this->PreviousAggregateParentId;
+        $coverageFileLog->PreviousAggregateParentId = $this->PreviousAggregateParentId ?? null;
         $coverageFile = new CoverageFile();
         $coverageFile->FullPath = trim($path);
         $coverage = new Coverage();

--- a/app/Http/Submission/Handlers/JSCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/JSCoverTarHandler.php
@@ -31,20 +31,18 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class JSCoverTarHandler extends AbstractSubmissionHandler
 {
-    private $CoverageSummaries;
+    protected array $CoverageSummaries = [];
+    protected array $Coverages = [];
+    protected array $CoverageFiles = [];
+    protected array $CoverageFileLogs = [];
 
     public function __construct(Build $build)
     {
         parent::__construct($build);
 
-        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;
-
-        $this->Coverages = [];
-        $this->CoverageFiles = [];
-        $this->CoverageFileLogs = [];
     }
 
     /**

--- a/app/Http/Submission/Handlers/JavaJSONTarHandler.php
+++ b/app/Http/Submission/Handlers/JavaJSONTarHandler.php
@@ -31,13 +31,12 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class JavaJSONTarHandler extends AbstractSubmissionHandler
 {
-    private $CoverageSummaries;
+    private array $CoverageSummaries = [];
 
     public function __construct(Build $init)
     {
         parent::__construct($init);
 
-        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;

--- a/app/Http/Submission/Handlers/NoteHandler.php
+++ b/app/Http/Submission/Handlers/NoteHandler.php
@@ -29,18 +29,16 @@ class NoteHandler extends AbstractXmlHandler
 {
     use UpdatesSiteInformation;
 
-    private $AdjustStartTime;
-    private $NoteCreator;
+    private bool $AdjustStartTime = false;
+    private NoteCreator $NoteCreator;
     protected static ?string $schema_file = '/app/Validators/Schemas/Notes.xsd';
+    protected $Timestamp = 0;
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
         $this->Site = new Site();
-
-        $this->AdjustStartTime = false;
-        $this->Timestamp = 0;
     }
 
     /** startElement function */

--- a/app/Http/Submission/Handlers/OpenCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/OpenCoverTarHandler.php
@@ -30,22 +30,24 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 class OpenCoverTarHandler extends AbstractXmlHandler
 {
-    protected $CoverageSummaries;
+    /** @var array<string,CoverageSummary> */
+    protected array $CoverageSummaries = [];
+    protected array $Coverages = [];
+    protected array $CoverageFiles = [];
+    protected array $CoverageFileLogs = [];
+    protected bool $ParseCSFiles = true;
+    protected $coverageFile;
+    protected $coverageFileLog;
+    protected $currentModule;
+    protected string $tarDir;
 
     public function __construct(Build $build)
     {
         parent::__construct($build);
 
-        $this->CoverageSummaries = [];
         $coverageSummary = new CoverageSummary();
         $coverageSummary->BuildId = $this->Build->Id;
         $this->CoverageSummaries['default'] = $coverageSummary;
-
-        $this->Coverages = [];
-        $this->CoverageFiles = [];
-        $this->CoverageFileLogs = [];
-
-        $this->ParseCSFiles = true;
     }
 
     public function startElement($parser, $name, $attributes): void
@@ -160,7 +162,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
                 $jsonContents = file_get_contents($fileinfo->getPath() . DIRECTORY_SEPARATOR . $fileinfo->getFilename());
                 $jsonDecoded = json_decode($jsonContents, true);
                 if (array_key_exists('parseCSFiles', $jsonDecoded)) {
-                    $this->ParseCSFiles = $jsonDecoded['parseCSFiles'];
+                    $this->ParseCSFiles = (bool) $jsonDecoded['parseCSFiles'];
                 }
             }
         }

--- a/app/Http/Submission/Handlers/ProjectHandler.php
+++ b/app/Http/Submission/Handlers/ProjectHandler.php
@@ -25,26 +25,21 @@ use Illuminate\Support\Facades\Log;
 
 class ProjectHandler extends AbstractXmlHandler
 {
-    private $SubProject;
-    private $SubProjectPosition;
-    private $Dependencies; // keep an array of dependencies in order to remove them
-    private $SubProjects; // keep an array of subprojects in order to remove them
-    private $CurrentDependencies; // The dependencies of the current SubProject.
-    private $ProjectNameMatches;
+    private SubProject $SubProject;
+    private int $SubProjectPosition = 1;
+    private array $Dependencies; // keep an array of dependencies in order to remove them
+    private array $SubProjects; // keep an array of subprojects in order to remove them
+    private array $CurrentDependencies; // The dependencies of the current SubProject.
+    // Only actually track stuff and write it into the database if the
+    // Project.xml file's name element matches this project's name in the
+    // database.
+    private bool $ProjectNameMatches = true;
     protected static ?string $schema_file = '/app/Validators/Schemas/Project.xsd';
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
-
-        // Only actually track stuff and write it into the database if the
-        // Project.xml file's name element matches this project's name in the
-        // database.
-        //
-        $this->ProjectNameMatches = true;
-
-        $this->SubProjectPosition = 1;
     }
 
     /** startElement function */

--- a/app/Http/Submission/Handlers/RetryHandler.php
+++ b/app/Http/Submission/Handlers/RetryHandler.php
@@ -25,12 +25,11 @@ use Illuminate\Support\Facades\Storage;
 class RetryHandler
 {
     private string $FileName;
-    public int $Retries;
+    public int $Retries = 0;
 
     public function __construct(string $filename)
     {
         $this->FileName = $filename;
-        $this->Retries = 0;
     }
 
     /** Increments the "retries" attribute on the root element of the specified

--- a/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
+++ b/app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
@@ -17,22 +17,13 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use CDash\Model\Build;
-use CDash\Model\Project;
 use CDash\Model\SubProject;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class SubProjectDirectoriesHandler extends AbstractSubmissionHandler
 {
-    private $SubProjectOrder;
-
-    public function __construct(Build|Project $init)
-    {
-        parent::__construct($init);
-
-        $this->SubProjectOrder = [];
-    }
+    private array $SubProjectOrder = [];
 
     /**
      * Parse a text file containing a Bazel package per line.

--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -31,46 +31,39 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
     use UpdatesSiteInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/Test.xsd';
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private $StartTimeStamp = 0;
+    private $EndTimeStamp = 0;
 
     private $TestMeasurement;
     private $Label;
 
     // TODO: Evaluate whether this is needed
-    private $Labels;
+    private array $Labels;
 
-    private $TestCreator;
+    private TestCreator $TestCreator;
 
     /** @var Build[] Builds */
-    private $Builds;
+    private $Builds = [];
     private array $BuildInformation;
 
     // Map SubProjects to Labels
-    private $SubProjects;
+    private $SubProjects = [];
     private $TestSubProjectName;
-    private $BuildName;
-    private $BuildStamp;
-    private $Generator;
+    private string $BuildName;
+    private string $BuildStamp;
+    private string $Generator;
     private $PullRequest;
 
     // Keep a record of the number of tests passed, failed and notrun
     // This works only because we have one test file per submission
-    private $NumberTestsFailed;
-    private $NumberTestsNotRun;
-    private $NumberTestsPassed;
+    private array $NumberTestsFailed = [];
+    private array $NumberTestsNotRun = [];
+    private array $NumberTestsPassed = [];
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
-        $this->Builds = [];
-        $this->SubProjects = [];
-        $this->NumberTestsFailed = [];
-        $this->NumberTestsNotRun = [];
-        $this->NumberTestsPassed = [];
-        $this->StartTimeStamp = 0;
-        $this->EndTimeStamp = 0;
     }
 
     /** Start Element */

--- a/app/Http/Submission/Handlers/TestingJUnitHandler.php
+++ b/app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -31,34 +31,25 @@ class TestingJUnitHandler extends AbstractXmlHandler
     private $StartTimeStamp;
     private $EndTimeStamp;
     // Should we update the end time of the build?
-    private $UpdateEndTime;
+    private bool $UpdateEndTime = false;
     // The buildgroup to submit to (defaults to Nightly).
-    private $Group;
+    private string $Group = 'Nightly';
 
     // Keep a record of the number of tests passed, failed and notrun.
     // This works only because we have one test file per submission.
-    private $NumberTestsFailed;
-    private $NumberTestsNotRun;
-    private $NumberTestsPassed;
-    private $TestProperties;
-    private $HasSiteTag;
-    private $BuildAdded;
-    private $TotalTestDuration;
+    private int $NumberTestsFailed = 0;
+    private int $NumberTestsNotRun = 0;
+    private int $NumberTestsPassed = 0;
+    private string $TestProperties = '';
+    private bool $HasSiteTag = false;
+    private bool $BuildAdded = false;
+    private $TotalTestDuration = 0;
+    protected TestCreator $TestCreator;
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
-
-        $this->UpdateEndTime = false;
-        $this->Group = 'Nightly';
-        $this->NumberTestsFailed = 0;
-        $this->NumberTestsNotRun = 0;
-        $this->NumberTestsPassed = 0;
-        $this->TestProperties = '';
-        $this->HasSiteTag = false;
-        $this->BuildAdded = false;
-        $this->TotalTestDuration = 0;
     }
 
     /** Destructor */

--- a/app/Http/Submission/Handlers/UpdateHandler.php
+++ b/app/Http/Submission/Handlers/UpdateHandler.php
@@ -43,7 +43,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
 {
     private $StartTimeStamp;
     private $EndTimeStamp;
-    private $Update;
+    private BuildUpdate $Update;
     private BuildUpdateFile $UpdateFile;
     protected static ?string $schema_file = '/app/Validators/Schemas/Update.xsd';
 

--- a/app/Http/Submission/Handlers/UploadHandler.php
+++ b/app/Http/Submission/Handlers/UploadHandler.php
@@ -48,28 +48,22 @@ class UploadHandler extends AbstractXmlHandler
     use UpdatesSiteInformation;
 
     private UploadFile $UploadFile;
-    private $TmpFilename;
-    private $Base64TmpFileWriteHandle;
-    private $Base64TmpFilename;
+    private string $TmpFilename = '';
+    private $Base64TmpFileWriteHandle = 0;
+    private string $Base64TmpFilename = '';
     private $Label;
-    private int $Timestamp;
-    private bool $BuildInitialized;
+    private int $Timestamp = 0;
+    private bool $BuildInitialized = false;
     protected static ?string $schema_file = '/app/Validators/Schemas/Upload.xsd';
 
     /** If True, means an error happened while processing the file */
-    private $UploadError;
+    private bool $UploadError = false;
 
     /** Constructor */
     public function __construct(Project $project)
     {
         parent::__construct($project);
         $this->Site = new Site();
-        $this->TmpFilename = '';
-        $this->Base64TmpFileWriteHandle = 0;
-        $this->Base64TmpFilename = '';
-        $this->UploadError = false;
-        $this->Timestamp = 0;
-        $this->BuildInitialized = false;
     }
 
     /** Start element */
@@ -136,12 +130,13 @@ class UploadHandler extends AbstractXmlHandler
             }
 
             // Create tmp file
-            $this->TmpFilename = tempnam(storage_path('app/tmp'), 'cdash_upload');
-            if ($this->TmpFilename === false) {
+            $tmpname = tempnam(storage_path('app/tmp'), 'cdash_upload');
+            if ($tmpname === false) {
                 Log::error('Failed to create temporary filename');
                 $this->UploadError = true;
                 return;
             }
+            $this->TmpFilename = $tmpname;
             $this->Base64TmpFilename = $this->TmpFilename . '-base64';
 
             // Open base64 temporary file for writing

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3301,6 +3301,24 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $BuildName. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $BuildStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $Generator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
 			identifier: empty.notAllowed
 			count: 8
@@ -3403,18 +3421,6 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Builds has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -3434,12 +3440,6 @@ parameters:
 
 		-
 			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$ErrorSubProjectName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Generator has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
@@ -3499,12 +3499,6 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Cannot access an offset on array|float|int|string|false|null.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
 			rawMessage: Cannot access property $log on mixed.
 			identifier: property.nonObject
 			count: 1
@@ -3524,6 +3518,24 @@ parameters:
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $BuildInformation. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $BuildName. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $BuildStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $Generator. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
@@ -3619,20 +3631,8 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$BuildName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$BuildStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Builds has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Builds type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
@@ -3649,19 +3649,7 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Generator has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Label has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Notified has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
@@ -3679,8 +3667,8 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$SubProjects has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$SubProjects type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
@@ -3689,6 +3677,24 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $Coverage. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $CoverageFile. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
@@ -3745,26 +3751,14 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$Coverage has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$CoverageSummaries type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$CoverageFile has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$CoverageSummaries has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$Coverages has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$Coverages type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
@@ -3775,16 +3769,28 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$Label has no type specified.
+			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$StartTimeStamp has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
+			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $Coverage. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
-			path: app/Http/Submission/Handlers/CoverageHandler.php
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $CoverageFile. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
 
 		-
 			rawMessage: 'Construct empty() is not allowed. Use more strict comparison.'
@@ -3841,25 +3847,7 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$Coverage has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$CoverageFile has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$Label has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -3883,8 +3871,14 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
 		-
-			rawMessage: Cannot access an offset on array|float|int|string|false|null.
-			identifier: offsetAccess.nonOffsetAccessible
+			rawMessage: Class App\Http\Submission\Handlers\CoverageLogHandler has an uninitialized property $CurrentCoverageFile. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageLogHandler has an uninitialized property $CurrentCoverageFileLog. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
@@ -3943,26 +3937,8 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CoverageFiles has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CurrentCoverageFile has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CurrentCoverageFileLog has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CurrentLine has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CoverageFiles type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
@@ -3981,6 +3957,12 @@ parameters:
 		-
 			rawMessage: Cannot access property $name on App\Models\Site|null.
 			identifier: property.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/DoneHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\DoneHandler has an uninitialized property $backupFileName. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/DoneHandler.php
 
@@ -4033,26 +4015,8 @@ parameters:
 			path: app/Http/Submission/Handlers/DoneHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\DoneHandler::$FinalAttempt has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DoneHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DoneHandler::$PendingSubmissions has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DoneHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DoneHandler::$Requeue has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DoneHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DoneHandler::$backupFileName has no type specified.
-			identifier: missingType.property
+			rawMessage: 'Only booleans are allowed in an if condition, int given.'
+			identifier: if.condNotBoolean
 			count: 1
 			path: app/Http/Submission/Handlers/DoneHandler.php
 
@@ -4399,14 +4363,8 @@ parameters:
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$CoverageSummary has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/GcovTarHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$Labels has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$Labels type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
 
@@ -4423,28 +4381,10 @@ parameters:
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$SubProjectSummaries has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$SubProjectSummaries type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageFileLogs.
-			identifier: property.notFound
-			count: 5
-			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageFiles.
-			identifier: property.notFound
-			count: 4
-			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\JSCoverTarHandler::$Coverages.
-			identifier: property.notFound
-			count: 3
-			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
 
 		-
 			rawMessage: 'Argument of an invalid type mixed supplied for foreach, only iterables are supported.'
@@ -4519,8 +4459,32 @@ parameters:
 			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageSummaries has no type specified.
-			identifier: missingType.property
+			rawMessage: Possibly invalid array key type mixed.
+			identifier: offsetAccess.invalidOffset
+			count: 3
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageFileLogs type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageFiles type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\JSCoverTarHandler::$CoverageSummaries type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\JSCoverTarHandler::$Coverages type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/JSCoverTarHandler.php
 
@@ -4591,15 +4555,15 @@ parameters:
 			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\JavaJSONTarHandler::$CoverageSummaries has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\JavaJSONTarHandler::$CoverageSummaries type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/JavaJSONTarHandler.php
 
 		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\NoteHandler::$Timestamp.
-			identifier: property.notFound
-			count: 6
+			rawMessage: Class App\Http\Submission\Handlers\NoteHandler has an uninitialized property $NoteCreator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
 			path: app/Http/Submission/Handlers/NoteHandler.php
 
 		-
@@ -4723,64 +4687,10 @@ parameters:
 			path: app/Http/Submission/Handlers/NoteHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\NoteHandler::$AdjustStartTime has no type specified.
+			rawMessage: Property App\Http\Submission\Handlers\NoteHandler::$Timestamp has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/NoteHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\NoteHandler::$NoteCreator has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/NoteHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$CoverageFileLogs.
-			identifier: property.notFound
-			count: 5
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$CoverageFiles.
-			identifier: property.notFound
-			count: 4
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$Coverages.
-			identifier: property.notFound
-			count: 3
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$ParseCSFiles.
-			identifier: property.notFound
-			count: 3
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$coverageFile.
-			identifier: property.notFound
-			count: 4
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$coverageFileLog.
-			identifier: property.notFound
-			count: 5
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$currentModule.
-			identifier: property.notFound
-			count: 2
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
-
-		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\OpenCoverTarHandler::$tarDir.
-			identifier: property.notFound
-			count: 4
-			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
 		-
 			rawMessage: 'Argument of an invalid type list<string>|false supplied for foreach, only iterables are supported.'
@@ -4809,6 +4719,12 @@ parameters:
 		-
 			rawMessage: 'Cannot call method getPath() on mixed.'
 			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\OpenCoverTarHandler has an uninitialized property $tarDir. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
@@ -4969,10 +4885,64 @@ parameters:
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$CoverageSummaries has no type specified.
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$CoverageFileLogs type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$CoverageFiles type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$Coverages type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$coverageFile has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$coverageFileLog has no type specified.
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$currentModule has no type specified.
+			identifier: missingType.property
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ProjectHandler has an uninitialized property $CurrentDependencies. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ProjectHandler has an uninitialized property $Dependencies. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ProjectHandler has an uninitialized property $SubProject. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ProjectHandler has an uninitialized property $SubProjects. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ProjectHandler.php
 
 		-
 			rawMessage: 'Loose comparison via "!=" is not allowed.'
@@ -5041,38 +5011,20 @@ parameters:
 			path: app/Http/Submission/Handlers/ProjectHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$CurrentDependencies has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$CurrentDependencies type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/ProjectHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$Dependencies has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$Dependencies type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/ProjectHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$ProjectNameMatches has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ProjectHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$SubProject has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ProjectHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$SubProjectPosition has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ProjectHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$SubProjects has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\ProjectHandler::$SubProjects type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/ProjectHandler.php
 
@@ -5119,8 +5071,8 @@ parameters:
 			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\SubProjectDirectoriesHandler::$SubProjectOrder has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\SubProjectDirectoriesHandler::$SubProjectOrder type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/SubProjectDirectoriesHandler.php
 
@@ -5138,6 +5090,36 @@ parameters:
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $BuildInformation. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $BuildName. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $BuildStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $Generator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $Labels. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $TestCreator. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
@@ -5209,6 +5191,12 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
+			rawMessage: 'Only booleans are allowed in an if condition, array given.'
+			identifier: if.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
 			rawMessage: 'Only numeric types are allowed in +, int|false given on the right side.'
 			identifier: plus.rightNonNumeric
 			count: 3
@@ -5227,25 +5215,7 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$BuildName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$BuildStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$Generator has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
@@ -5257,26 +5227,26 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$Labels has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$Labels type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsFailed has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsFailed type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsNotRun has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsNotRun type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsPassed has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$NumberTestsPassed type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
@@ -5299,12 +5269,6 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$TestCreator has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$TestMeasurement has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -5317,9 +5281,9 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Access to an undefined property App\Http\Submission\Handlers\TestingJUnitHandler::$TestCreator.
-			identifier: property.notFound
-			count: 8
+			rawMessage: Class App\Http\Submission\Handlers\TestingJUnitHandler has an uninitialized property $TestCreator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
@@ -5419,43 +5383,7 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$BuildAdded has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$Group has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$HasSiteTag has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$NumberTestsFailed has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$NumberTestsNotRun has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$NumberTestsPassed has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -5467,19 +5395,7 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$TestProperties has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$TotalTestDuration has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$UpdateEndTime has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -5487,6 +5403,12 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method CDash\Messaging\Preferences\NotificationPreferencesInterface::get().'
 			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\UpdateHandler has an uninitialized property $Update. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/UpdateHandler.php
 
@@ -5564,12 +5486,6 @@ parameters:
 
 		-
 			rawMessage: Property App\Http\Submission\Handlers\UpdateHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UpdateHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\UpdateHandler::$Update has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/UpdateHandler.php
@@ -5713,25 +5629,7 @@ parameters:
 			path: app/Http/Submission/Handlers/UploadHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$Base64TmpFilename has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UploadHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$Label has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UploadHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$TmpFilename has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UploadHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$UploadError has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/UploadHandler.php


### PR DESCRIPTION
This maintenance PR achieves three goals:
1. Explicitly define all fields on every submission handler.  (dynamically defining fields is deprecated, and will be removed in a future version of PHP)
2. Move field initialization out of the constructor wherever possible
3. Add type annotations to fields where it's easy to do so

Note that (3) does not attempt to add type annotations to all fields, but rather just those for which the type is easily identified and safe to add.  A follow-up PR will be created to handle the more difficult cases.  Adding type annotations makes refactoring other parts of the codebase safer because static analysis tools have a better depth of analysis.