### PR TITLE
Deprecate ldapFilter argument in createProject mutation

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -224,7 +224,7 @@ input CreateProjectInput {
   authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions") @rules(attribute: "authenticatesubmissions", apply: ["App\\Rules\\ProjectAuthenticateSubmissionsRule"])
 
   "A LDAP group users must be a member of to access the project."
-  ldapFilter: String @rename(attribute: "ldapfilter")
+  ldapFilter: String @deprecated(reason: "This field will be removed in the next major version of CDash.") @rename(attribute: "ldapfilter")
 }
 
 


### PR DESCRIPTION
The `createProject()` mutation was initially envisioned as a way to create projects while setting all optional fields at the same time, similar to the legacy create/edit project endpoint.  In hindsight, this was a poor idea because it makes managing default values vs nulls vs user-defined values significantly more difficult.  This PR deprecates the only non-essential field currently in the `createProject()` mutation in favor of a new approach where only a minimal subset of fields can be specified via this mutation.  A separate `updateProject()` allowing updates of individual fields will follow soon.