### PR TITLE
Expose Dynamic Analysis info via GraphQL

### DIFF
--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -222,6 +222,10 @@ add_feature_test(/Feature/GraphQL/NoteTypeTest)
 
 add_feature_test(/Feature/GraphQL/CoverageTypeTest)
 
+add_feature_test(/Feature/GraphQL/DynamicAnalysisTypeTest)
+
+add_feature_test(/Feature/GraphQL/DynamicAnalysisDefectTypeTest)
+
 add_feature_test(/Feature/GraphQL/ProjectInvitationTypeTest)
 
 add_feature_test(/Feature/GraphQL/LabelTypeTest)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -535,6 +535,10 @@ type Build {
   subProject: SubProject! @belongsTo
 
   configure: Configure @hasOneThrough
+
+  dynamicAnalyses(
+    filters: _ @filter
+  ): [DynamicAnalysis!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: ASC)
 }
 
 
@@ -928,4 +932,39 @@ type SubProject {
   id: ID!
 
   name: String!
+}
+
+
+type DynamicAnalysis {
+  "Unique primary key."
+  id: ID!
+
+  status: String! @filterable
+
+  checker: String! @filterable
+
+  name: String! @filterable
+
+  path: String! @filterable
+
+  fullCommandLine: String! @rename(attribute: "fullcommandline") @filterable
+
+  log: String!
+
+  "This relationship is deliberately not paginated because we expect users to want all defects all the time."
+  defects: [DynamicAnalysisDefect!]! @hasMany @orderBy(column: "id", direction: DESC)
+
+  labels(
+    filters: _ @filter
+  ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+}
+
+
+type DynamicAnalysisDefect {
+  "Unique primary key."
+  id: ID!
+
+  type: String!
+
+  value: Int!
 }

--- a/tests/Feature/GraphQL/DynamicAnalysisDefectTypeTest.php
+++ b/tests/Feature/GraphQL/DynamicAnalysisDefectTypeTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Build;
+use App\Models\DynamicAnalysis;
+use App\Models\DynamicAnalysisDefect;
+use App\Models\Project;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class DynamicAnalysisDefectTypeTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic test to ensure that each of the fields works
+     */
+    public function testBasicFieldAccess(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var DynamicAnalysis $da */
+        $da = $build->dynamicAnalyses()->create([
+            'status' => 'Passed',
+            'checker' => Str::uuid()->toString(),
+            'name' => Str::uuid()->toString(),
+            'path' => Str::uuid()->toString(),
+            'fullcommandline' => Str::uuid()->toString(),
+            'log' => Str::uuid()->toString(),
+        ]);
+
+        /** @var DynamicAnalysisDefect $da_defect */
+        $da_defect = $da->defects()->create([
+            'type' => Str::uuid()->toString(),
+            'value' => 42,
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    dynamicAnalyses {
+                        edges {
+                            node {
+                                defects {
+                                    id
+                                    type
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'dynamicAnalyses' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'defects' => [
+                                        [
+                                            'id' => (string) $da_defect->id,
+                                            'type' => $da_defect->type,
+                                            'value' => $da_defect->value,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/DynamicAnalysisTypeTest.php
+++ b/tests/Feature/GraphQL/DynamicAnalysisTypeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Build;
+use App\Models\DynamicAnalysis;
+use App\Models\Project;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class DynamicAnalysisTypeTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A basic test to ensure that each of the fields works
+     */
+    public function testBasicFieldAccess(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var DynamicAnalysis $da */
+        $da = $build->dynamicAnalyses()->create([
+            'status' => 'Passed',
+            'checker' => Str::uuid()->toString(),
+            'name' => Str::uuid()->toString(),
+            'path' => Str::uuid()->toString(),
+            'fullcommandline' => Str::uuid()->toString(),
+            'log' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    dynamicAnalyses {
+                        edges {
+                            node {
+                                id
+                                status
+                                checker
+                                name
+                                path
+                                fullCommandLine
+                                log
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'dynamicAnalyses' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $da->id,
+                                    'status' => $da->status,
+                                    'checker' => $da->checker,
+                                    'name' => $da->name,
+                                    'path' => $da->path,
+                                    'fullCommandLine' => $da->fullcommandline,
+                                    'log' => $da->log,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/GraphQL/LabelTypeTest.php
+++ b/tests/Feature/GraphQL/LabelTypeTest.php
@@ -200,4 +200,64 @@ class LabelTypeTest extends TestCase
             ],
         ]);
     }
+
+    public function testDynamicAnalysisRelationship(): void
+    {
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $da = $build->dynamicAnalyses()->create([
+            'log' => Str::uuid()->toString(),
+        ]);
+
+        $this->labels['label1'] = $da->labels()->create([
+            'text' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    dynamicAnalyses {
+                        edges {
+                            node {
+                                labels {
+                                    edges {
+                                        node {
+                                            text
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'dynamicAnalyses' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'labels' => [
+                                        'edges' => [
+                                            [
+                                                'node' => [
+                                                    'text' => $this->labels['label1']->text,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
Support work for the upcoming deprecation and removal of existing dynamic analysis API endpoints.  Subsequent PRs will switch over the backend for our dynamic analysis pages.