### PR TITLE
Fix build history plots

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -1160,7 +1160,7 @@ final class BuildController extends AbstractBuildController
                                 b.starttime,
                                 b.endtime
                             FROM build AS b
-                            LEFT JOIN buildupdate AS bu ON (bu.updateid=b.id)
+                            LEFT JOIN buildupdate AS bu ON (b.updateid=bu.id)
                             WHERE
                                 siteid = ?
                                 AND b.type = ?


### PR DESCRIPTION
The graphs under `/builds/<id>` were broken in https://github.com/Kitware/CDash/pull/3370.