### PR TITLE
Upgrade to "recommended" eslint-vue ruleset

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
   js.configs.recommended,
-  pluginVue.configs['flat/essential'],
+  ...pluginVue.configs['flat/recommended'],
 
   globalIgnores([
     'vendor/*',


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/3295 accidentally downgraded the set of rules used to lint vue code.

This PR upgrades CDash back to the [highest](https://eslint.vuejs.org/user-guide/#bundle-configurations-eslint-config-js) level of Vue linting rules.