### PR TITLE
Revamp login page

### DIFF
--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -536,7 +536,8 @@ class KWWebTestCase extends WebTestCase
             $html = "{$response->getBody()}";
             $dom = new DOMDocument();
             @$dom->loadHTML($html);
-            $token = $dom->getElementById('csrf-token')
+            $token = $dom->getElementsByTagName('input')
+                ->item(0)
                 ->getAttribute('value');
 
             $response = $client->request('POST',

--- a/config/saml2.php
+++ b/config/saml2.php
@@ -5,7 +5,7 @@ return [
     'enabled' => env('SAML2_ENABLED', false),
 
     /* What text to display in the SAML2 login button */
-    'login_text' => env('SAML2_LOGIN_TEXT', 'SAML2'),
+    'login_text' => env('SAML2_LOGIN_TEXT', 'Sign in with SAML2'),
 
     /* Whether or not to automatically register new users */
     'autoregister_new_users' => env('SAML2_AUTO_REGISTER_NEW_USERS', false),

--- a/config/services.php
+++ b/config/services.php
@@ -20,7 +20,7 @@ return [
         'redirect' => env('APP_URL') . '/auth/github/callback',
         'enable' => env('GITHUB_ENABLE', false),
         'oauth' => true,
-        'display_name' => env('GITHUB_DISPLAY_NAME', 'GitHub'),
+        'display_name' => env('GITHUB_DISPLAY_NAME', 'Sign in with GitHub'),
     ],
     'gitlab' => [
         'client_id' => env('GITLAB_CLIENT_ID'),
@@ -29,7 +29,7 @@ return [
         'instance_uri' => env('GITLAB_DOMAIN'),
         'enable' => env('GITLAB_ENABLE', false),
         'oauth' => true,
-        'display_name' => env('GITLAB_DISPLAY_NAME', 'GitLab'),
+        'display_name' => env('GITLAB_DISPLAY_NAME', 'Sign in with GitLab'),
     ],
 
     'google' => [
@@ -39,7 +39,7 @@ return [
         'redirect' => env('APP_URL') . '/auth/google/callback',
         'enable' => env('GOOGLE_ENABLE', false),
         'oauth' => true,
-        'display_name' => env('GOOGLE_DISPLAY_NAME', 'Google'),
+        'display_name' => env('GOOGLE_DISPLAY_NAME', 'Sign in with Google'),
     ],
 
     'pingidentity' => [
@@ -52,7 +52,7 @@ return [
         'user_endpoint' => env('PINGIDENTITY_USER_ENDPOINT', '/idp/userinfo.openid'),
         'enable' => env('PINGIDENTITY_ENABLE', false),
         'oauth' => true,
-        'display_name' => env('PINGIDENTITY_DISPLAY_NAME', 'PingIdentity'),
+        'display_name' => env('PINGIDENTITY_DISPLAY_NAME', 'Sign in with PingIdentity'),
     ],
 
     'mailgun' => [

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -69,7 +69,7 @@ To begin, you will need to
 | GITHUB_CLIENT_ID | The Client ID assigned to your GitHub OAuth2 app. | '' |
 | GITHUB_CLIENT_SECRET | The Client Secret created for your GitHub OAuth2 app. | '' |
 | GITHUB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
-| GITHUB_DISPLAY_NAME | The text displayed on the GitHub OAuth2 login button | GitHub |
+| GITHUB_DISPLAY_NAME | The text displayed on the GitHub OAuth2 login button | Sign in with GitHub |
 
 ###### GitLab
 
@@ -82,7 +82,7 @@ First [configure GitLab as an OAuth2 authentication identity provider](https://d
 | GITLAB_CLIENT_SECRET | The OAuth 2 Client Secret from the Secret field. | '' |
 | GITLAB_DOMAIN | The GitLab server to authenticate against. | https://gitlab.com |
 | GITLAB_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
-| GITLAB_DISPLAY_NAME | The text displayed on the GitLab OAuth2 login button | GitLab |
+| GITLAB_DISPLAY_NAME | The text displayed on the GitLab OAuth2 login button | Sign in with GitLab |
 
 ###### Google
 
@@ -94,7 +94,7 @@ Begin by [creating OAuth2 credentials for your Google project](https://developer
 | GOOGLE_CLIENT_ID | The client ID from your Google OAuth2 credentials. | '' |
 | GOOGLE_CLIENT_SECRET | The client secret from your Google OAuth2 credentials. | '' |
 | GOOGLE_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
-| GOOGLE_DISPLAY_NAME | The text displayed on the Google OAuth2 login button | Google |
+| GOOGLE_DISPLAY_NAME | The text displayed on the Google OAuth2 login button | Sign in with Google |
 
 ###### PingIdentity
 
@@ -110,7 +110,7 @@ Begin by [creating OAuth2 client in your PingIdentity console](https://docs.ping
 | PINGIDENTITY_TOKEN_ENDPOINT | The URL fragment to the endpoint to ask for the Token | '/as/token.oauth2' |
 | PINGIDENTITY_USER_ENDPOINT | The URL fragment to the endpoint to ask for the user's information with the token | '/idp/userinfo.openid' |
 | PINGIDENTITY_AUTO_REGISTER_NEW_USERS | Whether to automatically register a new user or provide them the Registration form | false |
-| PINGIDENTITY_DISPLAY_NAME | The text displayed on the PingIdentity OAuth2 login button | PingIdentity |
+| PINGIDENTITY_DISPLAY_NAME | The text displayed on the PingIdentity OAuth2 login button | Sign in with PingIdentity |
 
 ## SAML2
 
@@ -122,6 +122,6 @@ Relevant `.env` variables for CDash SAML2 authentication:
 | Variable | Description | Default |
 | -------- |------------ | ------- |
 | SAML2_ENABLED | Whether or not to use SAML2 authentication. | false |
-| SAML2_LOGIN_TEXT | What text to display in the SAML2 login button. | SAML2 |
+| SAML2_LOGIN_TEXT | What text to display in the SAML2 login button. | Sign in with SAML2 |
 | SAML2_AUTO_REGISTER_NEW_USERS | Whether or not to automatically register new users upon first login. | false |
 | SAML2_PROXY_VARS | Whether or not to trust the X-Forwarded-Proto HTTP header | false |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18574,19 +18574,19 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:832::__construct() has parameter $response with no type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:833::__construct() has parameter $response with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:832::getSent() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:833::getSent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:832::read() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:833::read() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -18814,7 +18814,7 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:832::$read has no type specified.
+			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:833::$read has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php

--- a/tests/Feature/CDashTest.php
+++ b/tests/Feature/CDashTest.php
@@ -88,7 +88,8 @@ class CDashTest extends TestCase
         URL::forceRootUrl('http://localhost');
         Config::set('cdash.login_field', 'User');
         $this->get('/login')
-            ->assertSeeText('User:');
+            ->assertSeeText('User')
+            ->assertDontSeeText('Email');
     }
 
     public function testViewProjectsRedirectNoPublicProjects(): void

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -50,7 +50,7 @@ class LoginAndRegistration extends TestCase
         // Verify that the normal login form is shown by default.
         $response = $this->get('/login');
         $response->assertOk();
-        $response->assertSeeText('Email:');
+        $response->assertSeeText('Email');
     }
 
     public function testRegisterUser(): void


### PR DESCRIPTION
This PR brings a brand new login page, matching the new UI elements being introduced elsewhere across the site.

Before:
<img width="2822" height="658" alt="image" src="https://github.com/user-attachments/assets/b213ec7d-f560-4deb-bf2d-e3d4a041386c" />

After:
<img width="2834" height="1944" alt="image" src="https://github.com/user-attachments/assets/596d3d9d-2bd8-40b5-9c32-9e0d464fc791" />
