### PR TITLE
Use seconds for TestStartTime entries

### DIFF
--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -287,7 +287,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
                     $this->TestCreator->testCommand .= $data;
                     break;
                 case 'STARTTESTTIME':
-                    $this->TestCreator->testStartTime = Carbon::createFromTimestampMsUTC($data);
+                    $this->TestCreator->testStartTime = Carbon::createFromTimestampUTC($data);
                     break;
             }
         } elseif ($parent === 'NAMEDMEASUREMENT' && $element === 'VALUE') {

--- a/tests/Feature/Submission/Tests/TestXMLTest.php
+++ b/tests/Feature/Submission/Tests/TestXMLTest.php
@@ -149,7 +149,7 @@ class TestXMLTest extends TestCase
                             [
                                 'node' => [
                                     'name' => 'exec',
-                                    'startTime' => '2026-02-13T18:03:54+00:00',
+                                    'startTime' => '2026-02-16T13:56:30+00:00',
                                 ],
                             ],
                         ],

--- a/tests/Feature/Submission/Tests/data/with_starttesttime.xml
+++ b/tests/Feature/Submission/Tests/data/with_starttesttime.xml
@@ -14,7 +14,7 @@
 			<Path>.</Path>
 			<FullName>./exec</FullName>
 			<FullCommandLine>testExec</FullCommandLine>
-			<StartTestTime>1771005834991</StartTestTime>
+			<StartTestTime>1771250190.659912</StartTestTime>
 			<Results>
 				<NamedMeasurement type="numeric/double" name="Execution Time">
 					<Value>0.00234227</Value>


### PR DESCRIPTION
Following the update to the Test entry for TestStartTime, do not use the `createFromTimeStampMsUTC`, but instead the function that creates it from seconds.

See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11694#note_1773126