### PR TITLE
Remove Laravel aliases

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -11,7 +11,6 @@ use Illuminate\Bus\BusServiceProvider;
 use Illuminate\Cache\CacheServiceProvider;
 use Illuminate\Cookie\CookieServiceProvider;
 use Illuminate\Database\DatabaseServiceProvider;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\EncryptionServiceProvider;
 use Illuminate\Filesystem\FilesystemServiceProvider;
 use Illuminate\Foundation\Providers\ConsoleSupportServiceProvider;
@@ -24,35 +23,10 @@ use Illuminate\Pipeline\PipelineServiceProvider;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Session\SessionServiceProvider;
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\Broadcast;
-use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Cookie;
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Response;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Facades\View;
 use Illuminate\Translation\TranslationServiceProvider;
 use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\View\ViewServiceProvider;
@@ -257,38 +231,5 @@ return [
     */
 
     'aliases' => [
-        'App' => Illuminate\Support\Facades\App::class,
-        'Artisan' => Artisan::class,
-        'Auth' => Auth::class,
-        'Blade' => Blade::class,
-        'Broadcast' => Broadcast::class,
-        'Bus' => Bus::class,
-        'Cache' => Cache::class,
-        'Config' => Config::class,
-        'Cookie' => Cookie::class,
-        'Crypt' => Crypt::class,
-        'DB' => DB::class,
-        'Eloquent' => Model::class,
-        'Event' => Event::class,
-        'File' => File::class,
-        'Gate' => Gate::class,
-        'Hash' => Hash::class,
-        'Lang' => Lang::class,
-        'Log' => Log::class,
-        'Mail' => Mail::class,
-        'Notification' => Notification::class,
-        'Password' => Password::class,
-        'Queue' => Queue::class,
-        'Redirect' => Redirect::class,
-        'Request' => Request::class,
-        'Response' => Response::class,
-        'Route' => Route::class,
-        'Schema' => Schema::class,
-        'Session' => Session::class,
-        'Socialite' => Socialite::class,
-        'Storage' => Storage::class,
-        'URL' => URL::class,
-        'Validator' => Validator::class,
-        'View' => View::class,
     ],
 ];

--- a/database/migrations/2025_12_30_195827_drop_showipaddresses_column.php
+++ b/database/migrations/2025_12_30_195827_drop_showipaddresses_column.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2025_12_30_213518_project_logo_image_foreign_key_constraint.php
+++ b/database/migrations/2025_12_30_213518_project_logo_image_foreign_key_constraint.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2025_12_31_035659_boolean_project_options.php
+++ b/database/migrations/2025_12_31_035659_boolean_project_options.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_05_021305_drop_builderror_crc32.php
+++ b/database/migrations/2026_01_05_021305_drop_builderror_crc32.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_15_143405_drop_build2update_table.php
+++ b/database/migrations/2026_01_15_143405_drop_build2update_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_18_161331_nullable_project_description.php
+++ b/database/migrations/2026_01_18_161331_nullable_project_description.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_26_211114_buildemail_time_index.php
+++ b/database/migrations/2026_01_26_211114_buildemail_time_index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_26_212012_successful_jobs_finished_at_index.php
+++ b/database/migrations/2026_01_26_212012_successful_jobs_finished_at_index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/database/migrations/2026_01_27_131726_move_buildfailuredetails_to_buildfailure_table.php
+++ b/database/migrations/2026_01_27_131726_move_buildfailuredetails_to_buildfailure_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27530,9 +27530,3 @@ parameters:
 			identifier: phpunit.assertEquals
 			count: 1
 			path: tests/Unit/Middleware/InternalTest.php
-
-		-
-			rawMessage: 'Call to static method set() on an unknown class Config.'
-			identifier: class.notFound
-			count: 3
-			path: tests/Unit/Validators/PasswordTest.php

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,3 +1,5 @@
+@use(Illuminate\Support\Facades\View)
+
 @php
     $oauthCollection = collect(config('services'))->where("oauth","true");
     $has_oauth_login = $oauthCollection->firstWhere('enable', true);

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,6 +1,7 @@
 @php
 use Illuminate\Support\Str;
 use App\Services\ProjectService;
+use Illuminate\Support\Facades\Auth;
 
 if (isset($project)) {
     $logoid = $project->ImageId;

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -11,4 +11,6 @@
 |
 */
 
+use Illuminate\Support\Facades\Broadcast;
+
 Broadcast::channel('App.User.{id}', fn ($user, $id) => (int) $user->id === (int) $id);

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
-
 /*
 |--------------------------------------------------------------------------
 | Console Routes
@@ -12,7 +10,3 @@ use Illuminate\Foundation\Inspiring;
 | simple approach to interacting with each command's IO methods.
 |
 */
-
-Artisan::command('inspire', function (): void {
-    $this->comment(Inspiring::quote());
-})->describe('Display an inspiring quote');

--- a/tests/Unit/Validators/PasswordTest.php
+++ b/tests/Unit/Validators/PasswordTest.php
@@ -18,8 +18,8 @@
 namespace Tests\Unit\Validators;
 
 use App\Validators\Password as PasswordValidator;
-use Config;
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Validation\Validator;
 use Mockery;
 use Tests\TestCase;


### PR DESCRIPTION
Laravel's default template contains aliases for facade classes.  Some of these classes conflict with our own class names, which is problematic for PHPStan and IDEs.  It's more clear to use the FQN anyway, so this PR removes all of the aliases.