### PR TITLE
Add `labels` relationship to GraphQL `BuildError` type

### DIFF
--- a/app/Models/BuildError.php
+++ b/app/Models/BuildError.php
@@ -85,4 +85,12 @@ class BuildError extends Model
             get: fn (mixed $value, array $attributes): ?string => $this->arguments->isEmpty() ? null : $this->arguments->sortBy('pivot.place')->pluck('argument')->implode(' '),
         );
     }
+
+    /**
+     * @return BelongsToMany<Label, $this>
+     */
+    public function labels(): BelongsToMany
+    {
+        return $this->belongsToMany(Label::class, 'label2buildfailure', 'buildfailureid', 'labelid');
+    }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -997,6 +997,10 @@ type BuildError {
   sourceLine: Int @rename(attribute: "sourceline") @filterable
 
   command: String @with(relation: "arguments")
+
+  labels(
+    filters: _ @filter
+  ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id")
 }
 
 


### PR DESCRIPTION
This completes our effort to expose all build error information via GraphQL.