### PR TITLE
Fix GraphQL create project name validation

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -206,7 +206,7 @@ enum ProjectVisibility {
 
 input CreateProjectInput {
   "Unique name."
-  name: String! @rules(apply: ["App\\Rules\\ProjectVisibilityRule"])
+  name: String! @rules(apply: ["App\\Rules\\ProjectNameRule"])
 
   "Description."
   description: String!


### PR DESCRIPTION
Thus mutation was somehow added without robust tests.  I plan to add tests and implement a page which uses this mutation in a follow-up PR.