### PR TITLE
Add `updateProject` GraphQL mutation

### DIFF
--- a/app/GraphQL/Mutations/AbstractMutation.php
+++ b/app/GraphQL/Mutations/AbstractMutation.php
@@ -13,7 +13,7 @@ abstract class AbstractMutation
     /**
      * @param array<string,mixed> $args
      */
-    final public function __invoke(null $_, array $args): self
+    public function __invoke(null $_, array $args): self
     {
         try {
             $this->mutate($args);
@@ -30,5 +30,7 @@ abstract class AbstractMutation
      *
      * @param array<string,mixed> $args
      */
-    abstract protected function mutate(array $args): void;
+    protected function mutate(array $args): void
+    {
+    }
 }

--- a/app/GraphQL/Mutations/UpdateProject.php
+++ b/app/GraphQL/Mutations/UpdateProject.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Project;
+use Illuminate\Support\Facades\Gate;
+
+final class UpdateProject extends AbstractMutation
+{
+    public ?Project $project = null;
+
+    /**
+     * @param array<string,mixed> $args
+     */
+    public function __invoke(null $_, array $args): self
+    {
+        $project = Project::find((int) $args['id']);
+
+        Gate::authorize('update', $project);
+
+        unset($args['id']);
+
+        $project?->update($args);
+
+        $this->project = $project;
+
+        return $this;
+    }
+}

--- a/app/GraphQL/Validators/UpdateProjectInputValidator.php
+++ b/app/GraphQL/Validators/UpdateProjectInputValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Validators;
+
+use App\Models\Project;
+use App\Rules\ProjectAuthenticateSubmissionsRule;
+use App\Rules\ProjectNameRule;
+use App\Rules\ProjectVisibilityRule;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class UpdateProjectInputValidator extends Validator
+{
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                Rule::unique(Project::class, 'name'),
+                new ProjectNameRule(),
+            ],
+            'visibility' => [
+                new ProjectVisibilityRule(),
+            ],
+            'authenticateSubmissions' => [
+                new ProjectAuthenticateSubmissionsRule(),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.unique' => 'A project with this name already exists.',
+        ];
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -256,6 +256,8 @@ add_feature_test_in_transaction(/Feature/Mail/AuthTokenExpiredTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateProjectTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/Mutations/UpdateProjectTest)
+
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/InviteToProjectTest)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -76,6 +76,8 @@ type Mutation {
   "Create a new project."
   createProject(input: CreateProjectInput! @spread): Project @field(resolver: "CreateProject")
 
+  updateProject(input: UpdateProjectInput! @spread): UpdateProjectMutationPayload! @field(resolver: "UpdateProject")
+
   "Subscribe the current user to the specified site."
   claimSite(input: ClaimSiteInput! @spread): ClaimSiteMutationPayload! @field(resolver: "ClaimSite")
 
@@ -373,6 +375,77 @@ input CreateProjectInput @validator {
 
   "A LDAP group users must be a member of to access the project."
   ldapFilter: String @deprecated(reason: "This field will be removed in the next major version of CDash.") @rename(attribute: "ldapfilter")
+}
+
+
+input UpdateProjectInput @validator {
+  id: ID!
+
+  name: String
+
+  description: String
+
+  homeUrl: Url @rename(attribute: "homeurl")
+
+  vcsViewer: VcsViewer @rename(attribute: "cvsviewertype")
+
+  vcsUrl: Url @rename(attribute: "cvsurl")
+
+  bugTracker: BugTracker @rename(attribute: "bugtrackertype")
+
+  bugTrackerUrl: Url @rename(attribute: "bugtrackerurl")
+
+  bugTrackerNewIssueUrl: Url @rename(attribute: "bugtrackernewissueurl")
+
+  documentationUrl: Url @rename(attribute: "documentationurl")
+
+  testDataUrl: Url @rename(attribute: "testingdataurl")
+
+  visibility: ProjectVisibility @rename(attribute: "public")
+
+  authenticateSubmissions: Boolean @rename(attribute: "authenticatesubmissions")
+
+  ldapFilter: String @rename(attribute: "ldapfilter")
+
+  coverageThreshold: Int @rename(attribute: "coveragethreshold")
+
+  nightlyTime: Time @rename(attribute: "nightlytime")
+
+  emailLowCoverage: Boolean @rename(attribute: "emaillowcoverage")
+
+  emailTestTimingChanged: Boolean @rename(attribute: "emailtesttimingchanged")
+
+  emailBrokenSubmissions: Boolean @rename(attribute: "emailbrokensubmission")
+
+  emailRedundantFailures: Boolean @rename(attribute: "emailredundantfailures")
+
+  testTimeStdMultiplier: Float @rename(attribute: "testtimestd")
+
+  testTimeStdThreshold: Float @rename(attribute: "testtimestdthreshold")
+
+  enableTestTiming: Boolean @rename(attribute: "showtesttime")
+
+  timeStatusFailureThreshold: Int @rename(attribute: "testtimemaxstatus")
+
+  emailMaxItems: Int @rename(attribute: "emailmaxitems")
+
+  emailMaxCharacters: Int @rename(attribute: "emailmaxchars")
+
+  displayLabels: Boolean @rename(attribute: "displaylabels")
+
+  autoRemoveTimeFrame: Int @rename(attribute: "autoremovetimeframe")
+
+  autoRemoveMaxBuilds: Int @rename(attribute: "autoremovemaxbuilds")
+
+  fileUploadLimit: Int @rename(attribute: "uploadquota")
+
+  showCoverageCode: Boolean @rename(attribute: "showcoveragecode")
+
+  shareLabelFilters: Boolean @rename(attribute: "sharelabelfilters")
+
+  showViewSubProjectsLink: Boolean @rename(attribute: "viewsubprojectslink")
+
+  banner: String
 }
 
 
@@ -916,6 +989,15 @@ type Site {
     filters: _ @filter
   ): [User!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 }
+
+
+type UpdateProjectMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+
+  project: Project
+}
+
 
 input ClaimSiteInput {
   siteId: ID!

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,6 +361,12 @@ parameters:
 			path: app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
 
 		-
+			rawMessage: Cannot cast mixed to int.
+			identifier: cast.int
+			count: 1
+			path: app/GraphQL/Mutations/UpdateProject.php
+
+		-
 			rawMessage: 'Parameter #1 $args (array{siteId: int, description: string}) of method App\GraphQL\Mutations\UpdateSiteDescription::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
 			identifier: method.childParameterType
 			count: 1
@@ -27152,6 +27158,12 @@ parameters:
 			identifier: missingType.checkedException
 			count: 1
 			path: tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+
+		-
+			rawMessage: 'Parameter #1 $user of method Illuminate\Foundation\Testing\TestCase::actingAs() expects Illuminate\Contracts\Auth\Authenticatable, App\Models\User|null given.'
+			identifier: argument.type
+			count: 2
+			path: tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
 
 		-
 			rawMessage: 'Method Tests\Feature\GraphQL\ProjectInvitationTypeTest::testAdminCanViewInvitations() throws checked exception OverflowException but it''s missing from the PHPDoc @throws tag.'

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class UpdateProjectTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    public function testCannotUpdateNonExistentProject(): void
+    {
+        $user = $this->makeAdminUser();
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => 123456789,
+                'name' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+    }
+
+    public function testCannotUpdateProjectAsAnonymousUser(): void
+    {
+        $project = $this->makePublicProject();
+        $original_name = $project->name;
+        $this->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+        self::assertSame($original_name, $project->fresh()?->name);
+    }
+
+    public function testCannotUpdateProjectAsNormalUser(): void
+    {
+        $project = $this->makePublicProject();
+        $original_name = $project->name;
+        $user = $this->makeNormalUser();
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+        self::assertSame($original_name, $project->fresh()?->name);
+    }
+
+    public function testCannotUpdateProjectAsNormalProjectUser(): void
+    {
+        $project = $this->makePublicProject();
+        $original_name = $project->name;
+        $user = $this->makeNormalUser();
+        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+        self::assertSame($original_name, $project->fresh()?->name);
+    }
+
+    public function testCanUpdateProjectAsProjectAdmin(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeNormalUser();
+        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+
+        $name = Str::uuid()->toString();
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => $name,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'updateProject' => [
+                    'project' => [
+                        'name' => $name,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+        self::assertSame($name, $project->fresh()?->name);
+    }
+
+    public function testCanUpdateProjectAsGlobalAdmin(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+        $name = Str::uuid()->toString();
+
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => $name,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'updateProject' => [
+                    'project' => [
+                        'name' => $name,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+        self::assertSame($name, $project->fresh()?->name);
+    }
+
+    public static function fieldValues(): array
+    {
+        return [
+            ['description', 'new description', 'description', 'new description'],
+            ['homeUrl', 'https://kitware.com', 'homeurl', 'https://kitware.com'],
+            ['vcsViewer', 'GITLAB', 'cvsviewertype', 'gitlab'],
+            ['vcsUrl', 'https://gitlab.kitware.com/kitware/cdash', 'cvsurl', 'https://gitlab.kitware.com/kitware/cdash'],
+            ['bugTracker', 'JIRA', 'bugtrackertype', 'JIRA'],
+            ['bugTrackerUrl', 'https://jira.kitware.com', 'bugtrackerurl', 'https://jira.kitware.com'],
+            ['bugTrackerNewIssueUrl', 'https://jira.kitware.com/new', 'bugtrackernewissueurl', 'https://jira.kitware.com/new'],
+            ['documentationUrl', 'https://cdash.org/documentation', 'documentationurl', 'https://cdash.org/documentation'],
+            ['testDataUrl', 'https://cdash.org/test-data', 'testingdataurl', 'https://cdash.org/test-data'],
+            ['visibility', 'PROTECTED', 'public', 2],
+            ['authenticateSubmissions', true, 'authenticatesubmissions', true],
+            ['ldapFilter', '(uid=user)', 'ldapfilter', '(uid=user)'],
+            ['coverageThreshold', 90, 'coveragethreshold', 90],
+            ['nightlyTime', '01:00:00', 'nightlytime', '01:00:00'],
+            ['emailLowCoverage', true, 'emaillowcoverage', true],
+            ['emailTestTimingChanged', true, 'emailtesttimingchanged', true],
+            ['emailBrokenSubmissions', true, 'emailbrokensubmission', true],
+            ['emailRedundantFailures', true, 'emailredundantfailures', true],
+            ['testTimeStdMultiplier', 5.0, 'testtimestd', '5.00'],
+            ['testTimeStdThreshold', 2.0, 'testtimestdthreshold', '2.00'],
+            ['enableTestTiming', false, 'showtesttime', false],
+            ['timeStatusFailureThreshold', 3, 'testtimemaxstatus', 3],
+            ['emailMaxItems', 20, 'emailmaxitems', 20],
+            ['emailMaxCharacters', 2000, 'emailmaxchars', 2000],
+            ['displayLabels', false, 'displaylabels', false],
+            ['autoRemoveTimeFrame', 10, 'autoremovetimeframe', 10],
+            ['autoRemoveMaxBuilds', 20, 'autoremovemaxbuilds', 20],
+            ['fileUploadLimit', 50, 'uploadquota', 50],
+            ['showCoverageCode', false, 'showcoveragecode', false],
+            ['shareLabelFilters', false, 'sharelabelfilters', false],
+            ['showViewSubProjectsLink', false, 'viewsubprojectslink', false],
+            ['banner', 'new banner', 'banner', 'new banner'],
+        ];
+    }
+
+    #[DataProvider('fieldValues')]
+    public function testUpdateEachField(string $gqlField, mixed $value, string $dbField, mixed $expected): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $this->actingAs($user)->graphQL("
+            mutation updateProject(\$input: UpdateProjectInput!) {
+                updateProject(input: \$input) {
+                    project {
+                        {$gqlField}
+                    }
+                    message
+                }
+            }
+        ", [
+            'input' => [
+                'id' => $project->id,
+                $gqlField => $value,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'updateProject' => [
+                    'project' => [
+                        $gqlField => $value,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertSame($expected, $project->fresh()?->getAttribute($dbField));
+    }
+
+    public function testCannotChangeNameToExistingProjectName(): void
+    {
+        $project1 = $this->makePublicProject();
+        $original_name = $project1->name;
+        $project2 = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project1->id,
+                'name' => $project2->name,
+            ],
+        ])->assertGraphQLErrorMessage('Validation failed for the field [updateProject].');
+        self::assertSame($original_name, $project1->fresh()?->name);
+    }
+
+    public function testCannotChangeNameToInvalidName(): void
+    {
+        $project = $this->makePublicProject();
+        $original_name = $project->name;
+        $user = $this->makeAdminUser();
+
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => 'invalid name %',
+            ],
+        ])->assertGraphQLErrorMessage('Validation failed for the field [updateProject].');
+        self::assertSame($original_name, $project->fresh()?->name);
+    }
+
+    public static function visibilityRules(): array
+    {
+        return [
+            ['normal', 'PUBLIC', 'PUBLIC', false],
+            ['normal', 'PROTECTED', 'PUBLIC', false],
+            ['normal', 'PRIVATE', 'PUBLIC', false],
+            ['project_admin', 'PUBLIC', 'PUBLIC', true],
+            ['project_admin', 'PROTECTED', 'PUBLIC', true],
+            ['project_admin', 'PRIVATE', 'PUBLIC', true],
+            ['admin', 'PUBLIC', 'PUBLIC', true],
+            ['admin', 'PROTECTED', 'PUBLIC', true],
+            ['admin', 'PRIVATE', 'PUBLIC', true],
+        ];
+    }
+
+    #[DataProvider('visibilityRules')]
+    public function testVisibilityRules(string $userRole, string $newVisibility, string $maxVisibility, bool $shouldSucceed): void
+    {
+        Config::set('cdash.user_create_projects', true);
+        Config::set('cdash.max_project_visibility', $maxVisibility);
+
+        $project = $this->makePublicProject();
+
+        $user = null;
+        if ($userRole === 'normal') {
+            $user = $this->makeNormalUser();
+        } elseif ($userRole === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($userRole === 'project_admin') {
+            $user = $this->makeNormalUser();
+            $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        }
+
+        $response = $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        visibility
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'visibility' => $newVisibility,
+            ],
+        ]);
+
+        if ($shouldSucceed) {
+            $response->assertExactJson([
+                'data' => [
+                    'updateProject' => [
+                        'project' => [
+                            'visibility' => $newVisibility,
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+        } else {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+        }
+    }
+
+    public static function authenticatedSubmissionRules(): array
+    {
+        return [
+            ['project_admin', true, false, true],
+            ['project_admin', false, true, false],
+            ['admin', true, false, true],
+            ['admin', false, true, true],
+        ];
+    }
+
+    #[DataProvider('authenticatedSubmissionRules')]
+    public function testAuthenticatedSubmissionRules(string $userRole, bool $newAuthValue, bool $configAuthValue, bool $shouldSucceed): void
+    {
+        Config::set('cdash.user_create_projects', true);
+        Config::set('cdash.require_authenticated_submissions', $configAuthValue);
+
+        $project = $this->makePublicProject();
+
+        $user = null;
+        if ($userRole === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($userRole === 'project_admin') {
+            $user = $this->makeNormalUser();
+            $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        }
+
+        $response = $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        authenticateSubmissions
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'authenticateSubmissions' => $newAuthValue,
+            ],
+        ]);
+
+        if ($shouldSucceed) {
+            $response->assertExactJson([
+                'data' => [
+                    'updateProject' => [
+                        'project' => [
+                            'authenticateSubmissions' => $newAuthValue,
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+            self::assertSame($newAuthValue, $project->fresh()?->authenticatesubmissions);
+        } else {
+            $response->assertGraphQLErrorMessage('Validation failed for the field [updateProject].');
+        }
+    }
+}


### PR DESCRIPTION
This commit adds an `updateProject` mutation which will form the basis for the overhaul of the project settings page.  Note that our infrastructure doesn't support multi-part GraphQL requests yet, so I plan to create a separate dedicated route for project logo uploads, outside the GraphQL API.