### PR TITLE
Improve test creation performance

### DIFF
--- a/app/Utils/TestCreator.php
+++ b/app/Utils/TestCreator.php
@@ -137,7 +137,7 @@ class TestCreator
             }
         }
 
-        DB::transaction(function () use ($build) {
+        DB::transaction(function () use ($build): void {
             $outputid = TestOutput::select('id')->firstOrCreate([
                 'path' => $this->testPath,
                 'command' => $this->testCommand,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7051,12 +7051,6 @@ parameters:
 			path: app/Utils/TestCreator.php
 
 		-
-			rawMessage: 'Property App\Models\Test::$time (float) does not accept string.'
-			identifier: assign.propertyType
-			count: 1
-			path: app/Utils/TestCreator.php
-
-		-
 			rawMessage: Property App\Utils\TestCreator::$alreadyCompressed has no type specified.
 			identifier: missingType.property
 			count: 1


### PR DESCRIPTION
Test insertion is the most performance-critical part of CDash, simply because there are often 2-4 orders of magnitude more tests than builds.  Each of those tests then has an additional order of magnitude more measurements and/or labels associated with it.  This PR improves two things:

1. Only the test output ID is queried instead of the entire model.  This reduces the amount of network I/O to the database.
2. The entire test creation process is wrapped in a transaction.  In addition to ensuring consistency, this also avoids the overhead of committing after many small transactions.

There's more to be done here, particularly relating to bulk inserts of labels, measurements, and images, but some substantial refactoring needs to be done first.