### PR TITLE
Fix project logo upload

### DIFF
--- a/resources/js/vue/components/EditProject.vue
+++ b/resources/js/vue/components/EditProject.vue
@@ -2322,7 +2322,7 @@ export default {
               this.previewLogo = null;
               this.uploadedLogo = null;
               // Use a decache to force the logo to refresh even if the imageid didn't change.
-              const imageid = `${response.data.imageid}&decache=${new Date().getTime()}`;
+              const imageid = `${response.data.imageid}?decache=${new Date().getTime()}`;
               this.cdash.project.ImageId = imageid;
               this.cdash.logoid = imageid;
             }


### PR DESCRIPTION
Fixes an issue with the project logo preview when uploading new logos.  This page is due for a refactor in the near future, so this is a temporary patch.