### PR TITLE
Centralize previous/next nav logic

### DIFF
--- a/app/Http/Controllers/AbstractBuildController.php
+++ b/app/Http/Controllers/AbstractBuildController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Utils\TestingDay;
 use CDash\Model\Build;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 abstract class AbstractBuildController extends AbstractProjectController
@@ -17,8 +18,21 @@ abstract class AbstractBuildController extends AbstractProjectController
             return parent::view($view, $title);
         }
 
+        $previousBuildId = $this->build->GetPreviousBuildId();
+        $latestBuildId = $this->build->GetCurrentBuildId();
+        $nextBuildId = $this->build->GetNextBuildId();
+
+        $previousUrl = $previousBuildId > 0 ? Str::replace((string) $this->build->Id, (string) $previousBuildId, request()->fullUrl()) : null;
+        $latestUrl = $latestBuildId > 0 ? Str::replace((string) $this->build->Id, (string) $latestBuildId, request()->fullUrl()) : null;
+        $nextUrl = $nextBuildId > 0 ? Str::replace((string) $this->build->Id, (string) $nextBuildId, request()->fullUrl()) : null;
+
+        // We assume the first instance of the current build ID in the URL is the build ID.  Users
+        // of this method can override these values if the routing scheme is different.
         return parent::view($view, $title)
-            ->with('build', $this->build);
+            ->with('build', $this->build)
+            ->with('previousUrl', $previousUrl)
+            ->with('latestUrl', $latestUrl)
+            ->with('nextUrl', $nextUrl);
     }
 
     // Fetch data used by all build-specific pages in CDash.

--- a/app/Http/Controllers/TestDetailsController.php
+++ b/app/Http/Controllers/TestDetailsController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Test;
+use CDash\Controller\Api\TestDetails as LegacyTestDetailsController;
+use CDash\Database;
+use CDash\Model\Build;
+use CDash\Model\Project;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class TestDetailsController extends AbstractBuildController
+{
+    public function details(int $id): View
+    {
+        $test = Test::find($id);
+        $this->setBuildById($test->buildid ?? -1);
+
+        $previousBuild = \App\Models\Build::find($this->build->GetPreviousBuildId());
+        $latestBuild = \App\Models\Build::find($this->build->GetCurrentBuildId());
+        $nextBuild = \App\Models\Build::find($this->build->GetNextBuildId());
+
+        $previousTest = $previousBuild?->tests()->firstWhere('testname', $test?->testname);
+        $latestTest = $latestBuild?->tests()->firstWhere('testname', $test?->testname);
+        $nextTest = $nextBuild?->tests()->firstWhere('testname', $test?->testname);
+
+        return $this->vue('test-details', 'Test Results')
+            ->with('previousUrl', $previousTest?->GetUrlForSelf())
+            ->with('latestUrl', $latestTest?->GetUrlForSelf())
+            ->with('nextUrl', $nextTest?->GetUrlForSelf());
+    }
+
+    public function apiTestDetails(): JsonResponse|StreamedResponse
+    {
+        $buildtestid = request()->input('buildtestid');
+        if (!is_numeric($buildtestid)) {
+            abort(400, 'A valid test was not specified.');
+        }
+
+        $buildtest = Test::where('id', '=', $buildtestid)->first();
+        if ($buildtest === null) {
+            // Create a dummy project object to prevent information leakage between different error cases
+            $project = new Project();
+            $project->Id = -1;
+        } else {
+            $build = new Build();
+            $build->Id = $buildtest->buildid;
+            $build->FillFromId($build->Id);
+            $project = $build->GetProject();
+        }
+
+        Gate::authorize('view-project', $project);
+
+        // This case should never occur since it should always be caught by the Gate::authorize check above.
+        // This is only here to satisfy PHPStan...
+        if ($buildtest === null) {
+            abort(500);
+        }
+
+        $controller = new LegacyTestDetailsController(Database::getInstance(), $buildtest);
+        return $controller->getResponse();
+    }
+}

--- a/resources/js/vue/components/page-header/HeaderNav.vue
+++ b/resources/js/vue/components/page-header/HeaderNav.vue
@@ -1,15 +1,12 @@
 <template>
-  <ul
-    v-if="showNav"
-    class="projectnav_controls clearfix"
-  >
+  <ul class="projectnav_controls clearfix">
     <li
       id="header-nav-previous-btn"
       :class="previousClass"
     >
       <a
         class="cdash-link"
-        :href="previous"
+        :href="previousUrl"
       >
         <svg
           id="i-chevron-left"
@@ -30,11 +27,11 @@
     </li>
     <li
       id="header-nav-current-btn"
-      :class="currentClass"
+      :class="latestClass"
     >
       <a
         class="cdash-link"
-        :href="current"
+        :href="latestUrl"
       >LATEST</a>
     </li>
     <li
@@ -43,7 +40,7 @@
     >
       <a
         class="cdash-link"
-        :href="next"
+        :href="nextUrl"
       >
         NEXT
         <svg
@@ -66,54 +63,39 @@
 </template>
 
 <script>
-import ApiLoader from '../shared/ApiLoader';
 export default {
   name: 'HeaderNav',
 
-  data() {
-    return {
-      previous: null,
-      current: null,
-      next: null,
-      showNav: false,
-    };
+  props: {
+    previousUrl: {
+      type: [String, null],
+      default: null,
+    },
+
+    latestUrl: {
+      type: [String, null],
+      default: null,
+    },
+
+    nextUrl: {
+      type: [String, null],
+      default: null,
+    },
   },
 
   computed: {
     previousClass () {
-      return this.previous === null ? 'btn-disabled' : 'btn-enabled';
+      return this.previousUrl === null ? 'btn-disabled' : 'btn-enabled';
     },
 
-    currentClass () {
-      return this.current === null ? 'btn-disabled' : 'btn-enabled';
+    latestClass () {
+      return this.latestUrl === null ? 'btn-disabled' : 'btn-enabled';
     },
 
     nextClass () {
-      return this.next === null ? 'btn-disabled' : 'btn-enabled';
+      return this.nextUrl === null ? 'btn-disabled' : 'btn-enabled';
     },
   },
-
-  mounted() {
-    ApiLoader.$on('api-loaded', cdash => {
-      if (!cdash.menu) {
-        return;
-      }
-
-      if (cdash.menu.previous) {
-        this.previous = this.$baseURL + cdash.menu.previous;
-        this.showNav = true;
-      }
-      if (cdash.menu.current) {
-        this.current = this.$baseURL + cdash.menu.current;
-        this.showNav = true;
-      }
-      if (cdash.menu.next) {
-        this.next = this.$baseURL + cdash.menu.next;
-        this.showNav = true;
-      }
-    });
-  },
-
 };
 </script>
 

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -12,6 +12,8 @@ $hideRegistration = config('auth.user_registration_form_enabled') === false;
 $currentDateString = now()->toDateString();
 
 $userInProject = isset($project) && auth()->user() !== null && \App\Models\Project::findOrFail($project->Id)->users()->where('id', auth()->user()->id)->exists();
+
+$showHeaderNav = isset($build);
 @endphp
 
 <div id="header">
@@ -87,8 +89,18 @@ $userInProject = isset($project) && auth()->user() !== null && \App\Models\Proje
                         </li>
                     </ul>
                 @endverbatim
-            @elseif(isset($vue) && $vue === true)
-                <header-nav></header-nav>
+            @elseif(isset($vue) && $vue === true && $showHeaderNav)
+                <header-nav
+                    @if($previousUrl)
+                        previous-url="{{ $previousUrl }}"
+                    @endif
+                    @if($latestUrl)
+                        latest-url="{{ $latestUrl }}"
+                    @endif
+                    @if($nextUrl)
+                        next-url="{{ $nextUrl }}"
+                    @endif
+                />
             @endif
         </nav>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ Route::get('/v1/viewUpdate.php', 'BuildController@viewUpdatePageContent');
 
 Route::get('/v1/viewTest.php', 'ViewTestController@fetchPageContent');
 
-Route::get('/v1/testDetails.php', 'TestController@apiTestDetails');
+Route::get('/v1/testDetails.php', 'TestDetailsController@apiTestDetails');
 
 Route::get('/v1/viewBuildError.php', 'BuildController@apiViewBuildError');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -192,7 +192,7 @@ Route::get('/viewMap.php', function (Request $request) {
     return redirect("/projects/{$project->id}/sites", 301);
 });
 
-Route::get('/tests/{id}', 'TestController@details')
+Route::get('/tests/{id}', 'TestDetailsController@details')
     ->whereNumber('id');
 Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {


### PR DESCRIPTION
The previous/latest/next nav menu is currently populated by a Vue component which assumes all pages use the legacy API.  This PR moves the logic to compute the URLs to a centralized location, and injects it into the page directly.