### PR TITLE
Fix build error formatting

### DIFF
--- a/app/cdash/app/Model/BuildError.php
+++ b/app/cdash/app/Model/BuildError.php
@@ -18,6 +18,7 @@
 namespace CDash\Model;
 
 use App\Models\BasicBuildAlert;
+use Illuminate\Support\Str;
 
 /** BuildError */
 class BuildError
@@ -54,7 +55,7 @@ class BuildError
             'sourceline' => (int) $this->SourceLine,
             'repeatcount' => (int) $this->RepeatCount,
             'newstatus' => 0,
-            'stdoutput' => $this->PreContext . $this->Text . $this->PostContext,
+            'stdoutput' => $this->PreContext . Str::rtrim($this->Text) . PHP_EOL . $this->PostContext,
             'stderror' => $this->Text,
         ]);
     }


### PR DESCRIPTION
CTest stopped adding trailing newlines to the `Build.xml` `<Text>` element sometime between the versions used to generate most of the test data and the most recent version of CTest.  This commit resolves the issue by ensuring that exactly one newline is placed between the Text and PostContext.