### PR TITLE
Fix test namespaces

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -83,13 +83,13 @@ endif()
 # Tests from this point to the next cdash_install() are expected to not need database or other
 # system resources.
 
-add_unit_test(/Unit/app/ControllerNameTest)
+add_unit_test(/Unit/ControllerNameTest)
 
-add_unit_test(/Unit/app/FillableAttributesTest)
+add_unit_test(/Unit/FillableAttributesTest)
 
-add_unit_test(/Unit/app/Validators/PasswordTest)
+add_unit_test(/Unit/Validators/PasswordTest)
 
-add_unit_test(/Unit/app/Middleware/InternalTest)
+add_unit_test(/Unit/Middleware/InternalTest)
 
 # TODO: Is this test useful now?
 add_legacy_unit_test(/PHPUnitTest)
@@ -98,7 +98,7 @@ add_legacy_unit_test(/CDash/ServiceContainer)
 
 add_legacy_unit_test(/CDash/LinkifyCompilerOutput)
 
-add_unit_test(/Unit/app/Console/Command/ValidateXmlCommandTest)
+add_unit_test(/Unit/Console/Command/ValidateXmlCommandTest)
 
 add_php_test(seconds_from_interval)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27769,28 +27769,28 @@ parameters:
 			rawMessage: 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type'
 			identifier: phpunit.assertEquals
 			count: 2
-			path: tests/Unit/app/Console/Command/ValidateXmlCommandTest.php
+			path: tests/Unit/Console/Command/ValidateXmlCommandTest.php
 
 		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, array<string>|string given.'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/app/ControllerNameTest.php
+			path: tests/Unit/ControllerNameTest.php
 
 		-
 			rawMessage: 'Parameter #2 ...$arrays of function array_merge expects array, mixed given.'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/app/ControllerNameTest.php
+			path: tests/Unit/ControllerNameTest.php
 
 		-
 			rawMessage: 'Parameter #3 $subject of function str_replace expects array<string>|string, mixed given.'
 			identifier: argument.type
 			count: 1
-			path: tests/Unit/app/ControllerNameTest.php
+			path: tests/Unit/ControllerNameTest.php
 
 		-
 			rawMessage: 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type'
 			identifier: phpunit.assertEquals
 			count: 1
-			path: tests/Unit/app/Middleware/InternalTest.php
+			path: tests/Unit/Middleware/InternalTest.php

--- a/tests/Feature/Mail/AuthTokenExpiredTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiredTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Jobs;
+namespace Tests\Feature\Mail;
 
 use App\Mail\AuthTokenExpired;
 use App\Models\AuthToken;

--- a/tests/Feature/Mail/AuthTokenExpiringTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiringTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Jobs;
+namespace Tests\Feature\Mail;
 
 use App\Mail\AuthTokenExpiring;
 use App\Models\AuthToken;

--- a/tests/Feature/Submission/Tests/TestXMLTest.php
+++ b/tests/Feature/Submission/Tests/TestXMLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Submission\Instrumentation;
+namespace Tests\Feature\Submission\Tests;
 
 use App\Models\Project;
 use Tests\TestCase;

--- a/tests/Unit/Console/Command/ValidateXmlCommandTest.php
+++ b/tests/Unit/Console/Command/ValidateXmlCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Unit\Console\Command;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;

--- a/tests/Unit/ControllerNameTest.php
+++ b/tests/Unit/ControllerNameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\app;
+namespace Tests\Unit;
 
 use Tests\TestCase;
 use Tests\Traits\IteratesControllers;

--- a/tests/Unit/FillableAttributesTest.php
+++ b/tests/Unit/FillableAttributesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\app;
+namespace Tests\Unit;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\MassAssignmentException;

--- a/tests/Unit/Middleware/InternalTest.php
+++ b/tests/Unit/Middleware/InternalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\app\Middleware;
+namespace Tests\Unit\Middleware;
 
 use App\Http\Middleware\Internal;
 use Illuminate\Http\Request;

--- a/tests/Unit/Validators/PasswordTest.php
+++ b/tests/Unit/Validators/PasswordTest.php
@@ -15,7 +15,7 @@
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-namespace App\Validators;
+namespace Tests\Unit\Validators;
 
 use App\Validators\Password as PasswordValidator;
 use Config;


### PR DESCRIPTION
Some of the tests have incorrect namespaces.  This PR fixes those discrepancies and reorganizes the contents of the unit test directory.