### PR TITLE
Remove ng-file-upload dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "jquery.cookie": "^1.4.1",
         "laravel-mix": "^6.0.49",
         "luxon": "^3.7.2",
-        "ng-file-upload": "^12.0.4",
         "nvd3": "^1.8.5",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.97.1",
@@ -13762,11 +13761,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "node_modules/ng-file-upload": {
-      "version": "12.2.13",
-      "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
-      "integrity": "sha512-YFjxwmVcNssYc8hq8eCbtYSliPnrObozSZRC9yg4GoDtI0xGKUeHgEcOh+nsMF/9cTzMB/lQZAYdf29oyQgF0g=="
     },
     "node_modules/no-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jquery.cookie": "^1.4.1",
     "laravel-mix": "^6.0.49",
     "luxon": "^3.7.2",
-    "ng-file-upload": "^12.0.4",
     "nvd3": "^1.8.5",
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.97.1",

--- a/resources/js/angular/legacy.js
+++ b/resources/js/angular/legacy.js
@@ -17,7 +17,6 @@ import 'as-jqplot/dist/jquery.jqplot.js';
 import 'as-jqplot/dist/plugins/jqplot.dateAxisRenderer.js';
 import 'as-jqplot/dist/plugins/jqplot.highlighter.js';
 import 'd3/d3.js';
-import 'ng-file-upload/dist/ng-file-upload.js';
 import 'nvd3/build/nv.d3.js';
 import './ui-bootstrap-tpls-0.14.2.min.js';
 import './tabNavigation.js';
@@ -26,7 +25,6 @@ import './jquery.metadata.js';
 
 const CDash = angular.module('CDash', [
   'ngAnimate',
-  'ngFileUpload',
   'ui.sortable',
   'ui.bootstrap',
 ]);


### PR DESCRIPTION
This dependency hasn't been used for quite some time.  Usage info can be found here: https://www.npmjs.com/package/ng-file-upload