### PR TITLE
Allow users to set auth token expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,9 +128,8 @@ DB_PASSWORD=secret
 # Log when a page takes more this this many seconds to load.
 #SLOW_PAGE_TIME=10
 
-# How long authentication tokens should last before expiring (in seconds).
-# Default is six months.
-# 0 here means that tokens do not expire.
+# The maximum allowable token duration (in seconds). Default is six months.
+# 0 here means that there's no limit on token validity.
 #TOKEN_DURATION=15811200
 
 # Whitelist of projects that are allowed to have unlimited builds.

--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -61,6 +61,7 @@ final class AuthTokenController extends AbstractController
                 $projectid,
                 $request->input('scope'),
                 $request->input('description'),
+                $request->date('expiration'),
             );
         } catch (InvalidArgumentException $e) {
             return response()->json(['error' => $e->getMessage()], Response::HTTP_BAD_REQUEST);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -58,6 +58,7 @@ final class UserController extends AbstractController
         $response['user_name'] = $user->firstname;
         $response['user_is_admin'] = $user->admin;
         $response['show_monitor'] = config('queue.default') === 'database';
+        $response['max_token_expiration'] = AuthTokenUtil::getMaximumTokenExpiration()->toIso8601String();
 
         if ((bool) config('cdash.user_create_projects')) {
             $response['user_can_create_projects'] = 1;

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -247,6 +247,8 @@ add_feature_test_in_transaction(/Feature/Jobs/PruneAuthTokensTest)
 
 add_feature_test_in_transaction(/Feature/UserCommand)
 
+add_feature_test_in_transaction(/Feature/AuthTokenTest)
+
 add_feature_test_in_transaction(/Feature/RemoteWorkers)
 set_property(TEST /Feature/RemoteWorkers APPEND PROPERTY
     DISABLED "$<NOT:$<STREQUAL:${CDASH_STORAGE_TYPE},local>>"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6061,25 +6061,13 @@ parameters:
 			path: app/Utils/AuthTokenUtil.php
 
 		-
-			rawMessage: Implicit array creation is not allowed - variable $params does not exist.
-			identifier: variable.implicitArray
-			count: 1
-			path: app/Utils/AuthTokenUtil.php
-
-		-
 			rawMessage: 'Method App\Utils\AuthTokenUtil::getUserIdFromRequest() should return int|null but returns mixed.'
 			identifier: return.type
 			count: 1
 			path: app/Utils/AuthTokenUtil.php
 
 		-
-			rawMessage: 'Parameter #2 $timestamp of function gmdate expects int|null, float|int given.'
-			identifier: argument.type
-			count: 1
-			path: app/Utils/AuthTokenUtil.php
-
-		-
-			rawMessage: 'Part $duration (mixed) of encapsed string cannot be cast to string.'
+			rawMessage: 'Part $maxDuration (mixed) of encapsed string cannot be cast to string.'
 			identifier: encapsedStringPart.nonString
 			count: 1
 			path: app/Utils/AuthTokenUtil.php
@@ -26816,6 +26804,12 @@ parameters:
 			identifier: missingType.checkedException
 			count: 1
 			path: tests/Browser/Pages/UsersPageTest.php
+
+		-
+			rawMessage: 'Parameter #1 $time of static method Carbon\Carbon::parse() expects Carbon\Month|Carbon\WeekDay|DateTimeInterface|float|int|string|null, mixed given.'
+			identifier: argument.type
+			count: 1
+			path: tests/Feature/AuthTokenTest.php
 
 		-
 			rawMessage: Access to an undefined property CDash\Model\Build::$Endime.

--- a/tests/Feature/AuthTokenTest.php
+++ b/tests/Feature/AuthTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AuthToken;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tests\Traits\CreatesUsers;
+
+class AuthTokenTest extends TestCase
+{
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function setTokenExpirationCases(): array
+    {
+        $oneYear = Carbon::now()->addYear();
+        $oneMonth = Carbon::now()->addMonth();
+        $oneMonthAgo = Carbon::now()->subMonth();
+
+        return [
+            // Defaults to 1 year if no expiration provided
+            [null, $oneYear, 0, true],
+            // Basic case with no limit
+            [$oneMonth, $oneMonth, 0, true],
+            // Sets to limit if expiration beyond limit
+            [$oneYear, $oneMonth, (int) Carbon::now()->diffInUTCSeconds($oneMonth), true],
+            // Test expiration in the past
+            [$oneMonthAgo, Carbon::now(), 0, false],
+        ];
+    }
+
+    #[DataProvider('setTokenExpirationCases')]
+    public function testSetTokenExpiration(
+        ?Carbon $expirationParam,
+        Carbon $expectedExpiration,
+        int $tokenDuration,
+        bool $shouldPass,
+    ): void {
+        config(['cdash.token_duration' => $tokenDuration]);
+        $admin = $this->makeAdminUser();
+
+        $response = $this->actingAs($admin)->post('/api/authtokens/create', [
+            'description' => Str::uuid()->toString(),
+            'scope' => AuthToken::SCOPE_FULL_ACCESS,
+            'expiration' => $expirationParam,
+        ]);
+
+        if ($shouldPass) {
+            $response->assertOk();
+            $actualExpiration = Carbon::parse($response->json('token.expires'));
+            self::assertEqualsWithDelta($expectedExpiration->timestamp, $actualExpiration->timestamp, 10);
+        } else {
+            $response->assertBadRequest();
+        }
+    }
+}


### PR DESCRIPTION
The `TOKEN_DURATION` environment variable is used to set the length of time authentication tokens are valid.  This commit changes `TOKEN_DURATION` to be an upper bound on token duration, allowing users to set shorter durations.