### PR TITLE
Add coverage percentage filters

### DIFF
--- a/app/Models/Coverage.php
+++ b/app/Models/Coverage.php
@@ -15,10 +15,13 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int $covered
  * @property int $loctested
  * @property int $locuntested
+ * @property float $linepercentage
  * @property int $branchestested
  * @property int $branchesuntested
+ * @property float $branchpercentage
  * @property int $functionstested
  * @property int $functionsuntested
+ * @property float $functionpercentage
  *
  * @mixin Builder<Coverage>
  */

--- a/app/Models/CoverageView.php
+++ b/app/Models/CoverageView.php
@@ -18,10 +18,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int $covered
  * @property int $loctested
  * @property int $locuntested
+ * @property float $linepercentage
  * @property int $branchestested
  * @property int $branchesuntested
+ * @property float $branchpercentage
  * @property int $functionstested
  * @property int $functionsuntested
+ * @property float $functionpercentage
  * @property ?string $fullpath
  * @property ?string $file
  * @property ?string $log

--- a/database/migrations/2026_02_07_175901_coverage_percentage.php
+++ b/database/migrations/2026_02_07_175901_coverage_percentage.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('DROP VIEW coverageview');
+
+        DB::statement('
+            ALTER TABLE coverage
+            ADD COLUMN linepercentage real
+            GENERATED ALWAYS AS (
+                CASE
+                    WHEN loctested + locuntested = 0 THEN 100
+                    ELSE (loctested / (loctested + locuntested)::real) * 100
+                END
+            ) STORED NOT NULL
+        ');
+
+        DB::statement('
+            ALTER TABLE coverage
+            ADD COLUMN branchpercentage real
+            GENERATED ALWAYS AS (
+                CASE
+                    WHEN branchestested + branchesuntested = 0 THEN 100
+                    ELSE (branchestested / (branchestested + branchesuntested)::real) * 100
+                END
+            ) STORED NOT NULL
+        ');
+
+        DB::statement('
+            ALTER TABLE coverage
+            ADD COLUMN functionpercentage real
+            GENERATED ALWAYS AS (
+                CASE
+                    WHEN functionstested + functionsuntested = 0 THEN 100
+                    ELSE (functionstested / (functionstested + functionsuntested)::real) * 100
+                END
+            ) STORED NOT NULL
+        ');
+
+        // Recreate view using the definition in 2025_07_25_131613_coverage_view.php, with new percentage cols added.
+        DB::statement('
+            CREATE VIEW coverageview AS
+                SELECT
+                    coverage.id,
+                    coverage.buildid,
+                    coverage.covered,
+                    coverage.loctested,
+                    coverage.locuntested,
+                    coverage.linepercentage,
+                    coverage.branchestested,
+                    coverage.branchesuntested,
+                    coverage.branchpercentage,
+                    coverage.functionstested,
+                    coverage.functionsuntested,
+                    coverage.functionpercentage,
+                    coveragefile.fullpath,
+                    coveragefile.file,
+                    coveragefilelog.log
+                FROM
+                    coverage
+                    LEFT JOIN coveragefile ON (
+                        coverage.fileid = coveragefile.id
+                    )
+                    LEFT JOIN coveragefilelog ON (
+                        coverage.buildid = coveragefilelog.buildid
+                        AND coverage.fileid = coveragefilelog.fileid
+                    )
+        ');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1107,13 +1107,19 @@ type Coverage @model(class: "App\\Models\\CoverageView") {
 
   linesOfCodeUntested: Int! @rename(attribute: "locuntested") @filterable
 
+  linePercentage: Float! @rename(attribute: "linepercentage") @filterable
+
   branchesTested: Int! @rename(attribute: "branchestested") @filterable
 
   branchesUntested: Int! @rename(attribute: "branchesuntested") @filterable
 
+  branchPercentage: Float! @rename(attribute: "branchpercentage") @filterable
+
   functionsTested: Int! @rename(attribute: "functionstested") @filterable
 
   functionsUntested: Int! @rename(attribute: "functionsuntested") @filterable
+
+  functionPercentage: Float! @rename(attribute: "functionpercentage") @filterable
 
   filePath: String @rename(attribute: "fullpath") @filterable
 


### PR DESCRIPTION
This PR adds generated columns for the percentage of each coverage metric, allowing users to filter by percentage instead of lines (un)covered.  Coverage for files with no content is defined to be 100%.