### PR TITLE
Show instrumentation details on command click

### DIFF
--- a/app/Policies/BuildCommandPolicy.php
+++ b/app/Policies/BuildCommandPolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\BuildCommand;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class BuildCommandPolicy
+{
+    public function view(?User $user, BuildCommand $buildCommand): bool
+    {
+        return Gate::check('view', $buildCommand->build?->project);
+    }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -60,6 +60,12 @@ type Query {
   ): Site @find
 
   invitations: [GlobalInvitation!]! @canResolved(ability: "viewInvitations") @paginate(type: CONNECTION) @orderBy(column: "id")
+
+  "Find a single build command by ID."
+  buildCommand(
+    "Search by primary key."
+    id: ID @eq
+  ): BuildCommand @find @canResolved(ability: "view", action: RETURN_VALUE, returnValue: null)
 }
 
 

--- a/resources/js/vue/components/BuildCommandsPage.vue
+++ b/resources/js/vue/components/BuildCommandsPage.vue
@@ -225,6 +225,7 @@ export default {
 
       return this.allCommands?.map(edge => {
         return {
+          id: edge.node.id,
           startTime: DateTime.fromISO(edge.node.startTime),
           duration: Duration.fromMillis(edge.node.duration),
           type: edge.node.type,

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -229,6 +229,7 @@ export default {
       return commands?.map(edge => {
         const targetId = edge.node.target?.id;
         return {
+          id: edge.node.id,
           startTime: DateTime.fromISO(edge.node.startTime),
           duration: Duration.fromMillis(edge.node.duration),
           type: edge.node.type,

--- a/resources/js/vue/components/shared/CommandInfoCard.vue
+++ b/resources/js/vue/components/shared/CommandInfoCard.vue
@@ -1,0 +1,219 @@
+<template>
+  <div>
+    <loading-indicator :is-loading="!buildCommand">
+      <div class="tw-font-bold tw-text-lg">
+        Details
+      </div>
+      <table class="tw-table tw-table-sm">
+        <tbody>
+          <tr>
+            <td class="tw-font-bold tw-w-px">
+              Type
+            </td>
+            <td>{{ buildCommand.type }}</td>
+          </tr>
+          <tr v-if="buildCommand.target">
+            <td class="tw-font-bold">
+              Target
+            </td>
+            <td>{{ buildCommand.target.name }}</td>
+          </tr>
+          <tr>
+            <td class="tw-font-bold">
+              Start Time
+            </td>
+            <td>{{ commandStartTime }}</td>
+          </tr>
+          <tr>
+            <td class="tw-font-bold">
+              Duration
+            </td>
+            <td>{{ commandDuration }}</td>
+          </tr>
+          <tr v-if="buildCommand.language">
+            <td class="tw-font-bold">
+              Language
+            </td>
+            <td>{{ buildCommand.language }}</td>
+          </tr>
+          <tr v-if="buildCommand.config">
+            <td class="tw-font-bold">
+              Config
+            </td>
+            <td>{{ buildCommand.config }}</td>
+          </tr>
+          <tr v-if="buildCommand.source">
+            <td class="tw-font-bold">
+              Source
+            </td>
+            <td class="tw-font-mono">
+              {{ buildCommand.source }}
+            </td>
+          </tr>
+          <tr>
+            <td class="tw-font-bold">
+              Command
+            </td>
+            <td class="tw-font-mono">
+              {{ buildCommand.command }}
+            </td>
+          </tr>
+          <tr>
+            <td class="tw-font-bold">
+              Working Directory
+            </td>
+            <td class="tw-font-mono">
+              {{ buildCommand.workingDirectory }}
+            </td>
+          </tr>
+          <tr>
+            <td class="tw-font-bold">
+              Result
+            </td>
+            <td class="tw-font-mono">
+              {{ buildCommand.result }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="tw-divider" />
+      <div class="tw-font-bold tw-text-lg">
+        Measurements
+      </div>
+      <table class="tw-table tw-table-sm">
+        <tbody>
+          <tr v-for="{ node: measurement } in buildCommand.measurements.edges">
+            <td class="tw-font-bold tw-w-px">
+              {{ measurement.name }}
+            </td>
+            <td>{{ addUnitsToSpecialMeasurements(measurement.name, measurement.value) }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <template v-if="buildCommand.outputs.edges.length > 0">
+        <div class="tw-divider" />
+        <div class="tw-font-bold tw-text-lg">
+          Output
+        </div>
+        <table class="tw-table tw-table-sm">
+          <tbody>
+            <tr v-for="{ node: output } in buildCommand.outputs.edges">
+              <td class="tw-font-bold tw-w-px">
+                {{ output.name }}
+              </td>
+              <td>{{ humanReadableMemory(output.size) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+    </loading-indicator>
+  </div>
+</template>
+
+<script>
+import gql from 'graphql-tag';
+import LoadingIndicator from './LoadingIndicator.vue';
+import { DateTime } from 'luxon';
+import Utils from './Utils';
+
+export default {
+  components: {LoadingIndicator},
+  props: {
+    commandId: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  apollo: {
+    buildCommand: {
+      query: gql`
+        query($id: ID) {
+          buildCommand(id: $id) {
+            id
+            type
+            startTime
+            duration
+            command
+            workingDirectory
+            result
+            source
+            language
+            config
+            target {
+              id
+              name
+            }
+            measurements(first: 10000) {
+              edges {
+                node {
+                  id
+                  name
+                  value
+                }
+              }
+            }
+            outputs(first: 10000) {
+              edges {
+                node {
+                  id
+                  name
+                  size
+                }
+              }
+            }
+          }
+        }
+      `,
+
+      variables() {
+        return {
+          id: this.commandId,
+        };
+      },
+    },
+  },
+
+  computed: {
+    commandStartTime() {
+      return DateTime.fromISO(this.buildCommand.startTime).toSQL();
+    },
+
+    commandDuration() {
+      return Utils.formatDuration(this.buildCommand.duration);
+    },
+  },
+
+  methods: {
+    humanReadableMemory(inputInBytes) {
+      if (!inputInBytes) {
+        return '';
+      }
+
+      if (inputInBytes < 1024) {
+        return `${inputInBytes} Bytes`;
+      }
+      else if (inputInBytes < 1024 ** 2) {
+        return `${(inputInBytes / 1024).toFixed(2)} KiB`;
+      }
+      else if (inputInBytes < 1024 ** 3) {
+        return `${(inputInBytes / (1024 ** 2)).toFixed(2)} MiB`;
+      }
+      else if (inputInBytes < 1024 ** 4) {
+        return `${(inputInBytes / (1024 ** 3)).toFixed(2)} GiB`;
+      }
+      else {
+        return `${(inputInBytes / (1024 ** 4)).toFixed(2)} TiB`;
+      }
+    },
+
+    addUnitsToSpecialMeasurements(measurementName, measurementValue) {
+      if (['BeforeHostMemoryUsed', 'AfterHostMemoryUsed'].includes(measurementName)) {
+        return this.humanReadableMemory(measurementValue);
+      }
+
+      return measurementValue;
+    },
+  },
+};
+</script>

--- a/resources/js/vue/components/shared/LineChart.vue
+++ b/resources/js/vue/components/shared/LineChart.vue
@@ -7,8 +7,8 @@
 </template>
 
 <script>
-import { Duration } from 'luxon';
 import VChart from 'vue-echarts';
+import Utils from './Utils';
 
 export default {
   name: 'LineChart',
@@ -69,7 +69,7 @@ export default {
             ...baseOption.xAxis,
             axisLabel: {
               formatter: (value) => {
-                return this.formatDuration(value);
+                return Utils.formatDuration(value);
               },
             },
           },
@@ -116,19 +116,6 @@ export default {
       }
 
       return baseOption;
-    },
-  },
-
-  methods: {
-    formatDuration(ms) {
-      if (ms < 1000) {
-        return `${ms}ms`;
-      }
-      if (ms < 60000) {
-        return `${(ms / 1000).toFixed(2)}s`;
-      }
-      const duration = Duration.fromMillis(ms);
-      return duration.toFormat("m'm' ss's'");
     },
   },
 };

--- a/resources/js/vue/components/shared/Utils.js
+++ b/resources/js/vue/components/shared/Utils.js
@@ -1,0 +1,15 @@
+import {Duration} from 'luxon';
+
+export default {
+  formatDuration(ms) {
+    if (ms < 1000) {
+      return `${ms}ms`;
+    }
+    if (ms < 60000) {
+      return `${(ms / 1000).toFixed(2)}s`;
+    }
+    const duration = Duration.fromMillis(ms);
+    // Use Luxon's toFormat which intelligently omits larger units if they are zero.
+    return duration.toFormat("m'm' ss's'");
+  },
+};

--- a/tests/Feature/GraphQL/QueryTypeTest.php
+++ b/tests/Feature/GraphQL/QueryTypeTest.php
@@ -2,18 +2,28 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Enums\BuildCommandType;
+use App\Models\BuildCommand;
+use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
 
 class QueryTypeTest extends TestCase
 {
+    use CreatesProjects;
     use CreatesUsers;
     use DatabaseTransactions;
 
     /** @var array<User> */
     private array $users = [];
+
+    /** @var array<Project> */
+    private array $projects = [];
 
     protected function tearDown(): void
     {
@@ -21,6 +31,11 @@ class QueryTypeTest extends TestCase
             $user->delete();
         }
         $this->users = [];
+
+        foreach ($this->projects as $project) {
+            $project->delete();
+        }
+        $this->projects = [];
 
         parent::tearDown();
     }
@@ -150,6 +165,80 @@ class QueryTypeTest extends TestCase
                         ],
                     ],
                 ],
+            ],
+        ]);
+    }
+
+    public function testBuildCommandFieldRestrictsAccessByProject(): void
+    {
+        $user = $this->makeNormalUser();
+        $this->users[] = $user;
+
+        $project1 = $this->makePrivateProject();
+        $project1->users()
+            ->attach($user->id, [
+                'emailtype' => 0,
+                'emailcategory' => 0,
+                'emailsuccess' => true,
+                'emailmissingsites' => true,
+                'role' => Project::PROJECT_ADMIN,
+            ]);
+        /** @var BuildCommand $command1 */
+        $command1 = $project1->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->commands()->create([
+            'type' => BuildCommandType::CUSTOM,
+            'starttime' => Carbon::now(),
+            'duration' => 0,
+            'command' => '',
+            'result' => '',
+            'workingdirectory' => Str::uuid()->toString(),
+        ]);
+        $this->projects[] = $project1;
+
+        $project2 = $this->makePrivateProject();
+        /** @var BuildCommand $command2 */
+        $command2 = $project2->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ])->commands()->create([
+            'type' => BuildCommandType::CUSTOM,
+            'starttime' => Carbon::now(),
+            'duration' => 0,
+            'command' => '',
+            'result' => '',
+            'workingdirectory' => Str::uuid()->toString(),
+        ]);
+        $this->projects[] = $project2;
+
+        $this->actingAs($user)->graphQL('
+            query($id: ID!) {
+                buildCommand(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $command1->id,
+        ])->assertExactJson([
+            'data' => [
+                'buildCommand' => [
+                    'id' => (string) $command1->id,
+                ],
+            ],
+        ]);
+
+        $this->actingAs($user)->graphQL('
+            query($id: ID!) {
+                buildCommand(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $command2->id,
+        ])->assertExactJson([
+            'data' => [
+                'buildCommand' => null,
             ],
         ]);
     }


### PR DESCRIPTION
The tooltip visible when hovering over commands in the instrumentation command flame graph contains a subset of the instrumentation data CDash stores.  This PR introduces the ability to click on commands for more information, including the full command, measurements, and output.

<img width="2362" height="4390" alt="image" src="https://github.com/user-attachments/assets/a79ba446-6d76-4cc5-93eb-70978a0a3c7c" />
