### PR TITLE
Add instrumentation links to build summary page

### DIFF
--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -761,6 +761,23 @@
       </div>
       <br>
 
+      <!-- Instrumentation section -->
+      <div class="title-divider">
+        Instrumentation
+        <a href="https://cmake.org/cmake/help/latest/manual/cmake-instrumentation.7.html">
+          <font-awesome-icon :icon="FA.faQuestionCircle" />
+        </a>
+      </div>
+      <a :href="$baseURL + '/builds/' + cdash.build.id + '/targets'">
+        View Targets
+      </a>
+      <br>
+      <a :href="$baseURL + '/builds/' + cdash.build.id + '/commands'">
+        View Commands
+      </a>
+      <br>
+      <br>
+
       <!-- Display comments for this build -->
       <div
         v-if="cdash.notes.length > 0 || cdash.user.id > 0"
@@ -1163,8 +1180,13 @@
 
 <script>
 import ApiLoader from './shared/ApiLoader';
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {
+  faQuestionCircle,
+} from '@fortawesome/free-solid-svg-icons';
 export default {
   name: 'BuildSummary',
+  components: {FontAwesomeIcon},
 
   data () {
     return {
@@ -1193,6 +1215,14 @@ export default {
         'tests': false,
       },
     };
+  },
+
+  computed: {
+    FA() {
+      return {
+        faQuestionCircle,
+      };
+    },
   },
 
   mounted () {

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -201,7 +201,6 @@ export default {
           name: {
             value: edge.node.name,
             text: edge.node.name,
-            href: `${this.$baseURL}/targets/${edge.node.id}`,
           },
           type: {
             value: edge.node.type,


### PR DESCRIPTION
By adding links to `/builds/<id>/targets` and `/builds/<id>/commands` to the build summary page, these instrumentation pages are now official CDash features users can navigate to though normal usage of the website.  I intend to improve the integration of these pages with the rest of the site as part of a future revamp of the build summary page.