### PR TITLE
Add measurement columns to new tests page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Build as EloquentBuild;
 use App\Models\BuildUpdateFile;
 use App\Models\Comment;
+use App\Models\Project;
 use App\Models\RichBuildAlert;
 use App\Models\UploadFile;
 use App\Models\User;
@@ -93,12 +94,15 @@ final class BuildController extends AbstractBuildController
 
         $filters = json_decode(request()->get('filters')) ?? ['all' => []];
 
+        $eloquent_project = Project::findOrFail((int) $this->project->Id);
+
         return $this->vue('build-tests-page', 'Tests', [
             'build-id' => $this->build->Id,
-            'show-test-time-status' => (bool) $this->project->ShowTestTime,
-            'project-name' => $this->project->Name,
+            'show-test-time-status' => (bool) $eloquent_project->showtesttime,
+            'project-name' => $eloquent_project->name,
             'build-time' => Carbon::parse($this->build->StartTime)->toIso8601String(),
             'initial-filters' => $filters,
+            'pinned-measurements' => $eloquent_project->measurements()->orderBy('position')->pluck('name')->toArray(),
         ]);
     }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -534,7 +534,9 @@ type Test {
   Test measurements for this test, sorted in descending order so newer results
   appear first when using paginated queries.
   """
-  testMeasurements: [TestMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  testMeasurements(
+    filters: _ @filter
+  ): [TestMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
   labels(
     filters: _ @filter
@@ -558,12 +560,12 @@ type TestMeasurement {
   """
   Example: "Exit Value"
   """
-  name: String!
+  name: String! @filterable
 
   """
   Example: "text/string", "numeric/double", "text/preformatted", etc
   """
-  type: String!
+  type: String! @filterable
 
   """
   The value for this measurement.  Even though some values may be numeric, all

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -308,4 +308,82 @@ class BuildTestsPageTest extends BrowserTestCase
             ;
         });
     }
+
+    public function testMeasurementColumns(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Test $test */
+        $test = $build->tests()->create([
+            'testname' => Str::uuid()->toString(),
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $measurement1 = $test->testMeasurements()->create([
+            'name' => Str::uuid()->toString(),
+            'type' => 'text/string',
+            'value' => Str::uuid()->toString(),
+        ]);
+
+        $measurement2 = $test->testMeasurements()->create([
+            'name' => Str::uuid()->toString(),
+            'type' => 'text/string',
+            'value' => Str::uuid()->toString(),
+        ]);
+
+        $this->project->measurements()->create([
+            'name' => $measurement1->name,
+            'position' => 1,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build, $measurement1, $measurement2): void {
+            $browser->visit("/builds/{$build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table', $measurement1->name)
+                ->assertSeeIn('@tests-table', $measurement1->value)
+                ->assertDontSeeIn('@tests-table', $measurement2->name)
+                ->assertDontSeeIn('@tests-table', $measurement2->value)
+            ;
+        });
+    }
+
+    public function testMeasurementColumnOrder(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $measurement1 = $this->project->measurements()->create([
+            'name' => Str::uuid()->toString(),
+            'position' => 1,
+        ]);
+
+        $measurement2 = $this->project->measurements()->create([
+            'name' => Str::uuid()->toString(),
+            'position' => 2,
+        ]);
+
+        $measurement3 = $this->project->measurements()->create([
+            'name' => Str::uuid()->toString(),
+            'position' => 3,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build, $measurement1, $measurement2, $measurement3): void {
+            $browser->visit("/builds/{$build->id}/tests")
+                ->waitFor('@tests-table')
+                ->assertSeeIn('@tests-table th:nth-child(3)', $measurement1->name)
+                ->assertSeeIn('@tests-table th:nth-child(4)', $measurement2->name)
+                ->assertSeeIn('@tests-table th:nth-child(5)', $measurement3->name)
+            ;
+        });
+    }
 }


### PR DESCRIPTION
`viewTest.php` can be configured to display selected test measurement columns.  This PR brings the functionality to the replacement `/builds/<id>/tests` page.