### PR TITLE
Add administration page and header link

### DIFF
--- a/app/Http/Controllers/AdministrationController.php
+++ b/app/Http/Controllers/AdministrationController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\View\View;
+
+final class AdministrationController extends AbstractController
+{
+    public function __invoke(): View
+    {
+        return $this->vue('administration-page', 'Administration');
+    }
+}

--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -36,6 +36,7 @@ const app = Vue.createApp({
     CoverageFilePage: Vue.defineAsyncComponent(() => import('./components/CoverageFilePage.vue')),
     BuildCoveragePage: Vue.defineAsyncComponent(() => import('./components/BuildCoveragePage.vue')),
     CreateProjectPage: Vue.defineAsyncComponent(() => import('./components/CreateProjectPage.vue')),
+    AdministrationPage: Vue.defineAsyncComponent(() => import('./components/AdministrationPage.vue')),
   },
 });
 

--- a/resources/js/vue/components/AdministrationPage.vue
+++ b/resources/js/vue/components/AdministrationPage.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="tw-container tw-mx-auto tw-p-4 tw-max-w-screen-lg">
+    <div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-6">
+      <administration-page-card
+        href="/projects/new"
+        title="Create Project"
+        :icon="FA.faFolderPlus"
+      />
+      <administration-page-card
+        href="/users"
+        title="Manage Users"
+        :icon="FA.faUsers"
+      />
+      <administration-page-card
+        href="/authtokens/manage"
+        title="Manage Authentication Tokens"
+        :icon="FA.faKey"
+      />
+      <administration-page-card
+        href="/sites"
+        title="Site Statistics"
+        :icon="FA.faChartBar"
+      />
+      <administration-page-card
+        href="/removeBuilds.php"
+        title="Remove Builds"
+        :icon="FA.faTrashCan"
+      />
+      <administration-page-card
+        href="/monitor"
+        title="Submission Status"
+        :icon="FA.faListCheck"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import AdministrationPageCard from './shared/AdministrationPageCard.vue';
+import {
+  faFolderPlus,
+  faUsers,
+  faKey,
+  faChartBar,
+  faTrashCan,
+  faListCheck,
+} from '@fortawesome/free-solid-svg-icons';
+
+export default {
+  name: 'AdministrationPage',
+  components: {
+    AdministrationPageCard,
+  },
+  computed: {
+    FA() {
+      return {
+        faFolderPlus,
+        faUsers,
+        faKey,
+        faChartBar,
+        faTrashCan,
+        faListCheck,
+      };
+    },
+  },
+};
+</script>

--- a/resources/js/vue/components/shared/AdministrationPageCard.vue
+++ b/resources/js/vue/components/shared/AdministrationPageCard.vue
@@ -1,0 +1,48 @@
+<template>
+  <a
+    :href="$baseURL + href"
+    class="tw-flex tw-items-center tw-p-6 tw-bg-base-100 tw-border tw-border-base-300 tw-rounded-xl tw-shadow hover:tw-bg-base-200 tw-transition-colors tw-gap-4"
+  >
+    <div
+      v-if="icon"
+      class="tw-flex-shrink-0 tw-flex tw-items-center tw-justify-center"
+    >
+      <font-awesome-icon
+        :icon="icon"
+        class="tw-h-8 tw-w-8 tw-text-black"
+      />
+    </div>
+    <div class="tw-flex tw-flex-col tw-justify-center">
+      <h5 class="tw-text-xl tw-font-bold tw-m-0">
+        {{ title }}
+      </h5>
+      <slot />
+    </div>
+  </a>
+</template>
+
+<script>
+import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+
+export default {
+  name: 'AdministrationPageCard',
+  components: {
+    FontAwesomeIcon,
+  },
+  props: {
+    href: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+  },
+};
+</script>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -30,6 +30,9 @@ $showHeaderNav = isset($build);
                 @if(Auth::check())
                     <a class="cdash-link" href="{{ url('/user') }}">My CDash</a>
                 @endif
+                @if(Auth::user()?->admin)
+                    <a class="cdash-link" href="{{ url('/administration') }}">Administration</a>
+                @endif
             </span>
 
             @if(config('cdash.global_banner') !== null && strlen(config('cdash.global_banner')) > 0)

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@
 |
 */
 
+use App\Http\Controllers\AdministrationController;
 use App\Http\Controllers\CoverageFileController;
 use App\Http\Controllers\CreateProjectController;
 use App\Http\Controllers\GlobalInvitationController;
@@ -326,6 +327,8 @@ Route::middleware(['auth'])->group(function (): void {
         ->whereNumber('invitationId');
 
     Route::middleware(['admin'])->group(function (): void {
+        Route::get('/administration', AdministrationController::class);
+
         Route::get('/authtokens/manage', 'AuthTokenController@manage');
 
         Route::get('/removeBuilds.php', 'AdminController@removeBuilds');


### PR DESCRIPTION
The "My CDash" page will be removed in an upcoming version of CDash.  This PR adds a new "Administration" page and associated header link to replace the admin links currently on the "My CDash" page.

<img width="2838" height="2004" alt="image" src="https://github.com/user-attachments/assets/38cfc528-9db2-4ca5-a71c-274a5c17d0f7" />
