### PR TITLE
Add test output fields to GraphQL API

### DIFF
--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -6,6 +6,7 @@ use App\Enums\TestTimeStatusCategory;
 use Carbon\Carbon;
 use CDash\Model\Label;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -129,6 +130,36 @@ class Test extends Model
     public function testImages(): HasMany
     {
         return $this->hasMany(TestImage::class, 'testid');
+    }
+
+    /**
+     * @return Attribute<?string,null>
+     */
+    protected function path(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): ?string => $this->testOutput->path ?? null,
+        );
+    }
+
+    /**
+     * @return Attribute<?string,null>
+     */
+    protected function command(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): ?string => $this->testOutput->command ?? null,
+        );
+    }
+
+    /**
+     * @return Attribute<?string,null>
+     */
+    protected function output(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value, array $attributes): ?string => $this->testOutput->output ?? null,
+        );
     }
 
     /**

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -889,6 +889,12 @@ type Test {
 
   details: String! @filterable
 
+  path: String @with(relation: "testOutput")
+
+  command: String @with(relation: "testOutput")
+
+  output: String @with(relation: "testOutput")
+
   testMeasurements(
     filters: _ @filter
   ): [TestMeasurement!]! @hasMany @orderBy(column: "id", direction: DESC)

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Project;
+use App\Models\Test;
 use App\Models\TestOutput;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Str;
@@ -80,6 +81,9 @@ class TestTypeTest extends TestCase
                                             details
                                             runningTime
                                             startTime
+                                            path
+                                            command
+                                            output
                                         }
                                     }
                                 }
@@ -107,6 +111,9 @@ class TestTypeTest extends TestCase
                                                     'details' => 'details text',
                                                     'runningTime' => 1.2,
                                                     'startTime' => '2026-02-13T18:03:54+00:00',
+                                                    'path' => 'a',
+                                                    'command' => 'b',
+                                                    'output' => 'c',
                                                 ],
                                             ],
                                         ],


### PR DESCRIPTION
This commit continues our ongoing effort to expose all CDash data via GraphQL.  These new `path`, `command`, and `output` fields are not currently filterable because they are pulled from a separate relation.  In the future, we can create a Postgres view which joins these relations and a corresponding model to allow these fields to be filtered.