### PR TITLE
Drop builderror crc32 column

### DIFF
--- a/app/Models/BasicBuildAlert.php
+++ b/app/Models/BasicBuildAlert.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $precontext
  * @property string|null $postcontext
  * @property int $repeatcount
- * @property int $crc32
  * @property bool $newstatus
  *
  * @mixin Builder<BasicBuildAlert>
@@ -37,7 +36,6 @@ class BasicBuildAlert extends Model
         'precontext',
         'postcontext',
         'repeatcount',
-        'crc32',
         'newstatus',
     ];
 
@@ -48,7 +46,6 @@ class BasicBuildAlert extends Model
         'text' => 'string',
         'sourceline' => 'integer',
         'repeatcount' => 'integer',
-        'crc32' => 'integer',
         'newstatus' => 'boolean',
     ];
 }

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -47,13 +47,6 @@ class BuildError
             $this->RepeatCount = 0;
         }
 
-        // Compute the crc32
-        if ($this->SourceLine === 0) {
-            $crc32 = crc32($this->Text); // no need for precontext or postcontext, this doesn't work for parallel build
-        } else {
-            $crc32 = crc32($this->Text . $this->SourceFile . $this->SourceLine); // some warnings can be on the same line
-        }
-
         BasicBuildAlert::create([
             'buildid' => (int) $this->BuildId,
             'type' => $this->Type,
@@ -65,7 +58,6 @@ class BuildError
             'postcontext' => $this->PostContext,
             'repeatcount' => (int) $this->RepeatCount,
             'newstatus' => 0,
-            'crc32' => $crc32,
         ]);
     }
 

--- a/database/migrations/2026_01_05_021305_drop_builderror_crc32.php
+++ b/database/migrations/2026_01_05_021305_drop_builderror_crc32.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE builderror DROP COLUMN crc32');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
CDash historically used crc32 hashes to determine uniqueness for various record types as part of a complex deduplication scheme.  This has caused numerous issues over the years, with frequent bugs and changes to the hashing logic.  Instead, we're now in the process of switching to a system where full records are matched against rather than hashes.  This PR removes the builderror crc32 column.  No performance hits are expected as a result of this change, because the database can still look up records efficiently by build ID.