### PR TITLE
Expose authentication tokens via GraphQL

### DIFF
--- a/app/GraphQL/Mutations/CreateAuthenticationToken.php
+++ b/app/GraphQL/Mutations/CreateAuthenticationToken.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\AuthToken;
+use App\Models\Project;
+use App\Utils\AuthTokenUtil;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
+
+final class CreateAuthenticationToken extends AbstractMutation
+{
+    public ?string $rawToken = null;
+    public ?AuthToken $token = null;
+
+    /**
+     * @param array{
+     *     projectId: ?int,
+     *     scope: string,
+     *     description: ?string,
+     *     expiration: Carbon,
+     * } $args
+     */
+    public function __invoke(null $_, array $args): self
+    {
+        $user = auth()->user();
+        if ($user === null) {
+            throw new AuthenticationException('This action is unauthorized.');
+        }
+
+        if (isset($args['projectId'])) {
+            $project = Project::find((int) $args['projectId']);
+            Gate::authorize('createAuthToken', $project);
+        }
+
+        [
+            'token' => $this->token,
+            'raw_token' => $this->rawToken,
+        ] = AuthTokenUtil::generateToken(
+            $user->id,
+            (int) ($args['projectId'] ?? -1),
+            $args['scope'],
+            $args['description'] ?? '',
+            $args['expiration'],
+        );
+
+        return $this;
+    }
+}

--- a/app/GraphQL/Mutations/DeleteAuthenticationToken.php
+++ b/app/GraphQL/Mutations/DeleteAuthenticationToken.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\AuthToken;
+use App\Utils\AuthTokenUtil;
+use Illuminate\Auth\AuthenticationException;
+
+final class DeleteAuthenticationToken extends AbstractMutation
+{
+    /**
+     * @param array{
+     *     tokenId: int,
+     * } $args
+     */
+    public function __invoke(null $_, array $args): self
+    {
+        $token = AuthToken::find((int) $args['tokenId']);
+        $userid = auth()->user()->id ?? null;
+
+        // This method performs its own authorization checks.
+        // TODO: Move the logic to this method and delete the utils method.
+        if ($userid === null || !AuthTokenUtil::deleteToken($token->hash ?? '', $userid)) {
+            throw new AuthenticationException('This action is unauthorized.');
+        }
+
+        return $this;
+    }
+}

--- a/app/GraphQL/Validators/CreateAuthenticationTokenInputValidator.php
+++ b/app/GraphQL/Validators/CreateAuthenticationTokenInputValidator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\GraphQL\Validators;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\Rule;
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class CreateAuthenticationTokenInputValidator extends Validator
+{
+    public function rules(): array
+    {
+        $allowFullAccessTokens = Config::get('cdash.allow_full_access_tokens') === true;
+        $allowSubmitOnlyTokens = Config::get('cdash.allow_submit_only_tokens') === true;
+
+        $validScopes = ['submit_only'];
+        if ($allowFullAccessTokens) {
+            $validScopes[] = 'full_access';
+        }
+
+        $durationConfig = (int) Config::get('cdash.token_duration');
+        $maximumExpiration = $durationConfig === 0 ? Carbon::now()->endOfMillennium() : Carbon::now()->addSeconds($durationConfig);
+
+        return [
+            'scope' => [
+                'required',
+                Rule::in($validScopes),
+            ],
+            'projectId' => [
+                'prohibited_unless:scope,submit_only',
+                Rule::requiredIf(!$allowFullAccessTokens && !$allowSubmitOnlyTokens),
+                Rule::requiredIf(!$allowSubmitOnlyTokens && $this->arg('scope') === 'submit_only'),
+            ],
+            'expiration' => [
+                'required',
+                Rule::date()->future(),
+                Rule::date()->beforeOrEqual($maximumExpiration),
+            ],
+        ];
+    }
+}

--- a/app/Models/AuthToken.php
+++ b/app/Models/AuthToken.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Database\Factories\AuthTokenFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
 /**
+ * @property int $id
  * @property string $hash
  * @property int $userid
  * @property Carbon $created
@@ -24,6 +27,9 @@ use Illuminate\Support\Carbon;
  */
 class AuthToken extends Model
 {
+    /** @use HasFactory<AuthTokenFactory> */
+    use HasFactory;
+
     public const SCOPE_FULL_ACCESS = 'full_access';
     public const SCOPE_SUBMIT_ONLY = 'submit_only';
 
@@ -33,10 +39,6 @@ class AuthToken extends Model
     public const UPDATED_AT = null;
 
     protected $table = 'authtoken';
-
-    protected $primaryKey = 'hash';
-    public $incrementing = false;
-    protected $keyType = 'string';
 
     protected $fillable = [
         'hash',
@@ -49,6 +51,7 @@ class AuthToken extends Model
     ];
 
     protected $casts = [
+        'id' => 'integer',
         'userid' => 'integer',
         'created' => 'datetime',
         'expires' => 'datetime',
@@ -64,10 +67,36 @@ class AuthToken extends Model
     }
 
     /**
-     * @return HasOne<User, $this>
+     * @param Builder<AuthToken> $query
      */
-    public function user(): HasOne
+    public function scopeVisibleToCurrentUser(Builder $query): void
     {
-        return $this->hasOne(User::class, 'id', 'userid');
+        $user = auth()->user();
+
+        if ($user === null) {
+            // Show no results for anonymous users
+            $query->where('userid', -1);
+        } elseif ($user->admin) {
+            // Admins can see all tokens
+            return;
+        } else {
+            $query->where('userid', $user->id);
+        }
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'userid');
+    }
+
+    /**
+     * @return BelongsTo<Project, $this>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'projectid');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -84,7 +84,7 @@ class User extends Authenticatable implements MustVerifyEmail, LdapAuthenticatab
     /**
      * @return HasMany<AuthToken, $this>
      */
-    public function authTokens(): HasMany
+    public function authenticationTokens(): HasMany
     {
         return $this->hasMany(AuthToken::class, 'userid');
     }

--- a/app/Policies/AuthTokenPolicy.php
+++ b/app/Policies/AuthTokenPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class AuthTokenPolicy
+{
+    public function viewAll(User $user): bool
+    {
+        return $user->admin;
+    }
+}

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -166,6 +166,11 @@ class ProjectPolicy
         return $this->update($currentUser, $project);
     }
 
+    public function createAuthToken(User $currentUser, Project $project): bool
+    {
+        return $currentUser->admin || $project->users()->where('id', $currentUser->id)->exists();
+    }
+
     private function isLdapControlledMembership(Project $project): bool
     {
         // If a LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -63,4 +63,9 @@ class UserPolicy
 
         return false;
     }
+
+    public function viewAuthenticationTokens(User $currentUser, User $user): bool
+    {
+        return $currentUser->admin || $currentUser->id === $user->id;
+    }
 }

--- a/app/Utils/AuthTokenUtil.php
+++ b/app/Utils/AuthTokenUtil.php
@@ -7,6 +7,7 @@ namespace App\Utils;
 use App\Models\AuthToken;
 use App\Models\User;
 use CDash\Model\Project;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
@@ -28,8 +29,13 @@ class AuthTokenUtil
      *
      * @throws InvalidArgumentException
      */
-    public static function generateToken(int $user_id, int $project_id, string $scope, string $description): array
-    {
+    public static function generateToken(
+        int $user_id,
+        int $project_id,
+        string $scope,
+        string $description,
+        ?Carbon $expiration = null,
+    ): array {
         // 86 characters generates more than 512 bits of entropy (and is thus limited by the entropy of the hash)
         $token = Str::password(86, true, true, false);
         $params['hash'] = hash('sha512', $token);
@@ -45,11 +51,18 @@ class AuthTokenUtil
             throw new InvalidArgumentException('Invalid token_duration configuration');
         }
 
-        if ((int) $duration === 0) {
-            // this token "never" expires
-            $params['expires'] = '9999-01-01 00:00:00';
+        // We trust the expiration to be pre-validated if one was provided.  If an expiration wasn't
+        // provided, we set the expiration to the maximum allowed.  In the future, the expiration
+        // argument should be mandatory.
+        if ($expiration !== null) {
+            $params['expires'] = $expiration;
         } else {
-            $params['expires'] = gmdate(FMT_DATETIME, $now + $duration);
+            if ((int) $duration === 0) {
+                // this token "never" expires
+                $params['expires'] = '9999-01-01 00:00:00';
+            } else {
+                $params['expires'] = gmdate(FMT_DATETIME, $now + $duration);
+            }
         }
 
         $params['description'] = $description;
@@ -92,7 +105,7 @@ class AuthTokenUtil
      */
     public static function checkToken(string $token_hash, int $project_id): bool
     {
-        $auth_token = AuthToken::find($token_hash);
+        $auth_token = AuthToken::firstWhere('hash', $token_hash);
         if ($auth_token === null) {
             Log::error('Invalid Token');
             return false;
@@ -151,10 +164,9 @@ class AuthTokenUtil
      */
     public static function deleteToken(string $token_hash, int $expected_user_id): bool
     {
-        $auth_token = AuthToken::find($token_hash);
+        $auth_token = AuthToken::firstWhere('hash', $token_hash);
         if ($auth_token === null) {
-            Log::error('Invalid Token');
-            return false;
+            throw new AuthenticationException('This action is unauthorized.');
         }
 
         /** @var User $user */
@@ -265,7 +277,7 @@ class AuthTokenUtil
             return null;
         }
 
-        $auth_token = AuthToken::find($token_hash);
+        $auth_token = AuthToken::firstWhere('hash', $token_hash);
         if ($auth_token === null
             || self::isTokenExpired($auth_token)
             || $auth_token['scope'] !== AuthToken::SCOPE_FULL_ACCESS

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -296,6 +296,10 @@ add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateRepositoryTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/DeleteRepositoryTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateAuthenticationTokenTest)
+
+add_feature_test_in_transaction(/Feature/GraphQL/Mutations/DeleteAuthenticationTokenTest)
+
 add_feature_test_in_transaction(/Feature/GlobalInvitationAcceptanceTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/GlobalInvitationTypeTest)

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -246,7 +246,7 @@ class AuthTokenTestCase extends KWWebTestCase
         $this->delete($this->url . "/api/authtokens/delete/$this->Hash");
 
         // Make sure the token is really gone.
-        if (AuthToken::find($this->Hash)) {
+        if (AuthToken::firstWhere('hash', $this->Hash)) {
             $this->fail('Token still exists after it was revoked');
         }
     }
@@ -268,7 +268,7 @@ class AuthTokenTestCase extends KWWebTestCase
         }
 
         // Make sure this token does not exist anymore.
-        if (AuthToken::find($this->Hash)) {
+        if (AuthToken::firstWhere('hash', $this->Hash)) {
             $this->fail('Expired token still exists after submission');
         }
     }

--- a/database/factories/AuthTokenFactory.php
+++ b/database/factories/AuthTokenFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AuthToken;
+use App\Utils\AuthTokenUtil;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<AuthToken>
+ */
+class AuthTokenFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'created' => Carbon::now(),
+            'expires' => Carbon::now()->addYear(),
+            'description' => Str::uuid()->toString(),
+            'scope' => AuthToken::SCOPE_FULL_ACCESS,
+            'hash' => AuthTokenUtil::hashToken(Str::uuid()->toString()),
+        ];
+    }
+}

--- a/database/migrations/2026_03_10_200134_authtoken_pkey.php
+++ b/database/migrations/2026_03_10_200134_authtoken_pkey.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE authtoken ADD COLUMN id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -74,6 +74,9 @@ type Query {
     "Search by primary key."
     id: ID @eq
   ): DynamicAnalysis @find @canResolved(ability: "view", action: RETURN_VALUE, returnValue: null)
+
+  "All authentication tokens across the entire instance.  Only available to administrators."
+  authenticationTokens: [AuthToken!]! @canResolved(ability: "viewAll") @paginate(type: CONNECTION) @orderBy(column: "id")
 }
 
 
@@ -137,6 +140,23 @@ type Mutation {
 
   "Delete a repository by ID."
   deleteRepository(input: DeleteRepositoryInput! @spread): DeleteRepositoryMutationPayload! @field(resolver: "DeleteRepository")
+
+  "Add an authentication token.  The token cannot be retrieved again."
+  createAuthenticationToken(input: CreateAuthenticationTokenInput! @spread): CreateAuthenticationTokenMutationPayload! @field(resolver: "CreateAuthenticationToken")
+
+  """
+  Delete an authentication token by ID.
+
+  Project-scoped submit-only tokens can be deleted by:
+   1. The user who created them
+   2. A project administrator
+   3. A system administrator
+
+  Full-access and submit-only tokens not associated with a project can be deleted by:
+   1. The user who created them
+   2. A system administrator
+  """
+  deleteAuthenticationToken(input: DeleteAuthenticationTokenInput! @spread): DeleteAuthenticationTokenMutationPayload! @field(resolver: "DeleteAuthenticationToken")
 }
 
 
@@ -170,6 +190,8 @@ type User {
   projects(
     filters: _ @filter
   ): [Project!]! @hasMany(type: CONNECTION, scopes: ["forUser"]) @orderBy(column: "id")
+
+  authenticationTokens: [AuthToken!]! @canRoot(ability: "viewAuthenticationTokens") @hasMany(type: CONNECTION) @orderBy(column: "id")
 }
 
 
@@ -685,6 +707,41 @@ input DeleteRepositoryInput {
 
 
 type DeleteRepositoryMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+}
+
+
+input CreateAuthenticationTokenInput @validator {
+  "Optional project"
+  projectId: ID
+
+  scope: AuthTokenScope!
+
+  description: String
+
+  expiration: DateTimeTz!
+}
+
+
+type CreateAuthenticationTokenMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+
+  "The raw token.  This token cannot be retrieved again."
+  rawToken: String
+
+  "The new token model."
+  token: AuthToken
+}
+
+
+input DeleteAuthenticationTokenInput {
+  tokenId: ID!
+}
+
+
+type DeleteAuthenticationTokenMutationPayload implements MutationPayloadInterface {
   "Optional error message."
   message: String
 }
@@ -1441,4 +1498,31 @@ type Repository {
   username: String!
 
   branch: String!
+}
+
+
+type AuthToken {
+  "Unique primary key."
+  id: ID!
+
+  created: DateTimeTz!
+
+  expires: DateTimeTz!
+
+  description: String
+
+  scope: AuthTokenScope!
+
+  project: Project
+
+  user: User
+}
+
+
+enum AuthTokenScope {
+  "Provides full API access."
+  FULL_ACCESS @enum(value: "full_access")
+
+  "Only valid for authenticated submissions.  If associated with a project, only valid for that project."
+  SUBMIT_ONLY @enum(value: "submit_only")
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,6 +265,18 @@ parameters:
 			path: app/GraphQL/Mutations/ClaimSite.php
 
 		-
+			rawMessage: 'Method App\GraphQL\Mutations\CreateAuthenticationToken::__invoke() throws checked exception Illuminate\Auth\AuthenticationException but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/GraphQL/Mutations/CreateAuthenticationToken.php
+
+		-
+			rawMessage: 'Parameter #2 $args (array{projectId: int|null, scope: string, description: string|null, expiration: Illuminate\Support\Carbon}) of method App\GraphQL\Mutations\CreateAuthenticationToken::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/GraphQL/Mutations/CreateAuthenticationToken.php
+
+		-
 			rawMessage: 'Parameter #1 $args (array{email: string, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\CreateGlobalInvitation::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
 			identifier: method.childParameterType
 			count: 1
@@ -287,6 +299,18 @@ parameters:
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/CreateRepository.php
+
+		-
+			rawMessage: 'Method App\GraphQL\Mutations\DeleteAuthenticationToken::__invoke() throws checked exception Illuminate\Auth\AuthenticationException but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/GraphQL/Mutations/DeleteAuthenticationToken.php
+
+		-
+			rawMessage: 'Parameter #2 $args (array{tokenId: int}) of method App\GraphQL\Mutations\DeleteAuthenticationToken::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/GraphQL/Mutations/DeleteAuthenticationToken.php
 
 		-
 			rawMessage: 'Parameter #1 $args (array{id: int}) of method App\GraphQL\Mutations\DeletePinnedTestMeasurement::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
@@ -449,6 +473,12 @@ parameters:
 			identifier: encapsedStringPart.nonString
 			count: 2
 			path: app/GraphQL/Scalars/Url.php
+
+		-
+			rawMessage: Cannot cast mixed to int.
+			identifier: cast.int
+			count: 1
+			path: app/GraphQL/Validators/CreateAuthenticationTokenInputValidator.php
 
 		-
 			rawMessage: Class App\Http\Controllers\AbstractBuildController has an uninitialized property $build. Give it default value or assign it in the constructor.
@@ -6237,6 +6267,12 @@ parameters:
 		-
 			rawMessage: Implicit array creation is not allowed - variable $params does not exist.
 			identifier: variable.implicitArray
+			count: 1
+			path: app/Utils/AuthTokenUtil.php
+
+		-
+			rawMessage: 'Method App\Utils\AuthTokenUtil::deleteToken() throws checked exception Illuminate\Auth\AuthenticationException but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
 			count: 1
 			path: app/Utils/AuthTokenUtil.php
 
@@ -18616,7 +18652,7 @@ parameters:
 			path: app/cdash/tests/test_authtoken.php
 
 		-
-			rawMessage: 'Only booleans are allowed in an if condition, App\Models\AuthToken|Illuminate\Database\Eloquent\Collection<int, App\Models\AuthToken>|null given.'
+			rawMessage: 'Only booleans are allowed in an if condition, App\Models\AuthToken|null given.'
 			identifier: if.condNotBoolean
 			count: 2
 			path: app/cdash/tests/test_authtoken.php

--- a/tests/Feature/GraphQL/Mutations/CreateAuthenticationTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateAuthenticationTokenTest.php
@@ -1,0 +1,445 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\AuthToken;
+use App\Models\Project;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class CreateAuthenticationTokenTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    public function testCannotCreateProjectSpecificSubmitOnlyAuthTokenWhenProjectDoesNotExist(): void
+    {
+        $user = $this->makeAdminUser();
+
+        $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    rawToken
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'projectId' => 123456789,
+                'scope' => 'SUBMIT_ONLY',
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        self::assertDatabaseEmpty(AuthToken::class);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function projectScopedSubmitOnlyTokenCreationPermissionsCases(): array
+    {
+        return [
+            [null, null, false],
+            ['normal', null, false],
+            ['normal', Project::PROJECT_USER, true],
+            ['normal', Project::PROJECT_ADMIN, true],
+            ['admin', Project::PROJECT_USER, true],
+            ['admin', Project::PROJECT_ADMIN, true],
+            ['admin', null, true],
+        ];
+    }
+
+    #[DataProvider('projectScopedSubmitOnlyTokenCreationPermissionsCases')]
+    public function testProjectScopedSubmitOnlyTokenCreationPermissions(
+        ?string $user,
+        ?int $projectRole,
+        bool $canCreateAuthToken,
+    ): void {
+        $project = $this->makePublicProject();
+
+        if ($user === 'normal') {
+            $user = $this->makeNormalUser();
+        } elseif ($user === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($user !== null) {
+            throw new Exception('Invalid user provided.');
+        }
+
+        if ($projectRole !== null) {
+            $project->users()->attach($user, ['role' => $projectRole]);
+        }
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $response = ($user === null ? $this : $this->actingAs($user))->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        project {
+                            id
+                        }
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'projectId' => $project->id,
+                'scope' => 'SUBMIT_ONLY',
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+            ],
+        ]);
+
+        if ($canCreateAuthToken) {
+            $response->assertExactJson([
+                'data' => [
+                    'createAuthenticationToken' => [
+                        'token' => [
+                            'project' => [
+                                'id' => (string) $project->id,
+                            ],
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+            self::assertDatabaseHas(AuthToken::class, [
+                'projectid' => $project->id,
+                'userid' => $user?->id,
+                'scope' => 'submit_only',
+            ]);
+        } else {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+            self::assertDatabaseEmpty(AuthToken::class);
+        }
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function fullAccessAndGlobalSubmitOnlyTokenCreationPermissionsCases(): array
+    {
+        return [
+            [null, 'full_access', false],
+            [null, 'submit_only', false],
+            ['normal', 'full_access', true],
+            ['normal', 'submit_only', true],
+            ['admin', 'full_access', true],
+            ['admin', 'submit_only', true],
+        ];
+    }
+
+    #[DataProvider('fullAccessAndGlobalSubmitOnlyTokenCreationPermissionsCases')]
+    public function testFullAccessAndGlobalSubmitOnlyTokenCreationPermissions(
+        ?string $user,
+        string $scope,
+        bool $canCreateAuthToken,
+    ): void {
+        if ($user === 'normal') {
+            $user = $this->makeNormalUser();
+        } elseif ($user === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($user !== null) {
+            throw new Exception('Invalid user provided.');
+        }
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $response = ($user === null ? $this : $this->actingAs($user))->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'scope' => Str::upper($scope),
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+            ],
+        ]);
+
+        if ($canCreateAuthToken) {
+            $token = AuthToken::firstOrFail();
+            $response->assertExactJson([
+                'data' => [
+                    'createAuthenticationToken' => [
+                        'token' => [
+                            'id' => (string) $token->id,
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+            self::assertDatabaseHas(AuthToken::class, [
+                'projectid' => null,
+                'userid' => $user?->id,
+                'scope' => $scope,
+            ]);
+        } else {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+            self::assertDatabaseEmpty(AuthToken::class);
+        }
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function disableFullAccessAndGlobalSubmitOnlyTokensCases(): array
+    {
+        return [
+            ['cdash.allow_full_access_tokens', true, 'full_access', true, null],
+            ['cdash.allow_full_access_tokens', false, 'full_access', false, 'input.scope'],
+            ['cdash.allow_full_access_tokens', true, 'submit_only', true, null],
+            ['cdash.allow_full_access_tokens', false, 'submit_only', true, null],
+            ['cdash.allow_submit_only_tokens', true, 'full_access', true, null],
+            ['cdash.allow_submit_only_tokens', false, 'full_access', true, null],
+            ['cdash.allow_submit_only_tokens', true, 'submit_only', true, null],
+            ['cdash.allow_submit_only_tokens', false, 'submit_only', false, 'input.projectId'],
+        ];
+    }
+
+    #[DataProvider('disableFullAccessAndGlobalSubmitOnlyTokensCases')]
+    public function testDisableFullAccessAndGlobalSubmitOnlyTokens(
+        string $configKey,
+        bool $configValue,
+        string $scope,
+        bool $canCreateAuthToken,
+        ?string $validationErrorKey,
+    ): void {
+        Config::set($configKey, $configValue);
+
+        $user = $this->makeAdminUser();
+        $project = $this->makePublicProject();
+        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $response = $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'scope' => Str::upper($scope),
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+            ],
+        ]);
+
+        if ($canCreateAuthToken) {
+            $token = AuthToken::firstOrFail();
+            $response->assertExactJson([
+                'data' => [
+                    'createAuthenticationToken' => [
+                        'token' => [
+                            'id' => (string) $token->id,
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+            self::assertDatabaseHas(AuthToken::class, [
+                'projectid' => null,
+                'userid' => $user->id,
+                'scope' => $scope,
+            ]);
+        } else {
+            $response->assertGraphQLValidationKeys([$validationErrorKey]);
+            self::assertDatabaseEmpty(AuthToken::class);
+        }
+
+        // Wipe the auth token if it exists so we can create a new one
+        AuthToken::query()->delete();
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        // It's impossible to disable project-specific submit-only tokens.
+        $response = $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'projectId' => $project->id,
+                'scope' => 'SUBMIT_ONLY',
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+            ],
+        ]);
+        $token = AuthToken::firstOrFail();
+        $response->assertExactJson([
+            'data' => [
+                'createAuthenticationToken' => [
+                    'token' => [
+                        'id' => (string) $token->id,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+        self::assertDatabaseHas(AuthToken::class, [
+            'projectid' => $project->id,
+            'userid' => $user->id,
+            'scope' => 'submit_only',
+        ]);
+    }
+
+    /**
+     * CDash doesn't currently support full API access on a per-project basis.
+     */
+    public function testRejectsFullAccessScopeWhenProjectProvided(): void
+    {
+        $user = $this->makeAdminUser();
+        $project = $this->makePublicProject();
+        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'scope' => 'FULL_ACCESS',
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+                'projectId' => $project->id,
+            ],
+        ])->assertGraphQLValidationKeys(['input.projectId']);
+        self::assertDatabaseEmpty(AuthToken::class);
+    }
+
+    public function testCanSetDescription(): void
+    {
+        $user = $this->makeAdminUser();
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $description = Str::uuid()->toString();
+
+        $response = $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        description
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'scope' => 'FULL_ACCESS',
+                'expiration' => Carbon::now()->addDay()->toIso8601String(),
+                'description' => $description,
+            ],
+        ]);
+
+        $response->assertExactJson([
+            'data' => [
+                'createAuthenticationToken' => [
+                    'token' => [
+                        'description' => $description,
+                    ],
+                    'message' => null,
+                ],
+            ],
+        ]);
+        self::assertDatabaseHas(AuthToken::class, [
+            'userid' => $user->id,
+            'scope' => 'full_access',
+            'description' => $description,
+        ]);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function expirationTimeCases(): array
+    {
+        $now = Carbon::now()->roundSecond();
+
+        return [
+            [$now->copy()->addDay(), (int) $now->diffInSeconds($now->copy()->addMonths(6)), true],
+            [$now->copy()->subDay(), (int) $now->diffInSeconds($now->copy()->addMonths(6)), false],
+            [$now->copy()->addYears(10), (int) $now->diffInSeconds($now->copy()->addMonths(6)), false],
+            [$now->copy()->addYears(10), 0, true],
+        ];
+    }
+
+    #[DataProvider('expirationTimeCases')]
+    public function testExpirationTime(
+        Carbon $expiration,
+        int $tokenDurationConfig,
+        bool $canCreateAuthToken,
+    ): void {
+        Config::set('cdash.token_duration', $tokenDurationConfig);
+
+        $user = $this->makeAdminUser();
+
+        self::assertDatabaseEmpty(AuthToken::class);
+
+        $response = $this->actingAs($user)->graphQL('
+            mutation ($input: CreateAuthenticationTokenInput!) {
+                createAuthenticationToken(input: $input) {
+                    token {
+                        id
+                    }
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'scope' => 'FULL_ACCESS',
+                'expiration' => $expiration->toIso8601String(),
+            ],
+        ]);
+
+        if ($canCreateAuthToken) {
+            $token = AuthToken::firstOrFail();
+            $response->assertExactJson([
+                'data' => [
+                    'createAuthenticationToken' => [
+                        'token' => [
+                            'id' => (string) $token->id,
+                        ],
+                        'message' => null,
+                    ],
+                ],
+            ]);
+            self::assertDatabaseHas(AuthToken::class, [
+                'userid' => $user->id,
+                'expires' => $expiration,
+            ]);
+        } else {
+            $response->assertGraphQLValidationKeys(['input.expiration']);
+            self::assertDatabaseEmpty(AuthToken::class);
+        }
+    }
+}

--- a/tests/Feature/GraphQL/Mutations/DeleteAuthenticationTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/DeleteAuthenticationTokenTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\AuthToken;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class DeleteAuthenticationTokenTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    public function testCannotDeleteMissingToken(): void
+    {
+        $user = $this->makeAdminUser();
+        $user->authenticationTokens()->save(AuthToken::factory()->make());
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($user)->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => 123456789,
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+    }
+
+    public function testAnonymousUserCannotDeleteToken(): void
+    {
+        $user = $this->makeAdminUser();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make());
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+    }
+
+    public function testNormalUserCannotDeleteTokenOwnedByAnotherUser(): void
+    {
+        $user = $this->makeAdminUser();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make());
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($this->makeNormalUser())->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+    }
+
+    public function testNormalUserCanDeleteOwnTokens(): void
+    {
+        $user = $this->makeNormalUser();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make());
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($user)->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'deleteAuthenticationToken' => [
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertDatabaseEmpty(AuthToken::class);
+    }
+
+    public function testAdminCanDeleteTokenOwnedByAnotherUser(): void
+    {
+        $user = $this->makeAdminUser();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make());
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($this->makeAdminUser())->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'deleteAuthenticationToken' => [
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertDatabaseEmpty(AuthToken::class);
+    }
+
+    public function testProjectAdminCanDeleteProjectScopedTokenOwnedByAnotherUser(): void
+    {
+        $user = $this->makeAdminUser();
+        $project = $this->makePublicProject();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make([
+            'scope' => 'submit_only',
+            'projectid' => $project->id,
+        ]));
+
+        $projectUser = $this->makeNormalUser();
+        $project->users()->attach($projectUser, ['role' => Project::PROJECT_ADMIN]);
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($projectUser)->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertExactJson([
+            'data' => [
+                'deleteAuthenticationToken' => [
+                    'message' => null,
+                ],
+            ],
+        ]);
+
+        self::assertDatabaseEmpty(AuthToken::class);
+    }
+
+    public function testNormalProjectUserCannotDeleteProjectScopedTokenOwnedByAnotherUser(): void
+    {
+        $user = $this->makeAdminUser();
+        $project = $this->makePublicProject();
+        /** @var AuthToken $authToken */
+        $authToken = $user->authenticationTokens()->save(AuthToken::factory()->make([
+            'scope' => 'submit_only',
+            'projectid' => $project->id,
+        ]));
+
+        $projectUser = $this->makeNormalUser();
+        $project->users()->attach($projectUser, ['role' => Project::PROJECT_USER]);
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+
+        $this->actingAs($projectUser)->graphQL('
+            mutation ($input: DeleteAuthenticationTokenInput!) {
+                deleteAuthenticationToken(input: $input) {
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'tokenId' => $authToken->id,
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        self::assertDatabaseCount(AuthToken::class, 1);
+    }
+}

--- a/tests/Feature/GraphQL/QueryTypeTest.php
+++ b/tests/Feature/GraphQL/QueryTypeTest.php
@@ -3,13 +3,16 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Enums\BuildCommandType;
+use App\Models\AuthToken;
 use App\Models\BuildCommand;
 use App\Models\DynamicAnalysis;
 use App\Models\Project;
 use App\Models\User;
+use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesUsers;
@@ -314,5 +317,72 @@ class QueryTypeTest extends TestCase
                 'dynamicAnalysis' => null,
             ],
         ]);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function authenticationTokensRelationshipVisibilityCases(): array
+    {
+        return [
+            [null, false],
+            ['normal', false],
+            ['self', false],
+            ['admin', true],
+        ];
+    }
+
+    #[DataProvider('authenticationTokensRelationshipVisibilityCases')]
+    public function testAuthenticationTokensRelationshipVisibility(
+        ?string $user,
+        bool $canSeeAuthToken,
+    ): void {
+        $tokenOwner = $this->makeNormalUser();
+        /** @var AuthToken $authToken */
+        $authToken = $tokenOwner->authenticationTokens()->save(AuthToken::factory()->make());
+
+        if ($user === 'normal') {
+            $user = $this->makeNormalUser();
+        } elseif ($user === 'self') {
+            $user = $tokenOwner;
+        } elseif ($user === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($user === null) {
+            $user = null;
+        } else {
+            throw new Exception('Invalid user.');
+        }
+
+        $response = ($user === null ? $this : $this->actingAs($user))->graphQL('
+            query {
+                authenticationTokens {
+                    edges {
+                        node {
+                            id
+                        }
+                    }
+                }
+            }
+        ', [
+            'userid' => $tokenOwner->id,
+        ]);
+
+        if ($canSeeAuthToken) {
+            $response->assertExactJson([
+                'data' => [
+                    'authenticationTokens' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'id' => (string) $authToken->id,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        } else {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+        }
     }
 }

--- a/tests/Feature/GraphQL/UserTypeTest.php
+++ b/tests/Feature/GraphQL/UserTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Models\AuthToken;
 use App\Models\Project;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -36,6 +37,13 @@ class UserTypeTest extends TestCase
                             }
                         }
                     }
+                    authenticationTokens {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
                 }
             }
         ')->assertExactJson([
@@ -48,6 +56,9 @@ class UserTypeTest extends TestCase
                     'institution' => $normalUser->institution,
                     'admin' => $normalUser->admin,
                     'projects' => [
+                        'edges' => [],
+                    ],
+                    'authenticationTokens' => [
                         'edges' => [],
                     ],
                 ],
@@ -228,5 +239,82 @@ class UserTypeTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function authenticationTokensRelationshipVisibilityCases(): array
+    {
+        return [
+            [null, false],
+            ['normal', false],
+            ['self', true],
+            ['admin', true],
+        ];
+    }
+
+    #[DataProvider('authenticationTokensRelationshipVisibilityCases')]
+    public function testAuthenticationTokensRelationshipVisibility(
+        ?string $user,
+        bool $canSeeAuthToken,
+    ): void {
+        AuthToken::factory()->create([
+            'userid' => $this->makeNormalUser()->id,
+        ]);
+
+        $tokenOwner = $this->makeNormalUser();
+        /** @var AuthToken $authToken */
+        $authToken = $tokenOwner->authenticationTokens()->save(AuthToken::factory()->make());
+
+        if ($user === 'normal') {
+            $user = $this->makeNormalUser();
+        } elseif ($user === 'self') {
+            $user = $tokenOwner;
+        } elseif ($user === 'admin') {
+            $user = $this->makeAdminUser();
+        } elseif ($user === null) {
+            $user = null;
+        } else {
+            throw new Exception('Invalid user.');
+        }
+
+        $response = ($user === null ? $this : $this->actingAs($user))->graphQL('
+            query($userid: ID) {
+                user(id: $userid) {
+                    id
+                    authenticationTokens {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'userid' => $tokenOwner->id,
+        ]);
+
+        if ($canSeeAuthToken) {
+            $response->assertExactJson([
+                'data' => [
+                    'user' => [
+                        'id' => (string) $tokenOwner->id,
+                        'authenticationTokens' => [
+                            'edges' => [
+                                [
+                                    'node' => [
+                                        'id' => (string) $authToken->id,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        } else {
+            $response->assertGraphQLErrorMessage('This action is unauthorized.');
+        }
     }
 }

--- a/tests/Feature/Jobs/NotifyExpiringAuthTokensTest.php
+++ b/tests/Feature/Jobs/NotifyExpiringAuthTokensTest.php
@@ -37,7 +37,7 @@ class NotifyExpiringAuthTokensTest extends TestCase
     {
         Mail::fake();
 
-        $this->user->authTokens()->create([
+        $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now()->addDays(8),
             'scope' => 'test',
@@ -51,7 +51,7 @@ class NotifyExpiringAuthTokensTest extends TestCase
     {
         Mail::fake();
 
-        $this->user->authTokens()->create([
+        $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now()->addDays(6),
             'scope' => 'test',
@@ -66,7 +66,7 @@ class NotifyExpiringAuthTokensTest extends TestCase
     {
         Mail::fake();
 
-        $this->user->authTokens()->create([
+        $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now()->addHour(),
             'scope' => 'test',

--- a/tests/Feature/Jobs/PruneAuthTokensTest.php
+++ b/tests/Feature/Jobs/PruneAuthTokensTest.php
@@ -46,11 +46,11 @@ class PruneAuthTokensTest extends TestCase
             'userid' => $this->user->id,
         ]);
 
-        self::assertNotNull(AuthToken::find($hash));
+        self::assertNotNull(AuthToken::firstWhere('hash', $hash));
 
         PruneAuthTokens::dispatch();
 
-        self::assertNull(AuthToken::find($hash));
+        self::assertNull(AuthToken::firstWhere('hash', $hash));
 
         Mail::assertQueuedCount(1);
         Mail::assertQueued(AuthTokenExpired::class);
@@ -66,10 +66,10 @@ class PruneAuthTokensTest extends TestCase
             'userid' => $this->user->id,
         ]);
 
-        self::assertNotNull(AuthToken::find($hash));
+        self::assertNotNull(AuthToken::firstWhere('hash', $hash));
 
         PruneAuthTokens::dispatch();
 
-        self::assertNotNull(AuthToken::find($hash));
+        self::assertNotNull(AuthToken::firstWhere('hash', $hash));
     }
 }

--- a/tests/Feature/Mail/AuthTokenExpiredTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiredTest.php
@@ -37,7 +37,7 @@ class AuthTokenExpiredTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',
@@ -53,7 +53,7 @@ class AuthTokenExpiredTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',
@@ -69,7 +69,7 @@ class AuthTokenExpiredTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',

--- a/tests/Feature/Mail/AuthTokenExpiringTest.php
+++ b/tests/Feature/Mail/AuthTokenExpiringTest.php
@@ -37,7 +37,7 @@ class AuthTokenExpiringTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::create(2025, 3, 14),
             'scope' => 'test',
@@ -53,7 +53,7 @@ class AuthTokenExpiringTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',
@@ -69,7 +69,7 @@ class AuthTokenExpiringTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',
@@ -85,7 +85,7 @@ class AuthTokenExpiringTest extends TestCase
         /**
          * @var AuthToken $authtoken
          */
-        $authtoken = $this->user->authTokens()->create([
+        $authtoken = $this->user->authenticationTokens()->create([
             'hash' => Str::uuid()->toString(),
             'expires' => Carbon::now(),
             'scope' => 'test',


### PR DESCRIPTION
This commit adds new `createAuthenticationToken` and `deleteAuthenticationToken` mutations, plus the ability to query all authentication tokens for the instance and all authentication tokens for a given user.  This sets the foundation for future efforts to deprecate and eventually remove our existing authentication token endpoints.