### PR TITLE
Allow `updateProject` mutation to accept same name

### DIFF
--- a/app/GraphQL/Validators/UpdateProjectInputValidator.php
+++ b/app/GraphQL/Validators/UpdateProjectInputValidator.php
@@ -15,7 +15,8 @@ final class UpdateProjectInputValidator extends Validator
     {
         return [
             'name' => [
-                Rule::unique(Project::class, 'name'),
+                Rule::unique(Project::class, 'name')
+                    ->ignore($this->arg('id')),
                 new ProjectNameRule(),
             ],
             'visibility' => [

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -295,6 +295,38 @@ class UpdateProjectTest extends TestCase
         self::assertSame($original_name, $project->fresh()?->name);
     }
 
+    public function testCanChangeNameToCurrentName(): void
+    {
+        $project = $this->makePublicProject();
+        $user = $this->makeAdminUser();
+
+        $this->actingAs($user)->graphQL('
+            mutation updateProject($input: UpdateProjectInput!) {
+                updateProject(input: $input) {
+                    project {
+                        name
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $project->id,
+                'name' => $project->name,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'updateProject' => [
+                    'project' => [
+                        'name' => $project->name,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+        self::assertSame($project->name, $project->fresh()?->name);
+    }
+
     public static function visibilityRules(): array
     {
         return [


### PR DESCRIPTION
The `updateProject` mutation added in #3438 currently rejects requests with the name field set to the project's current name.  It's much more convenient to be able to submit all fields, regardless of whether they were changed or not.  This PR allows the mutation to be called with the project's current name.