### PR TITLE
Add project logo update API route

### DIFF
--- a/app/Http/Controllers/UpdateProjectLogoController.php
+++ b/app/Http/Controllers/UpdateProjectLogoController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use App\Services\ProjectService;
+use Exception;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+
+final class UpdateProjectLogoController extends AbstractController
+{
+    /**
+     * @throws Exception
+     * @throws ValidationException
+     */
+    public function __invoke(Request $request, int $project_id): RedirectResponse
+    {
+        $project = Project::find($project_id);
+        Gate::authorize('update', $project);
+
+        $request->validate([
+            'logo' => 'required|image',
+        ]);
+
+        if ($project === null) {
+            throw new Exception();
+        }
+
+        ProjectService::setLogo($project, $request->file('logo'));
+
+        return response()->redirectTo(url("/projects/{$project->id}/settings"));
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -187,6 +187,8 @@ add_feature_test_in_transaction(/Feature/GraphQL/BuildTypeTest)
 
 add_feature_test_in_transaction(/Feature/ProjectInvitationAcceptanceTest)
 
+add_feature_test_in_transaction(/Feature/UpdateProjectLogoTest)
+
 add_feature_test_in_transaction(/Feature/GraphQL/FilterTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/QueryTypeTest)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2473,6 +2473,12 @@ parameters:
 			path: app/Http/Controllers/TimelineController.php
 
 		-
+			rawMessage: 'Parameter #2 $file of static method App\Services\ProjectService::setLogo() expects Illuminate\Http\UploadedFile, (array<int, Illuminate\Http\UploadedFile>|Illuminate\Http\UploadedFile|null) given.'
+			identifier: argument.type
+			count: 1
+			path: app/Http/Controllers/UpdateProjectLogoController.php
+
+		-
 			rawMessage: Access to an undefined property App\Models\Project::$pivot.
 			identifier: property.notFound
 			count: 1

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\CoverageFileController;
 use App\Http\Controllers\CreateProjectController;
 use App\Http\Controllers\GlobalInvitationController;
 use App\Http\Controllers\ProjectInvitationController;
+use App\Http\Controllers\UpdateProjectLogoController;
 use App\Models\DynamicAnalysis;
 use App\Models\Project;
 use App\Models\Test;
@@ -166,6 +167,9 @@ Route::get('/viewBuildError.php', function (Request $request) {
     $buildid = $request->integer('buildid');
     return redirect("/builds/{$buildid}/errors", 301);
 });
+
+Route::post('/projects/{project_id}/logo', UpdateProjectLogoController::class)
+    ->whereNumber('project_id');
 
 Route::get('/projects/{id}/edit', 'EditProjectController@edit')
     ->whereNumber('id');

--- a/tests/Feature/UpdateProjectLogoTest.php
+++ b/tests/Feature/UpdateProjectLogoTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class UpdateProjectLogoTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    public function testCannotUploadToNonExistentProject(): void
+    {
+        $user = $this->makeAdminUser();
+        $response = $this->actingAs($user)->postJson('/projects/123456789/logo', [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+        $response->assertForbidden();
+    }
+
+    public function testCannotUseNonIntegerProjectId(): void
+    {
+        $user = $this->makeAdminUser();
+        $response = $this->actingAs($user)->postJson('/projects/abc/logo', [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+        $response->assertNotFound();
+    }
+
+    public function testCannotUploadAsAnonymousUser(): void
+    {
+        $project = $this->makePublicProject();
+
+        $response = $this->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+
+        $response->assertForbidden();
+        self::assertNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCannotUploadAsNormalUser(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeNormalUser();
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+
+        $response->assertForbidden();
+        self::assertNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCannotUploadAsProjectUser(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeNormalUser();
+        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+
+        $response->assertForbidden();
+        self::assertNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCanUploadAsProjectAdmin(): void
+    {
+        Storage::fake('public');
+        $project = $this->makePublicProject();
+        $user = $this->makeNormalUser();
+        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+
+        $response->assertRedirect(url("/projects/{$project->id}/settings"));
+        self::assertNotNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCanUploadAsGlobalAdmin(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->image('logo.jpg'),
+        ]);
+
+        $response->assertRedirect(url("/projects/{$project->id}/settings"));
+        self::assertNotNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCannotUploadNonImage(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->create('document.pdf'),
+        ]);
+
+        $response->assertStatus(422);
+        self::assertNull($project->fresh()?->logoUrl);
+    }
+
+    public function testCannotUploadSvg(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
+            'logo' => UploadedFile::fake()->create('logo.svg'),
+        ]);
+
+        $response->assertStatus(422);
+        self::assertNull($project->fresh()?->logoUrl);
+    }
+}


### PR DESCRIPTION
Our infrastructure doesn't support the multi-part requests necessary to handle uploaded files via GraphQL.  This commit adds a special `/projects/<id>/logo` POST route which can be used to set the logo for a project.