### PR TITLE
Merge builderror and buildfailure tables

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -186,6 +186,16 @@ class Build extends Model
     }
 
     /**
+     * @return HasMany<BuildError, $this>
+     */
+    public function buildErrors(): HasMany
+    {
+        return $this->hasMany(BuildError::class, 'buildid');
+    }
+
+    /**
+     * @deprecated 02/09/2026 Use buildErrors() instead
+     *
      * @return HasMany<BasicBuildAlert, $this>
      */
     public function basicAlerts(): HasMany
@@ -194,6 +204,8 @@ class Build extends Model
     }
 
     /**
+     * @deprecated 02/09/2026 Use buildErrors() instead
+     *
      * @return HasMany<BasicBuildAlert, $this>
      */
     public function basicErrors(): HasMany
@@ -203,6 +215,8 @@ class Build extends Model
     }
 
     /**
+     * @deprecated 02/09/2026 Use buildErrors() instead
+     *
      * @return HasMany<BasicBuildAlert, $this>
      */
     public function basicWarnings(): HasMany
@@ -212,6 +226,8 @@ class Build extends Model
     }
 
     /**
+     * @deprecated 02/09/2026 Use buildErrors() instead
+     *
      * @return HasMany<RichBuildAlert, $this>
      */
     public function richAlerts(): HasMany

--- a/app/Models/BuildError.php
+++ b/app/Models/BuildError.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\BuildErrorFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $buildid
+ * @property ?string $workingdirectory
+ * @property string $sourcefile
+ * @property bool $newstatus
+ * @property int $type
+ * @property string $stdoutput
+ * @property string $stderror
+ * @property ?string $exitcondition
+ * @property ?string $language
+ * @property ?string $targetname
+ * @property ?string $outputfile
+ * @property ?string $outputtype
+ * @property ?int $logline
+ * @property ?int $sourceline
+ * @property ?int $repeatcount
+ *
+ * @mixin Builder<BuildError>
+ */
+class BuildError extends Model
+{
+    /** @use HasFactory<BuildErrorFactory> */
+    use HasFactory;
+
+    protected $table = 'builderrors';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'buildid',
+        'workingdirectory',
+        'sourcefile',
+        'newstatus',
+        'type',
+        'stdoutput',
+        'stderror',
+        'exitcondition',
+        'language',
+        'targetname',
+        'outputfile',
+        'outputtype',
+        'logline',
+        'sourceline',
+        'repeatcount',
+    ];
+
+    protected $casts = [
+        'buildid' => 'integer',
+        'type' => 'integer', // TODO: Convert this to an enum
+        'logline' => 'integer',
+        'stdoutput' => 'string',
+        'stderror' => 'string',
+        'sourceline' => 'integer',
+        'repeatcount' => 'integer',
+        'newstatus' => 'boolean',
+    ];
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -227,6 +227,8 @@ add_feature_test_in_transaction(/Feature/GraphQL/UpdateFileTypeTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/PinnedTestMeasurementTypeTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/BuildErrorTypeTest)
+
 add_feature_test_in_transaction(/Feature/RouteAccessTest)
 
 add_feature_test_in_transaction(/Feature/Monitor)

--- a/database/factories/BuildErrorFactory.php
+++ b/database/factories/BuildErrorFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BuildError;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<BuildError>
+ */
+class BuildErrorFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'sourcefile' => Str::uuid()->toString(),
+            'newstatus' => 0,
+            'type' => 0,
+            'stdoutput' => Str::uuid()->toString(),
+            'stderror' => Str::uuid()->toString(),
+        ];
+    }
+}

--- a/database/migrations/2026_02_08_003051_combine_build_errors_and_failures.php
+++ b/database/migrations/2026_02_08_003051_combine_build_errors_and_failures.php
@@ -1,0 +1,124 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE buildfailure RENAME TO builderrors');
+
+        // Add builderror columns which don't already exist in buildfailure (now named builderrors)
+        DB::statement('ALTER TABLE builderrors ADD COLUMN logline integer');
+        DB::statement('ALTER TABLE builderrors ADD COLUMN sourceline integer');
+        DB::statement('ALTER TABLE builderrors ADD COLUMN repeatcount integer');
+
+        // Drop not-null constraints on buildfailure-specific columns
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN workingdirectory DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN exitcondition DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN language DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN targetname DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN targetname DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN outputfile DROP NOT NULL');
+        DB::statement('ALTER TABLE builderrors ALTER COLUMN outputtype DROP NOT NULL');
+
+        // By copying builderror into what was previously called buildfailure, we preserve the
+        // buildfailure IDs and create new ones for builderror records.
+        DB::insert('
+            INSERT INTO builderrors (
+                buildid,
+                type,
+                logline,
+                stderror,
+                sourcefile,
+                sourceline,
+                repeatcount,
+                newstatus,
+                stdoutput
+            )
+            SELECT
+                buildid,
+                type,
+                logline,
+                stderror,
+                sourcefile,
+                sourceline,
+                repeatcount,
+                newstatus,
+                stdoutput
+            FROM builderror
+        ');
+
+        DB::statement('DROP TABLE builderror');
+
+        DB::statement('
+            CREATE VIEW builderror AS
+                SELECT
+                    builderrors.id,
+                    builderrors.buildid,
+                    builderrors.type,
+                    builderrors.logline,
+                    builderrors.stderror,
+                    builderrors.sourcefile,
+                    builderrors.sourceline,
+                    builderrors.repeatcount,
+                    builderrors.newstatus,
+                    builderrors.stdoutput
+                FROM
+                    builderrors
+                WHERE
+                    builderrors.id IS NOT NULL
+                    AND builderrors.buildid IS NOT NULL
+                    AND builderrors.type IS NOT NULL
+                    AND builderrors.logline IS NOT NULL
+                    AND builderrors.stderror IS NOT NULL
+                    AND builderrors.sourcefile IS NOT NULL
+                    AND builderrors.sourceline IS NOT NULL
+                    AND builderrors.repeatcount IS NOT NULL
+                    AND builderrors.newstatus IS NOT NULL
+                    AND builderrors.stdoutput IS NOT NULL
+        ');
+        DB::statement('ALTER VIEW builderror ALTER COLUMN logline SET DEFAULT 0');
+        DB::statement("ALTER VIEW builderror ALTER COLUMN sourcefile SET DEFAULT ''");
+        DB::statement('ALTER VIEW builderror ALTER COLUMN sourceline SET DEFAULT 0');
+        DB::statement('ALTER VIEW builderror ALTER COLUMN repeatcount SET DEFAULT 0');
+
+        DB::statement('
+            CREATE VIEW buildfailure AS
+                SELECT
+                    builderrors.id,
+                    builderrors.buildid,
+                    builderrors.workingdirectory,
+                    builderrors.sourcefile,
+                    builderrors.newstatus,
+                    builderrors.type,
+                    builderrors.stdoutput,
+                    builderrors.stderror,
+                    builderrors.exitcondition,
+                    builderrors.language,
+                    builderrors.targetname,
+                    builderrors.outputfile,
+                    builderrors.outputtype
+                FROM
+                    builderrors
+                WHERE
+                    builderrors.id IS NOT NULL
+                    AND builderrors.buildid IS NOT NULL
+                    AND builderrors.workingdirectory IS NOT NULL
+                    AND builderrors.sourcefile IS NOT NULL
+                    AND builderrors.newstatus IS NOT NULL
+                    AND builderrors.type IS NOT NULL
+                    AND builderrors.stdoutput IS NOT NULL
+                    AND builderrors.stderror IS NOT NULL
+                    AND builderrors.exitcondition IS NOT NULL
+                    AND builderrors.language IS NOT NULL
+                    AND builderrors.targetname IS NOT NULL
+                    AND builderrors.outputfile IS NOT NULL
+                    AND builderrors.outputtype IS NOT NULL
+        ');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -726,17 +726,22 @@ type Build {
     filters: _ @filter
   ): [Test!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
+  """
+  A list of warnings and errors submitted for this build.
+  """
+  buildErrors: [BuildError!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
   # TODO: Make an "errors" field which returns the union of basic and rich errors
   """
   A list of "basic" errors submitted for this build.
   """
-  basicErrors: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  basicErrors: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC) @deprecated(reason: "This field will be removed in the next major version of CDash.  Use buildErrors instead.")
 
   # TODO: Make a "warnings" field which returns the union of basic and rich warnings
   """
   A list of "basic" warnings submitted for this build.
   """
-  basicWarnings: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+  basicWarnings: [BasicBuildAlert!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)  @deprecated(reason: "This field will be removed in the next major version of CDash.  Use buildErrors instead.")
 
   project: Project! @belongsTo
 
@@ -960,6 +965,42 @@ type BasicBuildAlert {
   preContext: String @rename(attribute: "precontext")
 
   postContext: String @rename(attribute: "postcontext")
+}
+
+
+type BuildError {
+  "Unique primary key."
+  id: ID! @filterable
+
+  type: BuildErrorType! @filterable
+
+  sourceFile: String! @rename(attribute: "sourcefile") @filterable
+
+  stdOutput: String! @rename(attribute: "stdoutput") @filterable
+
+  stdError: String! @rename(attribute: "stderror") @filterable
+
+  workingDirectory: String @rename(attribute: "workingdirectory") @filterable
+
+  exitCondition: String @rename(attribute: "exitcondition") @filterable
+
+  language: String @filterable
+
+  targetName: String @rename(attribute: "targetname") @filterable
+
+  outputFile: String @rename(attribute: "outputfile") @filterable
+
+  outputType: String @rename(attribute: "outputtype") @filterable
+
+  logLine: Int @rename(attribute: "logline") @filterable
+
+  sourceLine: Int @rename(attribute: "sourceline") @filterable
+}
+
+
+enum BuildErrorType {
+  ERROR @enum(value: "0")
+  WARNING @enum(value: "1")
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6752,8 +6752,26 @@ parameters:
 
 		-
 			rawMessage: '''
+				Call to deprecated method basicAlerts() of class App\Models\Build:
+				02/09/2026 Use buildErrors() instead
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			rawMessage: '''
 				Call to deprecated method getPdo() of class CDash\Database:
 				04/22/2023  Use Laravel query builder or Eloquent instead
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: app/Utils/SubmissionUtils.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method richAlerts() of class App\Models\Build:
+				02/09/2026 Use buildErrors() instead
 			'''
 			identifier: method.deprecated
 			count: 1
@@ -9925,6 +9943,15 @@ parameters:
 			rawMessage: '''
 				Call to deprecated method getPdo() of class CDash\Database:
 				04/22/2023  Use Laravel query builder or Eloquent instead
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: app/cdash/app/Model/BuildFailure.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method richAlerts() of class App\Models\Build:
+				02/09/2026 Use buildErrors() instead
 			'''
 			identifier: method.deprecated
 			count: 1
@@ -26996,6 +27023,15 @@ parameters:
 			identifier: phpunit.assertEquals
 			count: 4
 			path: tests/Feature/GlobalInvitationAcceptanceTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method basicAlerts() of class App\Models\Build:
+				02/09/2026 Use buildErrors() instead
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: tests/Feature/GraphQL/BuildTypeTest.php
 
 		-
 			rawMessage: '''

--- a/tests/Feature/GraphQL/BuildErrorTypeTest.php
+++ b/tests/Feature/GraphQL/BuildErrorTypeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Build;
+use App\Models\BuildError;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Random\RandomException;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class BuildErrorTypeTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    /**
+     * @return array{
+     *     array{
+     *         string, mixed, string, mixed,
+     *     }
+     * }
+     *
+     * @throws RandomException
+     */
+    public static function fieldValues(): array
+    {
+        $random_string = Str::uuid()->toString();
+        $random_int = random_int(0, 100000);
+
+        return [
+            ['workingdirectory', $random_string, 'workingDirectory', $random_string],
+            ['workingdirectory', null, 'workingDirectory', null],
+            ['sourcefile', $random_string, 'sourceFile', $random_string],
+            ['type', 0, 'type', 'ERROR'],
+            ['type', 1, 'type', 'WARNING'],
+            ['stdoutput', $random_string, 'stdOutput', $random_string],
+            ['stderror', $random_string, 'stdError', $random_string],
+            ['exitcondition', $random_string, 'exitCondition', $random_string],
+            ['exitcondition', null, 'exitCondition', null],
+            ['language', $random_string, 'language', $random_string],
+            ['language', null, 'language', null],
+            ['targetname', $random_string, 'targetName', $random_string],
+            ['targetname', null, 'targetName', null],
+            ['outputfile', $random_string, 'outputFile', $random_string],
+            ['outputfile', null, 'outputFile', null],
+            ['outputtype', $random_string, 'outputType', $random_string],
+            ['outputtype', null, 'outputType', null],
+            ['logline', $random_int, 'logLine', $random_int],
+            ['logline', null, 'logLine', null],
+            ['sourceline', $random_int, 'sourceLine', $random_int],
+            ['sourceline', null, 'sourceLine', null],
+        ];
+    }
+
+    /**
+     * A basic test to ensure that each of the non-relationship fields works
+     */
+    #[DataProvider('fieldValues')]
+    public function testBuildErrorFields(string $modelField, mixed $modelValue, string $graphqlField, mixed $graphqlValue): void
+    {
+        $project = $this->makePublicProject();
+
+        /** @var Build $build */
+        $build = $project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var BuildError $buildError */
+        $buildError = $build->buildErrors()->save(BuildError::factory()->make([
+            $modelField => $modelValue,
+        ]));
+
+        $this->graphQL("
+            query build(\$id: ID) {
+                build(id: \$id) {
+                    buildErrors {
+                        edges {
+                            node {
+                                id
+                                $graphqlField
+                            }
+                        }
+                    }
+                }
+            }
+        ", [
+            'id' => $build->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'buildErrors' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $buildError->id,
+                                    $graphqlField => $graphqlValue,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
CDash previously used the `builderror` table to store warnings and errors collected via log scraping, and a separate `buildfailure` table to store more detailed warning and error information collected via launchers.  While convenient in some cases, having two tables which essentially store the same information requires near-duplicate code throughout the codebase and is very confusing for developers.  This commit combines the two tables into a single `builderrors` table and creates `builderror` and `buildfailure` updateable views to remain backwards compatible with existing code.  This commit also adds a new `buildErrors` GraphQL field, and deprecates the now-unnecessary `basicErrors` and `basicWarnings` fields.