### PR TITLE
Apply unique name validation rule to createProject mutation

### DIFF
--- a/app/GraphQL/Validators/CreateProjectInputValidator.php
+++ b/app/GraphQL/Validators/CreateProjectInputValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Validators;
+
+use App\Models\Project;
+use App\Rules\ProjectAuthenticateSubmissionsRule;
+use App\Rules\ProjectNameRule;
+use App\Rules\ProjectVisibilityRule;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class CreateProjectInputValidator extends Validator
+{
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                Rule::unique(Project::class, 'name'),
+                new ProjectNameRule(),
+            ],
+            'homeurl' => [
+                'prohibits:homeUrl',
+            ],
+            'homeUrl' => [
+                'prohibits:homeurl',
+            ],
+            'visibility' => [
+                new ProjectVisibilityRule(),
+            ],
+            'authenticateSubmissions' => [
+                new ProjectAuthenticateSubmissionsRule(),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.unique' => 'A project with this name already exists.',
+        ];
+    }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -214,24 +214,24 @@ enum ProjectVisibility {
   PRIVATE @enum(value: 0)
 }
 
-input CreateProjectInput {
+input CreateProjectInput @validator {
   "Unique name."
-  name: String! @rules(apply: ["App\\Rules\\ProjectNameRule"])
+  name: String!
 
   "Description."
   description: String
 
   "Project homepage"
-  homeurl: Url @deprecated(reason: "Use 'homeUrl' instead.") @rules(apply: ["prohibits:homeUrl"])
+  homeurl: Url @deprecated(reason: "Use 'homeUrl' instead.")
 
   "Project homepage"
-  homeUrl: Url @rename(attribute: "homeurl") @rules(apply: ["prohibits:homeurl"])
+  homeUrl: Url @rename(attribute: "homeurl") @deprecated(reason: "This field will be removed in the next major version of CDash.")
 
   "Visibility."
-  visibility: ProjectVisibility! @rename(attribute: "public") @rules(attribute: "public", apply: ["App\\Rules\\ProjectVisibilityRule"])
+  visibility: ProjectVisibility! @rename(attribute: "public")
 
   "A boolean indicating whether authenticated submissions are required."
-  authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions") @rules(attribute: "authenticatesubmissions", apply: ["App\\Rules\\ProjectAuthenticateSubmissionsRule"])
+  authenticateSubmissions: Boolean! @rename(attribute: "authenticatesubmissions")
 
   "A LDAP group users must be a member of to access the project."
   ldapFilter: String @deprecated(reason: "This field will be removed in the next major version of CDash.") @rename(attribute: "ldapfilter")

--- a/tests/Browser/Pages/CreateProjectPageTest.php
+++ b/tests/Browser/Pages/CreateProjectPageTest.php
@@ -4,6 +4,7 @@ namespace Tests\Browser\Pages;
 
 use App\Models\Project;
 use App\Models\User;
+use App\Services\ProjectService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -75,6 +76,28 @@ class CreateProjectPageTest extends BrowserTestCase
                 ->click('@create-project-button')
                 ->waitFor('@project-name-validation-errors')
                 ->assertSeeIn('@project-name-validation-errors', 'Project name may only contain letters, numbers, dashes, and underscores.')
+            ;
+        });
+    }
+
+    public function testShowsErrorWhenProjectAlreadyExists(): void
+    {
+        $this->users['admin'] = $this->makeAdminUser();
+
+        $project_name = Str::uuid()->toString();
+
+        $this->projects[] = ProjectService::create([
+            'name' => $project_name,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($project_name): void {
+            $browser->loginAs($this->users['admin'])
+                ->visit('/projects/new')
+                ->waitFor('@create-project-page')
+                ->type('@project-name-input', $project_name)
+                ->click('@create-project-button')
+                ->waitFor('@project-name-validation-errors')
+                ->assertSeeIn('@project-name-validation-errors', 'A project with this name already exists.')
             ;
         });
     }


### PR DESCRIPTION
While Postgres enforces unique project names correctly, the resulting error message for this common situation is a standard server error.  This commit moves the createProject validation logic to a dedicated validator and adds a unique name validation rule.