### PR TITLE
Add type annotations to most handler properties

### DIFF
--- a/app/Http/Submission/Handlers/AbstractXmlHandler.php
+++ b/app/Http/Submission/Handlers/AbstractXmlHandler.php
@@ -35,9 +35,9 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
     private Stack $stack;
     protected bool $Append = false;
     protected Site $Site;
-    protected $SubProjectName;
+    protected string $SubProjectName = '';
 
-    private $ModelFactory;
+    private ServiceContainer $ModelFactory;
 
     protected static ?string $schema_file = null;
 
@@ -46,6 +46,7 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
         parent::__construct($init);
 
         $this->stack = new Stack();
+        $this->ModelFactory = ServiceContainer::getInstance();
     }
 
     /**
@@ -186,9 +187,6 @@ abstract class AbstractXmlHandler extends AbstractSubmissionHandler
 
     protected function getModelFactory(): ServiceContainer
     {
-        if (!$this->ModelFactory) {
-            $this->ModelFactory = ServiceContainer::getInstance();
-        }
         return $this->ModelFactory;
     }
 

--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -33,29 +33,30 @@ use stdClass;
 
 class BazelJSONHandler extends AbstractSubmissionHandler
 {
-    private $Builds = [];
-    private $BuildErrors = [
+    /** @var array<string,Build> */
+    private array $Builds = [];
+    private array $BuildErrors = [
         '' => [],
     ];
-    private $CommandLine = '';
+    private string $CommandLine = '';
     private array $Configures = [];
     private ?bool $_HasSubProjects = null;
-    private $NumTestsPassed = [
+    private array $NumTestsPassed = [
         '' => 0,
     ];
-    private $NumTestsFailed = [
+    private array $NumTestsFailed = [
         '' => 0,
     ];
-    private $NumTestsNotRun = [
+    private array $NumTestsNotRun = [
         '' => 0,
     ];
-    private $ParentBuild;
-    private $RecordingTestOutput = false;
-    private $RecordingTestSummary = false;
-    private $Tests = [];
-    private $TestsOutput = [];
-    private $TestName = '';
-    private $ParseConfigure = true;
+    private Build $ParentBuild;
+    private bool $RecordingTestOutput = false;
+    private bool $RecordingTestSummary = false;
+    private array $Tests = [];
+    private array $TestsOutput = [];
+    private string $TestName = '';
+    private bool $ParseConfigure = true;
     private ?BuildErrorFilter $BuildErrorFilter = null;
 
     public function __construct(Build $build)
@@ -661,7 +662,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         // Initialize the child build.
         $child_build = new Build();
         $child_build->Generator = $this->ParentBuild->Generator;
-        $child_build->GroupId = (int) $this->ParentBuild->GroupId;
+        $child_build->GroupId = $this->ParentBuild->GroupId;
         $child_build->Name = $this->ParentBuild->Name;
         $child_build->ProjectId = $this->ParentBuild->ProjectId;
         $child_build->SiteId = $this->ParentBuild->SiteId;

--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -38,19 +38,19 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp = 0;
-    private $EndTimeStamp = 0;
+    private int $StartTimeStamp = 0;
+    private int $EndTimeStamp = 0;
     private array $Builds = [];
     private array $BuildInformation;
     // Map SubProjects to Labels
     private array $SubProjects = [];
-    private $Configure;
-    private $Label;
+    private BuildConfigure $Configure;
+    private Label $Label;
     private bool $Notified = false;
     private string $BuildName;
     private string $BuildStamp;
     private string $Generator;
-    private $PullRequest;
+    private string $PullRequest = '';
     protected static ?string $schema_file = '/app/Validators/Schemas/Configure.xsd';
 
     public function __construct(Project $project)
@@ -75,7 +75,6 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
             $this->BuildStamp = '';
             $this->SubProjectName = '';
             $this->Generator = '';
-            $this->PullRequest = '';
 
             // Fill in the attribute
             foreach ($attributes as $key => $value) {
@@ -86,7 +85,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                 } elseif ($key === 'GENERATOR') {
                     $this->Generator = $value;
                 } elseif ($key === 'CHANGEID') {
-                    $this->PullRequest = $value;
+                    $this->PullRequest = (string) $value;
                 } else {
                     $siteInformation->SetValue($key, $value);
                     switch ($key) {
@@ -226,7 +225,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
 
                 // Record configure duration with the build.
                 $duration = $this->EndTimeStamp - $this->StartTimeStamp;
-                $build->SetConfigureDuration((int) $duration, !$all_at_once);
+                $build->SetConfigureDuration($duration, !$all_at_once);
                 if ($all_at_once && !$parent_duration_set) {
                     $parent_build = $this->getModelFactory()->create(Build::class);
                     $parent_build->Id = $build->GetParentId();
@@ -261,10 +260,10 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
         if ($this->currentPathMatches('site.configure.*')) {
             switch ($element) {
                 case 'STARTCONFIGURETIME':
-                    $this->StartTimeStamp = $data;
+                    $this->StartTimeStamp = (int) $data;
                     break;
                 case 'ENDCONFIGURETIME':
-                    $this->EndTimeStamp = $data;
+                    $this->EndTimeStamp = (int) $data;
                     break;
                 case 'BUILDCOMMAND':
                     $this->Configure->Command .= $data;

--- a/app/Http/Submission/Handlers/CoverageHandler.php
+++ b/app/Http/Submission/Handlers/CoverageHandler.php
@@ -34,8 +34,8 @@ class CoverageHandler extends AbstractXmlHandler
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
 
     private Coverage $Coverage;
     private array $Coverages = [];
@@ -200,10 +200,10 @@ class CoverageHandler extends AbstractXmlHandler
         if ($parent === 'COVERAGE') {
             switch ($element) {
                 case 'STARTTIME':
-                    $this->StartTimeStamp = $data;
+                    $this->StartTimeStamp = (int) $data;
                     break;
                 case 'ENDTIME':
-                    $this->EndTimeStamp = $data;
+                    $this->EndTimeStamp = (int) $data;
                     break;
             }
         } elseif ($parent === 'FILE') {

--- a/app/Http/Submission/Handlers/CoverageJUnitHandler.php
+++ b/app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -31,8 +31,8 @@ class CoverageJUnitHandler extends AbstractXmlHandler
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
 
     private Coverage $Coverage;
     private CoverageFile $CoverageFile;
@@ -102,8 +102,8 @@ class CoverageJUnitHandler extends AbstractXmlHandler
             $this->Label = new Label();
         } elseif ($parent === 'REPORT' && $name === 'SESSIONINFO') {
             // timestamp are in miliseconds
-            $this->StartTimeStamp = substr($attributes['START'], 0, -3);
-            $this->EndTimeStamp = substr($attributes['DUMP'], 0, -3);
+            $this->StartTimeStamp = (int) substr($attributes['START'], 0, -3);
+            $this->EndTimeStamp = (int) substr($attributes['DUMP'], 0, -3);
         } elseif ($parent === 'REPORT' && $name === 'COUNTER') {
             switch ($attributes['TYPE']) {
                 case 'COMPLEXITY':

--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -28,8 +28,8 @@ use CDash\Model\SubProject;
 
 class CoverageLogHandler extends AbstractXmlHandler
 {
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
 
     private CoverageFile $CurrentCoverageFile;
     private CoverageFileLog $CurrentCoverageFileLog;
@@ -164,10 +164,10 @@ class CoverageLogHandler extends AbstractXmlHandler
                 $this->CurrentLine .= $data;
                 break;
             case 'STARTTIME':
-                $this->StartTimeStamp = $data;
+                $this->StartTimeStamp = (int) $data;
                 break;
             case 'ENDTIME':
-                $this->EndTimeStamp = $data;
+                $this->EndTimeStamp = (int) $data;
                 break;
         }
     }

--- a/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+++ b/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -40,23 +40,23 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp;
-    private $EndTimeStamp;
-    private $Checker;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
+    private string $Checker;
 
     private DynamicAnalysis $DynamicAnalysis;
     private DynamicAnalysisDefect $DynamicAnalysisDefect;
-    private $DynamicAnalysisSummaries = [];
-    private $Label;
+    private array $DynamicAnalysisSummaries = [];
+    private Label $Label;
 
-    private $Builds = [];
+    private array $Builds = [];
     private array $BuildInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/DynamicAnalysis.xsd';
 
     // Map SubProjects to Labels
-    private $SubProjects = [];
-    private $TestSubProjectName;
+    private array $SubProjects = [];
+    private string $TestSubProjectName = '';
 
     /** Constructor */
     public function __construct(Project $project)
@@ -222,10 +222,10 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
         if ($parent === 'DYNAMICANALYSIS') {
             switch ($element) {
                 case 'STARTTESTTIME':
-                    $this->StartTimeStamp = $data;
+                    $this->StartTimeStamp = (int) $data;
                     break;
                 case 'ENDTESTTIME':
-                    $this->EndTimeStamp = $data;
+                    $this->EndTimeStamp = (int) $data;
                     break;
             }
         } elseif ($parent === 'TEST') {

--- a/app/Http/Submission/Handlers/GcovTarHandler.php
+++ b/app/Http/Submission/Handlers/GcovTarHandler.php
@@ -35,8 +35,8 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 class GcovTarHandler extends AbstractSubmissionHandler
 {
     private CoverageSummary $CoverageSummary;
-    private $SourceDirectory = '';
-    private $BinaryDirectory = '';
+    private string $SourceDirectory = '';
+    private string $BinaryDirectory = '';
     private array $Labels = [];
     private ?string $SubProjectPath = null;
     private array $SubProjectSummaries = [];

--- a/app/Http/Submission/Handlers/NoteHandler.php
+++ b/app/Http/Submission/Handlers/NoteHandler.php
@@ -32,7 +32,7 @@ class NoteHandler extends AbstractXmlHandler
     private bool $AdjustStartTime = false;
     private NoteCreator $NoteCreator;
     protected static ?string $schema_file = '/app/Validators/Schemas/Notes.xsd';
-    protected $Timestamp = 0;
+    protected int $Timestamp = 0;
 
     /** Constructor */
     public function __construct(Project $project)
@@ -159,7 +159,7 @@ class NoteHandler extends AbstractXmlHandler
                     // Prefer the <Time> element if it wasn't specified in
                     // scientific notation (CTest v3.11.0 or newer).
                     if (!str_contains($data, 'e+')) {
-                        $this->Timestamp = $data;
+                        $this->Timestamp = (int) $data;
                         $this->AdjustStartTime = false;
                     }
                     break;

--- a/app/Http/Submission/Handlers/OpenCoverTarHandler.php
+++ b/app/Http/Submission/Handlers/OpenCoverTarHandler.php
@@ -38,7 +38,7 @@ class OpenCoverTarHandler extends AbstractXmlHandler
     protected bool $ParseCSFiles = true;
     protected $coverageFile;
     protected $coverageFileLog;
-    protected $currentModule;
+    protected array $currentModule;
     protected string $tarDir;
 
     public function __construct(Build $build)

--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -31,13 +31,12 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
     use UpdatesSiteInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/Test.xsd';
-    private $StartTimeStamp = 0;
-    private $EndTimeStamp = 0;
+    private int $StartTimeStamp = 0;
+    private int $EndTimeStamp = 0;
 
-    private $TestMeasurement;
-    private $Label;
+    private TestMeasurement $TestMeasurement;
+    private Label $Label;
 
-    // TODO: Evaluate whether this is needed
     private array $Labels;
 
     private TestCreator $TestCreator;
@@ -245,7 +244,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                 if ($this->StartTimeStamp > 0 && $this->EndTimeStamp > 0) {
                     // Update test duration in the Build table.
                     $duration = $this->EndTimeStamp - $this->StartTimeStamp;
-                    $build->UpdateTestDuration((int) $duration, !$all_at_once);
+                    $build->UpdateTestDuration($duration, !$all_at_once);
                     if ($all_at_once && !$parent_duration_set) {
                         $parent_build = $factory->create(Build::class);
                         $parent_build->Id = $build->GetParentId();
@@ -269,10 +268,10 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
         if ($parent === 'TESTING') {
             switch ($element) {
                 case 'STARTTESTTIME':
-                    $this->StartTimeStamp = $data;
+                    $this->StartTimeStamp = (int) $data;
                     break;
                 case 'ENDTESTTIME':
-                    $this->EndTimeStamp = $data;
+                    $this->EndTimeStamp = (int) $data;
                     break;
             }
         } elseif ($parent === 'TEST') {
@@ -305,10 +304,8 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                     break;
                 }
             }
-            if (is_a($this->Label, Label::class)) {
-                $this->Label->Text = $data;
-                $this->Labels[] = $this->Label;
-            }
+            $this->Label->Text = $data;
+            $this->Labels[] = $this->Label;
         }
     }
 

--- a/app/Http/Submission/Handlers/TestingJUnitHandler.php
+++ b/app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -28,8 +28,8 @@ class TestingJUnitHandler extends AbstractXmlHandler
 {
     use UpdatesSiteInformation;
 
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
     // Should we update the end time of the build?
     private bool $UpdateEndTime = false;
     // The buildgroup to submit to (defaults to Nightly).
@@ -43,7 +43,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
     private string $TestProperties = '';
     private bool $HasSiteTag = false;
     private bool $BuildAdded = false;
-    private $TotalTestDuration = 0;
+    private int $TotalTestDuration = 0;
     protected TestCreator $TestCreator;
 
     /** Constructor */
@@ -189,8 +189,8 @@ class TestingJUnitHandler extends AbstractXmlHandler
             }
 
             $this->StartTimeStamp = $timestamp;
-            $this->EndTimeStamp = $this->StartTimeStamp + $attributes['TIME'];
-            $this->TotalTestDuration += $attributes['TIME'];
+            $this->EndTimeStamp = $this->StartTimeStamp + (int) $attributes['TIME'];
+            $this->TotalTestDuration += (int) $attributes['TIME'];
         }
     }
 
@@ -218,7 +218,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
             // Record this test in the database.
             $this->TestCreator->create($this->Build);
         } elseif ($name === 'SITE' || ($this->HasSiteTag == false && $name === 'TESTSUITE')) {
-            if (strlen($this->EndTimeStamp) > 0 && $this->UpdateEndTime) {
+            if (isset($this->EndTimeStamp) && $this->UpdateEndTime) {
                 $end_time = gmdate(FMT_DATETIME, $this->EndTimeStamp); // The EndTimeStamp
                 $this->Build->UpdateEndTime($end_time);
             }

--- a/app/Http/Submission/Handlers/UpdateHandler.php
+++ b/app/Http/Submission/Handlers/UpdateHandler.php
@@ -41,8 +41,8 @@ use Illuminate\Support\Carbon;
  *  In case of a lot of updates this might take up some memory */
 class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {
-    private $StartTimeStamp;
-    private $EndTimeStamp;
+    private int $StartTimeStamp;
+    private int $EndTimeStamp;
     private BuildUpdate $Update;
     private BuildUpdateFile $UpdateFile;
     protected static ?string $schema_file = '/app/Validators/Schemas/Update.xsd';
@@ -169,7 +169,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
                     $this->Build->SetPullRequest($data);
                     break;
                 case 'ENDTIME':
-                    $this->EndTimeStamp = $data;
+                    $this->EndTimeStamp = (int) $data;
                     break;
                 case 'PATH':
                     $this->Update->Path = $data;
@@ -185,7 +185,7 @@ class UpdateHandler extends AbstractXmlHandler implements ActionableBuildInterfa
                     $this->Site = Site::firstOrCreate(['name' => $sitename], ['name' => $sitename]);
                     break;
                 case 'STARTTIME':
-                    $this->StartTimeStamp = $data;
+                    $this->StartTimeStamp = (int) $data;
                     break;
                 case 'UPDATECOMMAND':
                     $this->Update->Command .= $data;

--- a/app/Http/Submission/Handlers/UploadHandler.php
+++ b/app/Http/Submission/Handlers/UploadHandler.php
@@ -51,7 +51,7 @@ class UploadHandler extends AbstractXmlHandler
     private string $TmpFilename = '';
     private $Base64TmpFileWriteHandle = 0;
     private string $Base64TmpFilename = '';
-    private $Label;
+    private Label $Label;
     private int $Timestamp = 0;
     private bool $BuildInitialized = false;
     protected static ?string $schema_file = '/app/Validators/Schemas/Upload.xsd';
@@ -345,7 +345,7 @@ class UploadHandler extends AbstractXmlHandler
         $this->Build->GetIdFromName($this->SubProjectName);
         $this->Build->RemoveIfDone();
 
-        if ($this->Label) {
+        if (isset($this->Label)) {
             $this->Build->AddLabel($this->Label);
         }
 
@@ -355,7 +355,7 @@ class UploadHandler extends AbstractXmlHandler
             $this->Build->InsertErrors = false;
             SubmissionUtils::add_build($this->Build);
         } else {
-            if ($this->Label) {
+            if (isset($this->Label)) {
                 $this->Build->InsertLabelAssociations();
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2905,18 +2905,6 @@ parameters:
 			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\AbstractXmlHandler::$ModelFactory has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\AbstractXmlHandler::$SubProjectName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/AbstractXmlHandler.php
-
-		-
 			rawMessage: Access to an undefined property object::$details.
 			identifier: property.notFound
 			count: 1
@@ -3000,6 +2988,12 @@ parameters:
 		-
 			rawMessage: 'Cannot access offset int<min, -1>|int<1, max>|non-falsy-string on mixed.'
 			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\BazelJSONHandler has an uninitialized property $ParentBuild. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
@@ -3136,6 +3130,12 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
+			rawMessage: 'Only numeric types are allowed in +, int|false given on the left side.'
+			identifier: plus.leftNonNumeric
+			count: 3
+			path: app/Http/Submission/Handlers/BazelJSONHandler.php
+
+		-
 			rawMessage: 'Parameter #1 $array of function array_keys expects array, mixed given.'
 			identifier: argument.type
 			count: 1
@@ -3172,20 +3172,14 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$BuildErrors has no type specified.
-			identifier: missingType.property
+			rawMessage: Possibly invalid array key type mixed.
+			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$Builds has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$CommandLine has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$BuildErrors type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
@@ -3196,62 +3190,32 @@ parameters:
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsFailed has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsFailed type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsNotRun has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsNotRun type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsPassed has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$NumTestsPassed type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$ParentBuild has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$Tests type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$ParseConfigure has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$RecordingTestOutput has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$RecordingTestSummary has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$TestName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$Tests has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BazelJSONHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$TestsOutput has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BazelJSONHandler::$TestsOutput type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BazelJSONHandler.php
 
@@ -3274,20 +3238,8 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: 'Call to an undefined method object::AddLabel().'
-			identifier: method.notFound
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
 			rawMessage: 'Call to function in_array() requires parameter #3 to be set.'
 			identifier: function.strict
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: 'Cannot access offset '''' on 0|0.0|''''|''0''|array{}|false|null.'
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
@@ -3322,7 +3274,19 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $Error. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
 			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $Generator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\BuildHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
@@ -3406,87 +3370,39 @@ parameters:
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildCommand has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildGroup has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildGroup is unused.
-			identifier: property.unused
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$BuildInformation type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Builds has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Builds type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Labels type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Error has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$SubProjects type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$ErrorSubProjectName has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Label has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$Labels has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$PullRequest has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\BuildHandler::$SubProjects has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/BuildHandler.php
-
-		-
-			rawMessage: Variable property access on mixed.
+			rawMessage: Variable property access on CDash\Model\BuildError|CDash\Model\BuildFailure.
 			identifier: property.dynamicName
-			count: 12
+			count: 3
+			path: app/Http/Submission/Handlers/BuildHandler.php
+
+		-
+			rawMessage: Variable property access on CDash\Model\BuildFailure.
+			identifier: property.dynamicName
+			count: 9
 			path: app/Http/Submission/Handlers/BuildHandler.php
 
 		-
@@ -3544,7 +3460,19 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $Configure. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
 			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $Generator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/ConfigureHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\ConfigureHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
@@ -3628,18 +3556,6 @@ parameters:
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
 		-
-			rawMessage: 'Parameter #1 $buildConfigure of method CDash\Model\Build::SetBuildConfigure() expects CDash\Model\BuildConfigure, object given.'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: 'Parameter #1 $duration of method CDash\Model\Build::SetConfigureDuration() expects int, (float|int) given.'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$BuildInformation type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
 			count: 1
@@ -3648,36 +3564,6 @@ parameters:
 		-
 			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Builds type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Configure has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$Label has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$PullRequest has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/ConfigureHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\ConfigureHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/ConfigureHandler.php
 
@@ -3715,7 +3601,19 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
 			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageHandler.php
@@ -3787,18 +3685,6 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageHandler.php
-
-		-
 			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $Coverage. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
@@ -3811,7 +3697,19 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
 			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageJUnitHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -3871,18 +3769,6 @@ parameters:
 			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageJUnitHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageJUnitHandler.php
-
-		-
 			rawMessage: Access to an undefined property object::$Id.
 			identifier: property.notFound
 			count: 1
@@ -3911,6 +3797,18 @@ parameters:
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\CoverageLogHandler has an uninitialized property $CurrentCoverageFileLog. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageLogHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/CoverageLogHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\CoverageLogHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -3972,18 +3870,6 @@ parameters:
 		-
 			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$CoverageFiles type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/CoverageLogHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\CoverageLogHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/CoverageLogHandler.php
 
@@ -4090,13 +3976,13 @@ parameters:
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: 'Cannot access offset mixed on 0|0.0|''''|''0''|array{}|false|null.'
-			identifier: offsetAccess.nonOffsetAccessible
+			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $BuildInformation. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $BuildInformation. Give it default value or assign it in the constructor.
+			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $Checker. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -4109,6 +3995,24 @@ parameters:
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $DynamicAnalysisDefect. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\DynamicAnalysisHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -4186,50 +4090,26 @@ parameters:
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$Builds has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$Builds type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$Checker has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$DynamicAnalysisSummaries type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$DynamicAnalysisSummaries has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$SubProjects type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$Label has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$SubProjects has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$TestSubProjectName has no type specified.
-			identifier: missingType.property
+			rawMessage: 'Property App\Http\Submission\Handlers\DynamicAnalysisHandler::$TestSubProjectName (string) does not accept (int|string).'
+			identifier: assign.propertyType
 			count: 1
 			path: app/Http/Submission/Handlers/DynamicAnalysisHandler.php
 
@@ -4384,12 +4264,6 @@ parameters:
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$BinaryDirectory has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/GcovTarHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$Labels type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
 			count: 1
@@ -4397,12 +4271,6 @@ parameters:
 
 		-
 			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$PreviousAggregateParentId has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/GcovTarHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\GcovTarHandler::$SourceDirectory has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/GcovTarHandler.php
@@ -4714,12 +4582,6 @@ parameters:
 			path: app/Http/Submission/Handlers/NoteHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\NoteHandler::$Timestamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/NoteHandler.php
-
-		-
 			rawMessage: 'Argument of an invalid type list<string>|false supplied for foreach, only iterables are supported.'
 			identifier: foreach.nonIterable
 			count: 1
@@ -4746,6 +4608,12 @@ parameters:
 		-
 			rawMessage: 'Cannot call method getPath() on mixed.'
 			identifier: method.nonObject
+			count: 1
+			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\OpenCoverTarHandler has an uninitialized property $currentModule. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
@@ -4942,8 +4810,8 @@ parameters:
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$currentModule has no type specified.
-			identifier: missingType.property
+			rawMessage: Property App\Http\Submission\Handlers\OpenCoverTarHandler::$currentModule type has no value type specified in iterable type array.
+			identifier: missingType.iterableValue
 			count: 1
 			path: app/Http/Submission/Handlers/OpenCoverTarHandler.php
 
@@ -5149,6 +5017,12 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
 			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $Labels. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
@@ -5156,6 +5030,12 @@ parameters:
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $TestCreator. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingHandler has an uninitialized property $TestMeasurement. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
@@ -5227,6 +5107,18 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
+			rawMessage: 'Only booleans are allowed in &&, string given on the right side.'
+			identifier: booleanAnd.rightNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: 'Only booleans are allowed in an elseif condition, string given.'
+			identifier: elseif.condNotBoolean
+			count: 1
+			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
 			rawMessage: 'Only booleans are allowed in an if condition, array given.'
 			identifier: if.condNotBoolean
 			count: 1
@@ -5239,26 +5131,8 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: 'Parameter #1 $duration of method CDash\Model\Build::UpdateTestDuration() expects int, (float|int) given.'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$BuildInformation type has no value type specified in iterable type array.
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$Label has no type specified.
-			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
@@ -5293,19 +5167,7 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
 			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$SubProjects has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingHandler::$TestMeasurement has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
@@ -5315,6 +5177,18 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/TestingHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingJUnitHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\TestingJUnitHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
 			rawMessage: Class App\Http\Submission\Handlers\TestingJUnitHandler has an uninitialized property $TestCreator. Give it default value or assign it in the constructor.
@@ -5365,6 +5239,12 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
+			rawMessage: 'Method App\Http\Submission\Handlers\TestingJUnitHandler::startElement() throws checked exception TypeError but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
+
+		-
 			rawMessage: 'Method App\Http\Submission\Handlers\TestingJUnitHandler::text() has parameter $data with no type specified.'
 			identifier: missingType.parameter
 			count: 1
@@ -5373,12 +5253,6 @@ parameters:
 		-
 			rawMessage: 'Method App\Http\Submission\Handlers\TestingJUnitHandler::text() has parameter $parser with no type specified.'
 			identifier: missingType.parameter
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: 'Only numeric types are allowed in +, int|false given on the left side.'
-			identifier: plus.leftNonNumeric
 			count: 1
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
@@ -5419,26 +5293,26 @@ parameters:
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\TestingJUnitHandler::$TotalTestDuration has no type specified.
-			identifier: missingType.property
+			rawMessage: 'Property App\Http\Submission\Handlers\TestingJUnitHandler::$StartTimeStamp (int) does not accept int|false.'
+			identifier: assign.propertyType
 			count: 1
 			path: app/Http/Submission/Handlers/TestingJUnitHandler.php
 
 		-
 			rawMessage: 'Call to an undefined method CDash\Messaging\Preferences\NotificationPreferencesInterface::get().'
 			identifier: method.notFound
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\UpdateHandler has an uninitialized property $EndTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: app/Http/Submission/Handlers/UpdateHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\UpdateHandler has an uninitialized property $StartTimeStamp. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/UpdateHandler.php
 
@@ -5515,20 +5389,14 @@ parameters:
 			path: app/Http/Submission/Handlers/UpdateHandler.php
 
 		-
-			rawMessage: Property App\Http\Submission\Handlers\UpdateHandler::$EndTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UpdateHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\UpdateHandler::$StartTimeStamp has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UpdateHandler.php
-
-		-
 			rawMessage: 'Call to function base64_decode() requires parameter #2 to be set.'
 			identifier: function.strict
+			count: 1
+			path: app/Http/Submission/Handlers/UploadHandler.php
+
+		-
+			rawMessage: Class App\Http\Submission\Handlers\UploadHandler has an uninitialized property $Label. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
 			count: 1
 			path: app/Http/Submission/Handlers/UploadHandler.php
 
@@ -5660,12 +5528,6 @@ parameters:
 
 		-
 			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$Base64TmpFileWriteHandle has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/Http/Submission/Handlers/UploadHandler.php
-
-		-
-			rawMessage: Property App\Http\Submission\Handlers\UploadHandler::$Label has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/Http/Submission/Handlers/UploadHandler.php


### PR DESCRIPTION
Prep work for upcoming changes to the structure of some of these handler files.  By allowing PHPStan to better understand the types, refactors to this critical component of CDash will be slightly safer.