### PR TITLE
Restore notes link on build summary page

### DIFF
--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -531,6 +531,19 @@
       <br>
       <br>
 
+      <!-- Notes section -->
+      <div class="title-divider">
+        Notes
+      </div>
+      <a
+        class="tw-link tw-link-hover"
+        :href="$baseURL + '/builds/' + cdash.build.id + '/notes'"
+      >
+        View Notes
+      </a>
+      <br>
+      <br>
+
       <!-- Instrumentation section -->
       <div class="title-divider">
         Instrumentation


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/3259 updated the header of the build summary page, which deleted the link to the notes page in the process.  This PR re-adds it as a dedicated section.  I plan to move all of the links to `/builds/<id>/*` pages to a new sidebar UI element in the next 1-3 releases, so I expect this solution to be a temporary fix.