### PR TITLE
Force project logos to be square on projects page

### DIFF
--- a/resources/js/vue/components/ProjectsPage.vue
+++ b/resources/js/vue/components/ProjectsPage.vue
@@ -71,7 +71,7 @@
                 <project-logo
                   :image-url="project.logoUrl"
                   :project-name="project.name"
-                  class="tw-w-8"
+                  class="tw-w-8 tw-h-8"
                 />
               </td>
               <td class="tw-align-middle tw-w-full">


### PR DESCRIPTION
#3478 relaxed the project logo height constraints such that large images are no longer forced into the visible square for the logo.  This PR fixes that, forcing the full height of all images to fit within the space.

Before:
<img width="504" height="120" alt="image" src="https://github.com/user-attachments/assets/5c49c669-2a99-4910-a170-f2866a9a66c8" />


After:
<img width="506" height="126" alt="image" src="https://github.com/user-attachments/assets/cb0b7ee7-23f0-4b29-acf2-f45befa5eb2a" />
