### PR TITLE
Add explicit cast for passed arguments to removeBuilds

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -63,7 +63,7 @@ final class AdminController extends AbstractController
 
         // Delete the builds
         if (isset($_POST['Submit'])) {
-            $timestamp_sql = "CAST(CONCAT(?, '-', ?, '-', ?, ' 00:00:00') AS timestamp)";
+            $timestamp_sql = "CAST(CONCAT(?::text, '-', ?::text, '-', ?::text, ' 00:00:00') AS timestamp)";
 
             $build = DB::select("
                          SELECT id


### PR DESCRIPTION
Fix issue with SQLSTATE[42P18]: Indeterminate datatype when trying to remove builds from admin page

Illuminate\Database\QueryException
SQLSTATE[42P18]: Indeterminate datatype: 7 ERROR: could not determine data type of parameter $2 (Connection: pgsql, SQL: SELECT id FROM build WHERE projectid = 1 AND parentid IN (0, -1) AND starttime <= CAST(CONCAT(2025, '-', 9, '-', 12, ' 00:00:00') AS timestamp) AND starttime >= CAST(CONCAT(2025, '-', 8, '-', 21, ' 00:00:00') AS timestamp) ORDER BY starttime ASC )

This is with PostGreSQL: (PostgreSQL) 14.20 (Ubuntu 14.20-0ubuntu0.22.04.1)