### PR TITLE
Move targets link to dedicated section of build summary page

### DIFF
--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -553,16 +553,22 @@
       </div>
       <a
         class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/targets'"
-      >
-        View Targets
-      </a>
-      <br>
-      <a
-        class="tw-link tw-link-hover"
         :href="$baseURL + '/builds/' + cdash.build.id + '/commands'"
       >
         View Commands
+      </a>
+      <br>
+      <br>
+
+      <!-- Targets section -->
+      <div class="title-divider">
+        Targets
+      </div>
+      <a
+        class="tw-link tw-link-hover"
+        :href="$baseURL + '/builds/' + cdash.build.id + '/targets'"
+      >
+        View Targets
       </a>
       <br>
       <br>


### PR DESCRIPTION
A CDash user expressed confusion about the difference between the targets page and the commands page, since both appear under the instrumentation header.  This PR moves the targets page to a separate section of the build summary page to make it clear that it isn't just instrumentation data.

<img width="2832" height="1524" alt="image" src="https://github.com/user-attachments/assets/c47b1e92-747d-42a9-bad4-cbb6b2af13c5" />
