### PR TITLE
Fix jest test glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/Kitware/CDash",
   "license": "BSD-3-Clause",
   "scripts": {
-    "test": "jest tests/Spec/*.spec.js tests/Spec/**/*.spec.js",
+    "test": "jest",
     "development": "mix",
     "dev": "npm run development",
     "watch": "mix watch",


### PR DESCRIPTION
Running `npm run test` currently prints the message `Invalid testPattern tests/Spec/build-summary.spec.js|tests/Spec/edit-project.spec.js|tests/Spec/manage-measurements.spec.js|tests/Spec/test-details.spec.js|tests/Spec/**/*.spec.js supplied. Running all tests instead.`

This PR fixes the test pattern to instead let jest find all the tests itself.