### PR TITLE
Migrate most of legacy BuildGroup model to Eloquent

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -224,7 +224,7 @@ class Build extends Model
      */
     public function buildGroups(): BelongsToMany
     {
-        return $this->belongsToMany(BuildGroup::class, 'build2group', 'groupid', 'buildid');
+        return $this->belongsToMany(BuildGroup::class, 'build2group', 'buildid', 'groupid');
     }
 
     /**

--- a/app/Models/BuildGroup.php
+++ b/app/Models/BuildGroup.php
@@ -59,7 +59,7 @@ class BuildGroup extends Model
      */
     public function project(): BelongsTo
     {
-        return $this->belongsTo(Project::class, 'id', 'projectid');
+        return $this->belongsTo(Project::class, 'projectid');
     }
 
     /**

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -370,7 +370,7 @@ class Build
             $this->SubProjectId = $subprojectid;
         }
 
-        $this->GroupId = (int) (DB::select('SELECT groupid FROM build2group WHERE buildid = ?', [$buildid])[0]->groupid ?? false);
+        $this->GroupId = $model->buildGroups()->first()->id ?? 0;
         $this->Filled = true;
     }
 
@@ -1475,12 +1475,15 @@ class Build
             ]);
             return false;
         }
-        $stmt = $this->PDO->prepare(
-            'SELECT groupid FROM build2group WHERE buildid = ?');
-        if (!pdo_execute($stmt, [$this->Id])) {
+
+        /** @var \App\Models\BuildGroup $buildgroup */
+        $buildgroup = EloquentBuild::findOrFail((int) $this->Id)->buildGroups()->first();
+
+        if ($buildgroup === null) {
             return false;
         }
-        return (int) $stmt->fetchColumn();
+
+        return $buildgroup->id;
     }
 
     /** Get the number of errors for a build */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -627,7 +627,7 @@ parameters:
 		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
-			count: 11
+			count: 13
 			path: app/Http/Controllers/BuildController.php
 
 		-
@@ -8907,7 +8907,7 @@ parameters:
 				v2.5.0 01/22/2018
 			'''
 			identifier: function.deprecated
-			count: 15
+			count: 14
 			path: app/cdash/app/Model/Build.php
 
 		-
@@ -9319,6 +9319,12 @@ parameters:
 			rawMessage: 'Only numeric types are allowed in -, int|false given on the right side.'
 			identifier: minus.rightNonNumeric
 			count: 3
+			path: app/cdash/app/Model/Build.php
+
+		-
+			rawMessage: 'PHPDoc tag @var with type App\Models\BuildGroup is not subtype of type (App\Models\BuildGroup&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null.'
+			identifier: varTag.type
+			count: 1
 			path: app/cdash/app/Model/Build.php
 
 		-


### PR DESCRIPTION
Incremental progress towards removing all legacy models in favor of Eloquent models.  I also fixed issues with several previously unused relationships.