### PR TITLE
Add Source and Binary directory to build

### DIFF
--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -69,6 +69,8 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
     private string $BuildStamp;
     private string $Generator;
     private string $PullRequest = '';
+    private ?string $SourceDirectory = null;
+    private ?string $BinaryDirectory = null;
     private ?BuildErrorFilter $BuildErrorFilter = null;
     protected static ?string $schema_file = '/app/Validators/Schemas/Build.xsd';
 
@@ -344,6 +346,8 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                 $build->StartTime = $start_time;
                 $build->EndTime = $end_time;
                 $build->SubmitTime = $submit_time;
+                $build->SourceDirectory = $this->SourceDirectory;
+                $build->BinaryDirectory = $this->BinaryDirectory;
                 if (empty($subproject)) {
                     $build->SetSubProject($this->SubProjectName);
                 } else {
@@ -565,6 +569,12 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                     break;
                 case 'BUILDCOMMAND':
                     $this->BuildCommand = htmlspecialchars_decode($data);
+                    break;
+                case 'SOURCEDIRECTORY':
+                    $this->SourceDirectory = $data;
+                    break;
+                case 'BINARYDIRECTORY':
+                    $this->BinaryDirectory = $data;
                     break;
             }
         } elseif ($this->getParent() === 'ACTION') {

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -47,6 +47,8 @@ use Illuminate\Support\Str;
  * @property string $osversion
  * @property string $compilername
  * @property string $compilerversion
+ * @property ?string $sourcedirectory
+ * @property ?string $binarydirectory
  *
  * @method static Builder<Build> betweenDates(?Carbon $starttime, ?Carbon $endtime)
  *
@@ -95,6 +97,8 @@ class Build extends Model
         'osversion',
         'compilername',
         'compilerversion',
+        'sourcedirectory',
+        'binarydirectory',
     ];
 
     protected $casts = [

--- a/app/Validators/Schemas/Build.xsd
+++ b/app/Validators/Schemas/Build.xsd
@@ -35,6 +35,8 @@
                   <xs:element name="Labels" type="LabelsType" />
                   <xs:element name="StartDateTime" type="xs:string" />
                   <xs:element name="StartBuildTime" type="xs:unsignedInt" />
+                  <xs:element name="SourceDirectory" type="xs:string" minOccurs="0" />
+                  <xs:element name="BinaryDirectory" type="xs:string" minOccurs="0" />
                   <xs:element name="BuildCommand" type="xs:string" />
                   <xs:element name="Error">
                     <xs:complexType>

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -66,6 +66,8 @@ class Build
     public ?string $OSVersion = null;
     public ?string $CompilerName = null;
     public ?string $CompilerVersion = null;
+    public ?string $SourceDirectory = null;
+    public ?string $BinaryDirectory = null;
     public int $BuildErrorCount;
     public int $TestFailedCount;
 
@@ -364,6 +366,8 @@ class Build
         $this->OSVersion = $model->osversion;
         $this->CompilerName = $model->compilername;
         $this->CompilerVersion = $model->compilerversion;
+        $this->SourceDirectory = $model->sourcedirectory;
+        $this->BinaryDirectory = $model->binarydirectory;
 
         $subprojectid = $this->QuerySubProjectId($buildid);
         if ($subprojectid) {
@@ -1715,7 +1719,12 @@ class Build
             if ($this->CompilerVersion !== null && $this->CompilerVersion !== $build->compilerversion) {
                 $fields_to_update['compilerversion'] = $this->CompilerVersion;
             }
-
+            if ($this->SourceDirectory !== null && $this->SourceDirectory !== $build->sourcedirectory) {
+                $fields_to_update['sourcedirectory'] = $this->SourceDirectory;
+            }
+            if ($this->BinaryDirectory !== null && $this->BinaryDirectory !== $build->binarydirectory) {
+                $fields_to_update['binarydirectory'] = $this->BinaryDirectory;
+            }
             if (!empty($fields_to_update)) {
                 $build->update($fields_to_update);
             }
@@ -2213,6 +2222,8 @@ class Build
                     'osversion' => $this->OSVersion,
                     'compilername' => $this->CompilerName,
                     'compilerversion' => $this->CompilerVersion,
+                    'sourcedirectory' => $this->SourceDirectory,
+                    'binarydirectory' => $this->BinaryDirectory,
                 ])->id;
                 $build_created = true;
                 $this->AssignToGroup();

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -336,6 +336,8 @@ add_feature_test(/Feature/Submission/Instrumentation/BuildInstrumentationTest)
 
 add_feature_test(/Feature/Submission/Tests/TestXMLTest)
 
+add_feature_test(/Feature/Submission/Tests/BuildXMLTest)
+
 add_browser_test(/Browser/Pages/SitesIdPageTest)
 
 add_browser_test(/Browser/Pages/ProjectSitesPageTest)

--- a/database/migrations/2026_02_23_150347_add_source_binary_directories_to_build_table.php
+++ b/database/migrations/2026_02_23_150347_add_source_binary_directories_to_build_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE build ADD COLUMN sourcedirectory text');
+        DB::statement('ALTER TABLE build ADD COLUMN binarydirectory text');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -691,6 +691,10 @@ type Build {
   "The command used to drive the build. Example: /usr/local/bin/cmake --build . --config Release"
   command: String! @filterable
 
+  sourceDirectory: String @filterable @rename(attribute: "sourcedirectory")
+
+  binaryDirectory: String @filterable @rename(attribute: "binarydirectory")
+
   "The number of errors generated during the configuration step."
   configureErrorsCount: Int @rename(attribute: "configureerrors")
 

--- a/tests/Feature/Submission/Tests/BuildXMLTest.php
+++ b/tests/Feature/Submission/Tests/BuildXMLTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Submission\Tests;
+
+use App\Models\Project;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSubmissions;
+
+class BuildXMLTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSubmissions;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test parsing a valid Build.xml file that contains
+     * the Source and Binary directories
+     */
+    public function testBuildDirectoriesHandling(): void
+    {
+        $this->submitFiles($this->project->name, [
+            base_path(
+                'tests/Feature/Submission/Tests/data/with_build_source_binary_directories.xml'
+            ),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+              build(id: $id) {
+                sourceDirectory
+                binaryDirectory
+              }
+            }
+        ', [
+            'id' => $this->project->builds()->firstOrFail()->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'sourceDirectory' => '/home/user/Work/cmake',
+                    'binaryDirectory' => '/home/user/Work/cmake-build',
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Submission/Tests/data/with_build_source_binary_directories.xml
+++ b/tests/Feature/Submission/Tests/data/with_build_source_binary_directories.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="dummy_test_name"
+  BuildStamp="dummy_stamp"
+  Name="dummy_name"
+	>
+	<Build>
+		<StartDateTime>Feb 23 10:47 EST</StartDateTime>
+		<StartBuildTime>1771861653</StartBuildTime>
+		<SourceDirectory>/home/user/Work/cmake</SourceDirectory>
+		<BinaryDirectory>/home/user/Work/cmake-build</BinaryDirectory>
+		<BuildCommand>/usr/local/bin/cmake --build . --config "Release"</BuildCommand>
+		<Log Encoding="base64" Compression="bin/gzip"/>
+		<EndDateTime>Feb 23 10:47 EST</EndDateTime>
+		<EndBuildTime>1771861655</EndBuildTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Build>
+</Site>


### PR DESCRIPTION
Add the ability to store the source and binary directory of an incoming build.  This information will be available in CMake soon

See https://gitlab.kitware.com/cmake/cmake/-/issues/27628