### PR TITLE
Move CDash config definitions to `cdash.php`

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -48,7 +48,7 @@ final class RegisterController extends AbstractController
 
     public function showRegistrationForm(Request $request): View
     {
-        if (config('auth.user_registration_form_enabled') === false) {
+        if (config('cdash.user_registration_form_enabled') === false) {
             abort(404, 'Registration via form is disabled');
         }
         // We can route a user here with our form pre-populated
@@ -117,7 +117,7 @@ final class RegisterController extends AbstractController
      */
     public function register(Request $request): Response|RedirectResponse
     {
-        if (config('auth.user_registration_form_enabled') === false) {
+        if (config('cdash.user_registration_form_enabled') === false) {
             return response('Registration via form is disabled', 404);
         }
         try {

--- a/config/auth.php
+++ b/config/auth.php
@@ -4,9 +4,6 @@ use App\Ldap\Rules\FilterRules;
 use App\Models\User;
 
 return [
-    // Whether or not "normal" username+password authentication is enabled
-    'user_registration_form_enabled' => env('USER_REGISTRATION_FORM_ENABLED', true),
-
     /*
     |--------------------------------------------------------------------------
     | Authentication Defaults

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -69,6 +69,8 @@ return [
     'project_admin_registration_form_enabled' => env('PROJECT_ADMIN_REGISTRATION_FORM_ENABLED', true),
     // Text displayed at the top of all pages.  Accepts inline markdown (links, bold, italics).
     'global_banner' => env('GLOBAL_BANNER'),
+    // Whether or not new CDash users can register email+password accounts
+    'user_registration_form_enabled' => env('USER_REGISTRATION_FORM_ENABLED', true),
     // Whether or not "normal" username+password authentication is enabled
     'username_password_authentication_enabled' => env('USERNAME_PASSWORD_AUTHENTICATION_ENABLED', true),
     'ldap_enabled' => env('CDASH_AUTHENTICATION_PROVIDER') === 'ldap',

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -7,7 +7,7 @@ if (isset($project)) {
     $logoid = $project->ImageId;
 }
 
-$hideRegistration = config('auth.user_registration_form_enabled') === false;
+$hideRegistration = config('cdash.user_registration_form_enabled') === false;
 
 $currentDateString = now()->toDateString();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ use Illuminate\Support\Facades\Route;
 
 $routeList = ['verify' => true];
 
-if (config('auth.user_registration_form_enabled') === false) {
+if (config('cdash.user_registration_form_enabled') === false) {
     $routeList['register'] = false;
 }
 Auth::routes($routeList);

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -349,7 +349,7 @@ class LoginAndRegistration extends TestCase
     {
         // Create a user by sending proper data
 
-        config(['auth.user_registration_form_enabled' => false]);
+        config(['cdash.user_registration_form_enabled' => false]);
         $post_data = [
             'fname' => 'Test',
             'lname' => 'User',
@@ -370,7 +370,7 @@ class LoginAndRegistration extends TestCase
     {
         // Disable username+password authentication and verify that the
         // form is no longer displayed.
-        config(['auth.user_registration_form_enabled' => false]);
+        config(['cdash.user_registration_form_enabled' => false]);
         $response = $this->get('/register');
         $response->assertStatus(404);
     }


### PR DESCRIPTION
This PR moves the `user_registration_form_enabled` configuration option to `cdash.php` instead of Laravel's `auth.php`, keeping all of the custom CDash options in a single place.