### PR TITLE
Expose all project fields via GraphQL

### DIFF
--- a/app/GraphQL/Scalars/Time.php
+++ b/app/GraphQL/Scalars/Time.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\GraphQL\Scalars;
+
+use Carbon\Exceptions\InvalidFormatException;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\ValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use Illuminate\Support\Carbon;
+
+final class Time extends ScalarType
+{
+    public function serialize(mixed $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * @throws InvariantViolation
+     */
+    public function parseValue(mixed $value): string
+    {
+        if (!$this->validateTime($value)) {
+            throw new InvariantViolation("The value $value is not a valid Time format (H:i:s).");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param ValueNode&Node $valueNode
+     * @param array<string, mixed>|null $variables
+     *
+     * @throws InvariantViolation
+     */
+    public function parseLiteral(Node $valueNode, ?array $variables = null): string
+    {
+        if (!property_exists($valueNode, 'value')) {
+            throw new InvariantViolation('Time must be a string.');
+        }
+
+        if (!$this->validateTime($valueNode->value)) {
+            throw new InvariantViolation("The value {$valueNode->value} is not a valid Time.");
+        }
+
+        return $valueNode->value;
+    }
+
+    private function validateTime(string $time): bool
+    {
+        // Simple regex for HH:MM:SS* format to make sure it's actually a time, not a datetime.
+        if (preg_match('/^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]/', $time) !== 1) {
+            return false;
+        }
+
+        try {
+            Carbon::parse($time);
+            return true;
+        } catch (InvalidFormatException) {
+            return false;
+        }
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -14,23 +14,23 @@ use Illuminate\Support\Facades\Auth;
 /**
  * @property int $id
  * @property string $name
- * @property string $description
- * @property string $homeurl
- * @property string $cvsurl
- * @property string $bugtrackerurl
- * @property string $bugtrackernewissueurl
- * @property string $bugtrackertype
- * @property string $documentationurl
+ * @property ?string $description
+ * @property ?string $homeurl
+ * @property ?string $cvsurl
+ * @property ?string $bugtrackerurl
+ * @property ?string $bugtrackernewissueurl
+ * @property ?string $bugtrackertype
+ * @property ?string $documentationurl
  * @property int $imageid
  * @property int $public
  * @property int $coveragethreshold
- * @property string $testingdataurl
+ * @property ?string $testingdataurl
  * @property string $nightlytime
  * @property bool $emaillowcoverage
  * @property bool $emailtesttimingchanged
  * @property bool $emailbrokensubmission
  * @property bool $emailredundantfailures
- * @property string $cvsviewertype
+ * @property ?string $cvsviewertype
  * @property int $testtimestd
  * @property int $testtimestdthreshold
  * @property bool $showtesttime

--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -664,7 +664,7 @@ class GitHub implements RepositoryInterface
 
     protected function getRepositoryInformation(): void
     {
-        $url = str_replace('//', '', $this->project->CvsUrl);
+        $url = str_replace('//', '', $this->project->CvsUrl ?? '');
         $parts = explode('/', $url);
         if (isset($parts[1])) {
             $this->owner = $parts[1];

--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -110,7 +110,7 @@ class BuildError
             'logline' => (int) $data['logline'],
             'cvsurl' => RepositoryUtils::get_diff_url($project->Id, $project->CvsUrl, $sourceFile['directory'], $sourceFile['file'], $revision),
             'precontext' => '',
-            'text' => RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir, $revision, $data['stdoutput']),
+            'text' => RepositoryUtils::linkify_compiler_output($project->CvsUrl ?? '', $source_dir, $revision, $data['stdoutput']),
             'postcontext' => '',
             'sourcefile' => $data['sourcefile'],
             'sourceline' => $data['sourceline'],

--- a/app/cdash/app/Model/BuildFailure.php
+++ b/app/cdash/app/Model/BuildFailure.php
@@ -255,7 +255,7 @@ class BuildFailure
             $file = basename($data['sourcefile']);
             $directory = dirname($data['sourcefile']);
 
-            $source_dir = RepositoryUtils::get_source_dir($project->Id, $project->CvsUrl, $directory);
+            $source_dir = RepositoryUtils::get_source_dir($project->Id, $project->CvsUrl ?? '', $directory);
             if (str_starts_with($directory, $source_dir)) {
                 $directory = substr($directory, strlen($source_dir));
             }
@@ -267,9 +267,9 @@ class BuildFailure
                 $revision);
 
             if ($source_dir !== null && $linkifyOutput) {
-                $marshaled['stderror'] = RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir,
+                $marshaled['stderror'] = RepositoryUtils::linkify_compiler_output($project->CvsUrl ?? '', $source_dir,
                     $revision, $data['stderror']);
-                $marshaled['stdoutput'] = RepositoryUtils::linkify_compiler_output($project->CvsUrl, $source_dir,
+                $marshaled['stdoutput'] = RepositoryUtils::linkify_compiler_output($project->CvsUrl ?? '', $source_dir,
                     $revision, $data['stdoutput']);
             }
         }

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -43,17 +43,17 @@ class Project
 {
     public $Name;
     public $Id;
-    public $Description;
-    public $HomeUrl;
-    public $CvsUrl;
-    public $DocumentationUrl;
-    public $BugTrackerUrl;
-    public $BugTrackerNewIssueUrl;
-    public $BugTrackerType;
+    public ?string $Description = null;
+    public ?string $HomeUrl = null;
+    public ?string $CvsUrl = null;
+    public ?string $DocumentationUrl = null;
+    public ?string $BugTrackerUrl = null;
+    public ?string $BugTrackerNewIssueUrl = null;
+    public ?string $BugTrackerType = null;
     public ?int $ImageId = null;
     public $Public;
     public $CoverageThreshold;
-    public $TestingDataUrl;
+    public ?string $TestingDataUrl = null;
     public $NightlyTime;
     public $NightlyDateTime;
     public $NightlyTimezone;
@@ -61,7 +61,7 @@ class Project
     public $EmailTestTimingChanged = 0;
     public $EmailBrokenSubmission = 0;
     public $EmailRedundantFailures = 0;
-    public $CvsViewerType;
+    public ?string $CvsViewerType = null;
     public $TestTimeStd;
     public $TestTimeStdThreshold;
     public $ShowTestTime = 0;
@@ -115,15 +115,15 @@ class Project
         $project->fill([
             'name' => $this->Name ?? '',
             'description' => $this->Description,
-            'homeurl' => $this->HomeUrl ?? '',
-            'cvsurl' => $this->CvsUrl ?? '',
-            'documentationurl' => $this->DocumentationUrl ?? '',
-            'bugtrackerurl' => $this->BugTrackerUrl ?? '',
-            'bugtrackernewissueurl' => $this->BugTrackerNewIssueUrl ?? '',
-            'bugtrackertype' => $this->BugTrackerType ?? '',
+            'homeurl' => $this->HomeUrl,
+            'cvsurl' => $this->CvsUrl,
+            'documentationurl' => $this->DocumentationUrl,
+            'bugtrackerurl' => $this->BugTrackerUrl,
+            'bugtrackernewissueurl' => $this->BugTrackerNewIssueUrl,
+            'bugtrackertype' => $this->BugTrackerType,
             'public' => (int) $this->Public,
             'coveragethreshold' => (int) $this->CoverageThreshold,
-            'testingdataurl' => $this->TestingDataUrl ?? '',
+            'testingdataurl' => $this->TestingDataUrl,
             'nightlytime' => $this->NightlyTime ?? '',
             'emaillowcoverage' => (bool) $this->EmailLowCoverage,
             'emailtesttimingchanged' => (bool) $this->EmailTestTimingChanged,
@@ -137,7 +137,7 @@ class Project
             'autoremovetimeframe' => (int) $this->AutoremoveTimeframe,
             'autoremovemaxbuilds' => (int) $this->AutoremoveMaxBuilds,
             'uploadquota' => (int) $this->UploadQuota,
-            'cvsviewertype' => $this->CvsViewerType ?? '',
+            'cvsviewertype' => $this->CvsViewerType,
             'testtimestd' => (int) $this->TestTimeStd,
             'testtimestdthreshold' => (int) $this->TestTimeStdThreshold,
             'showtesttime' => (bool) $this->ShowTestTime,

--- a/app/cdash/app/Model/Repository.php
+++ b/app/cdash/app/Model/Repository.php
@@ -107,7 +107,7 @@ class Repository
 
     public static function getRepositoryInterface(Project $project): RepositoryInterface
     {
-        switch (strtolower($project->CvsViewerType)) {
+        switch (strtolower($project->CvsViewerType ?? '')) {
             case strtolower(self::VIEWER_GITHUB):
                 $service = new GitHub($project);
                 break;

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -572,10 +572,10 @@ function get_dashboard_JSON($projectname, $date, &$response): void
     $project->FindByName($projectname);
 
     $project_array = [];
-    $project_array['cvsurl'] = $project->Id ? $project->CvsUrl : 'unknown';
-    $project_array['bugtrackerurl'] = $project->Id ? $project->BugTrackerUrl : 'unknown';
-    $project_array['documentationurl'] = $project->Id ? $project->DocumentationUrl : 'unknown';
-    $project_array['homeurl'] = $project->Id ? $project->HomeUrl : 'unknown';
+    $project_array['cvsurl'] = $project->CvsUrl ?? '';
+    $project_array['bugtrackerurl'] = $project->BugTrackerUrl ?? '';
+    $project_array['documentationurl'] = $project->DocumentationUrl ?? '';
+    $project_array['homeurl'] = $project->HomeUrl ?? '';
     $project_array['name'] = $projectname;
     $project_array['nightlytime'] = $project->Id ? $project->NightlyTime : '00:00:00';
 

--- a/app/cdash/tests/test_builddetails.php
+++ b/app/cdash/tests/test_builddetails.php
@@ -24,7 +24,7 @@ class BuildDetailsTestCase extends KWWebTestCase
 
         $this->createProject([
             'Name' => 'BuildDetails',
-            'CvsViewerType' => 'viewcvs',
+            'CvsViewerType' => null,
         ]);
 
         foreach ($this->testDataFiles as $testDataFile) {

--- a/database/migrations/2026_01_30_045544_project_column_types.php
+++ b/database/migrations/2026_01_30_045544_project_column_types.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project ALTER COLUMN homeurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN homeurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN homeurl TYPE text');
+        DB::update("UPDATE project SET homeurl = NULL WHERE homeurl = ''");
+
+        DB::statement('ALTER TABLE project ALTER COLUMN cvsurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN cvsurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN cvsurl TYPE text');
+        DB::update("UPDATE project SET cvsurl = NULL WHERE cvsurl = ''");
+
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackerurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackerurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackerurl TYPE text');
+        DB::update("UPDATE project SET bugtrackerurl = NULL WHERE bugtrackerurl = ''");
+
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackernewissueurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackernewissueurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN bugtrackernewissueurl TYPE text');
+        DB::update("UPDATE project SET bugtrackernewissueurl = NULL WHERE bugtrackernewissueurl = ''");
+
+        DB::statement('ALTER TABLE project ALTER COLUMN documentationurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN documentationurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN documentationurl TYPE text');
+        DB::update("UPDATE project SET documentationurl = NULL WHERE documentationurl = ''");
+
+        DB::statement('ALTER TABLE project ALTER COLUMN testingdataurl DROP NOT NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN testingdataurl DROP DEFAULT');
+        DB::statement('ALTER TABLE project ALTER COLUMN testingdataurl TYPE text');
+        DB::update("UPDATE project SET testingdataurl = NULL WHERE testingdataurl = ''");
+
+        DB::update('UPDATE project SET testtimestd = 4 WHERE testtimestd IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN testtimestd SET NOT NULL');
+
+        DB::update('UPDATE project SET testtimestdthreshold = 1 WHERE testtimestdthreshold IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN testtimestdthreshold SET NOT NULL');
+
+        DB::update('UPDATE project SET testtimemaxstatus = 3 WHERE testtimemaxstatus IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN testtimemaxstatus SET NOT NULL');
+
+        DB::update('UPDATE project SET emailmaxitems = 5 WHERE emailmaxitems IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN emailmaxitems SET NOT NULL');
+
+        DB::update('UPDATE project SET emailmaxchars = 255 WHERE emailmaxchars IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN emailmaxchars SET NOT NULL');
+
+        DB::update('UPDATE project SET autoremovetimeframe = 0 WHERE autoremovetimeframe IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN autoremovetimeframe SET NOT NULL');
+
+        DB::update('UPDATE project SET autoremovemaxbuilds = 300 WHERE autoremovemaxbuilds IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN autoremovemaxbuilds SET NOT NULL');
+
+        DB::update('UPDATE project SET uploadquota = 0 WHERE uploadquota IS NULL');
+        DB::statement('ALTER TABLE project ALTER COLUMN uploadquota SET NOT NULL');
+
+        DB::statement('ALTER TABLE project ALTER COLUMN ldapfilter TYPE text');
+
+        DB::statement('ALTER TABLE project ALTER COLUMN banner TYPE text');
+
+        // We drop the type first in case the database has been truncated previously.
+        DB::statement('DROP TYPE IF EXISTS cvsviewertype');
+        DB::statement("CREATE TYPE cvsviewertype AS ENUM ('github', 'gitlab')");
+        DB::statement("
+            ALTER TABLE project
+            ALTER COLUMN cvsviewertype
+            TYPE cvsviewertype USING
+                CASE
+                    WHEN cvsviewertype = 'github' THEN 'github'::cvsviewertype
+                    WHEN cvsviewertype = 'gitlab' THEN 'gitlab'::cvsviewertype
+                    ELSE NULL
+                END
+        ");
+
+        // We drop the type first in case the database has been truncated previously.
+        DB::statement('DROP TYPE IF EXISTS bugtrackertype');
+        DB::statement("CREATE TYPE bugtrackertype AS ENUM ('GitHub', 'Buganizer', 'JIRA')");
+        DB::statement("
+            ALTER TABLE project
+            ALTER COLUMN bugtrackertype
+            TYPE bugtrackertype USING
+                CASE
+                    WHEN bugtrackertype = 'GitHub' THEN 'GitHub'::bugtrackertype
+                    WHEN bugtrackertype = 'Buganizer' THEN 'Buganizer'::bugtrackertype
+                    WHEN bugtrackertype = 'JIRA' THEN 'JIRA'::bugtrackertype
+                    ELSE NULL
+                END
+        ");
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -13,6 +13,8 @@ scalar NonNegativeIntegerMilliseconds @scalar(class: "App\\GraphQL\\Scalars\\Non
 
 scalar Url @scalar(class: "App\\GraphQL\\Scalars\\Url")
 
+scalar Time @scalar(class: "App\\GraphQL\\Scalars\\Time")
+
 
 "Indicates what fields are available at the top level of a query operation."
 type Query {
@@ -158,6 +160,24 @@ type Project {
   "Homepage for this project."
   homeUrl: Url @rename(attribute: "homeurl")
 
+  vcsViewer: VcsViewer @rename(attribute: "cvsviewertype")
+
+  "Example: https://github.com/Kitware/CDash"
+  vcsUrl: Url @rename(attribute: "cvsurl")
+
+  bugTracker: BugTracker @rename(attribute: "bugtrackertype")
+
+  "Example: https://github.com/Kitware/CDash/issues"
+  bugTrackerUrl: Url @rename(attribute: "bugtrackerurl")
+
+  "Example: https://github.com/Kitware/CDash/issues/new"
+  bugTrackerNewIssueUrl: Url @rename(attribute: "bugtrackernewissueurl")
+
+  "Example: https://cmake.org/cmake/help/latest"
+  documentationUrl: Url @rename(attribute: "documentationurl")
+
+  testDataUrl: Url @rename(attribute: "testingdataurl")
+
   "Visibility."
   visibility: ProjectVisibility! @rename(attribute: "public") @filterable
 
@@ -169,6 +189,91 @@ type Project {
 
   "A full URL string pointing to the location of the project's logo."
   logoUrl: String
+
+  "Coverage percentages above this threshold will be displayed in green."
+  coverageThreshold: Int! @rename(attribute: "coveragethreshold")
+
+  nightlyTime: Time! @rename(attribute: "nightlytime")
+
+  "Should emails be sent when the coverage for files is lower than the `coverageThreshold` value?"
+  emailLowCoverage: Boolean! @rename(attribute: "emaillowcoverage")
+
+  "Should emails be sent when the test time status changes?"
+  emailTestTimingChanged: Boolean! @rename(attribute: "emailtesttimingchanged")
+
+  "Should emails be sent for broken submissions?"
+  emailBrokenSubmissions: Boolean! @rename(attribute: "emailbrokensubmission")
+
+  "Send emails for all failures if true.  Otherwise, only send emails after the first failure."
+  emailRedundantFailures: Boolean! @rename(attribute: "emailredundantfailures")
+
+  """
+  Set a multiplier for the standard deviation for a test time. If the time for a test is higher
+  than mean+multiplier*standarddeviation, the test time status is marked as failed. Note that
+  changing this value doesn’t affect previous builds.
+  """
+  testTimeStdMultiplier: Float! @rename(attribute: "testtimestd")
+
+  """
+  Set a minimum standard deviation for a test time failure. If the current standard deviation for a
+  test is lower than this threshold then the threshold is used instead. This is particularly
+  important for tests that have a very low standard deviation but still some variability. Note that
+  changing this value doesn’t affect previous builds.
+  """
+  testTimeStdThreshold: Float! @rename(attribute: "testtimestdthreshold")
+
+  "Enable/Disable test timing for this project."
+  enableTestTiming: Boolean! @rename(attribute: "showtesttime")
+
+  """
+  The number of times a test must violate the time status check before it is flagged as a failure.
+  For example, if this is set to 2, then a test will need to run more slowly than expected twice
+  in a row before it is marked as having failed the time status check.
+  """
+  timeStatusFailureThreshold: Int! @rename(attribute: "testtimemaxstatus")
+
+  "Maximum number of items per email."
+  emailMaxItems: Int! @rename(attribute: "emailmaxitems")
+
+  "Maximum number of characters per email."
+  emailMaxCharacters: Int! @rename(attribute: "emailmaxchars")
+
+  "Enable/Disable the display of the label column throughout the project."
+  displayLabels: Boolean! @rename(attribute: "displaylabels")
+
+  """
+  Builds older than the configured number of days will be removed.  Builds will be retained for at
+  least two days regardless of this setting.
+  """
+  autoRemoveTimeFrame: Int! @rename(attribute: "autoremovetimeframe")
+
+  """
+  The maximum number of builds to be removed on any given day.
+  """
+  autoRemoveMaxBuilds: Int! @rename(attribute: "autoremovemaxbuilds")
+
+  """
+  Uploaded files exceeding this limit (in GB) will be deleted from oldest to newest.
+  """
+  fileUploadLimit: Int! @rename(attribute: "uploadquota")
+
+  """
+  Enable/Disable the display of source code for the project. Only administrators can see the source
+  code in the coverage section when this option is disabled.
+  """
+  showCoverageCode: Boolean! @rename(attribute: "showcoveragecode")
+
+  "Forward label filters from index.php to queryTests.php and viewTest.php."
+  shareLabelFilters: Boolean! @rename(attribute: "sharelabelfilters")
+
+  """
+  If true and this Project uses SubProjects, show a per-SubProject breakdown by default. If false,
+  CDash will show per-build results instead.
+  """
+  showViewSubProjectsLink: Boolean! @rename(attribute: "viewsubprojectslink")
+
+  "Custom text displayed at the top of a project's dashboard."
+  banner: String
 
   builds(
     filters: _ @filter
@@ -203,6 +308,7 @@ type Project {
   invitations: [ProjectInvitation!]! @canRoot(ability: "inviteUser") @hasMany(type: CONNECTION) @orderBy(column: "id")
 }
 
+
 enum ProjectVisibility {
   "Available to all users and guests."
   PUBLIC @enum(value: 1)
@@ -213,6 +319,20 @@ enum ProjectVisibility {
   "Only available to users added to the project."
   PRIVATE @enum(value: 0)
 }
+
+
+enum VcsViewer {
+  GITHUB @enum(value: "github")
+  GITLAB @enum(value: "gitlab")
+}
+
+
+enum BugTracker {
+  GITHUB @enum(value: "GitHub")
+  BUGANIZER @enum(value: "Buganizer")
+  JIRA @enum(value: "JIRA")
+}
+
 
 input CreateProjectInput @validator {
   "Unique name."

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -343,6 +343,30 @@ parameters:
 			path: app/GraphQL/Scalars/NonNegativeSeconds.php
 
 		-
+			rawMessage: 'Method App\GraphQL\Scalars\Time::parseValue() should return string but returns mixed.'
+			identifier: return.type
+			count: 1
+			path: app/GraphQL/Scalars/Time.php
+
+		-
+			rawMessage: 'Method App\GraphQL\Scalars\Time::serialize() should return string but returns mixed.'
+			identifier: return.type
+			count: 1
+			path: app/GraphQL/Scalars/Time.php
+
+		-
+			rawMessage: 'Parameter #1 $time of method App\GraphQL\Scalars\Time::validateTime() expects string, mixed given.'
+			identifier: argument.type
+			count: 1
+			path: app/GraphQL/Scalars/Time.php
+
+		-
+			rawMessage: 'Part $value (mixed) of encapsed string cannot be cast to string.'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: app/GraphQL/Scalars/Time.php
+
+		-
 			rawMessage: Cannot cast mixed to string.
 			identifier: cast.string
 			count: 1
@@ -8749,12 +8773,6 @@ parameters:
 			path: app/cdash/app/Lib/Repository/GitHub.php
 
 		-
-			rawMessage: 'Parameter #2 $string of function explode expects string, (array<string>|string) given.'
-			identifier: argument.type
-			count: 1
-			path: app/cdash/app/Lib/Repository/GitHub.php
-
-		-
 			rawMessage: Possibly invalid array key type mixed.
 			identifier: offsetAccess.invalidOffset
 			count: 2
@@ -11083,55 +11101,13 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$BugTrackerNewIssueUrl has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$BugTrackerType has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$BugTrackerUrl has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$CoverageThreshold has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$CvsUrl has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$CvsViewerType has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$Description has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$DisplayLabels has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$DocumentationUrl has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -11174,12 +11150,6 @@ parameters:
 
 		-
 			rawMessage: Property CDash\Model\Project::$ErrorsFilter has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$HomeUrl has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/Project.php
@@ -11252,12 +11222,6 @@ parameters:
 
 		-
 			rawMessage: Property CDash\Model\Project::$TestTimeStdThreshold has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
-			rawMessage: Property CDash\Model\Project::$TestingDataUrl has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/app/Model/Project.php

--- a/tests/Browser/Pages/SitesIdPageTest.php
+++ b/tests/Browser/Pages/SitesIdPageTest.php
@@ -125,8 +125,8 @@ class SitesIdPageTest extends BrowserTestCase
                 ->whenAvailable('@site-projects-table', function (Browser $browser): void {
                     $browser->assertSee($this->projects['public1']->name);
                     $browser->assertSee($this->projects['public2']->name);
-                    $browser->assertSee($this->projects['public1']->description);
-                    $browser->assertSee($this->projects['public2']->description);
+                    $browser->assertSee((string) $this->projects['public1']->description);
+                    $browser->assertSee((string) $this->projects['public2']->description);
                 });
         });
     }

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -95,6 +95,116 @@ class ProjectTypeTest extends TestCase
     /**
      * @return array{
      *     array{
+     *         string, mixed, string, mixed,
+     *     }
+     * }
+     */
+    public static function fieldValues(): array
+    {
+        // TODO: once VcsViewer is an enum, get cases dynamically.
+        $vcsViewerValues = [
+            ['cvsviewertype', 'github', 'vcsViewer', 'GITHUB'],
+            ['cvsviewertype', 'gitlab', 'vcsViewer', 'GITLAB'],
+            ['cvsviewertype', null, 'vcsViewer', null],
+        ];
+
+        // TODO: once BugTracker is an enum, get cases dynamically.
+        $bugTrackerValues = [
+            ['bugtrackertype', 'GitHub', 'bugTracker', 'GITHUB'],
+            ['bugtrackertype', 'Buganizer', 'bugTracker', 'BUGANIZER'],
+            ['bugtrackertype', 'JIRA', 'bugTracker', 'JIRA'],
+            ['bugtrackertype', null, 'bugTracker', null],
+        ];
+
+        return [
+            ['description', 'abc', 'description', 'abc'],
+            ['description', null, 'description', null],
+            ['homeurl', 'https://cdash.org', 'homeurl', 'https://cdash.org'],
+            ['homeurl', null, 'homeurl', null],
+            ['homeurl', 'https://cdash.org', 'homeUrl', 'https://cdash.org'],
+            ['homeurl', null, 'homeUrl', null],
+            ...$vcsViewerValues,
+            ['cvsurl', 'https://github.com/Kitware/CDash', 'vcsUrl', 'https://github.com/Kitware/CDash'],
+            ['cvsurl', null, 'vcsUrl', null],
+            ...$bugTrackerValues,
+            ['bugtrackerurl', 'https://github.com/Kitware/CDash/issues', 'bugTrackerUrl', 'https://github.com/Kitware/CDash/issues'],
+            ['bugtrackerurl', null, 'bugTrackerUrl', null],
+            ['bugtrackernewissueurl', 'https://github.com/Kitware/CDash/issues/new', 'bugTrackerNewIssueUrl', 'https://github.com/Kitware/CDash/issues/new'],
+            ['bugtrackernewissueurl', null, 'bugTrackerNewIssueUrl', null],
+            ['documentationurl', 'https://cmake.org/cmake/help/latest', 'documentationUrl', 'https://cmake.org/cmake/help/latest'],
+            ['documentationurl', null, 'documentationUrl', null],
+            ['testingdataurl', 'https://example.com', 'testDataUrl', 'https://example.com'],
+            ['testingdataurl', null, 'testDataUrl', null],
+            ['authenticatesubmissions', true, 'authenticateSubmissions', true],
+            ['authenticatesubmissions', false, 'authenticateSubmissions', false],
+            ['ldapfilter', '(uid=*group_1*)', 'ldapFilter', '(uid=*group_1*)'],
+            ['ldapfilter', null, 'ldapFilter', null],
+            ['coveragethreshold', 80, 'coverageThreshold', 80],
+            ['nightlytime', '00:00:00', 'nightlyTime', '00:00:00'],
+            ['nightlytime', '02:00:00 UTC', 'nightlyTime', '02:00:00 UTC'],
+            ['nightlytime', '22:00:00 EST', 'nightlyTime', '22:00:00 EST'],
+            ['nightlytime', '00:00:00 America/New_York', 'nightlyTime', '00:00:00 America/New_York'],
+            ['emaillowcoverage', true, 'emailLowCoverage', true],
+            ['emaillowcoverage', false, 'emailLowCoverage', false],
+            ['emailtesttimingchanged', true, 'emailTestTimingChanged', true],
+            ['emailtesttimingchanged', false, 'emailTestTimingChanged', false],
+            ['emailbrokensubmission', true, 'emailBrokenSubmissions', true],
+            ['emailbrokensubmission', false, 'emailBrokenSubmissions', false],
+            ['emailredundantfailures', true, 'emailRedundantFailures', true],
+            ['emailredundantfailures', false, 'emailRedundantFailures', false],
+            ['testtimestd', 10, 'testTimeStdMultiplier', 10],
+            ['testtimestdthreshold', 10, 'testTimeStdThreshold', 10],
+            ['showtesttime', true, 'enableTestTiming', true],
+            ['showtesttime', false, 'enableTestTiming', false],
+            ['testtimemaxstatus', 10, 'timeStatusFailureThreshold', 10],
+            ['emailmaxitems', 10, 'emailMaxItems', 10],
+            ['emailmaxchars', 10, 'emailMaxCharacters', 10],
+            ['displaylabels', true, 'displayLabels', true],
+            ['displaylabels', false, 'displayLabels', false],
+            ['autoremovemaxbuilds', 10, 'autoRemoveMaxBuilds', 10],
+            ['uploadquota', 10, 'fileUploadLimit', 10],
+            ['showcoveragecode', true, 'showCoverageCode', true],
+            ['showcoveragecode', false, 'showCoverageCode', false],
+            ['sharelabelfilters', true, 'shareLabelFilters', true],
+            ['sharelabelfilters', false, 'shareLabelFilters', false],
+            ['viewsubprojectslink', true, 'showViewSubProjectsLink', true],
+            ['viewsubprojectslink', false, 'showViewSubProjectsLink', false],
+            ['banner', 'test', 'banner', 'test'],
+            ['banner', null, 'banner', null],
+        ];
+    }
+
+    /**
+     * A basic test to ensure that each of the non-relationship fields works
+     */
+    #[DataProvider('fieldValues')]
+    public function testBasicFieldAccess(string $modelField, mixed $modelValue, string $graphqlField, mixed $graphqlValue): void
+    {
+        $project = $this->makePublicProject();
+        $project->setAttribute($modelField, $modelValue);
+        $project->save();
+        $this->projects['test'] = $project;
+
+        $this->graphQL("
+            query project(\$id: ID) {
+                project(id: \$id) {
+                    $graphqlField
+                }
+            }
+        ", [
+            'id' => $project->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    $graphqlField => $graphqlValue,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     array{
      *         string|null, array<string>
      *     }
      * }


### PR DESCRIPTION
This PR adds all of the missing Project fields and solidifies the database types to better enforce our constraints.  I plan to follow this work with a new `updateProject` mutation.