### PR TITLE
Add index for dynamic build groups

### DIFF
--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -217,10 +217,16 @@ class Index extends ResultsApi
             $buildgroup_id = $rule->id;
             $buildgroup_position = $rule->position;
             if ($rule->type === 'Latest') {
-                $sql = $this->getIndexQuery();
-
                 $whereClauses = [];
                 $query_params = [];
+
+                $sql = $this->getIndexQuery();
+
+                // Add a projectid filter to help the planner choose a better execution plan, even
+                // though all the groups are already associated with the project.
+                $whereClauses[] = 'b.projectid=?';
+                $query_params[] = (int) $this->project->Id;
+
                 // optional fields: parentgroupid, site, and build name match.
                 // Use these to construct a WHERE clause for our query.
                 if (!empty($rule->parentgroupid)) {

--- a/database/migrations/2026_03_10_181145_dynamic_builds_index.php
+++ b/database/migrations/2026_03_10_181145_dynamic_builds_index.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX ON build(projectid, siteid, name, submittime)');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
This commit adds an index and adds a query condition which together make it much more efficient to query the members of a dynamic build group.