### PR TITLE
Add parent build index

### DIFF
--- a/database/migrations/2026_03_10_154418_build_projectid_parentid_index.php
+++ b/database/migrations/2026_03_10_154418_build_projectid_parentid_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build(projectid, id) WHERE parentid = 0 OR parentid = 1');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Postgres currently scans the entire build table when querying the list of parent builds.  This commit adds an index which allows it to specifically query parent builds, ordered by build ID.