### PR TITLE
Improve query plans for test measurement GraphQL field

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -553,13 +553,9 @@ type Test {
 
   details: String! @filterable
 
-  """
-  Test measurements for this test, sorted in descending order so newer results
-  appear first when using paginated queries.
-  """
   testMeasurements(
     filters: _ @filter
-  ): [TestMeasurement!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  ): [TestMeasurement!]! @hasMany @orderBy(column: "id", direction: DESC)
 
   labels(
     filters: _ @filter

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -159,13 +159,13 @@ parameters:
 		-
 			rawMessage: Access to an undefined property GraphQL\Language\AST\ListTypeNode|GraphQL\Language\AST\NamedTypeNode|GraphQL\Language\AST\NonNullTypeNode::$name.
 			identifier: property.notFound
-			count: 4
+			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
 			rawMessage: Access to an undefined property GraphQL\Language\AST\ListTypeNode|GraphQL\Language\AST\NamedTypeNode|GraphQL\Language\AST\NonNullTypeNode::$type.
 			identifier: property.notFound
-			count: 4
+			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -123,14 +123,10 @@ export default {
                   details
                   runningTime
                   timeStatusCategory
-                  testMeasurements(filters: $measurementFilters, first: 100) {
-                    edges {
-                      node {
-                        id
-                        name
-                        value
-                      }
-                    }
+                  testMeasurements(filters: $measurementFilters) {
+                    id
+                    name
+                    value
                   }
                 }
               }
@@ -148,14 +144,10 @@ export default {
                         details
                         runningTime
                         timeStatusCategory
-                        testMeasurements(filters: $measurementFilters, first: 100) {
-                          edges {
-                            node {
-                              id
-                              name
-                              value
-                            }
-                          }
+                        testMeasurements(filters: $measurementFilters) {
+                          id
+                          name
+                          value
                         }
                       }
                     }
@@ -254,7 +246,7 @@ export default {
           },
           ...this.pinnedMeasurements.reduce((acc, name) => ({
             ...acc,
-            [name]: edge.node.testMeasurements.edges.find((measurementEdge) => measurementEdge.node.name === name)?.node.value ?? '',
+            [name]: edge.node.testMeasurements.find((measurementEdge) => measurementEdge.name === name)?.value ?? '',
           }), {}),
         };
       });

--- a/tests/Feature/GraphQL/TestMeasurementTypeTest.php
+++ b/tests/Feature/GraphQL/TestMeasurementTypeTest.php
@@ -82,13 +82,9 @@ class TestMeasurementTypeTest extends TestCase
                                         node {
                                             name
                                             testMeasurements {
-                                                edges {
-                                                    node {
-                                                        name
-                                                        type
-                                                        value
-                                                    }
-                                                }
+                                                name
+                                                type
+                                                value
                                             }
                                         }
                                     }
@@ -114,21 +110,15 @@ class TestMeasurementTypeTest extends TestCase
                                                 'node' => [
                                                     'name' => 'test1',
                                                     'testMeasurements' => [
-                                                        'edges' => [
-                                                            [
-                                                                'node' => [
-                                                                    'name' => 'measurement 2',
-                                                                    'type' => 'numeric/double',
-                                                                    'value' => '6',
-                                                                ],
-                                                            ],
-                                                            [
-                                                                'node' => [
-                                                                    'name' => 'measurement 1',
-                                                                    'type' => 'text/string',
-                                                                    'value' => 'test',
-                                                                ],
-                                                            ],
+                                                        [
+                                                            'name' => 'measurement 2',
+                                                            'type' => 'numeric/double',
+                                                            'value' => '6',
+                                                        ],
+                                                        [
+                                                            'name' => 'measurement 1',
+                                                            'type' => 'text/string',
+                                                            'value' => 'test',
                                                         ],
                                                     ],
                                                 ],


### PR DESCRIPTION
Our GraphQL backend, Lighthouse, currently requires fields using relay-style pagination to specify a limit or fall back to the default limit.  This creates extremely inefficient queries when nested paginated fields are used, leading to substantial slowness on the new tests page.  It's very unlikely that any CDash users will actually want to paginate test measurement results, so this PR makes the field non-paginated and adds the necessary infrastructure to the filtering system to handle such fields.  It would be beneficial to upstream a change to Lighthouse to allow unlimited results for paginated fields.