### PR TITLE
Remove legacy PHPUnit config

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ function(add_legacy_unit_test TestName)
       ${PHP_EXE}
       ${phpunit_extra_arg}
       ${PHPUNIT}
-      -c ${testing_dir}/phpunit.xml
+      -c ${CDash_SOURCE_DIR}/phpunit.xml
       --bootstrap ${testing_dir}/bootstrap.php
       ${testing_dir}/case/${TestName}Test.php
   )

--- a/app/cdash/tests/phpunit.xml
+++ b/app/cdash/tests/phpunit.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="true" bootstrap="app/cdash/tests/bootstrap.php" colors="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" timeoutForSmallTests="1" timeoutForMediumTests="10" timeoutForLargeTests="60" cacheDirectory=".phpunit.cache" backupStaticProperties="false" requireCoverageMetadata="false" displayDetailsOnPhpunitDeprecations="true">
-  <source/>
-</phpunit>


### PR DESCRIPTION
We no longer need to have a separate PHPUnit configuration for legacy and Laravel tests.