### PR TITLE
Remove confusing GraphQL filter button

### DIFF
--- a/resources/js/vue/components/shared/FilterBuilder.vue
+++ b/resources/js/vue/components/shared/FilterBuilder.vue
@@ -20,15 +20,6 @@
       >
         <font-awesome-icon :icon="FA.faMagnifyingGlass" /> Apply
       </a>
-      <a
-        role="button"
-        class="tw-btn tw-btn-xs"
-        :href="$baseURL + '/graphql/explorer'"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <font-awesome-icon :icon="FA.faTerminal" /> GraphQL
-      </a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This button is just a link to the GraphiQL interface, and we've received several user reports about it being confusing.