### PR TITLE
Reduce loading indicator delay

### DIFF
--- a/resources/js/vue/components/shared/LoadingIndicator.vue
+++ b/resources/js/vue/components/shared/LoadingIndicator.vue
@@ -30,7 +30,7 @@ export default {
     // Prevent a flicker if the page loads quickly
     setTimeout(() => {
       this.initialDelayComplete = true;
-    }, 500);
+    }, 200);
   },
 };
 </script>


### PR DESCRIPTION
The loading indicator currently waits for 0.5 seconds before displaying to prevent a flicker if data loads relatively quickly.  The current half-second wait makes it look slow in my opinion, and I think a 0.2 second wait improves the experience while still addressing the flicker issue.