### PR TITLE
Delete obsolete project(showipaddresses) column

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Facades\Auth;
  * @property int $emailtesttimingchanged
  * @property int $emailbrokensubmission
  * @property int $emailredundantfailures
- * @property int $showipaddresses
  * @property string $cvsviewertype
  * @property int $testtimestd
  * @property int $testtimestdthreshold
@@ -77,7 +76,6 @@ class Project extends Model
         'emailtesttimingchanged',
         'emailbrokensubmission',
         'emailredundantfailures',
-        'showipaddresses',
         'cvsviewertype',
         'testtimestd',
         'testtimestdthreshold',

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -68,7 +68,6 @@ class Project
     public $TestTimeMaxStatus;
     public $EmailMaxItems = 5;
     public $EmailMaxChars = 255;
-    public $ShowIPAddresses = 0;
     public $DisplayLabels = 0;
     public $ShareLabelFilters = 0;
     public $ViewSubProjectsLink = 0;
@@ -130,7 +129,6 @@ class Project
             'emailtesttimingchanged' => (int) $this->EmailTestTimingChanged,
             'emailbrokensubmission' => (int) $this->EmailBrokenSubmission,
             'emailredundantfailures' => (int) $this->EmailRedundantFailures,
-            'showipaddresses' => (int) $this->ShowIPAddresses,
             'displaylabels' => (int) $this->DisplayLabels,
             'sharelabelfilters' => (int) $this->ShareLabelFilters,
             'viewsubprojectslink' => (int) $this->ViewSubProjectsLink,
@@ -219,7 +217,6 @@ class Project
             $this->EmailTestTimingChanged = $project->emailtesttimingchanged;
             $this->EmailBrokenSubmission = $project->emailbrokensubmission;
             $this->EmailRedundantFailures = $project->emailredundantfailures;
-            $this->ShowIPAddresses = $project->showipaddresses;
             $this->DisplayLabels = $project->displaylabels;
             $this->ShareLabelFilters = $project->sharelabelfilters;
             $this->ViewSubProjectsLink = $project->viewsubprojectslink;

--- a/app/cdash/tests/test_actualtrilinossubmission.php
+++ b/app/cdash/tests/test_actualtrilinossubmission.php
@@ -22,7 +22,6 @@ class ActualTrilinosSubmissionTestCase extends TrilinosSubmissionTestCase
             'Name' => $project,
             'Description' => $project . ' project created by test code in file [' . __FILE__ . ']',
             'EmailBrokenSubmission' => '1',
-            'ShowIPAddresses' => '1',
             'DisplayLabels' => '1',
             'NightlyTime' => '21:00:00 America/New_York',
             'ShareLabelFilters' => '1'];

--- a/database/migrations/2025_12_30_195827_drop_showipaddresses_column.php
+++ b/database/migrations/2025_12_30_195827_drop_showipaddresses_column.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project DROP COLUMN showipaddresses');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11608,12 +11608,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$ShowIPAddresses has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$ShowTestTime has no type specified.
 			identifier: missingType.property
 			count: 1

--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -1650,44 +1650,6 @@
                     <td />
                     <td>
                       <div align="right">
-                        <strong>Show site IP addresses:</strong>
-                      </div>
-                    </td>
-                    <td>
-                      <input
-                        v-model="cdash.project.ShowIPAddresses"
-                        type="checkbox"
-                        name="showIPAddresses"
-                        true-value="1"
-                        false-value="0"
-                        @change="cdash.changesmade = true"
-                        @focus="showHelp('showSiteIPAddresses_help')"
-                      >
-                      <a
-                        href="http://www.cdash.org/Wiki/CDash:Administration#Creating_a_project"
-                        target="blank"
-                      >
-                        <img
-                          :src="$baseURL + '/img/help.gif'"
-                          border="0"
-                          @mouseover="showHelp('showSiteIPAddresses_help')"
-                        >
-                      </a>
-                      <span
-                        id="showSiteIPAddresses_help"
-                        class="help_content"
-                      >
-                        <b>Show Site IP Addresses</b>
-                        <br>
-                        Enable/Disable the display of IP addresses of the sites
-                        submitting to this project.
-                      </span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td />
-                    <td>
-                      <div align="right">
                         <strong>Display Labels:</strong>
                       </div>
                     </td>

--- a/tests/Spec/edit-project.spec.js
+++ b/tests/Spec/edit-project.spec.js
@@ -69,7 +69,6 @@ beforeEach(() => {
       Public: 1,
       ShareLabelFilters: 0,
       ShowCoverageCode: 1,
-      ShowIPAddresses: 0,
       ShowTestTime: 0,
       TestTimeMaxStatus: 3,
       TestTimeStd: 4,


### PR DESCRIPTION
The `showipaddresses` column hasn't been hooked up to anything since CDash 4.0, but was missed in my prior cleanup sweeps.  This PR removes the column and associated setting on the project page.