### PR TITLE
Create updatefile indexes on revision, priorrevision

### DIFF
--- a/database/migrations/2026_03_10_145852_updatefile_revision_index.php
+++ b/database/migrations/2026_03_10_145852_updatefile_revision_index.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON updatefile(revision)');
+        DB::statement('CREATE INDEX ON updatefile(priorrevision)');
+        DB::statement('CREATE INDEX ON updatefile(filename, revision)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
The GitHub app reporter executes a query which benefits from an index on `updatefile(filename, revision)`.  Additionally, several other queries search by `revision` or `priorrevision`.