### PR TITLE
Fix monitor page timestamp ordering

### DIFF
--- a/app/Http/Controllers/MonitorController.php
+++ b/app/Http/Controllers/MonitorController.php
@@ -150,6 +150,7 @@ final class MonitorController extends AbstractController
               COUNT(1) AS n_jobs
             "))
             ->groupBy('truncated_time')
+            ->orderBy('truncated_time')
             ->get();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Kitware/CDash/issues/3392.  This bug has been around for a while.  In most cases, the database ordering matches the real timestamp ordering pretty closely, making it appear correct.  If the database ordering diverges from the timestamp ordering, that's when things get wonky.  This PR fixes the issue by explicitly ordering by timestamp.