### PR TITLE
Add build name to filter conditions for test history plot

### DIFF
--- a/resources/js/vue/components/TestDetails.vue
+++ b/resources/js/vue/components/TestDetails.vue
@@ -229,6 +229,7 @@
         :project-id="cdash.projectid"
         :project-name="cdash.projectname"
         :test-name="cdash.test.test"
+        :build-name="cdash.test.build"
       />
 
       <br>

--- a/resources/js/vue/components/shared/TestHistoryPlot.vue
+++ b/resources/js/vue/components/shared/TestHistoryPlot.vue
@@ -83,6 +83,10 @@ export default {
       type: String,
       required: true,
     },
+    buildName: {
+      type: String,
+      required: true,
+    },
   },
 
   data() {
@@ -95,29 +99,38 @@ export default {
   apollo: {
     testStatuses: {
       query: gql`
-        query($projectid: ID, $testname: String!) {
+        query($projectid: ID, $testname: String!, $buildname: String!) {
           testStatuses: project(id: $projectid) {
             id
             name
             buildsWhereTestPassed: builds(filters: {
               any: [
                 {
-                  has: {
-                    tests: {
-                      all: [
-                        {
-                          eq: {
-                            status: PASSED
-                          }
-                        },
-                        {
-                          eq: {
-                            name: $testname
-                          }
-                        },
-                      ]
+                  all: [
+                    {
+                      has: {
+                        tests: {
+                          all: [
+                            {
+                              eq: {
+                                status: PASSED
+                              }
+                            },
+                            {
+                              eq: {
+                                name: $testname
+                              }
+                            },
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      eq: {
+                        name: $buildname
+                      }
                     }
-                  }
+                  ]
                 }
                 {
                   has: {
@@ -139,6 +152,11 @@ export default {
                                 },
                               ]
                             }
+                          }
+                        },
+                        {
+                          eq: {
+                            name: $buildname
                           }
                         }
                       ]
@@ -216,6 +234,7 @@ export default {
         return {
           projectid: this.projectId,
           testname: this.testName,
+          buildname: this.buildName,
         };
       },
     },


### PR DESCRIPTION
This change will make the plot load faster for large projects and give users the ability to tell generally flaky tests apart from tests which are flaky in a particular build configuration.