### PR TITLE
Handle "StartTestTime" attribute on each Test entry

### DIFF
--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -8,6 +8,7 @@ use App\Models\SiteInformation;
 use App\Models\TestMeasurement;
 use App\Utils\SubmissionUtils;
 use App\Utils\TestCreator;
+use Carbon\Carbon;
 use CDash\Collection\BuildCollection;
 use CDash\Collection\SubscriptionBuilderCollection;
 use CDash\Messaging\Notification\NotifyOn;
@@ -284,6 +285,9 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                     break;
                 case 'FULLCOMMANDLINE':
                     $this->TestCreator->testCommand .= $data;
+                    break;
+                case 'STARTTESTTIME':
+                    $this->TestCreator->testStartTime = Carbon::createFromTimestampMsUTC($data);
                     break;
             }
         } elseif ($parent === 'NAMEDMEASUREMENT' && $element === 'VALUE') {

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\TestTimeStatusCategory;
+use Carbon\Carbon;
 use CDash\Model\Label;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -27,6 +28,7 @@ use Illuminate\Support\Facades\Config;
  * @property int $newstatus
  * @property string $details
  * @property string $testname
+ * @property ?Carbon $starttime
  * @property TestTimeStatusCategory $timestatuscategory
  *
  * @mixin Builder<Test>
@@ -65,6 +67,7 @@ class Test extends Model
         'newstatus',
         'details',
         'testname',
+        'starttime',
     ];
 
     protected $casts = [
@@ -77,6 +80,7 @@ class Test extends Model
         'timestatus' => 'integer',
         'newstatus' => 'integer',
         'timestatuscategory' => TestTimeStatusCategory::class,
+        'starttime' => 'datetime',
     ];
 
     /**

--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -20,6 +20,7 @@ namespace App\Utils;
 use App\Models\Test;
 use App\Models\TestImage;
 use App\Models\TestOutput;
+use Carbon\Carbon;
 use CDash\Model\Build;
 use CDash\Model\Image;
 use ErrorException;
@@ -46,6 +47,7 @@ class TestCreator
     public $testName;
     public $testPath;
     public $testStatus;
+    public ?Carbon $testStartTime;
 
     public function __construct()
     {
@@ -62,6 +64,7 @@ class TestCreator
         $this->testOutput = '';
         $this->testPath = '';
         $this->testStatus = '';
+        $this->testStartTime = null;
     }
 
     private function saveImage(Image $image, int $testid): void
@@ -147,6 +150,7 @@ class TestCreator
         $buildtest->details = $this->testDetails;
         $buildtest->time = "$this->buildTestTime";
         $buildtest->testname = $this->testName;
+        $buildtest->starttime = $this->testStartTime;
 
         // Note: the newstatus column is currently handled in
         // ctestparserutils::compute_test_difference. This gets updated when we call

--- a/app/Validators/Schemas/Test.xsd
+++ b/app/Validators/Schemas/Test.xsd
@@ -36,6 +36,7 @@
                     <xs:element name="Path" type="xs:string" />
                     <xs:element name="FullName" type="xs:string" />
                     <xs:element name="FullCommandLine" type="xs:string" />
+                    <xs:element name="StartTestTime" type="xs:string" minOccurs="0" />
                     <xs:element name="Results">
                       <xs:complexType>
                         <xs:sequence>

--- a/app/cdash/tests/test_timestatus.php
+++ b/app/cdash/tests/test_timestatus.php
@@ -96,7 +96,7 @@ class TimeStatusTestCase extends KWWebTestCase
             FROM build b
             JOIN build2test b2t ON (b.id = b2t.buildid)
             WHERE projectid = ?
-            ORDER BY starttime');
+            ORDER BY b.starttime');
         if (!pdo_execute($stmt, [$projectid])) {
             $this->fail('SELECT query failed');
         }

--- a/database/migrations/2026_02_13_153356_add_teststarttime_to_tests_table.php
+++ b/database/migrations/2026_02_13_153356_add_teststarttime_to_tests_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE build2test ADD COLUMN starttime timestamp(3) with time zone');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -825,6 +825,8 @@ type Test {
 
   runningTime: NonNegativeSeconds! @rename(attribute: "time") @filterable
 
+  startTime: DateTimeTz! @rename(attribute: "starttime") @filterable
+
   details: String! @filterable
 
   testMeasurements(

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -62,6 +62,7 @@ class TestTypeTest extends TestCase
             'details' => 'details text',
             'time' => 1.2,
             'outputid' => $this->test_output->id,
+            'starttime' => '2026-02-13T18:03:54+00:00',
         ]);
 
         $this->graphQL('
@@ -78,6 +79,7 @@ class TestTypeTest extends TestCase
                                             status
                                             details
                                             runningTime
+                                            startTime
                                         }
                                     }
                                 }
@@ -104,6 +106,7 @@ class TestTypeTest extends TestCase
                                                     'status' => 'FAILED',
                                                     'details' => 'details text',
                                                     'runningTime' => 1.2,
+                                                    'startTime' => '2026-02-13T18:03:54+00:00',
                                                 ],
                                             ],
                                         ],

--- a/tests/Feature/Submission/Tests/TestXMLTest.php
+++ b/tests/Feature/Submission/Tests/TestXMLTest.php
@@ -113,4 +113,49 @@ class TestXMLTest extends TestCase
             ],
         ]);
     }
+
+    /**
+     * Test parsing a valid Test.xml file that contains the StartTestTime
+     * attribute for each Test entry in the test output.
+     */
+    public function testStartTestTime(): void
+    {
+        $this->submitFiles($this->project->name, [
+            base_path(
+                'tests/Feature/Submission/Tests/data/with_starttesttime.xml'
+            ),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+              build(id: $id) {
+                tests {
+                  edges {
+                    node {
+                      name
+                      startTime
+                    }
+                  }
+                }
+              }
+            }
+        ', [
+            'id' => $this->project->builds()->firstOrFail()->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'tests' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'exec',
+                                    'startTime' => '2026-02-13T18:03:54+00:00',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }

--- a/tests/Feature/Submission/Tests/data/with_starttesttime.xml
+++ b/tests/Feature/Submission/Tests/data/with_starttesttime.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="dummy_test_name"
+  BuildStamp="dummy_stamp"
+  Name="dummy_name"
+	>
+	<Testing>
+		<StartDateTime>Feb 13 13:03 EST</StartDateTime>
+		<StartTestTime>1771005834</StartTestTime>
+		<TestList>
+			<Test>./exec</Test>
+		</TestList>
+		<Test Status="passed">
+			<Name>exec</Name>
+			<Path>.</Path>
+			<FullName>./exec</FullName>
+			<FullCommandLine>testExec</FullCommandLine>
+			<StartTestTime>1771005834991</StartTestTime>
+			<Results>
+				<NamedMeasurement type="numeric/double" name="Execution Time">
+					<Value>0.00234227</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="numeric/double" name="Processors">
+					<Value>1</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Completion Status">
+					<Value>Completed</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Command Line">
+					<Value>testExec</Value>
+				</NamedMeasurement>
+				<NamedMeasurement type="text/string" name="Environment">
+					<Value>#CTEST_RESOURCE_GROUP_COUNT=</Value>
+				</NamedMeasurement>
+				<Measurement>
+					<Value encoding="base64" compression="gzip">eJzzSM3JyVcIzy/KSVF09Al3jAz2cw1zDSKFyQUA6eMU3Q==</Value>
+				</Measurement>
+			</Results>
+		</Test>
+		<EndDateTime>Feb 13 13:03 EST</EndDateTime>
+		<EndTestTime>1771005835</EndTestTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Testing>
+</Site>


### PR DESCRIPTION
CTest includes the start time of each individual test as of the merge in https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11684

Add the validation and the parsing of the field for the build2test table and the Test model.