### PR TITLE
Fix server error when submitting on non-existent project

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -150,8 +150,8 @@ final class SubmissionController extends AbstractProjectController
         // We can't use the usual $this->setProjectByName() function here because the auth token we have might not allow
         // full access to the project.  E.g., it might be a submit-only token.
         $this->project = new Project();
-        
-        if (!$this->project->FindByName($projectname) || intval($this->project->Id) < 1) {
+
+        if (!$this->project->FindByName($projectname)) {
             Storage::delete("inbox/{$filename}");
             Log::info("Rejected submission with invalid project name: $projectname");
             $this->failProcessing($filename, Response::HTTP_NOT_FOUND, 'The requested project does not exist.');


### PR DESCRIPTION
Previously, if a submission happened on a non-existent project, the `CheckForTooManyBuilds()` would result in a 500 http code, which caused me some confusion.

Thanks!