### PR TITLE
Add foreign key constraint to project logo ID

### DIFF
--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -50,7 +50,7 @@ class Project
     public $BugTrackerUrl;
     public $BugTrackerNewIssueUrl;
     public $BugTrackerType;
-    public $ImageId;
+    public ?int $ImageId = null;
     public $Public;
     public $CoverageThreshold;
     public $TestingDataUrl;
@@ -146,7 +146,7 @@ class Project
             'testtimemaxstatus' => (int) $this->TestTimeMaxStatus,
             'emailmaxitems' => (int) $this->EmailMaxItems,
             'emailmaxchars' => (int) $this->EmailMaxChars,
-            'imageid' => $this->ImageId ?? 0,
+            'imageid' => $this->ImageId,
             'ldapfilter' => $this->LdapFilter,
             'banner' => $this->Banner,
         ]);
@@ -180,13 +180,13 @@ class Project
     }
 
     /** Get the logo id */
-    private function GetLogoId(): int
+    private function GetLogoId(): ?int
     {
         if (!$this->Filled) {
             $this->Fill();
         }
 
-        return $this->Id > 0 ? $this->ImageId : 0;
+        return $this->Id > 0 ? $this->ImageId : null;
     }
 
     /** Fill in all the information from the database */
@@ -297,7 +297,7 @@ class Project
         $image->Extension = $filetype;
 
         $imgid = $this->GetLogoId();
-        if ($imgid > 0) {
+        if ($imgid !== null) {
             $image->Id = $imgid;
         }
 

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -601,7 +601,7 @@ function get_dashboard_JSON($projectname, $date, &$response): void
     $response['public'] = $project->Public;
     $response['previousdate'] = $previousdate;
     $response['nextdate'] = $nextdate;
-    $response['logoid'] = $project->ImageId ?? 0;
+    $response['logoid'] = $project->ImageId;
     $response['nightlytime'] = date('H:i T', strtotime($project_array['nightlytime']));
     if (empty($project_array['homeurl'])) {
         $response['home'] = 'index.php?project=' . urlencode($project_array['name']);

--- a/database/migrations/2025_12_30_213518_project_logo_image_foreign_key_constraint.php
+++ b/database/migrations/2025_12_30_213518_project_logo_image_foreign_key_constraint.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project ALTER COLUMN imageid DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN imageid DROP DEFAULT');
+        DB::update('
+            UPDATE project
+            SET imageid=NULL
+            WHERE imageid=0 OR NOT EXISTS (
+                SELECT * FROM image WHERE image.id=project.imageid
+            )');
+        DB::statement('ALTER TABLE project ADD FOREIGN KEY (imageid) REFERENCES image(id) ON DELETE SET NULL');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11560,12 +11560,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$ImageId has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$Name has no type specified.
 			identifier: missingType.property
 			count: 1

--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -569,11 +569,11 @@
                       <div valign="top">
                         <strong>Current logo:</strong>
                       </div>
-                      <span v-if="cdash.project.ImageId == 0">
+                      <span v-if="cdash.project.ImageId == null">
                         [none]
                       </span>
                       <img
-                        v-if="cdash.project.ImageId != 0"
+                        v-if="cdash.project.ImageId != null"
                         id="projectlogo"
                         border="0"
                         :alt="cdash.project_name"
@@ -2356,7 +2356,7 @@ export default {
         this.$axios
           .post('/api/v1/project.php', data, config)
           .then(response => {
-            if (response.data.imageid > 0) {
+            if (response.data.imageid !== null) {
               this.previewLogo = null;
               this.uploadedLogo = null;
               // Use a decache to force the logo to refresh even if the imageid didn't change.

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -50,7 +50,7 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
                     href="{{ url('/')}}"
                 @endif
             >
-                @if(isset($project) && $logoid > 0)
+                @if(isset($project) && $logoid !== null)
                     <img id="projectlogo" height="50px" alt="" src="{{ url('/image/' . $logoid) }}" />
                 @else
                     <img id="projectlogo" height="50px" alt="" src="{{ asset('img/cdash.svg') }}" />

--- a/tests/Spec/edit-project.spec.js
+++ b/tests/Spec/edit-project.spec.js
@@ -62,7 +62,7 @@ beforeEach(() => {
       ErrorsFilter: '',
       Filled: true,
       Id: 1,
-      ImageId: 0,
+      ImageId: 1,
       MaxUploadQuota: 10,
       Name: 'MyTestingProject',
       NightlyTime: '01:00:00 UTC',


### PR DESCRIPTION
The project `imageid` column was passed over in previous PRs introducing foreign-key constraints because the column used the value 0 to indicate a special case.  This PR switches that logic to use null to represent the missing logo case, thus allowing us to add a proper foreign key constraint.