### PR TITLE
Remove ansi_up from global imports

### DIFF
--- a/resources/js/angular/legacy.js
+++ b/resources/js/angular/legacy.js
@@ -12,7 +12,6 @@ import 'angular/angular.min.js';
 import 'angular-animate/angular-animate.min.js';
 import 'angular-ui-bootstrap/dist/ui-bootstrap.js';
 import 'angular-ui-sortable/dist/sortable.js';
-import 'ansi_up/ansi_up.js';
 import 'as-jqplot/dist/jquery.jqplot.js';
 import 'as-jqplot/dist/plugins/jqplot.dateAxisRenderer.js';
 import 'as-jqplot/dist/plugins/jqplot.highlighter.js';


### PR DESCRIPTION
ansi_up is imported explicitly everywhere it's used, so there's no need to build it into the global bundle.