### PR TITLE
Merge build error context into stdout/stderr columns

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -266,11 +266,11 @@ final class BuildController extends AbstractBuildController
         foreach ($e_errors as $error_array) {
             $error_response = [];
             $error_response['logline'] = $error_array['logline'];
-            $error_response['text'] = $error_array['text'];
+            $error_response['text'] = $error_array['stdoutput'];
             $error_response['sourcefile'] = $error_array['sourcefile'];
             $error_response['sourceline'] = $error_array['sourceline'];
-            $error_response['precontext'] = $error_array['precontext'];
-            $error_response['postcontext'] = $error_array['postcontext'];
+            $error_response['precontext'] = '';
+            $error_response['postcontext'] = '';
             $errors_response[] = $error_response;
         }
 
@@ -292,11 +292,11 @@ final class BuildController extends AbstractBuildController
         foreach ($e_warnings as $error_array) {
             $warning_response = [];
             $warning_response['logline'] = $error_array['logline'];
-            $warning_response['text'] = $error_array['text'];
+            $warning_response['text'] = $error_array['stdoutput'];
             $warning_response['sourcefile'] = $error_array['sourcefile'];
             $warning_response['sourceline'] = $error_array['sourceline'];
-            $warning_response['precontext'] = $error_array['precontext'];
-            $warning_response['postcontext'] = $error_array['postcontext'];
+            $warning_response['precontext'] = '';
+            $warning_response['postcontext'] = '';
             $warnings_response[] = $warning_response;
         }
 

--- a/app/Http/Controllers/BuildPropertiesController.php
+++ b/app/Http/Controllers/BuildPropertiesController.php
@@ -227,7 +227,7 @@ final class BuildPropertiesController extends AbstractBuildController
                 $valid_defect = true;
                 // Query builderror table.
                 $sql =
-                    "SELECT buildid, text AS descr
+                    "SELECT buildid, stderror AS descr
                     FROM builderror
                     WHERE type = $type AND
                     buildid IN $placeholder_str";

--- a/app/Models/BasicBuildAlert.php
+++ b/app/Models/BasicBuildAlert.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -10,11 +11,10 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $buildid
  * @property int $type
  * @property int $logline
- * @property string $text
+ * @property string $stdoutput
+ * @property string $stderror
  * @property string $sourcefile
  * @property int $sourceline
- * @property string|null $precontext
- * @property string|null $postcontext
  * @property int $repeatcount
  * @property bool $newstatus
  *
@@ -30,11 +30,10 @@ class BasicBuildAlert extends Model
         'buildid',
         'type',
         'logline',
-        'text',
+        'stdoutput',
+        'stderror',
         'sourcefile',
         'sourceline',
-        'precontext',
-        'postcontext',
         'repeatcount',
         'newstatus',
     ];
@@ -43,9 +42,30 @@ class BasicBuildAlert extends Model
         'buildid' => 'integer',
         'type' => 'integer', // TODO: Convert this to an enum
         'logline' => 'integer',
-        'text' => 'string',
+        'stdoutput' => 'string',
+        'stderror' => 'string',
         'sourceline' => 'integer',
         'repeatcount' => 'integer',
         'newstatus' => 'boolean',
     ];
+
+    /**
+     * @return Attribute<string,void>
+     */
+    protected function precontext(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): null => null,
+        );
+    }
+
+    /**
+     * @return Attribute<string,void>
+     */
+    protected function postcontext(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): null => null,
+        );
+    }
 }

--- a/app/Utils/RepositoryUtils.php
+++ b/app/Utils/RepositoryUtils.php
@@ -547,9 +547,9 @@ class RepositoryUtils
                 $info = '';
                 if (strlen($error->sourcefile) > 0) {
                     $info .= "{$error->sourcefile} line {$error->sourceline} ({$serverURI}/viewBuildError.php?buildid={$buildid})";
-                    $info .= "{$error->text}\n";
+                    $info .= "{$error->stderror}\n";
                 } else {
-                    $info .= "{$error->text}\n{$error->postcontext}\n";
+                    $info .= "{$error->stderror}\n";
                 }
                 $information .= mb_substr($info, 0, $maxchars);
             }
@@ -595,9 +595,9 @@ class RepositoryUtils
                 $info = '';
                 if (strlen($warning->sourcefile) > 0) {
                     $info .= "{$warning->sourcefile} line {$warning->sourceline} ({$serverURI}/viewBuildError.php?type=1&buildid={$buildid})\n";
-                    $info .= "{$warning->text}\n";
+                    $info .= "{$warning->stderror}\n";
                 } else {
-                    $info .= "{$warning->text}\n{$warning->postcontext}\n";
+                    $info .= "{$warning->stderror}\n";
                 }
                 $information .= substr($info, 0, $maxchars);
             }

--- a/app/Utils/SubmissionUtils.php
+++ b/app/Utils/SubmissionUtils.php
@@ -172,7 +172,7 @@ class SubmissionUtils
                     WHERE
                         builderror_previous.buildid = :previousbuildid
                         AND builderror_previous.type = builderror.type
-                        AND builderror_previous.text = builderror.text
+                        AND builderror_previous.stderror = builderror.stderror
                         AND builderror_previous.sourcefile = builderror.sourcefile
                         AND builderror_previous.sourceline = builderror.sourceline
                 )
@@ -230,7 +230,7 @@ class SubmissionUtils
                     WHERE
                         builderror.buildid = :buildid
                         AND builderror_previous.type = builderror.type
-                        AND builderror_previous.text = builderror.text
+                        AND builderror_previous.stderror = builderror.stderror
                         AND builderror_previous.sourcefile = builderror.sourcefile
                         AND builderror_previous.sourceline = builderror.sourceline
                 )

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -548,7 +548,7 @@ class Build
                     WHERE
                         builderror.buildid = ?
                         AND builderror_previous.type = builderror.type
-                        AND builderror_previous.text = builderror.text
+                        AND builderror_previous.stderror = builderror.stderror
                         AND builderror_previous.sourcefile = builderror.sourcefile
                         AND builderror_previous.sourceline = builderror.sourceline
                 )

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -51,13 +51,12 @@ class BuildError
             'buildid' => (int) $this->BuildId,
             'type' => $this->Type,
             'logline' => (int) $this->LogLine,
-            'text' => $this->Text,
             'sourcefile' => $this->SourceFile ?? '',
             'sourceline' => (int) $this->SourceLine,
-            'precontext' => $this->PreContext,
-            'postcontext' => $this->PostContext,
             'repeatcount' => (int) $this->RepeatCount,
             'newstatus' => 0,
+            'stdoutput' => $this->PreContext . $this->Text . $this->PostContext,
+            'stderror' => $this->Text,
         ]);
     }
 
@@ -74,7 +73,7 @@ class BuildError
         // Detect if the source directory has already been replaced by CTest
         // with /.../.  If so, sourcefile is already a relative path from the
         // root of the source tree.
-        if (str_contains($data['text'], '/.../')) {
+        if (str_contains($data['stdoutput'], '/.../')) {
             $parts = explode('/', $data['sourcefile']);
             $sourceFile['file'] = array_pop($parts);
             $sourceFile['directory'] = implode('/', $parts);
@@ -110,9 +109,9 @@ class BuildError
             'new' => (int) ($data['newstatus'] ?? -1),
             'logline' => (int) $data['logline'],
             'cvsurl' => RepositoryUtils::get_diff_url($project->Id, $project->CvsUrl, $sourceFile['directory'], $sourceFile['file'], $revision),
-            'precontext' => RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['precontext']),
-            'text' => RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['text']),
-            'postcontext' => RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['postcontext']),
+            'precontext' => '',
+            'text' => RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['stdoutput']),
+            'postcontext' => '',
             'sourcefile' => $data['sourcefile'],
             'sourceline' => $data['sourceline'],
         ];

--- a/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
+++ b/app/cdash/tests/case/CDash/Model/BuildErrorTest.php
@@ -37,23 +37,21 @@ class BuildErrorTest extends CDashTestCase
         $input_data = [
             'logline' => 16,
             'newstatus' => 1,
-            'precontext' => "Scanning dependencies of target main\n[ 83%] Building CXX object src/CMakeFiles/main.dir/main.cpp.o\n/.../foo/src/main.cpp: In function `int main(int, char**)`:",
-            'postcontext' => "   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
             'sourcefile' => 'src/main.cpp',
             'sourceline' => '2',
-            'text' => '/.../foo/src/main.cpp:2:3: error: `asdf` not declared in this scope',
+            'stdoutput' => "Scanning dependencies of target main\n[ 83%] Building CXX object src/CMakeFiles/main.dir/main.cpp.o\n/.../foo/src/main.cpp: In function `int main(int, char**)`:/.../foo/src/main.cpp:2:3: error: `asdf` not declared in this scope   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
         ];
 
         $this->mock_project->CvsUrl = 'https://github.com/FooCo/foo';
         $marshaled = BuildError::marshal($input_data, $this->mock_project, '12');
 
         $expected = [
-            'new' => '1',
-            'logline' => '16',
+            'new' => 1,
+            'logline' => 16,
             'cvsurl' => 'https://github.com/FooCo/foo/blob/12/src/main.cpp',
-            'precontext' => "Scanning dependencies of target main\n[ 83%] Building CXX object src/CMakeFiles/main.dir/main.cpp.o\n/.../foo/src/main.cpp: In function `int main(int, char**)`:",
-            'text' => "<a class='cdash-link' href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` not declared in this scope",
-            'postcontext' => "   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
+            'precontext' => '',
+            'text' => "Scanning dependencies of target main\n[ 83%] Building CXX object src/CMakeFiles/main.dir/main.cpp.o\n/.../foo/src/main.cpp: In function `int main(int, char**)`:<a class='cdash-link' href='https://github.com/FooCo/foo/blob/12/src/main.cpp#L2'>src/main.cpp:2</a>:3: error: `asdf` not declared in this scope   asdf = 0;\n   ^\n[100%] Linking CXX executable main",
+            'postcontext' => '',
             'sourcefile' => 'src/main.cpp',
             'sourceline' => '2',
         ];

--- a/database/migrations/2026_01_19_193919_builderror_context_to_stdout.php
+++ b/database/migrations/2026_01_19_193919_builderror_context_to_stdout.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE builderror ADD COLUMN stdoutput text');
+        DB::update('UPDATE builderror SET stdoutput = CONCAT(precontext, text, postcontext)');
+        DB::statement('ALTER TABLE builderror DROP COLUMN precontext');
+        DB::statement('ALTER TABLE builderror DROP COLUMN postcontext');
+        DB::statement('ALTER TABLE builderror RENAME COLUMN text TO stderror');
+        DB::statement('ALTER TABLE builderror ALTER COLUMN stdoutput SET NOT NULL');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -692,7 +692,7 @@ https://cmake.org/cmake/help/latest/manual/ctest.1.html#ctest-build-step
 type BasicBuildAlert {
   logLine: Int! @rename(attribute: "logline")
 
-  text: String!
+  text: String! @rename(attribute: "stdoutput")
 
   sourceFile: String! @rename(attribute: "sourcefile")
 

--- a/resources/js/angular/views/partials/buildError.html
+++ b/resources/js/angular/views/partials/buildError.html
@@ -46,11 +46,7 @@
       <span class="nobr"> {{cdash.errortypename}} </span>
     </th>
     <td ng-if="error.text">
-      <pre ng-if="error.precontext" class="compiler-output" ng-bind-html="error.precontext | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
-      <b>
-        <pre class="compiler-output" ng-bind-html="error.text | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
-      </b>
-      <pre ng-if="error.postcontext" class="compiler-output" ng-bind-html="error.postcontext | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
+      <pre class="compiler-output" ng-bind-html="error.text | ctestNonXmlCharEscape | terminalColors:false | trustAsHtml"></pre>
     </td>
   </tr>
 

--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -901,16 +901,8 @@
           Line: <b>{{ error.sourceline }}</b>
         </div>
         <code-box
-          v-if="error?.precontext?.trim()"
-          :text="error.precontext"
-        />
-        <code-box
           v-if="error?.text?.trim()"
           :text="error.text"
-        />
-        <code-box
-          v-if="error?.postcontext?.trim()"
-          :text="error.postcontext"
         />
 
         <div v-if="error?.stdoutput?.trim() || error?.stderror?.trim()">
@@ -953,16 +945,8 @@
           Line: <b>{{ warning.sourceline }}</b>
         </div>
         <code-box
-          v-if="warning?.precontext?.trim()"
-          :text="warning.precontext"
-        />
-        <code-box
           v-if="warning?.text?.trim()"
           :text="warning.text"
-        />
-        <code-box
-          v-if="warning?.postcontext?.trim()"
-          :text="warning.postcontext"
         />
 
         <div v-if="warning?.stdoutput?.trim() || warning?.stderror?.trim()">

--- a/tests/Feature/GraphQL/BuildTypeTest.php
+++ b/tests/Feature/GraphQL/BuildTypeTest.php
@@ -233,11 +233,10 @@ class BuildTypeTest extends TestCase
         $build->basicAlerts()->create([
             'type' => Build::TYPE_WARN,
             'logline' => 5,
-            'text' => 'def',
+            'stdoutput' => 'abc',
+            'stderror' => 'def',
             'sourcefile' => '/a/b/c',
             'sourceline' => 7,
-            'precontext' => 'ghi',
-            'postcontext' => 'jlk',
         ]);
 
         $this->graphQL('
@@ -286,11 +285,11 @@ class BuildTypeTest extends TestCase
                                             [
                                                 'node' => [
                                                     'logLine' => 5,
-                                                    'text' => 'def',
+                                                    'text' => 'abc',
                                                     'sourceFile' => '/a/b/c',
                                                     'sourceLine' => 7,
-                                                    'preContext' => 'ghi',
-                                                    'postContext' => 'jlk',
+                                                    'preContext' => null,
+                                                    'postContext' => null,
                                                 ],
                                             ],
                                         ],
@@ -316,11 +315,10 @@ class BuildTypeTest extends TestCase
         $build->basicAlerts()->create([
             'type' => Build::TYPE_ERROR,
             'logline' => 5,
-            'text' => 'def',
+            'stdoutput' => 'abc',
+            'stderror' => 'def',
             'sourcefile' => '/a/b/c',
             'sourceline' => 7,
-            'precontext' => 'ghi',
-            'postcontext' => 'jlk',
         ]);
 
         $this->graphQL('
@@ -372,11 +370,11 @@ class BuildTypeTest extends TestCase
                                             [
                                                 'node' => [
                                                     'logLine' => 5,
-                                                    'text' => 'def',
+                                                    'text' => 'abc',
                                                     'sourceFile' => '/a/b/c',
                                                     'sourceLine' => 7,
-                                                    'preContext' => 'ghi',
-                                                    'postContext' => 'jlk',
+                                                    'preContext' => null,
+                                                    'postContext' => null,
                                                 ],
                                             ],
                                         ],
@@ -401,20 +399,26 @@ class BuildTypeTest extends TestCase
         $errors = [];
         for ($i = 0; $i < 10; $i++) {
             $warning = [
-                'text' => Str::uuid()->toString(),
+                'stdoutput' => Str::uuid()->toString(),
+                'stderror' => Str::uuid()->toString(),
             ];
             $error = [
-                'text' => Str::uuid()->toString(),
+                'stdoutput' => Str::uuid()->toString(),
+                'stderror' => Str::uuid()->toString(),
             ];
 
             $build->basicAlerts()->create(array_merge($warning, ['type' => Build::TYPE_WARN]));
             $build->basicAlerts()->create(array_merge($error, ['type' => Build::TYPE_ERROR]));
 
             $warnings[] = [
-                'node' => $warning,
+                'node' => [
+                    'text' => $warning['stdoutput'],
+                ],
             ];
             $errors[] = [
-                'node' => $error,
+                'node' => [
+                    'text' => $error['stdoutput'],
+                ],
             ];
         }
 


### PR DESCRIPTION
CDash currently maintains two separate types of build errors: "build errors", which are scraped from the log, and "build failures" which are collected by launchers.  Needing (almost) duplicate logic to handle these two cases is a major pain point throughout the codebase.  This commit begins the process of merging errors and failures into a single table by migrating the precontext, text, and postcontext columns of the builderror table to a stdoutput column which contains precontext+text+postcontext, and a stderror column which contains just the error text.