### PR TITLE
Create Eloquent `Repository` model

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -308,4 +308,12 @@ class Project extends Model
     {
         return $this->hasMany(SubProjectGroup::class, 'projectid');
     }
+
+    /**
+     * @return HasMany<Repository, $this>
+     */
+    public function repositories(): HasMany
+    {
+        return $this->hasMany(Repository::class, 'projectid');
+    }
 }

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $projectid
+ * @property string $url
+ * @property string $username
+ * @property string $password
+ * @property string $branch
+ *
+ * @mixin Builder<Repository>
+ */
+class Repository extends Model
+{
+    protected $table = 'repositories';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'url',
+        'username',
+        'password',
+        'branch',
+    ];
+
+    protected $casts = [
+        'projectid' => 'integer',
+    ];
+}

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -309,27 +309,13 @@ class Project
     /** Get the repositories */
     public function GetRepositories(): array
     {
-        $repository = DB::select('
-                          SELECT
-                              url,
-                              username,
-                              password,
-                              branch
-                          FROM repositories, project2repositories
-                          WHERE
-                              repositories.id=project2repositories.repositoryid
-                              AND project2repositories.projectid=?
-                      ', [(int) $this->Id]);
-
-        $repositories = [];
-        foreach ($repository as $repository_array) {
-            $rep['url'] = $repository_array->url;
-            $rep['username'] = $repository_array->username;
-            $rep['password'] = $repository_array->password;
-            $rep['branch'] = $repository_array->branch;
-            $repositories[] = $rep;
-        }
-        return $repositories;
+        $project = EloquentProject::findOrFail((int) $this->Id);
+        return $project->repositories()->select([
+            'url',
+            'username',
+            'password',
+            'branch',
+        ])->get()->toArray();
     }
 
     /** Get the Name of the project */

--- a/app/cdash/public/api/v1/project.php
+++ b/app/cdash/public/api/v1/project.php
@@ -323,87 +323,16 @@ function set_logo($Project): void
 
 function addRepositoriesToProject(int $projectid, array $repositories, array $usernames, array $passwords, array $branches): void
 {
-    // First we update/delete any registered repositories
-    $currentRepository = 0;
-    $repositories_query = DB::select('
-        SELECT repositoryid
-        FROM project2repositories
-        WHERE projectid=?
-        ORDER BY repositoryid
-    ', [$projectid]);
+    $project = \App\Models\Project::findOrFail($projectid);
 
-    foreach ($repositories_query as $repository_array) {
-        $repositoryid = intval($repository_array->repositoryid);
-        if (!isset($repositories[$currentRepository]) || strlen($repositories[$currentRepository]) === 0) {
-            // TODO: (wiliamjallen) This should be done with one query
-            $query = DB::select('
-                SELECT COUNT(*) AS c
-                FROM project2repositories
-                WHERE repositoryid=?
-            ', [$repositoryid]);
-            if ((int) $query[0]->c === 1) {
-                DB::delete('DELETE FROM repositories WHERE id=?', [$repositoryid]);
-            }
-            DB::delete('
-                DELETE FROM project2repositories
-                WHERE projectid=? AND repositoryid=?
-            ', [$projectid, $repositoryid]);
-        } else {
-            // If the repository is not shared by any other project we update
-            $count_array = DB::select('
-                                   SELECT count(*) as c
-                                   FROM project2repositories
-                                   WHERE repositoryid=?
-                               ', [$repositoryid]);
-            if ((int) $count_array[0]->c === 1) {
-                DB::table('repositories')->where('id', $repositoryid)->update([
-                    'url' => $repositories[$currentRepository],
-                    'username' => $usernames[$currentRepository],
-                    'password' => $passwords[$currentRepository],
-                    'branch' => $branches[$currentRepository],
-                ]);
-            } else {
-                // Otherwise we remove it from the current project and add it to the queue to be created
-                DB::delete('
-                    DELETE FROM project2repositories
-                    WHERE projectid=? AND repositoryid=?
-                ', [$projectid, $repositoryid]);
-
-                $repositories[] = $repositories[$currentRepository];
-                $usernames[] = $usernames[$currentRepository];
-                $passwords[] = $passwords[$currentRepository];
-                $branches[] = $branches[$currentRepository];
-            }
-        }
-        $currentRepository++;
-    }
-
-    //  Then we add new repositories
-    for ($i = $currentRepository; $i < count($repositories); $i++) {
-        $url = $repositories[$i];
-        $username = $usernames[$i];
-        $password = $passwords[$i];
-        $branch = $branches[$i];
-        if (strlen($url) === 0) {
-            continue;
-        }
-
-        // Insert into repositories if not any
-        $repositories_query = DB::select('SELECT id FROM repositories WHERE url=?', [$url]);
-
-        if ($repositories_query === []) {
-            $repositoryid = DB::table('repositories')->insertGetId([
-                'url' => $url,
-                'username' => $username,
-                'password' => $password,
-                'branch' => $branch,
-            ]);
-        } else {
-            $repositoryid = intval($repositories['id']);
-        }
-        DB::table('project2repositories')->insert([
-            'projectid' => $projectid,
-            'repositoryid' => $repositoryid,
+    // Delete and re-add all repositories
+    $project->repositories()->delete();
+    foreach ($repositories as $index => $url) {
+        $project->repositories()->create([
+            'url' => $url,
+            'username' => $usernames[$index],
+            'password' => $passwords[$index],
+            'branch' => $branches[$index],
         ]);
     }
 }

--- a/database/migrations/2026_02_20_140406_remove_project2repositories_table.php
+++ b/database/migrations/2026_02_20_140406_remove_project2repositories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE repositories ADD COLUMN projectid bigint');
+        DB::statement('ALTER TABLE repositories ADD FOREIGN KEY (projectid) REFERENCES project(id) ON DELETE CASCADE');
+
+        DB::insert('
+            INSERT INTO repositories (projectid, url, username, password, branch)
+            SELECT project.id, repositories.url, repositories.username, repositories.password, repositories.branch
+            FROM repositories
+            INNER JOIN project2repositories ON repositories.id = project2repositories.repositoryid
+            INNER JOIN project ON project2repositories.projectid = project.id
+        ');
+
+        DB::delete('DELETE FROM repositories WHERE projectid IS NULL');
+        DB::statement('ALTER TABLE repositories ALTER COLUMN projectid SET NOT NULL');
+
+        DB::statement('DROP TABLE project2repositories');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10978,12 +10978,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Implicit array creation is not allowed - variable $rep might not exist.
-			identifier: variable.implicitArray
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: 'Loose comparison via "!=" is not allowed.'
 			identifier: notEqual.notAllowed
 			count: 2


### PR DESCRIPTION
Incremental progress towards our ongoing effort to migrate to Eloquent.  As part of this work, I removed the `project2repositories` pivot table, meaning that repositories are now directly related to projects.