### PR TITLE
Add index for efficient next/previous build lookup

### DIFF
--- a/database/migrations/2026_03_10_143442_next_previous_build_index.php
+++ b/database/migrations/2026_03_10_143442_next_previous_build_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build(projectid, siteid, name, type, starttime) INCLUDE (id)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
None of our indexes currently cover the very common case of looking up next and previous instances of a build.  This commit adds such an index, allowing the queries to avoid going to the heap.