### PR TITLE
Restructure legacy CSS files

### DIFF
--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -1,0 +1,4 @@
+@import 'bootstrap/dist/css/bootstrap.css';
+@import 'jquery-ui-dist/jquery-ui.css';
+@import 'nvd3/build/nv.d3.min.css';
+@import 'bootstrap.min.css';

--- a/resources/css/legacy_vue.css
+++ b/resources/css/legacy_vue.css
@@ -1,3 +1,5 @@
+@import 'legacy.css';
+
 .tooltip {
   display: block !important;
   z-index: 10000;

--- a/resources/views/cdash.blade.php
+++ b/resources/views/cdash.blade.php
@@ -30,24 +30,20 @@
 
     {{-- Framework-specific details --}}
     @if(isset($angular) && $angular === true)
-        <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_3rdparty.css')) }}"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy.css')) }}"/>
         <link rel="stylesheet" type="text/css" href="{{ asset(mix(get_css_file())) }} }}"/>
-        <link rel="stylesheet" href="{{ asset(mix('assets/css/bootstrap.min.css')) }}"/>
         <script src="{{ asset(mix('assets/js/legacy.js')) }}"></script>
     @elseif(isset($vue) && $vue === true)
         <link rel="stylesheet" type="text/css" href="{{ asset(mix(get_css_file())) }}"/>
         @if(isset($daisyui) && $daisyui === true)
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/app.css')) }}"/>
         @else
-            <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_3rdparty.css')) }}"/>
-            <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/vue_common.css')) }}"/>
-            <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/bootstrap.min.css')) }}"/>
+            <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_vue.css')) }}"/>
         @endif
         <script src="{{ asset(mix('assets/js/app.js')) }}" type="text/javascript" defer></script>
     @else
-        <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy_3rdparty.css')) }}"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/legacy.css')) }}"/>
         <link rel="stylesheet" type="text/css" href="{{ asset(mix(get_css_file())) }}"/>
-        <link rel="stylesheet" href="{{ asset(mix('assets/css/bootstrap.min.css')) }}"/>
         <script src="{{ asset(mix('assets/js/legacy.js')) }}"></script>
         @if(str_contains(request()->url(), 'viewCoverage.php')) {{-- This last XSL page needs special treatment... --}}
             <link rel="stylesheet" type="text/css" href="{{ asset(mix('assets/css/jquery.dataTables.css')) }}"/>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -26,15 +26,9 @@ mix.copy('resources/js/angular/views/partials/*.html', 'public/assets/js/angular
 mix.css('resources/css/cdash.css', 'public/assets/css/cdash.css');
 mix.css('resources/css/colorblind.css', 'public/assets/css/colorblind.css');
 mix.css('resources/css/jquery.dataTables.css', 'public/assets/css/jquery.dataTables.css');
-mix.css('resources/css/bootstrap.min.css', 'public/assets/css/bootstrap.min.css');
-mix.css('resources/css/vue_common.css', 'public/assets/css/vue_common.css');
 
-mix.styles([
-  'node_modules/bootstrap/dist/css/bootstrap.css',
-  'node_modules/jquery-ui-dist/jquery-ui.css',
-  'node_modules/nvd3/build/nv.d3.min.css',
-], 'public/assets/css/legacy_3rdparty.css');
-
+mix.css('resources/css/legacy.css', 'public/assets/css/legacy.css');
+mix.css('resources/css/legacy_vue.css', 'public/assets/css/legacy_vue.css');
 mix.sass('resources/sass/app.scss', 'public/assets/css/app.css');
 
 mix.copy('resources/js/angular/jquery.dataTables.min.js', 'public/assets/js/jquery.dataTables.min.js');


### PR DESCRIPTION
More incremental progress towards an eventual switch from Laravel Mix to Vite, by reducing the number of CSS targets to be built.