### PR TITLE
Fix bad error checking in build error handling logic

### DIFF
--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -451,10 +451,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
             if ($threshold > 0) {
                 $chunk_size = $threshold / 2;
                 foreach (['StdOutput', 'StdError'] as $field) {
-                    if (!($this->Error instanceof BuildFailure)) {
-                        throw new RuntimeException('Field "Error" is not instance of BuildFailure.');
-                    }
-                    if (isset($this->Error->$field)) {
+                    if ($this->Error instanceof BuildFailure && isset($this->Error->$field)) {
                         $outlen = strlen($this->Error->$field);
                         if ($outlen > $threshold) {
                             // First try removing suppressed warnings to see


### PR DESCRIPTION
The legacy BuildError and BuildFailure models are treated as if they're derived from the same parent class in the build handler, but there's no guarantee that the fields the build handler attempts to access actually exist on a particular object.  This PR resolves a critical issue introduced by https://github.com/Kitware/CDash/pull/3320 which causes failures when parsing builds with old style build errors.