### PR TITLE
Drop non-nullable marker from Test StartTime

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -831,7 +831,7 @@ type Test {
 
   runningTime: NonNegativeSeconds! @rename(attribute: "time") @filterable
 
-  startTime: DateTimeTz! @rename(attribute: "starttime") @filterable
+  startTime: DateTimeTz @rename(attribute: "starttime") @filterable
 
   details: String! @filterable
 


### PR DESCRIPTION
Prevent an error when using GraphQL by allowing the starttime field to be null
Before:
```
{
  "errors": [
    {
      "message": "Internal server error",
      "locations": [
        {
          "line": 11,
          "column": 21
        }
      ],
      "path": [
        "projects",
        "edges",
        1,
        "node",
        "builds",
        "edges",
        0,
        "node",
        "tests",
        "edges",
        0,
        "node",
        "startTime"
      ],
      "extensions": {
        "debugMessage": "Cannot return null for non-nullable field \"Test.startTime\".",
  ```
After:
```
"data": {
    "projects": {
      "edges": [
        {
          "node": {
            "builds": {
              "edges": []
            }
          }
        },
        {
          "node": {
            "builds": {
              "edges": [
                {
                  "node": {
                    "tests": {
                      "edges": [
                        {
                          "node": {
                            "startTime": null
                          }
```