### PR TITLE
Update all `require()` usages in app code

### DIFF
--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -1085,9 +1085,10 @@ export default {
     },
   },
 
-  mounted () {
+  async mounted () {
     // Ensure jQuery is globally available before loading plugins
     window.jQuery = $;
+    await import('flot/dist/es5/jquery.flot');
 
     const endpoint_path = `/api/v1/buildSummary.php?buildid=${this.buildId}`;
     ApiLoader.loadPageData(this, endpoint_path);
@@ -1206,8 +1207,6 @@ export default {
       }
 
       // Render the graph.
-      // eslint-disable-next-line no-undef
-      require('flot/dist/es5/jquery.flot');
       const plot = $.plot($(element), [{label: label, data: data}],
         options);
 

--- a/resources/js/vue/components/BuildUpdate.vue
+++ b/resources/js/vue/components/BuildUpdate.vue
@@ -178,9 +178,10 @@ export default {
     };
   },
 
-  mounted() {
+  async mounted() {
     // Ensure jQuery is globally available before loading plugins
     window.jQuery = $;
+    await import('flot/dist/es5/jquery.flot');
 
     this.buildid = window.location.pathname.split('/').at(-2);
     const endpoint_path = `/api/v1/viewUpdate.php?buildid=${this.buildid}`;
@@ -226,8 +227,6 @@ export default {
         colors: ['#0000FF', '#dba255', '#919733'],
       };
 
-      // eslint-disable-next-line no-undef
-      require('flot/dist/es5/jquery.flot');
       let plot = $.plot($('#graph_holder'), [{label: 'Number of changed files', data: data.data}], options);
 
       $('#graph_holder').bind('selected', (event, area) => {

--- a/resources/js/vue/components/TestDetails.vue
+++ b/resources/js/vue/components/TestDetails.vue
@@ -303,9 +303,11 @@ export default {
     },
   },
 
-  mounted () {
+  async mounted () {
     // Ensure jQuery is globally available before loading plugins
     window.jQuery = $;
+    await import('flot/dist/es5/jquery.flot');
+    await import('../../angular/je_compare.js');
 
     this.buildtestid = window.location.pathname.split('/').pop();
     let endpoint_path = `/api/v1/testDetails.php?buildtestid=${this.buildtestid}`;
@@ -322,8 +324,6 @@ export default {
       if (this.jeCompareInitialized) {
         return;
       }
-      // eslint-disable-next-line no-undef
-      require('../../angular/je_compare.js');
       $('.je_compare').je_compare({caption: true});
       this.jeCompareInitialized = true;
     },
@@ -486,8 +486,6 @@ export default {
         }
       });
 
-      // eslint-disable-next-line no-undef
-      require('flot/dist/es5/jquery.flot');
       $.plot($('#graph_holder'), chart_data, options);
 
       // Show tooltip on hover.


### PR DESCRIPTION
`require()` doesn't work with ESM build tools such as Vite without extensions.  This PR converts our existing `require()` calls to dynamic `import()` calls, excluding code where `require()` is necessary in build system code.