### PR TITLE
Enable logging for all PHPUnit notices

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stderr="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false" displayDetailsOnPhpunitDeprecations="true">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  processIsolation="false"
+  stderr="true"
+  stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false"
+  displayDetailsOnAllIssues="true"
+>
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit</directory>


### PR DESCRIPTION
Our PHPUnit config previously only had `displayDetailsOnPhpunitDeprecations` configured.  This commit upgrades to the `displayDetailsOnAllIssues` configuration which displays all types of notifications, not just deprecations.