### PR TITLE
Remove `flot` from global legacy JS bundle

### DIFF
--- a/resources/js/angular/legacy.js
+++ b/resources/js/angular/legacy.js
@@ -2,9 +2,6 @@
 import './jquery-init.js';
 
 import 'jquery-ui-dist/jquery-ui.js';
-import 'flot/lib/jquery.event.drag.js';
-import 'flot/dist/es5/jquery.flot.js';
-import 'flot/source/jquery.flot.pie.js';
 import 'jquery.cookie/jquery.cookie.js';
 import './bootstrap.min.js';
 import './je_compare.js';


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/3348 removed the last references to `flot` in our legacy codebase.  All remaining usages import flot explicitly when needed.