### PR TITLE
Delete invalid build2update rows before migration

### DIFF
--- a/database/migrations/2026_01_15_143405_drop_build2update_table.php
+++ b/database/migrations/2026_01_15_143405_drop_build2update_table.php
@@ -5,6 +5,8 @@ use Illuminate\Database\Migrations\Migration;
 return new class extends Migration {
     public function up(): void
     {
+        DB::delete('DELETE FROM build2update WHERE NOT EXISTS (SELECT 1 FROM buildupdate WHERE build2update.updateid = buildupdate.id)');
+
         DB::statement('ALTER TABLE build ADD COLUMN updateid bigint');
         DB::statement('ALTER TABLE build ADD FOREIGN KEY (updateid) REFERENCES buildupdate(id) ON DELETE SET NULL');
 


### PR DESCRIPTION
The updateid column did not have a foreign-key constraint, so it's possible for records to exist in the build2update table without a corresponding record in the buildupdate table.