### PR TITLE
Invert instrumentation tracks

### DIFF
--- a/resources/js/vue/components/shared/CommandGanttChart.vue
+++ b/resources/js/vue/components/shared/CommandGanttChart.vue
@@ -210,6 +210,7 @@ export default {
           show: false,
           type: 'category',
           data: this.processedChartData.tracks,
+          inverse: true,
         },
         dataZoom: [
           {


### PR DESCRIPTION
Putting the longest tracks at the top makes it clear that there's data present when the bottom of the plot is off the page when the page first loads

Before:
<img width="2680" height="1126" alt="image" src="https://github.com/user-attachments/assets/5f72569e-c2d1-4f03-8dca-020ff0faebe7" />


After:
<img width="2684" height="1152" alt="image" src="https://github.com/user-attachments/assets/bf93a9a1-54c5-42ee-af02-f023865e6b77" />
