### PR TITLE
Add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "monthly"
       time: "02:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - "release notes: external dependencies"
@@ -16,6 +18,8 @@ updates:
       interval: "monthly"
       time: "02:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - "release notes: external dependencies"
@@ -26,6 +30,8 @@ updates:
       interval: "monthly"
       time: "02:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - "release notes: external dependencies"


### PR DESCRIPTION
Dependabot will now only create dependency bump PRs for releases more than 7 days old.  For more information about this change, see the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-).