### PR TITLE
Optimize site information existence check

### DIFF
--- a/app/Http/Submission/Traits/UpdatesSiteInformation.php
+++ b/app/Http/Submission/Traits/UpdatesSiteInformation.php
@@ -13,7 +13,7 @@ trait UpdatesSiteInformation
      */
     protected function updateSiteInfoIfChanged(Site $site, SiteInformation $newInformation): void
     {
-        if ($site->information()->count() === 0) {
+        if ($site->information()->doesntExist()) {
             // No existing information, so save whatever we're given, regardless of whether it's all null.
             $site->information()->save($newInformation);
             return;


### PR DESCRIPTION
Every submission currently counts the site information records associated with the build's site, only to check whether that value is zero.  That count query adds up fast when projects use the same site name across many different machines with different specs.  This commit updates the offending query to instead check for the existence of any records instead of counting them.