### PR TITLE
Add `command` field to `BuildError` GraphQL type

### DIFF
--- a/app/Models/BuildError.php
+++ b/app/Models/BuildError.php
@@ -4,8 +4,10 @@ namespace App\Models;
 
 use Database\Factories\BuildErrorFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property int $id
@@ -64,4 +66,23 @@ class BuildError extends Model
         'repeatcount' => 'integer',
         'newstatus' => 'boolean',
     ];
+
+    /**
+     * @return BelongsToMany<BuildFailureArgument, $this>
+     */
+    public function arguments(): BelongsToMany
+    {
+        return $this->belongsToMany(BuildFailureArgument::class, 'buildfailure2argument', 'buildfailureid', 'argumentid')
+            ->withPivot('place');
+    }
+
+    /**
+     * @return Attribute<?string,null>
+     */
+    protected function command(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): ?string => $this->arguments->isEmpty() ? null : $this->arguments->sortBy('pivot.place')->pluck('argument')->implode(' '),
+        );
+    }
 }

--- a/app/Models/BuildFailureArgument.php
+++ b/app/Models/BuildFailureArgument.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $argument
+ *
+ * @mixin Builder<BuildError>
+ */
+class BuildFailureArgument extends Model
+{
+    protected $table = 'buildfailureargument';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'argument',
+    ];
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -995,6 +995,8 @@ type BuildError {
   logLine: Int @rename(attribute: "logline") @filterable
 
   sourceLine: Int @rename(attribute: "sourceline") @filterable
+
+  command: String @with(relation: "arguments")
 }
 
 


### PR DESCRIPTION
"Build failure arguments" are deduplicated to save space, but are logically a single BuildError field.  This PR adds a computed `command` field to the BuildError type in the GraphQL API.