### PR TITLE
Avoid unnecessary exists() calls in project policy

### DIFF
--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -9,7 +9,7 @@ class ProjectPolicy
 {
     public function view(?User $user, Project $project): bool
     {
-        if (!$project->exists()) {
+        if (!$project->exists) {
             return false;
         }
 
@@ -58,7 +58,7 @@ class ProjectPolicy
 
     public function update(User $user, Project $project): bool
     {
-        if (!$project->exists()) {
+        if (!$project->exists) {
             return false;
         }
 


### PR DESCRIPTION
`->exists()` makes an extra database query, while `->exists` uses Laravel's cached model property.  Eventually this check should be removed entirely.