### PR TITLE
Add sidebar to build pages

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -117,6 +117,7 @@ final class BuildController extends AbstractBuildController
         $this->setBuildById($build_id);
 
         return $this->vue('build-update', 'Files Updated', [
+            'build-id' => $this->build->Id,
             'repository-type' => $this->project->CvsViewerType,
             'repository-url' => $this->project->CvsUrl,
         ]);

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -415,6 +415,8 @@ add_browser_test(/Browser/Pages/BuildDynamicAnalysisIdPageTest)
 
 add_browser_test(/Browser/Pages/BuildSummaryPageTest)
 
+add_browser_test(/Browser/Pages/BuildSidebarComponentTest)
+
 add_php_test(image)
 set_tests_properties(image PROPERTIES DEPENDS /CDash/XmlHandler/UpdateHandler)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26452,6 +26452,15 @@ parameters:
 			path: tests/Browser/Pages/BuildErrorsPageTest.php
 
 		-
+			rawMessage: '''
+				Call to deprecated method coverageResults() of class App\Models\Build:
+				07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: tests/Browser/Pages/BuildSidebarComponentTest.php
+
+		-
 			rawMessage: 'Method Tests\Browser\Pages\ProjectMembersPageTest::testFullInvitationWorkflow() throws checked exception OverflowException but it''s missing from the PHPDoc @throws tag.'
 			identifier: missingType.checkedException
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -40,6 +40,7 @@ parameters:
             - 'Illuminate\Http\Client\ConnectionException'
             - 'Illuminate\Http\Exceptions\HttpResponseException'
             - 'Symfony\Component\Console\Exception\CommandNotFoundException'
+            - 'Facebook\WebDriver\Exception\TimeoutException'
 
         check:
             tooWideThrowType: true

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -897,7 +897,7 @@ div#index_top {
 }
 
 div#main_content {
-  padding: 1em 2em;
+  padding: 1em;
 }
 
 #settings {

--- a/resources/js/vue/components/BuildCommandsPage.vue
+++ b/resources/js/vue/components/BuildCommandsPage.vue
@@ -1,43 +1,49 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="commands"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
-      <FilterBuilder
-        filter-type="BuildCommandsFiltersMultiFilterInput"
-        primary-record-name="commands"
-        :initial-filters="initialFilters"
-        :execute-query-link="executeQueryLink"
-        @change-filters="filters => changedFilters = filters"
-      />
-
-      <loading-indicator :is-loading="!allCommands">
-        <CommandGanttChart :commands="formattedChartCommands" />
-      </loading-indicator>
-    </div>
-
-    <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
-      <h3 class="tw-text-xl tw-font-bold tw-mb-2">
-        Memory
-      </h3>
-
-      <loading-indicator :is-loading="!allCommands">
-        <LineChart
-          v-if="memoryChartData.length > 0"
-          y-label="Memory (GB)"
-          :data="memoryChartData"
+      <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+        <FilterBuilder
+          filter-type="BuildCommandsFiltersMultiFilterInput"
+          primary-record-name="commands"
+          :initial-filters="initialFilters"
+          :execute-query-link="executeQueryLink"
+          @change-filters="filters => changedFilters = filters"
         />
-        <div v-else>
-          No data available.
-        </div>
-      </loading-indicator>
+
+        <loading-indicator :is-loading="!allCommands">
+          <CommandGanttChart :commands="formattedChartCommands" />
+        </loading-indicator>
+      </div>
+
+      <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+        <h3 class="tw-text-xl tw-font-bold tw-mb-2">
+          Memory
+        </h3>
+
+        <loading-indicator :is-loading="!allCommands">
+          <LineChart
+            v-if="memoryChartData.length > 0"
+            y-label="Memory (GB)"
+            :data="memoryChartData"
+          />
+          <div v-else>
+            No data available.
+          </div>
+        </loading-indicator>
+      </div>
     </div>
-  </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import CommandGanttChart from './shared/CommandGanttChart.vue';
@@ -51,6 +57,7 @@ export default {
     FilterBuilder,
     LoadingIndicator,
     BuildSummaryCard,
+    BuildSidebar,
   },
 
   props: {

--- a/resources/js/vue/components/BuildConfigure.vue
+++ b/resources/js/vue/components/BuildConfigure.vue
@@ -1,50 +1,55 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <build-summary-card :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="configure"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <build-summary-card :build-id="buildId" />
 
-    <loading-indicator :is-loading="!configures">
-      <div v-if="configures.length === 0">
-        No configure found for this build.
-      </div>
-      <configure-card
-        v-else-if="hasSingleConfigure"
-        :return-value="configures[0].configure.returnValue"
-        :log="configures[0].configure.log"
-        :command="configures[0].configure.command"
-      />
-      <div
-        v-else
-        class="tw-join tw-join-vertical tw-w-full"
-      >
-        <details
-          v-for="configure in configures"
-          class="tw-collapse tw-collapse-plus tw-join-item tw-border"
-          :data-test="'collapse-' + configure.subProject.id"
+      <loading-indicator :is-loading="!configures">
+        <div v-if="configures.length === 0">
+          No configure found for this build.
+        </div>
+        <configure-card
+          v-else-if="hasSingleConfigure"
+          :return-value="configures[0].configure.returnValue"
+          :log="configures[0].configure.log"
+          :command="configures[0].configure.command"
+        />
+        <div
+          v-else
+          class="tw-join tw-join-vertical tw-w-full"
         >
-          <summary class="tw-collapse-title tw-text-xl tw-font-medium">
-            <span>{{ configure.subProject.name }}</span>
-            <span
-              v-if="configure.configureErrorsCount > 0"
-              class="tw-badge tw-ml-2 tw-bg-red-400"
-              :data-test="'errors-' + configure.subProject.id"
-            ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ configure.configureErrorsCount }}</span>
-            <span
-              v-if="configure.configureWarningsCount > 0"
-              class="tw-badge tw-ml-1 tw-bg-orange-400"
-              :data-test="'warnings-' + configure.subProject.id"
-            ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ configure.configureWarningsCount }}</span>
-          </summary>
-          <div class="tw-collapse-content">
-            <configure-card
-              :return-value="configure.configure.returnValue"
-              :log="configure.configure.log"
-              :command="configure.configure.command"
-            />
-          </div>
-        </details>
-      </div>
-    </loading-indicator>
-  </div>
+          <details
+            v-for="configure in configures"
+            class="tw-collapse tw-collapse-plus tw-join-item tw-border"
+            :data-test="'collapse-' + configure.subProject.id"
+          >
+            <summary class="tw-collapse-title tw-text-xl tw-font-medium">
+              <span>{{ configure.subProject.name }}</span>
+              <span
+                v-if="configure.configureErrorsCount > 0"
+                class="tw-badge tw-ml-2 tw-bg-red-400"
+                :data-test="'errors-' + configure.subProject.id"
+              ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ configure.configureErrorsCount }}</span>
+              <span
+                v-if="configure.configureWarningsCount > 0"
+                class="tw-badge tw-ml-1 tw-bg-orange-400"
+                :data-test="'warnings-' + configure.subProject.id"
+              ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ configure.configureWarningsCount }}</span>
+            </summary>
+            <div class="tw-collapse-content">
+              <configure-card
+                :return-value="configure.configure.returnValue"
+                :log="configure.configure.log"
+                :command="configure.configure.command"
+              />
+            </div>
+          </details>
+        </div>
+      </loading-indicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -52,6 +57,7 @@ import gql from 'graphql-tag';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import ConfigureCard from './shared/ConfigureCard.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import {
   faCircleExclamation,
   faTriangleExclamation,
@@ -59,7 +65,7 @@ import {
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
-  components: {FontAwesomeIcon, ConfigureCard, LoadingIndicator, BuildSummaryCard},
+  components: {FontAwesomeIcon, ConfigureCard, LoadingIndicator, BuildSummaryCard, BuildSidebar},
   props: {
     buildId: {
       type: Number,

--- a/resources/js/vue/components/BuildCoveragePage.vue
+++ b/resources/js/vue/components/BuildCoveragePage.vue
@@ -1,181 +1,187 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="coverage"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <div>
-      <span class="tw-font-bold tw-text-xl">
-        Coverage Summary
-      </span>
-      <loading-indicator :is-loading="!coverage">
-        <table class="tw-table tw-table-sm tw-w-auto">
-          <tbody>
-            <tr>
-              <th>Line Coverage</th>
-              <td data-test="line-coverage-summary">
-                <progress
-                  class="tw-progress tw-w-24"
-                  :class="percentToProgressBarColorClass(totalPercentageOfLinesCovered)"
-                  :value="totalPercentageOfLinesCovered"
-                  max="100"
-                />
-                {{ totalPercentageOfLinesCovered }}% ({{ totalLinesCovered }} / {{ totalLinesCovered + totalLinesUncovered }})
-              </td>
-            </tr>
-            <tr v-if="hasBranchCoverage">
-              <th>Branch Coverage</th>
-              <td data-test="branch-coverage-summary">
-                <progress
-                  class="tw-progress tw-w-24"
-                  :class="percentToProgressBarColorClass(totalPercentageOfBranchesCovered)"
-                  :value="totalPercentageOfBranchesCovered"
-                  max="100"
-                />
-                {{ totalPercentageOfBranchesCovered }}% ({{ totalBranchesCovered }} / {{ totalBranchesCovered + totalBranchesUncovered }})
-              </td>
-            </tr>
-            <tr>
-              <th>File Coverage</th>
-              <td data-test="file-coverage-summary">
-                <progress
-                  class="tw-progress tw-w-24"
-                  :class="percentToProgressBarColorClass(totalPercentageOfFilesCovered)"
-                  :value="totalPercentageOfFilesCovered"
-                  max="100"
-                />
-                {{ totalPercentageOfFilesCovered }}% ({{ totalFilesCovered }} / {{ totalFilesCovered + totalFilesUncovered }})
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </loading-indicator>
-    </div>
-
-    <filter-builder
-      filter-type="BuildCoverageFiltersMultiFilterInput"
-      primary-record-name="coverage files"
-      :initial-filters="initialFilters"
-      :execute-query-link="executeQueryLink"
-      @change-filters="filters => changedFilters = filters"
-    />
-
-    <div>
-      <div class="tw-flex tw-flex-row tw-gap-2 tw-items-center">
-        <button
-          class="tw-btn tw-btn-xs"
-          :class="{ 'tw-btn-disabled': currentPrefix === '' }"
-          data-test="breadcrumbs-back-button"
-          @click="currentPrefix = directoryAbovePath(currentPrefix)"
-        >
-          <font-awesome-icon :icon="FA.faReply" />
-          Back
-        </button>
-        <div
-          class="tw-breadcrumbs"
-          data-test="breadcrumbs"
-        >
-          <ul>
-            <li>
-              <a
-                href=""
-                class="tw-italic"
-                @click.prevent="currentPrefix = ''"
-              >{{ projectName }}</a>
-            </li>
-            <li
-              v-for="[index, dir_segment] of currentPrefix.split('/').slice(0, -1).entries()"
-              :key="dir_segment"
-            >
-              <a
-                href=""
-                @click.prevent="currentPrefix = currentPrefix.split('/').slice(0, index + 1).join('/') + '/'"
-              >
-                <font-awesome-icon
-                  :icon="FA.faFolder"
-                  class="tw-mr-1"
-                />
-                {{ dir_segment }}
-              </a>
-            </li>
-          </ul>
-        </div>
+      <div>
+        <span class="tw-font-bold tw-text-xl">
+          Coverage Summary
+        </span>
+        <loading-indicator :is-loading="!coverage">
+          <table class="tw-table tw-table-sm tw-w-auto">
+            <tbody>
+              <tr>
+                <th>Line Coverage</th>
+                <td data-test="line-coverage-summary">
+                  <progress
+                    class="tw-progress tw-w-24"
+                    :class="percentToProgressBarColorClass(totalPercentageOfLinesCovered)"
+                    :value="totalPercentageOfLinesCovered"
+                    max="100"
+                  />
+                  {{ totalPercentageOfLinesCovered }}% ({{ totalLinesCovered }} / {{ totalLinesCovered + totalLinesUncovered }})
+                </td>
+              </tr>
+              <tr v-if="hasBranchCoverage">
+                <th>Branch Coverage</th>
+                <td data-test="branch-coverage-summary">
+                  <progress
+                    class="tw-progress tw-w-24"
+                    :class="percentToProgressBarColorClass(totalPercentageOfBranchesCovered)"
+                    :value="totalPercentageOfBranchesCovered"
+                    max="100"
+                  />
+                  {{ totalPercentageOfBranchesCovered }}% ({{ totalBranchesCovered }} / {{ totalBranchesCovered + totalBranchesUncovered }})
+                </td>
+              </tr>
+              <tr>
+                <th>File Coverage</th>
+                <td data-test="file-coverage-summary">
+                  <progress
+                    class="tw-progress tw-w-24"
+                    :class="percentToProgressBarColorClass(totalPercentageOfFilesCovered)"
+                    :value="totalPercentageOfFilesCovered"
+                    max="100"
+                  />
+                  {{ totalPercentageOfFilesCovered }}% ({{ totalFilesCovered }} / {{ totalFilesCovered + totalFilesUncovered }})
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </loading-indicator>
       </div>
-      <loading-indicator :is-loading="!coverage">
-        <data-table
-          :columns="[
-            ...(hasSubProjects ? [{
-              name: 'subProject',
-              displayName: 'SubProject',
-            }] : []),
-            {
-              name: 'path',
-              displayName: 'Name',
-              expand: true,
-            },
-            {
-              name: 'linePercentage',
-              displayName: 'Percentage',
-            },
-            {
-              name: 'lines',
-              displayName: 'Lines Tested',
-            },
-            ...(hasBranchCoverage ? [{
-              name: 'branchPercentage',
-              displayName: 'Branch Percentage',
-            }, {
-              name: 'branches',
-              displayName: 'Branches Tested',
-            }] : []),
-          ]"
-          :rows="formattedTableRows"
-          :full-width="true"
-          test-id="coverage-table"
-          initial-sort-column="linePercentage"
-          :initial-sort-asc="false"
-        >
-          <template #path="{ props: obj }">
-            <a
-              v-if="obj.isDirectory"
-              href=""
-              data-test="coverage-directory-link"
-              @click.prevent="currentPrefix += obj.path + '/';"
-            >
-              <font-awesome-icon :icon="FA.faFolder" /> {{ obj.path }}
-            </a>
-            <a
-              v-else
-              :href="`${$baseURL}/builds/${buildId}/coverage/${obj.fileId}`"
-              data-test="coverage-file-link"
-            >
-              <font-awesome-icon :icon="FA.faFile" /> {{ obj.path }}
-            </a>
-          </template>
-          <template #linePercentage="{ props: { text: pct } }">
-            <progress
-              class="tw-progress tw-w-24"
-              :class="percentToProgressBarColorClass(pct)"
-              :value="pct"
-              max="100"
-            /> {{ pct }}%
-          </template>
-          <template #branchPercentage="{ props: { text: pct } }">
-            <progress
-              class="tw-progress tw-w-24"
-              :class="percentToProgressBarColorClass(pct)"
-              :value="pct"
-              max="100"
-            /> {{ pct }}%
-          </template>
-        </data-table>
-      </loading-indicator>
+
+      <filter-builder
+        filter-type="BuildCoverageFiltersMultiFilterInput"
+        primary-record-name="coverage files"
+        :initial-filters="initialFilters"
+        :execute-query-link="executeQueryLink"
+        @change-filters="filters => changedFilters = filters"
+      />
+
+      <div>
+        <div class="tw-flex tw-flex-row tw-gap-2 tw-items-center">
+          <button
+            class="tw-btn tw-btn-xs"
+            :class="{ 'tw-btn-disabled': currentPrefix === '' }"
+            data-test="breadcrumbs-back-button"
+            @click="currentPrefix = directoryAbovePath(currentPrefix)"
+          >
+            <font-awesome-icon :icon="FA.faReply" />
+            Back
+          </button>
+          <div
+            class="tw-breadcrumbs"
+            data-test="breadcrumbs"
+          >
+            <ul>
+              <li>
+                <a
+                  href=""
+                  class="tw-italic"
+                  @click.prevent="currentPrefix = ''"
+                >{{ projectName }}</a>
+              </li>
+              <li
+                v-for="[index, dir_segment] of currentPrefix.split('/').slice(0, -1).entries()"
+                :key="dir_segment"
+              >
+                <a
+                  href=""
+                  @click.prevent="currentPrefix = currentPrefix.split('/').slice(0, index + 1).join('/') + '/'"
+                >
+                  <font-awesome-icon
+                    :icon="FA.faFolder"
+                    class="tw-mr-1"
+                  />
+                  {{ dir_segment }}
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <loading-indicator :is-loading="!coverage">
+          <data-table
+            :columns="[
+              ...(hasSubProjects ? [{
+                name: 'subProject',
+                displayName: 'SubProject',
+              }] : []),
+              {
+                name: 'path',
+                displayName: 'Name',
+                expand: true,
+              },
+              {
+                name: 'linePercentage',
+                displayName: 'Percentage',
+              },
+              {
+                name: 'lines',
+                displayName: 'Lines Tested',
+              },
+              ...(hasBranchCoverage ? [{
+                name: 'branchPercentage',
+                displayName: 'Branch Percentage',
+              }, {
+                name: 'branches',
+                displayName: 'Branches Tested',
+              }] : []),
+            ]"
+            :rows="formattedTableRows"
+            :full-width="true"
+            test-id="coverage-table"
+            initial-sort-column="linePercentage"
+            :initial-sort-asc="false"
+          >
+            <template #path="{ props: obj }">
+              <a
+                v-if="obj.isDirectory"
+                href=""
+                data-test="coverage-directory-link"
+                @click.prevent="currentPrefix += obj.path + '/';"
+              >
+                <font-awesome-icon :icon="FA.faFolder" /> {{ obj.path }}
+              </a>
+              <a
+                v-else
+                :href="`${$baseURL}/builds/${buildId}/coverage/${obj.fileId}`"
+                data-test="coverage-file-link"
+              >
+                <font-awesome-icon :icon="FA.faFile" /> {{ obj.path }}
+              </a>
+            </template>
+            <template #linePercentage="{ props: { text: pct } }">
+              <progress
+                class="tw-progress tw-w-24"
+                :class="percentToProgressBarColorClass(pct)"
+                :value="pct"
+                max="100"
+              /> {{ pct }}%
+            </template>
+            <template #branchPercentage="{ props: { text: pct } }">
+              <progress
+                class="tw-progress tw-w-24"
+                :class="percentToProgressBarColorClass(pct)"
+                :value="pct"
+                max="100"
+              /> {{ pct }}%
+            </template>
+          </data-table>
+        </loading-indicator>
+      </div>
     </div>
-  </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import DataTable from './shared/DataTable.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import {faFolder, faReply} from '@fortawesome/free-solid-svg-icons';
@@ -183,7 +189,7 @@ import {faFile} from '@fortawesome/free-regular-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
-  components: {FontAwesomeIcon, FilterBuilder, LoadingIndicator, DataTable, BuildSummaryCard},
+  components: {FontAwesomeIcon, FilterBuilder, LoadingIndicator, DataTable, BuildSummaryCard, BuildSidebar},
 
   props: {
     buildId: {

--- a/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
+++ b/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
@@ -1,31 +1,37 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <build-summary-card :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="dynamic_analysis"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <build-summary-card :build-id="buildId" />
 
-    <loading-indicator :is-loading="!dynamicAnalysis">
-      <div class="tw-border-base-300 tw-bg-base-200 tw-border tw-rounded tw-p-2 tw-flex tw-flex-row tw-w-full tw-gap-1">
-        <div class="tw-font-mono tw-link tw-link-hover">
-          <a :href="link">
-            {{ dynamicAnalysis.name }}
-          </a>
+      <loading-indicator :is-loading="!dynamicAnalysis">
+        <div class="tw-border-base-300 tw-bg-base-200 tw-border tw-rounded tw-p-2 tw-flex tw-flex-row tw-w-full tw-gap-1">
+          <div class="tw-font-mono tw-link tw-link-hover">
+            <a :href="link">
+              {{ dynamicAnalysis.name }}
+            </a>
+          </div>
+          <div class="tw-flex-grow" />
+          <span
+            class="tw-badge"
+            :class="statusColor"
+          />
+          <span>{{ status }}</span>
         </div>
-        <div class="tw-flex-grow" />
-        <span
-          class="tw-badge"
-          :class="statusColor"
-        />
-        <span>{{ status }}</span>
-      </div>
 
-      <code-box :text="dynamicAnalysis.log" />
-    </loading-indicator>
-  </div>
+        <code-box :text="dynamicAnalysis.log" />
+      </loading-indicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import gql from 'graphql-tag';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import {
   faCircleExclamation,
   faTriangleExclamation,
@@ -33,7 +39,7 @@ import {
 import CodeBox from './shared/CodeBox.vue';
 
 export default {
-  components: {CodeBox, LoadingIndicator, BuildSummaryCard},
+  components: {CodeBox, LoadingIndicator, BuildSummaryCard, BuildSidebar},
   props: {
     buildId: {
       type: Number,

--- a/resources/js/vue/components/BuildErrorsPage.vue
+++ b/resources/js/vue/components/BuildErrorsPage.vue
@@ -1,56 +1,62 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <build-summary-card :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="errors"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <build-summary-card :build-id="buildId" />
 
-    <loading-indicator :is-loading="!build">
-      <div
-        v-if="build.children.edges.length > 0"
-        class="tw-join tw-join-vertical tw-w-full"
-      >
-        <details
-          v-for="{ node: childBuild } in build.children.edges"
-          class="tw-collapse tw-collapse-plus tw-join-item tw-border"
-          :data-test="'collapse-' + childBuild.subProject.id"
+      <loading-indicator :is-loading="!build">
+        <div
+          v-if="build.children.edges.length > 0"
+          class="tw-join tw-join-vertical tw-w-full"
         >
-          <summary class="tw-collapse-title tw-text-xl tw-font-medium">
-            <span>{{ childBuild.subProject.name }}</span>
-            <span
-              v-if="childBuild.buildErrorsCount > 0"
-              class="tw-badge tw-ml-2 tw-bg-error"
-              :data-test="'errors-' + childBuild.subProject.id"
-            ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ childBuild.buildErrorsCount }}</span>
-            <span
-              v-if="childBuild.buildWarningsCount > 0"
-              class="tw-badge tw-ml-1 tw-bg-warning"
-              :data-test="'warnings-' + childBuild.subProject.id"
-            ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ childBuild.buildWarningsCount }}</span>
-          </summary>
-          <div class="tw-collapse-content">
-            <build-error-list
-              :build-id="parseInt(childBuild.id)"
-              :previous-build-id="buildIdsToPreviousBuildIds[parseInt(childBuild.id)] ?? null"
-              :show-new-errors="showNewErrors"
-              :show-fixed-errors="showFixedErrors"
-            />
-          </div>
-        </details>
-      </div>
-      <div v-else>
-        <build-error-list
-          :build-id="buildId"
-          :previous-build-id="previousBuildId"
-          :show-new-errors="showNewErrors"
-          :show-fixed-errors="showFixedErrors"
-        />
-      </div>
-    </loading-indicator>
-  </div>
+          <details
+            v-for="{ node: childBuild } in build.children.edges"
+            class="tw-collapse tw-collapse-plus tw-join-item tw-border"
+            :data-test="'collapse-' + childBuild.subProject.id"
+          >
+            <summary class="tw-collapse-title tw-text-xl tw-font-medium">
+              <span>{{ childBuild.subProject.name }}</span>
+              <span
+                v-if="childBuild.buildErrorsCount > 0"
+                class="tw-badge tw-ml-2 tw-bg-error"
+                :data-test="'errors-' + childBuild.subProject.id"
+              ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ childBuild.buildErrorsCount }}</span>
+              <span
+                v-if="childBuild.buildWarningsCount > 0"
+                class="tw-badge tw-ml-1 tw-bg-warning"
+                :data-test="'warnings-' + childBuild.subProject.id"
+              ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ childBuild.buildWarningsCount }}</span>
+            </summary>
+            <div class="tw-collapse-content">
+              <build-error-list
+                :build-id="parseInt(childBuild.id)"
+                :previous-build-id="buildIdsToPreviousBuildIds[parseInt(childBuild.id)] ?? null"
+                :show-new-errors="showNewErrors"
+                :show-fixed-errors="showFixedErrors"
+              />
+            </div>
+          </details>
+        </div>
+        <div v-else>
+          <build-error-list
+            :build-id="buildId"
+            :previous-build-id="previousBuildId"
+            :show-new-errors="showNewErrors"
+            :show-fixed-errors="showFixedErrors"
+          />
+        </div>
+      </loading-indicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import gql from 'graphql-tag';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import {
   faCircleExclamation,
   faTriangleExclamation,
@@ -80,7 +86,7 @@ const BUILD_QUERY = gql`
 `;
 
 export default {
-  components: {BuildErrorList: BuildErrorList, FontAwesomeIcon, LoadingIndicator, BuildSummaryCard},
+  components: {BuildErrorList: BuildErrorList, FontAwesomeIcon, LoadingIndicator, BuildSummaryCard, BuildSidebar},
   props: {
     buildId: {
       type: Number,

--- a/resources/js/vue/components/BuildFilesPage.vue
+++ b/resources/js/vue/components/BuildFilesPage.vue
@@ -1,74 +1,80 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="files"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <div
-      v-if="urls && files && urls.edges.length === 0 && files.edges.length === 0"
-      data-test="no-urls-or-files-message"
-    >
-      No URLs or files were uploaded for this build.
+      <div
+        v-if="urls && files && urls.edges.length === 0 && files.edges.length === 0"
+        data-test="no-urls-or-files-message"
+      >
+        No URLs or files were uploaded for this build.
+      </div>
+
+      <loading-indicator :is-loading="!urls">
+        <data-table
+          v-if="urls.edges.length > 0"
+          :column-groups="[
+            {
+              displayName: 'URLs',
+              width: 100,
+            }
+          ]"
+          :columns="[
+            {
+              name: 'url',
+              displayName: 'URL',
+            },
+          ]"
+          :rows="formattedUrlRows"
+          :full-width="true"
+          test-id="urls-table"
+        />
+      </loading-indicator>
+
+      <loading-indicator :is-loading="!files">
+        <data-table
+          v-if="files.edges.length > 0"
+          :column-groups="[
+            {
+              displayName: 'Files',
+              width: 100,
+            }
+          ]"
+          :columns="[
+            {
+              name: 'name',
+              displayName: 'Name',
+            },
+            {
+              name: 'size',
+              displayName: 'Size',
+            },
+            {
+              name: 'hash',
+              displayName: 'SHA-1',
+            },
+          ]"
+          :rows="formattedFileRows"
+          :full-width="true"
+          test-id="files-table"
+        />
+      </loading-indicator>
     </div>
-
-    <loading-indicator :is-loading="!urls">
-      <data-table
-        v-if="urls.edges.length > 0"
-        :column-groups="[
-          {
-            displayName: 'URLs',
-            width: 100,
-          }
-        ]"
-        :columns="[
-          {
-            name: 'url',
-            displayName: 'URL',
-          },
-        ]"
-        :rows="formattedUrlRows"
-        :full-width="true"
-        test-id="urls-table"
-      />
-    </loading-indicator>
-
-    <loading-indicator :is-loading="!files">
-      <data-table
-        v-if="files.edges.length > 0"
-        :column-groups="[
-          {
-            displayName: 'Files',
-            width: 100,
-          }
-        ]"
-        :columns="[
-          {
-            name: 'name',
-            displayName: 'Name',
-          },
-          {
-            name: 'size',
-            displayName: 'Size',
-          },
-          {
-            name: 'hash',
-            displayName: 'SHA-1',
-          },
-        ]"
-        :rows="formattedFileRows"
-        :full-width="true"
-        test-id="files-table"
-      />
-    </loading-indicator>
-  </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import DataTable from './shared/DataTable.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 
 export default {
-  components: {LoadingIndicator, DataTable, BuildSummaryCard},
+  components: {LoadingIndicator, DataTable, BuildSummaryCard, BuildSidebar},
 
   props: {
     buildId: {

--- a/resources/js/vue/components/BuildNotesPage.vue
+++ b/resources/js/vue/components/BuildNotesPage.vue
@@ -1,71 +1,76 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="notes"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <div
-      v-if="notes && notes.edges.length === 0"
-      data-test="no-notes-message"
-    >
-      No notes were uploaded for this build.
-    </div>
+      <div
+        v-if="notes && notes.edges.length === 0"
+        data-test="no-notes-message"
+      >
+        No notes were uploaded for this build.
+      </div>
 
-    <div
-      v-if="notes && notes.edges.length > 0"
-      class="tw-flex tw-flex-col md:tw-flex-row"
-      data-test="notes-content"
-    >
-      <LoadingIndicator :is-loading="!notes">
-        <aside
-          class="tw-w-full md:tw-w-1/3 lg:tw-w-1/4"
-          data-test="notes-menu"
-        >
-          <div class="tw-sticky tw-top-28 tw-max-h-[calc(100vh-8rem)] tw-overflow-y-auto tw-border tw-rounded-box">
-            <ul class="tw-menu tw-bg-base-200">
-              <li
-                v-for="note in notes.edges"
-                :key="note.node.id"
-                class="tw-w-full"
-                data-test="notes-menu-item"
-              >
-                <a
-                  :href="`#${note.node.id}`"
-                  :class="{ 'tw-active': activeNoteId === note.node.id }"
-                  class="menu-item-wrap"
-                >{{ note.node.name }}</a>
-              </li>
-            </ul>
-          </div>
-        </aside>
-      </LoadingIndicator>
-
-      <LoadingIndicator :is-loading="!notes">
-        <main
-          class="tw-w-full md:tw-w-2/3 lg:tw-w-3/4 md:tw-pl-4 tw-pt-4 md:tw-pt-0"
-          data-test="notes-content"
-        >
-          <div class="tw-flex tw-flex-col tw-gap-4">
-            <div
-              v-for="note in notes.edges"
-              :id="note.node.id"
-              :key="note.node.id"
-              :ref="r => noteRefs.push(r)"
-              class="tw-border tw-border-base-300 tw-bg-base-100 tw-rounded-box tw-scroll-mt-28 tw-overflow-hidden"
-              data-test="notes-content-item"
-            >
-              <h3 class="tw-p-4 tw-text-xl tw-font-bold tw-break-words">
-                {{ note.node.name }}
-              </h3>
-              <hr>
-              <code-box
-                :text="note.node.text"
-                :bordered="false"
-              />
+      <div
+        v-if="notes && notes.edges.length > 0"
+        class="tw-flex tw-flex-col md:tw-flex-row"
+        data-test="notes-content"
+      >
+        <LoadingIndicator :is-loading="!notes">
+          <aside
+            class="tw-w-full md:tw-w-1/3 lg:tw-w-1/4"
+            data-test="notes-menu"
+          >
+            <div class="tw-sticky tw-top-[100px] tw-max-h-[calc(100vh-100px)] tw-overflow-y-auto tw-border tw-rounded-box">
+              <ul class="tw-menu tw-bg-base-200">
+                <li
+                  v-for="note in notes.edges"
+                  :key="note.node.id"
+                  class="tw-w-full"
+                  data-test="notes-menu-item"
+                >
+                  <a
+                    :href="`#${note.node.id}`"
+                    :class="{ 'tw-active': activeNoteId === note.node.id }"
+                    class="menu-item-wrap"
+                  >{{ note.node.name }}</a>
+                </li>
+              </ul>
             </div>
-          </div>
-        </main>
-      </LoadingIndicator>
+          </aside>
+        </LoadingIndicator>
+
+        <LoadingIndicator :is-loading="!notes">
+          <main
+            class="tw-w-full md:tw-w-2/3 lg:tw-w-3/4 md:tw-pl-4 tw-pt-4 md:tw-pt-0"
+            data-test="notes-content"
+          >
+            <div class="tw-flex tw-flex-col tw-gap-4">
+              <div
+                v-for="note in notes.edges"
+                :id="note.node.id"
+                :key="note.node.id"
+                :ref="r => noteRefs.push(r)"
+                class="tw-border tw-border-base-300 tw-bg-base-100 tw-rounded-box tw-scroll-mt-28 tw-overflow-hidden"
+                data-test="notes-content-item"
+              >
+                <h3 class="tw-p-4 tw-text-xl tw-font-bold tw-break-words">
+                  {{ note.node.name }}
+                </h3>
+                <hr>
+                <code-box
+                  :text="note.node.text"
+                  :bordered="false"
+                />
+              </div>
+            </div>
+          </main>
+        </LoadingIndicator>
+      </div>
     </div>
-  </div>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -73,10 +78,11 @@ import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import gql from 'graphql-tag';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import CodeBox from './shared/CodeBox.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 
 export default {
   name: 'BuildNotesPage',
-  components: {CodeBox, LoadingIndicator, BuildSummaryCard},
+  components: {CodeBox, LoadingIndicator, BuildSummaryCard, BuildSidebar},
 
   props: {
     buildId: {

--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -1,1004 +1,1009 @@
 <template>
-  <section v-if="errored">
-    <p>{{ cdash.error }}</p>
-  </section>
-  <section v-else>
-    <build-summary-card :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="summary"
+  >
+    <section v-if="errored">
+      <p>{{ cdash.error }}</p>
+    </section>
+    <section v-else>
+      <build-summary-card :build-id="buildId" />
 
-    <loading-indicator :is-loading="loading">
-      <!-- Display link to create bug tracker issue if supported. -->
-      <div v-if="cdash.newissueurl">
-        <a
-          class="tw-link tw-link-hover"
-          :href="cdash.newissueurl"
-        >
-          <b>Create {{ cdash.bugtracker }} issue for this build</b>
-        </a>
+      <loading-indicator :is-loading="loading">
+        <!-- Display link to create bug tracker issue if supported. -->
+        <div v-if="cdash.newissueurl">
+          <a
+            class="tw-link tw-link-hover"
+            :href="cdash.newissueurl"
+          >
+            <b>Create {{ cdash.bugtracker }} issue for this build</b>
+          </a>
+          <br>
+        </div>
         <br>
-      </div>
-      <br>
 
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <!-- Previous build -->
-              <table
-                v-if="cdash.previousbuild"
-                class="tabb striped"
-              >
-                <thead>
-                  <tr class="table-heading1">
-                    <th
-                      colspan="3"
-                      class="header"
-                    >
-                      <a
-                        class="tw-link tw-link-hover"
-                        :href="$baseURL + '/builds/' + cdash.previousbuild.buildid"
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <!-- Previous build -->
+                <table
+                  v-if="cdash.previousbuild"
+                  class="tabb striped"
+                >
+                  <thead>
+                    <tr class="table-heading1">
+                      <th
+                        colspan="3"
+                        class="header"
                       >
-                        <b>Previous Build</b>
-                      </a>
-                    </th>
-                  </tr>
-                  <tr class="table-heading">
-                    <th>Stage</th>
-                    <th>Errors</th>
-                    <th>Warnings</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <th>
-                      <b>Update</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nupdateerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
                         <a
                           class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/update'"
+                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid"
                         >
-                          {{ cdash.previousbuild.nupdateerrors }}
+                          <b>Previous Build</b>
                         </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/update'"
-                        >
-                          {{ cdash.previousbuild.nupdatewarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-
-                  <tr v-if="cdash.hasconfigure">
-                    <th>
-                      <b>Configure</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/configure'"
-                        >
-                          {{ cdash.previousbuild.nconfigureerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/configure'"
-                        >
-                          {{ cdash.previousbuild.nconfigurewarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-
-                  <tr>
-                    <th>
-                      <b>Build</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/errors'"
-                        >
-                          {{ cdash.previousbuild.nerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.nwarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + 'errors'"
-                        >
-                          {{ cdash.previousbuild.nwarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-
-                  <tr>
-                    <th>
-                      <b>Test</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.ntestfailed > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.previousbuild.ntestfailed }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.previousbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.previousbuild.ntestnotrun }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </td>
-
-            <!-- A horrible hack to put some space between these tables... -->
-            <!-- TODO: (williamjallen) Why do we have nested tables here to begin with??? -->
-            <td>&nbsp;</td>
-
-            <td>
-              <!-- Current build -->
-              <table class="tabb striped">
-                <thead>
-                  <tr class="table-heading1">
-                    <th
-                      colspan="3"
-                      class="header"
-                    >
-                      This Build
-                    </th>
-                  </tr>
-                  <tr class="table-heading">
-                    <th>Stage</th>
-                    <th>Errors</th>
-                    <th>Warnings</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <th>
-                      <a
-                        v-if="cdash.hasupdate"
-                        href="#Update"
-                      >
+                      </th>
+                    </tr>
+                    <tr class="table-heading">
+                      <th>Stage</th>
+                      <th>Errors</th>
+                      <th>Warnings</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th>
                         <b>Update</b>
-                      </a>
-                      <span v-if="!cdash.hasupdate">
-                        Update
-                      </span>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.update.nerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
-                        >
-                          {{ cdash.update.nerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.update.nwarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
-                        >
-                          {{ cdash.update.nwarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                  <tr v-if="cdash.hasconfigure">
-                    <th>
-                      <a
-                        class="tw-link tw-link-hover"
-                        href="#Configure"
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nupdateerrors > 0 ? 'error' : 'normal'"
                       >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/update'"
+                          >
+                            {{ cdash.previousbuild.nupdateerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/update'"
+                          >
+                            {{ cdash.previousbuild.nupdatewarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+
+                    <tr v-if="cdash.hasconfigure">
+                      <th>
                         <b>Configure</b>
-                      </a>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.configure.nerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
-                        >
-                          {{ cdash.configure.nerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.configure.nwarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
-                        >
-                          {{ cdash.configure.nwarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <a
-                        class="tw-link tw-link-hover"
-                        href="#Build"
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
                       >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/configure'"
+                          >
+                            {{ cdash.previousbuild.nconfigureerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/configure'"
+                          >
+                            {{ cdash.previousbuild.nconfigurewarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <th>
                         <b>Build</b>
-                      </a>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.build.nerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
-                        >
-                          {{ cdash.build.nerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.build.nwarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
-                        >
-                          {{ cdash.build.nwarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>
-                      <a
-                        class="tw-link tw-link-hover"
-                        href="#Test"
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nerrors > 0 ? 'error' : 'normal'"
                       >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/errors'"
+                          >
+                            {{ cdash.previousbuild.nerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.nwarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + 'errors'"
+                          >
+                            {{ cdash.previousbuild.nwarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <th>
                         <b>Test</b>
-                      </a>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.test.nfailed > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.test.nfailed }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.test.nnotrun > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.test.nnotrun }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </td>
-
-            <td>&nbsp;</td>
-
-            <td>
-              <!-- Next build -->
-              <table
-                v-if="cdash.nextbuild"
-                class="tabb striped"
-              >
-                <thead>
-                  <tr class="table-heading1">
-                    <th
-                      colspan="3"
-                      class="header"
-                    >
-                      <a
-                        class="tw-link tw-link-hover"
-                        :href="$baseURL + '/builds/' + cdash.nextbuild.buildid"
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.ntestfailed > 0 ? 'error' : 'normal'"
                       >
-                        <b>Next Build</b>
-                      </a>
-                    </th>
-                  </tr>
-                  <tr class="table-heading">
-                    <th>Stage</th>
-                    <th>Errors</th>
-                    <th>Warnings</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <th>
-                      <b>Update</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nupdateerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.previousbuild.ntestfailed }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.previousbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.previousbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.previousbuild.ntestnotrun }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+
+              <!-- A horrible hack to put some space between these tables... -->
+              <!-- TODO: (williamjallen) Why do we have nested tables here to begin with??? -->
+              <td>&nbsp;</td>
+
+              <td>
+                <!-- Current build -->
+                <table class="tabb striped">
+                  <thead>
+                    <tr class="table-heading1">
+                      <th
+                        colspan="3"
+                        class="header"
+                      >
+                        This Build
+                      </th>
+                    </tr>
+                    <tr class="table-heading">
+                      <th>Stage</th>
+                      <th>Errors</th>
+                      <th>Warnings</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th>
+                        <a
+                          v-if="cdash.hasupdate"
+                          href="#Update"
+                        >
+                          <b>Update</b>
+                        </a>
+                        <span v-if="!cdash.hasupdate">
+                          Update
+                        </span>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.update.nerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
+                          >
+                            {{ cdash.update.nerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.update.nwarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
+                          >
+                            {{ cdash.update.nwarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                    <tr v-if="cdash.hasconfigure">
+                      <th>
                         <a
                           class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/update'"
+                          href="#Configure"
                         >
-                          {{ cdash.nextbuild.nupdateerrors }}
+                          <b>Configure</b>
                         </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.configure.nerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
+                          >
+                            {{ cdash.configure.nerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.configure.nwarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
+                          >
+                            {{ cdash.configure.nwarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>
                         <a
                           class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/update'"
+                          href="#Build"
                         >
-                          {{ cdash.nextbuild.nupdatewarnings }}
+                          <b>Build</b>
                         </a>
-                      </b>
-                    </td>
-                  </tr>
-
-                  <tr v-if="cdash.hasconfigure">
-                    <th>
-                      <b>Configure</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.build.nerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
+                          >
+                            {{ cdash.build.nerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.build.nwarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
+                          >
+                            {{ cdash.build.nwarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>
                         <a
                           class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/configure'"
+                          href="#Test"
                         >
-                          {{ cdash.nextbuild.nconfigureerrors }}
+                          <b>Test</b>
                         </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.test.nfailed > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.test.nfailed }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.test.nnotrun > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.test.nnotrun }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+
+              <td>&nbsp;</td>
+
+              <td>
+                <!-- Next build -->
+                <table
+                  v-if="cdash.nextbuild"
+                  class="tabb striped"
+                >
+                  <thead>
+                    <tr class="table-heading1">
+                      <th
+                        colspan="3"
+                        class="header"
+                      >
                         <a
                           class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/configure'"
+                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid"
                         >
-                          {{ cdash.nextbuild.nconfigurewarnings }}
+                          <b>Next Build</b>
                         </a>
-                      </b>
-                    </td>
-                  </tr>
+                      </th>
+                    </tr>
+                    <tr class="table-heading">
+                      <th>Stage</th>
+                      <th>Errors</th>
+                      <th>Warnings</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <th>
+                        <b>Update</b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nupdateerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/update'"
+                          >
+                            {{ cdash.nextbuild.nupdateerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nupdatewarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/update'"
+                          >
+                            {{ cdash.nextbuild.nupdatewarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
 
-                  <tr>
-                    <th>
-                      <b>Build</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nerrors > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + 'errors'"
-                        >
-                          {{ cdash.nextbuild.nerrors }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.nwarnings > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/errors'"
-                        >
-                          {{ cdash.nextbuild.nwarnings }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
+                    <tr v-if="cdash.hasconfigure">
+                      <th>
+                        <b>Configure</b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nconfigureerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/configure'"
+                          >
+                            {{ cdash.nextbuild.nconfigureerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nconfigurewarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/configure'"
+                          >
+                            {{ cdash.nextbuild.nconfigurewarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
 
-                  <tr>
-                    <th>
-                      <b>Test</b>
-                    </th>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.ntestfailed > 0 ? 'error' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.nextbuild.ntestfailed }}
-                        </a>
-                      </b>
-                    </td>
-                    <td
-                      align="right"
-                      :class="cdash.nextbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
-                    >
-                      <b>
-                        <a
-                          class="tw-link tw-link-hover"
-                          :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
-                        >
-                          {{ cdash.nextbuild.ntestnotrun }}
-                        </a>
-                      </b>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <br>
+                    <tr>
+                      <th>
+                        <b>Build</b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nerrors > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + 'errors'"
+                          >
+                            {{ cdash.nextbuild.nerrors }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.nwarnings > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/errors'"
+                          >
+                            {{ cdash.nextbuild.nwarnings }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
 
-      <!-- Display the history table -->
-      <div class="title-divider">
-        History
-      </div>
+                    <tr>
+                      <th>
+                        <b>Test</b>
+                      </th>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.ntestfailed > 0 ? 'error' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.nextbuild.ntestfailed }}
+                          </a>
+                        </b>
+                      </td>
+                      <td
+                        align="right"
+                        :class="cdash.nextbuild.ntestnotrun > 0 ? 'warning' : 'normal'"
+                      >
+                        <b>
+                          <a
+                            class="tw-link tw-link-hover"
+                            :href="$baseURL + '/builds/' + cdash.nextbuild.buildid + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D'"
+                          >
+                            {{ cdash.nextbuild.ntestnotrun }}
+                          </a>
+                        </b>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <br>
 
-      <a
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/index.php?project=' + cdash.projectname_encoded + '&filtercount=4&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=' + cdash.build.sitename_encoded + '&field2=buildname&compare2=61&value2=' + cdash.build.name + '&field3=buildtype&compare3=61&value3=' + cdash.build.type + '&field4=buildstarttime&compare4=84&value4=' + cdash.build.starttime"
-      >
-        Show Build History
-      </a>
-      <br>
-      <br>
-
-      <!-- Notes section -->
-      <div class="title-divider">
-        Notes
-      </div>
-      <a
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/notes'"
-      >
-        View Notes
-      </a>
-      <br>
-      <br>
-
-      <!-- Instrumentation section -->
-      <div class="title-divider">
-        Instrumentation
-        <a href="https://cmake.org/cmake/help/latest/manual/cmake-instrumentation.7.html">
-          <font-awesome-icon :icon="FA.faQuestionCircle" />
-        </a>
-      </div>
-      <a
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/commands'"
-      >
-        View Commands
-      </a>
-      <br>
-      <br>
-
-      <!-- Targets section -->
-      <div class="title-divider">
-        Targets
-      </div>
-      <a
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/targets'"
-      >
-        View Targets
-      </a>
-      <br>
-      <br>
-
-      <!-- Display comments for this build -->
-      <loading-indicator :is-loading="!comments">
-        <div
-          v-if="comments.length > 0 || cdash.user.id > 0"
-          class="title-divider"
-        >
-          Comments ({{ comments.length }})
+        <!-- Display the history table -->
+        <div class="title-divider">
+          History
         </div>
 
-        <div v-if="comments.length > 0">
-          <div v-for="{node: comment} in comments">
-            <b>{{ comment.user.firstname }} {{ comment.user.lastname }}</b> {{ Utils.formatRelativeTimestamp(comment.timestamp) }}
-            <code-box :text="comment.text" />
-            <hr>
+        <a
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/index.php?project=' + cdash.projectname_encoded + '&filtercount=4&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=' + cdash.build.sitename_encoded + '&field2=buildname&compare2=61&value2=' + cdash.build.name + '&field3=buildtype&compare3=61&value3=' + cdash.build.type + '&field4=buildstarttime&compare4=84&value4=' + cdash.build.starttime"
+        >
+          Show Build History
+        </a>
+        <br>
+        <br>
+
+        <!-- Notes section -->
+        <div class="title-divider">
+          Notes
+        </div>
+        <a
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/notes'"
+        >
+          View Notes
+        </a>
+        <br>
+        <br>
+
+        <!-- Instrumentation section -->
+        <div class="title-divider">
+          Instrumentation
+          <a href="https://cmake.org/cmake/help/latest/manual/cmake-instrumentation.7.html">
+            <font-awesome-icon :icon="FA.faQuestionCircle" />
+          </a>
+        </div>
+        <a
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/commands'"
+        >
+          View Commands
+        </a>
+        <br>
+        <br>
+
+        <!-- Targets section -->
+        <div class="title-divider">
+          Targets
+        </div>
+        <a
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/targets'"
+        >
+          View Targets
+        </a>
+        <br>
+        <br>
+
+        <!-- Display comments for this build -->
+        <loading-indicator :is-loading="!comments">
+          <div
+            v-if="comments.length > 0 || cdash.user.id > 0"
+            class="title-divider"
+          >
+            Comments ({{ comments.length }})
           </div>
+
+          <div v-if="comments.length > 0">
+            <div v-for="{node: comment} in comments">
+              <b>{{ comment.user.firstname }} {{ comment.user.lastname }}</b> {{ Utils.formatRelativeTimestamp(comment.timestamp) }}
+              <code-box :text="comment.text" />
+              <hr>
+            </div>
+            <br>
+          </div>
+
+          <div v-if="cdash.user.id > 0">
+            <!-- Add Comments -->
+            <div class="tw-flex tw-flex-row">
+              <img
+                width="20"
+                height="20"
+                :src="$baseURL + '/img/document.png'"
+                title="graph"
+              >
+              <a
+                id="toggle_note"
+                class="tw-link tw-link-hover"
+                @click="toggleNote()"
+              >
+                Add a comment to this Build
+              </a>
+            </div>
+            <div
+              v-show="showNote"
+              id="new_note_div"
+            >
+              <table>
+                <tbody>
+                  <tr>
+                    <td><b>Comment:</b></td>
+                    <td>
+                      <textarea
+                        id="note_text"
+                        v-model="cdash.noteText"
+                        class="tw-textarea tw-textarea-bordered"
+                        cols="50"
+                        rows="5"
+                      />
+                    </td>
+                  </tr>
+                  <tr>
+                    <td />
+                    <td>
+                      <button
+                        id="add_note"
+                        class="tw-btn"
+                        :disabled="!cdash.noteText"
+                        @click="addNote()"
+                      >
+                        Add Note
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <br>
+          </div>
+        </loading-indicator>
+
+        <!-- Graphs -->
+        <div class="title-divider">
+          Graphs
+        </div>
+
+        <div class="tw-flex tw-flex-row">
+          <img
+            width="20"
+            height="20"
+            :src="$baseURL + '/img/graph.png'"
+            title="graph"
+          >
+          <a
+            id="toggle_time_graph"
+            class="tw-link tw-link-hover"
+            @click="toggleTimeGraph()"
+          >
+            Show Build Time Graph
+          </a>
+        </div>
+        <div style="text-align: center;">
+          <img
+            v-show="showTimeGraph && graphLoading"
+            :src="$baseURL + '/img/loading.gif'"
+          >
+          <div
+            v-show="showTimeGraph"
+            id="buildtimegrapholder"
+            class="graph_holder"
+          />
+        </div>
+
+        <div class="tw-flex tw-flex-row">
+          <img
+            width="20"
+            height="20"
+            :src="$baseURL + '/img/graph.png'"
+            title="graph"
+          >
+          <a
+            id="toggle_error_graph"
+            class="tw-link tw-link-hover"
+            @click="toggleErrorGraph()"
+          >
+            Show Build Errors Graph
+          </a>
+        </div>
+        <div style="text-align: center;">
+          <img
+            v-show="showErrorGraph && graphLoading"
+            :src="$baseURL + '/img/loading.gif'"
+          >
+          <div
+            v-show="showErrorGraph"
+            id="builderrorsgrapholder"
+            class="graph_holder"
+          />
+        </div>
+
+        <div class="tw-flex tw-flex-row">
+          <img
+            width="20"
+            height="20"
+            :src="$baseURL + '/img/graph.png'"
+            title="graph"
+          >
+          <a
+            id="toggle_warning_graph"
+            class="tw-link tw-link-hover"
+            @click="toggleWarningGraph()"
+          >
+            Show Build Warnings Graph
+          </a>
+        </div>
+        <div style="text-align: center;">
+          <img
+            v-show="showWarningGraph && graphLoading"
+            :src="$baseURL + '/img/loading.gif'"
+          >
+          <div
+            v-show="showWarningGraph"
+            id="buildwarningsgrapholder"
+            class="graph_holder"
+          />
+        </div>
+
+        <div class="tw-flex tw-flex-row">
+          <img
+            width="20"
+            height="20"
+            :src="$baseURL + '/img/graph.png'"
+            title="graph"
+          >
+          <a
+            id="toggle_test_graph"
+            class="tw-link tw-link-hover"
+            @click="toggleTestGraph()"
+          >
+            Show Build Tests Failed Graph
+          </a>
+        </div>
+        <div style="text-align: center;">
+          <img
+            v-show="showTestGraph && graphLoading"
+            :src="$baseURL + '/img/loading.gif'"
+          >
+          <div
+            v-show="showTestGraph"
+            id="buildtestsfailedgrapholder"
+            class="graph_holder"
+          />
+        </div>
+        <br>
+
+        <!-- Relationships -->
+        <div v-if="cdash.hasrelationships">
+          <div class="title-divider">
+            Relationships
+          </div>
+          <div
+            v-for="from in cdash.relationships_from"
+            :key="from.relatedid"
+          >
+            This build {{ from.relationship }} <a
+              class="tw-link tw-link-hover"
+              :href="$baseURL + '/builds/' + from.relatedid"
+            >{{ from.name }}</a>.
+          </div>
+          <div
+            v-for="to in cdash.relationships_to"
+            :key="to.buildid"
+          >
+            <a
+              class="tw-link tw-link-hover"
+              :href="$baseURL + '/builds/' + to.buildid"
+            >{{ to.name }}</a> {{ to.relationship }} this build.
+          </div>
+        </div>
+
+        <!-- Update -->
+        <div v-if="cdash.hasupdate">
+          <div
+            id="Update"
+            class="title-divider"
+          >
+            Stage: Update ({{ cdash.update.nerrors }} errors, {{ cdash.update.nwarnings }} warnings)
+          </div>
+          <br>
+
+          <b>Start Time: </b>{{ cdash.update.starttime }}
+          <br>
+
+          <b>End Time: </b>{{ cdash.update.endtime }}
+          <br>
+
+          <b>Update Command: </b> {{ cdash.update.command }}
+          <br>
+
+          <b>Update Type: </b> {{ cdash.update.type }}
+          <br>
+
+          <b>Number of Updates: </b>
+          <a
+            class="tw-link tw-link-hover"
+            :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
+          >
+            {{ cdash.update.nupdates }}
+          </a>
+          <div v-if="cdash.update.status">
+            <br>
+            <b>Update Status: </b>{{ cdash.update.status }}
+          </div>
+          <br>
           <br>
         </div>
 
-        <div v-if="cdash.user.id > 0">
-          <!-- Add Comments -->
-          <div class="tw-flex tw-flex-row">
-            <img
-              width="20"
-              height="20"
-              :src="$baseURL + '/img/document.png'"
-              title="graph"
-            >
-            <a
-              id="toggle_note"
-              class="tw-link tw-link-hover"
-              @click="toggleNote()"
-            >
-              Add a comment to this Build
-            </a>
-          </div>
+        <!-- Configure -->
+        <div v-if="cdash.hasconfigure">
           <div
-            v-show="showNote"
-            id="new_note_div"
+            id="Configure"
+            class="title-divider"
           >
-            <table>
-              <tbody>
-                <tr>
-                  <td><b>Comment:</b></td>
-                  <td>
-                    <textarea
-                      id="note_text"
-                      v-model="cdash.noteText"
-                      class="tw-textarea tw-textarea-bordered"
-                      cols="50"
-                      rows="5"
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td />
-                  <td>
-                    <button
-                      id="add_note"
-                      class="tw-btn"
-                      :disabled="!cdash.noteText"
-                      @click="addNote()"
-                    >
-                      Add Note
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            Configure ({{ cdash.configure.nerrors }} errors, {{ cdash.configure.nwarnings }} warnings)
           </div>
+          <br>
+
+          <b>Start Time: </b>{{ cdash.configure.starttime }}
+          <br>
+
+          <b>End Time: </b>{{ cdash.configure.endtime }}
+          <br>
+
+          <b>Configure Command:</b>
+          <code-box :text="cdash.configure.command" />
+
+          <b>Configure Return Value:</b>
+          <code-box :text="cdash.configure.status" />
+
+          <b>Configure Output:</b>
+
+          <code-box :text="cdash.configure.output" />
+
+          <a
+            id="configure_link"
+            class="tw-link tw-link-hover"
+            :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
+          >
+            View Configure Summary
+          </a>
+          <br>
+          <br>
+        </div>
+
+        <!-- Build -->
+        <div
+          id="Build"
+          class="title-divider"
+        >
+          Build ({{ cdash.build.nerrors }} errors, {{ cdash.build.nwarnings }} warnings)
+        </div>
+        <br>
+
+        <b>Build command: </b><code-box :text="cdash.build.command" />
+
+        <b>Start Time: </b>{{ cdash.build.starttime }}
+        <br>
+
+        <b>End Time: </b>{{ cdash.build.endtime }}
+        <br>
+        <br>
+
+        <!-- Show the errors -->
+        <div v-for="error in cdash.build.errors">
+          <div v-if="error.sourceline > 0">
+            <hr>
+            <h3>
+              <a>Build Log line {{ error.logline }}</a>
+            </h3>
+            <br>
+            File: <b>{{ error.sourcefile }}</b>
+            Line: <b>{{ error.sourceline }}</b>
+          </div>
+          <code-box
+            v-if="error?.text?.trim()"
+            :text="error.text"
+          />
+
+          <div v-if="error?.stdoutput?.trim() || error?.stderror?.trim()">
+            <br>
+            <b>{{ error.sourcefile }}</b>
+            <code-box
+              v-if="error?.stdoutput?.trim()"
+              :text="error.stdoutput"
+            />
+            <code-box
+              v-if="error?.stderror?.trim()"
+              :text="error.stderror"
+            />
+          </div>
+        </div>
+
+        <a
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
+        >
+          View Errors Summary
+        </a>
+        <br>
+        <br>
+
+        <!--  Warnings -->
+        <div
+          id="Warnings"
+          class="title-divider"
+        >
+          Build Warnings ({{ cdash.build.nwarnings }})
+        </div>
+
+        <div v-for="warning in cdash.build.warnings">
+          <div v-if="warning.sourceline > 0">
+            <hr>
+            <h3><a>Build Log line {{ warning.logline }}</a></h3>
+            <br>
+            File: <b>{{ warning.sourcefile }}</b>
+            Line: <b>{{ warning.sourceline }}</b>
+          </div>
+          <code-box
+            v-if="warning?.text?.trim()"
+            :text="warning.text"
+          />
+
+          <div v-if="warning?.stdoutput?.trim() || warning?.stderror?.trim()">
+            <br>
+            <b>{{ warning.sourcefile }}</b>
+            <code-box
+              v-if="warning?.stdoutput?.trim()"
+              :text="warning.stdoutput"
+            />
+            <code-box
+              v-if="warning?.stderror?.trim()"
+              :text="warning.stderror"
+            />
+          </div>
+        </div>
+        <br>
+
+        <a
+          id="warnings_link"
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
+        >
+          View Warnings Summary
+        </a>
+        <br>
+        <br>
+
+        <!-- Test -->
+        <div
+          id="Test"
+          class="title-divider"
+        >
+          Test ({{ cdash.test.npassed }}  passed, {{ cdash.test.nfailed }} failed, {{ cdash.test.nnotrun }} not run)
+        </div>
+        <a
+          id="tests_link"
+          class="tw-link tw-link-hover"
+          :href="$baseURL + '/builds/' + cdash.build.id + '/tests'"
+        >
+          View Tests Summary
+        </a>
+        <br>
+        <br>
+
+        <!-- Coverage -->
+        <div v-if="cdash.hascoverage">
+          <div
+            id="Coverage"
+            class="title-divider"
+          >
+            Coverage ({{ cdash.coverage }}%)
+          </div>
+          <a
+            id="coverage_link"
+            class="tw-link tw-link-hover"
+            :href="$baseURL + '/builds/' + cdash.build.id + '/coverage'"
+          >
+            View Coverage Summary
+          </a>
+          <br>
           <br>
         </div>
       </loading-indicator>
-
-      <!-- Graphs -->
-      <div class="title-divider">
-        Graphs
-      </div>
-
-      <div class="tw-flex tw-flex-row">
-        <img
-          width="20"
-          height="20"
-          :src="$baseURL + '/img/graph.png'"
-          title="graph"
-        >
-        <a
-          id="toggle_time_graph"
-          class="tw-link tw-link-hover"
-          @click="toggleTimeGraph()"
-        >
-          Show Build Time Graph
-        </a>
-      </div>
-      <div style="text-align: center;">
-        <img
-          v-show="showTimeGraph && graphLoading"
-          :src="$baseURL + '/img/loading.gif'"
-        >
-        <div
-          v-show="showTimeGraph"
-          id="buildtimegrapholder"
-          class="graph_holder"
-        />
-      </div>
-
-      <div class="tw-flex tw-flex-row">
-        <img
-          width="20"
-          height="20"
-          :src="$baseURL + '/img/graph.png'"
-          title="graph"
-        >
-        <a
-          id="toggle_error_graph"
-          class="tw-link tw-link-hover"
-          @click="toggleErrorGraph()"
-        >
-          Show Build Errors Graph
-        </a>
-      </div>
-      <div style="text-align: center;">
-        <img
-          v-show="showErrorGraph && graphLoading"
-          :src="$baseURL + '/img/loading.gif'"
-        >
-        <div
-          v-show="showErrorGraph"
-          id="builderrorsgrapholder"
-          class="graph_holder"
-        />
-      </div>
-
-      <div class="tw-flex tw-flex-row">
-        <img
-          width="20"
-          height="20"
-          :src="$baseURL + '/img/graph.png'"
-          title="graph"
-        >
-        <a
-          id="toggle_warning_graph"
-          class="tw-link tw-link-hover"
-          @click="toggleWarningGraph()"
-        >
-          Show Build Warnings Graph
-        </a>
-      </div>
-      <div style="text-align: center;">
-        <img
-          v-show="showWarningGraph && graphLoading"
-          :src="$baseURL + '/img/loading.gif'"
-        >
-        <div
-          v-show="showWarningGraph"
-          id="buildwarningsgrapholder"
-          class="graph_holder"
-        />
-      </div>
-
-      <div class="tw-flex tw-flex-row">
-        <img
-          width="20"
-          height="20"
-          :src="$baseURL + '/img/graph.png'"
-          title="graph"
-        >
-        <a
-          id="toggle_test_graph"
-          class="tw-link tw-link-hover"
-          @click="toggleTestGraph()"
-        >
-          Show Build Tests Failed Graph
-        </a>
-      </div>
-      <div style="text-align: center;">
-        <img
-          v-show="showTestGraph && graphLoading"
-          :src="$baseURL + '/img/loading.gif'"
-        >
-        <div
-          v-show="showTestGraph"
-          id="buildtestsfailedgrapholder"
-          class="graph_holder"
-        />
-      </div>
-      <br>
-
-      <!-- Relationships -->
-      <div v-if="cdash.hasrelationships">
-        <div class="title-divider">
-          Relationships
-        </div>
-        <div
-          v-for="from in cdash.relationships_from"
-          :key="from.relatedid"
-        >
-          This build {{ from.relationship }} <a
-            class="tw-link tw-link-hover"
-            :href="$baseURL + '/builds/' + from.relatedid"
-          >{{ from.name }}</a>.
-        </div>
-        <div
-          v-for="to in cdash.relationships_to"
-          :key="to.buildid"
-        >
-          <a
-            class="tw-link tw-link-hover"
-            :href="$baseURL + '/builds/' + to.buildid"
-          >{{ to.name }}</a> {{ to.relationship }} this build.
-        </div>
-      </div>
-
-      <!-- Update -->
-      <div v-if="cdash.hasupdate">
-        <div
-          id="Update"
-          class="title-divider"
-        >
-          Stage: Update ({{ cdash.update.nerrors }} errors, {{ cdash.update.nwarnings }} warnings)
-        </div>
-        <br>
-
-        <b>Start Time: </b>{{ cdash.update.starttime }}
-        <br>
-
-        <b>End Time: </b>{{ cdash.update.endtime }}
-        <br>
-
-        <b>Update Command: </b> {{ cdash.update.command }}
-        <br>
-
-        <b>Update Type: </b> {{ cdash.update.type }}
-        <br>
-
-        <b>Number of Updates: </b>
-        <a
-          class="tw-link tw-link-hover"
-          :href="$baseURL + '/builds/' + cdash.build.id + '/update'"
-        >
-          {{ cdash.update.nupdates }}
-        </a>
-        <div v-if="cdash.update.status">
-          <br>
-          <b>Update Status: </b>{{ cdash.update.status }}
-        </div>
-        <br>
-        <br>
-      </div>
-
-      <!-- Configure -->
-      <div v-if="cdash.hasconfigure">
-        <div
-          id="Configure"
-          class="title-divider"
-        >
-          Configure ({{ cdash.configure.nerrors }} errors, {{ cdash.configure.nwarnings }} warnings)
-        </div>
-        <br>
-
-        <b>Start Time: </b>{{ cdash.configure.starttime }}
-        <br>
-
-        <b>End Time: </b>{{ cdash.configure.endtime }}
-        <br>
-
-        <b>Configure Command:</b>
-        <code-box :text="cdash.configure.command" />
-
-        <b>Configure Return Value:</b>
-        <code-box :text="cdash.configure.status" />
-
-        <b>Configure Output:</b>
-
-        <code-box :text="cdash.configure.output" />
-
-        <a
-          id="configure_link"
-          class="tw-link tw-link-hover"
-          :href="$baseURL + '/builds/' + cdash.build.id + '/configure'"
-        >
-          View Configure Summary
-        </a>
-        <br>
-        <br>
-      </div>
-
-      <!-- Build -->
-      <div
-        id="Build"
-        class="title-divider"
-      >
-        Build ({{ cdash.build.nerrors }} errors, {{ cdash.build.nwarnings }} warnings)
-      </div>
-      <br>
-
-      <b>Build command: </b><code-box :text="cdash.build.command" />
-
-      <b>Start Time: </b>{{ cdash.build.starttime }}
-      <br>
-
-      <b>End Time: </b>{{ cdash.build.endtime }}
-      <br>
-      <br>
-
-      <!-- Show the errors -->
-      <div v-for="error in cdash.build.errors">
-        <div v-if="error.sourceline > 0">
-          <hr>
-          <h3>
-            <a>Build Log line {{ error.logline }}</a>
-          </h3>
-          <br>
-          File: <b>{{ error.sourcefile }}</b>
-          Line: <b>{{ error.sourceline }}</b>
-        </div>
-        <code-box
-          v-if="error?.text?.trim()"
-          :text="error.text"
-        />
-
-        <div v-if="error?.stdoutput?.trim() || error?.stderror?.trim()">
-          <br>
-          <b>{{ error.sourcefile }}</b>
-          <code-box
-            v-if="error?.stdoutput?.trim()"
-            :text="error.stdoutput"
-          />
-          <code-box
-            v-if="error?.stderror?.trim()"
-            :text="error.stderror"
-          />
-        </div>
-      </div>
-
-      <a
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
-      >
-        View Errors Summary
-      </a>
-      <br>
-      <br>
-
-      <!--  Warnings -->
-      <div
-        id="Warnings"
-        class="title-divider"
-      >
-        Build Warnings ({{ cdash.build.nwarnings }})
-      </div>
-
-      <div v-for="warning in cdash.build.warnings">
-        <div v-if="warning.sourceline > 0">
-          <hr>
-          <h3><a>Build Log line {{ warning.logline }}</a></h3>
-          <br>
-          File: <b>{{ warning.sourcefile }}</b>
-          Line: <b>{{ warning.sourceline }}</b>
-        </div>
-        <code-box
-          v-if="warning?.text?.trim()"
-          :text="warning.text"
-        />
-
-        <div v-if="warning?.stdoutput?.trim() || warning?.stderror?.trim()">
-          <br>
-          <b>{{ warning.sourcefile }}</b>
-          <code-box
-            v-if="warning?.stdoutput?.trim()"
-            :text="warning.stdoutput"
-          />
-          <code-box
-            v-if="warning?.stderror?.trim()"
-            :text="warning.stderror"
-          />
-        </div>
-      </div>
-      <br>
-
-      <a
-        id="warnings_link"
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/errors'"
-      >
-        View Warnings Summary
-      </a>
-      <br>
-      <br>
-
-      <!-- Test -->
-      <div
-        id="Test"
-        class="title-divider"
-      >
-        Test ({{ cdash.test.npassed }}  passed, {{ cdash.test.nfailed }} failed, {{ cdash.test.nnotrun }} not run)
-      </div>
-      <a
-        id="tests_link"
-        class="tw-link tw-link-hover"
-        :href="$baseURL + '/builds/' + cdash.build.id + '/tests'"
-      >
-        View Tests Summary
-      </a>
-      <br>
-      <br>
-
-      <!-- Coverage -->
-      <div v-if="cdash.hascoverage">
-        <div
-          id="Coverage"
-          class="title-divider"
-        >
-          Coverage ({{ cdash.coverage }}%)
-        </div>
-        <a
-          id="coverage_link"
-          class="tw-link tw-link-hover"
-          :href="$baseURL + '/builds/' + cdash.build.id + '/coverage'"
-        >
-          View Coverage Summary
-        </a>
-        <br>
-        <br>
-      </div>
-    </loading-indicator>
-  </section>
+    </section>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -1011,12 +1016,13 @@ import {
 import CodeBox from './shared/CodeBox.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 import Utils from './shared/Utils';
 
 export default {
   name: 'BuildSummary',
-  components: {BuildSummaryCard, LoadingIndicator, CodeBox, FontAwesomeIcon},
+  components: {BuildSummaryCard, LoadingIndicator, CodeBox, FontAwesomeIcon, BuildSidebar},
 
   props: {
     buildId: {

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -1,52 +1,58 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="targets"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <FilterBuilder
-      filter-type="BuildTargetsFiltersMultiFilterInput"
-      primary-record-name="targets"
-      :initial-filters="initialFilters"
-      :execute-query-link="executeQueryLink"
-      @change-filters="filters => changedFilters = filters"
-    />
-
-    <loading-indicator :is-loading="!build || !targets">
-      <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
-        <CommandGanttChart :commands="formattedCommands" />
-      </div>
-    </loading-indicator>
-
-    <LoadingIndicator :is-loading="!targets">
-      <DataTable
-        v-if="targets.edges.length > 0"
-        :column-groups="[
-          {
-            displayName: 'Targets',
-            width: 100,
-          }
-        ]"
-        :columns="[
-          {
-            name: 'name',
-            displayName: 'Name',
-          },
-          {
-            name: 'type',
-            displayName: 'Type',
-          },
-        ]"
-        :rows="formattedTargetRows"
-        :full-width="true"
-        test-id="targets-table"
+      <FilterBuilder
+        filter-type="BuildTargetsFiltersMultiFilterInput"
+        primary-record-name="targets"
+        :initial-filters="initialFilters"
+        :execute-query-link="executeQueryLink"
+        @change-filters="filters => changedFilters = filters"
       />
-    </LoadingIndicator>
-  </div>
+
+      <loading-indicator :is-loading="!build || !targets">
+        <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
+          <CommandGanttChart :commands="formattedCommands" />
+        </div>
+      </loading-indicator>
+
+      <LoadingIndicator :is-loading="!targets">
+        <DataTable
+          v-if="targets.edges.length > 0"
+          :column-groups="[
+            {
+              displayName: 'Targets',
+              width: 100,
+            }
+          ]"
+          :columns="[
+            {
+              name: 'name',
+              displayName: 'Name',
+            },
+            {
+              name: 'type',
+              displayName: 'Type',
+            },
+          ]"
+          :rows="formattedTargetRows"
+          :full-width="true"
+          test-id="targets-table"
+        />
+      </LoadingIndicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import DataTable from './shared/DataTable.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import CommandGanttChart from './shared/CommandGanttChart.vue';
@@ -59,6 +65,7 @@ export default {
     LoadingIndicator,
     DataTable,
     BuildSummaryCard,
+    BuildSidebar,
   },
 
   props: {

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -1,55 +1,60 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="tests"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <filter-builder
-      filter-type="BuildTestsFiltersMultiFilterInput"
-      primary-record-name="tests"
-      :initial-filters="initialFilters"
-      :execute-query-link="executeQueryLink"
-      @change-filters="filters => changedFilters = filters"
-    />
-    <loading-indicator :is-loading="!tests">
-      <data-table
-        :columns="[
-          ...(hasSubProjects ? [{
-            name: 'subProject',
-            displayName: 'SubProject',
-          }] : []),
-          {
-            name: 'name',
-            displayName: 'Name',
-            expand: true,
-          },
-          {
-            name: 'time',
-            displayName: 'Time',
-          },
-          ...pinnedMeasurementColumns,
-          {
-            name: 'details',
-            displayName: 'Details',
-          },
-          {
-            name: 'status',
-            displayName: 'Status',
-          },
-          ...(showTestTimeStatus ? [{
-            name: 'timeStatus',
-            displayName: 'Time Status',
-          }] : []),
-          {
-            name: 'history',
-            displayName: 'History',
-          },
-        ]"
-        :rows="formattedTestRows"
-        :full-width="true"
-        initial-sort-column="status"
-        test-id="tests-table"
+      <filter-builder
+        filter-type="BuildTestsFiltersMultiFilterInput"
+        primary-record-name="tests"
+        :initial-filters="initialFilters"
+        :execute-query-link="executeQueryLink"
+        @change-filters="filters => changedFilters = filters"
       />
-    </loading-indicator>
-  </div>
+      <loading-indicator :is-loading="!tests">
+        <data-table
+          :columns="[
+            ...(hasSubProjects ? [{
+              name: 'subProject',
+              displayName: 'SubProject',
+            }] : []),
+            {
+              name: 'name',
+              displayName: 'Name',
+              expand: true,
+            },
+            {
+              name: 'time',
+              displayName: 'Time',
+            },
+            ...pinnedMeasurementColumns,
+            {
+              name: 'details',
+              displayName: 'Details',
+            },
+            {
+              name: 'status',
+              displayName: 'Status',
+            },
+            ...(showTestTimeStatus ? [{
+              name: 'timeStatus',
+              displayName: 'Time Status',
+            }] : []),
+            {
+              name: 'history',
+              displayName: 'History',
+            },
+          ]"
+          :rows="formattedTestRows"
+          :full-width="true"
+          initial-sort-column="status"
+          test-id="tests-table"
+        />
+      </loading-indicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -59,6 +64,7 @@ import gql from 'graphql-tag';
 import FilterBuilder from './shared/FilterBuilder.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import {DateTime} from 'luxon';
 
 export default {
@@ -69,6 +75,7 @@ export default {
     LoadingIndicator,
     FilterBuilder,
     DataTable,
+    BuildSidebar,
   },
 
   props: {

--- a/resources/js/vue/components/BuildUpdate.vue
+++ b/resources/js/vue/components/BuildUpdate.vue
@@ -1,126 +1,131 @@
 <template>
-  <section v-if="errored">
-    <p>{{ cdash.error }}</p>
-  </section>
-  <section
-    v-else
-    class="tw-flex tw-flex-col tw-w-full tw-gap-4"
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="update"
   >
-    <loading-indicator :is-loading="loading">
-      <build-summary-card :build-id="cdash.build.buildid" />
+    <section v-if="errored">
+      <p>{{ cdash.error }}</p>
+    </section>
+    <section
+      v-else
+      class="tw-flex tw-flex-col tw-w-full tw-gap-4"
+    >
+      <build-summary-card :build-id="buildId" />
 
-      <div>
-        <div v-if="cdash.update.revision">
-          <b>Revision: </b>
-          <tt v-if="cdash.update.revisionurl.length > 0">
-            <a
-              class="tw-link tw-link-hover tw-link-info"
-              :href="repository?.getComparisonUrl(cdash.update.revision, cdash.update.priorrevision) ?? ''"
-            >{{ cdash.update.revision }}</a>
-          </tt>
-          <tt v-else>
-            {{ cdash.update.revision }}
-          </tt>
-        </div>
-        <div v-if="cdash.update.priorrevision">
-          <b>Prior Revision: </b>
-          <tt v-if="cdash.update.revisiondiff.length > 0">
-            <a
-              class="tw-link tw-link-hover tw-link-info"
-              :href="repository?.getCommitUrl(cdash.update.priorrevision) ?? ''"
-            >{{ cdash.update.priorrevision }}</a>
-          </tt>
-          <tt v-else>
-            {{ cdash.update.priorrevision }}
-          </tt>
-        </div>
-
-        <a
-          class="tw-link tw-link-hover tw-link-info"
-          @click="toggleGraph()"
-        >
-          <span v-text="showGraph ? 'Hide Activity Graph' : 'Show Activity Graph'" />
-        </a>
-        <div v-if="graphLoading">
-          <img
-            id="spinner"
-            :src="$baseURL + '/img/loading.gif'"
-          >
-        </div>
-        <div v-show="graphLoaded && showGraph">
-          <div id="graphoptions" />
-          <div id="graph" />
-          <div
-            id="graph_holder"
-            class="center-text"
-          />
-        </div>
-      </div>
-
-      <h3
-        v-if="cdash.update.status"
-        class="error"
-      >
-        {{ cdash.update.status }}
-      </h3>
-
-      <div v-for="group in cdash.updategroups">
-        <div class="tw-w-full">
-          <div @click="group.hidden = !group.hidden; $forceUpdate()">
-            <font-awesome-icon :icon="group.hidden ? FA.faChevronRight : FA.faChevronDown" />
-            <b>{{ group.description }}</b>
+      <loading-indicator :is-loading="loading">
+        <div>
+          <div v-if="cdash.update.revision">
+            <b>Revision: </b>
+            <tt v-if="cdash.update.revisionurl.length > 0">
+              <a
+                class="tw-link tw-link-hover tw-link-info"
+                :href="repository?.getComparisonUrl(cdash.update.revision, cdash.update.priorrevision) ?? ''"
+              >{{ cdash.update.revision }}</a>
+            </tt>
+            <tt v-else>
+              {{ cdash.update.revision }}
+            </tt>
           </div>
-          <div class="tw-flex tw-flex-col tw-gap-4 tw-ml-8">
-            <div
-              v-for="directory in group.directories"
-              v-show="!group.hidden"
+          <div v-if="cdash.update.priorrevision">
+            <b>Prior Revision: </b>
+            <tt v-if="cdash.update.revisiondiff.length > 0">
+              <a
+                class="tw-link tw-link-hover tw-link-info"
+                :href="repository?.getCommitUrl(cdash.update.priorrevision) ?? ''"
+              >{{ cdash.update.priorrevision }}</a>
+            </tt>
+            <tt v-else>
+              {{ cdash.update.priorrevision }}
+            </tt>
+          </div>
+
+          <a
+            class="tw-link tw-link-hover tw-link-info"
+            @click="toggleGraph()"
+          >
+            <span v-text="showGraph ? 'Hide Activity Graph' : 'Show Activity Graph'" />
+          </a>
+          <div v-if="graphLoading">
+            <img
+              id="spinner"
+              :src="$baseURL + '/img/loading.gif'"
             >
+          </div>
+          <div v-show="graphLoaded && showGraph">
+            <div id="graphoptions" />
+            <div id="graph" />
+            <div
+              id="graph_holder"
+              class="center-text"
+            />
+          </div>
+        </div>
+
+        <h3
+          v-if="cdash.update.status"
+          class="error"
+        >
+          {{ cdash.update.status }}
+        </h3>
+
+        <div v-for="group in cdash.updategroups">
+          <div class="tw-w-full">
+            <div @click="group.hidden = !group.hidden; $forceUpdate()">
+              <font-awesome-icon :icon="group.hidden ? FA.faChevronRight : FA.faChevronDown" />
+              <b>{{ group.description }}</b>
+            </div>
+            <div class="tw-flex tw-flex-col tw-gap-4 tw-ml-8">
               <div
-                @click="directory.hidden = !directory.hidden; $forceUpdate()"
+                v-for="directory in group.directories"
+                v-show="!group.hidden"
               >
-                <font-awesome-icon :icon="directory.hidden ? FA.faChevronRight : FA.faChevronDown" />
-                <tt>{{ directory.name }}</tt>
-              </div>
-              <div class="tw-flex tw-flex-col tw-gap-4 tw-ml-8">
                 <div
-                  v-for="file in directory.files"
-                  v-show="!directory.hidden"
+                  @click="directory.hidden = !directory.hidden; $forceUpdate()"
                 >
-                  <div>
-                    <tt>{{ file.filename }}</tt> Revision:
-                    <a
-                      v-if="file.diffurl"
-                      class="tw-link tw-link-hover tw-link-info"
-                      :href="file.diffurl"
-                    >
-                      <tt>{{ file.revision }}</tt>
-                    </a>
-                    <tt v-else>
-                      {{ file.revision }}
-                    </tt>
-                    <span v-if="file.author">
-                      by
+                  <font-awesome-icon :icon="directory.hidden ? FA.faChevronRight : FA.faChevronDown" />
+                  <tt>{{ directory.name }}</tt>
+                </div>
+                <div class="tw-flex tw-flex-col tw-gap-4 tw-ml-8">
+                  <div
+                    v-for="file in directory.files"
+                    v-show="!directory.hidden"
+                  >
+                    <div>
+                      <tt>{{ file.filename }}</tt> Revision:
                       <a
-                        v-if="file.email"
+                        v-if="file.diffurl"
                         class="tw-link tw-link-hover tw-link-info"
-                        :href="'mailto:' + file.email"
+                        :href="file.diffurl"
                       >
-                        {{ file.author }}
+                        <tt>{{ file.revision }}</tt>
                       </a>
-                      <span v-else>
-                        {{ file.author }}
+                      <tt v-else>
+                        {{ file.revision }}
+                      </tt>
+                      <span v-if="file.author">
+                        by
+                        <a
+                          v-if="file.email"
+                          class="tw-link tw-link-hover tw-link-info"
+                          :href="'mailto:' + file.email"
+                        >
+                          {{ file.author }}
+                        </a>
+                        <span v-else>
+                          {{ file.author }}
+                        </span>
                       </span>
-                    </span>
+                    </div>
+                    <code-box :text="file.log" />
                   </div>
-                  <code-box :text="file.log" />
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </loading-indicator>
-  </section>
+      </loading-indicator>
+    </section>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -128,6 +133,7 @@ import $ from 'jquery';
 import ApiLoader from './shared/ApiLoader';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 import CodeBox from './shared/CodeBox.vue';
 import {faChevronDown, faChevronRight} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
@@ -135,9 +141,14 @@ import {getRepository} from './shared/RepositoryIntegrations';
 
 export default {
   name: 'BuildUpdate',
-  components: {FontAwesomeIcon, CodeBox, LoadingIndicator, BuildSummaryCard},
+  components: {FontAwesomeIcon, CodeBox, LoadingIndicator, BuildSummaryCard, BuildSidebar},
 
   props: {
+    buildId: {
+      type: Number,
+      required: true,
+    },
+
     repositoryType: {
       type: String,
       required: true,
@@ -152,7 +163,6 @@ export default {
   data() {
     return {
       // API results.
-      buildid: null,
       cdash: {},
       loading: true,
       errored: false,
@@ -191,8 +201,7 @@ export default {
     window.jQuery = $;
     await import('flot/dist/es5/jquery.flot');
 
-    this.buildid = window.location.pathname.split('/').at(-2);
-    const endpoint_path = `/api/v1/viewUpdate.php?buildid=${this.buildid}`;
+    const endpoint_path = `/api/v1/viewUpdate.php?buildid=${this.buildId}`;
     ApiLoader.loadPageData(this, endpoint_path);
   },
 
@@ -207,7 +216,7 @@ export default {
     loadGraph: function() {
       this.graphLoading = true;
       this.$axios
-        .get(`/api/v1/buildUpdateGraph.php?buildid=${this.buildid}`)
+        .get(`/api/v1/buildUpdateGraph.php?buildid=${this.buildId}`)
         .then(response => {
           this.initializeGraph(response.data);
           this.graphLoaded = true;

--- a/resources/js/vue/components/CoverageFilePage.vue
+++ b/resources/js/vue/components/CoverageFilePage.vue
@@ -1,27 +1,32 @@
 <template>
-  <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-    <BuildSummaryCard :build-id="buildId" />
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="coverage"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
 
-    <LoadingIndicator :is-loading="!coverage">
-      <div class="tw-border-base-300 tw-bg-base-200 tw-border tw-rounded tw-p-2 tw-flex tw-flex-row tw-w-full tw-gap-4">
-        <div class="tw-font-mono">
-          {{ coverage.filePath }}
+      <LoadingIndicator :is-loading="!coverage">
+        <div class="tw-border-base-300 tw-bg-base-200 tw-border tw-rounded tw-p-2 tw-flex tw-flex-row tw-w-full tw-gap-4">
+          <div class="tw-font-mono">
+            {{ coverage.filePath }}
+          </div>
+          <div class="tw-flex-grow" />
+          <div>
+            {{ coverage.linesOfCodeTested }} / {{ totalLines }} lines covered
+            <template v-if="!isNaN(percentLinesCovered)">
+              ({{ percentLinesCovered }}%)
+            </template>
+          </div>
         </div>
-        <div class="tw-flex-grow" />
-        <div>
-          {{ coverage.linesOfCodeTested }} / {{ totalLines }} lines covered
-          <template v-if="!isNaN(percentLinesCovered)">
-            ({{ percentLinesCovered }}%)
-          </template>
-        </div>
-      </div>
 
-      <CoverageViewer
-        :file="coverage.file"
-        :coverage-lines="coverage.coveredLines"
-      />
-    </LoadingIndicator>
-  </div>
+        <CoverageViewer
+          :file="coverage.file"
+          :coverage-lines="coverage.coveredLines"
+        />
+      </LoadingIndicator>
+    </div>
+  </BuildSidebar>
 </template>
 
 <script>
@@ -29,9 +34,10 @@ import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import gql from 'graphql-tag';
 import CoverageViewer from './shared/CoverageViewer.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 
 export default {
-  components: {CoverageViewer, LoadingIndicator, BuildSummaryCard},
+  components: {BuildSidebar, CoverageViewer, LoadingIndicator, BuildSummaryCard},
 
   props: {
     buildId: {

--- a/resources/js/vue/components/ViewDynamicAnalysis.vue
+++ b/resources/js/vue/components/ViewDynamicAnalysis.vue
@@ -1,96 +1,102 @@
 <template>
-  <section v-if="errored">
-    <p>{{ cdash.error }}</p>
-  </section>
-  <section v-else>
-    <BuildSummaryCard :build-id="buildid" />
+  <BuildSidebar
+    :build-id="buildid"
+    active-tab="dynamic_analysis"
+  >
+    <section v-if="errored">
+      <p>{{ cdash.error }}</p>
+    </section>
+    <section v-else>
+      <BuildSummaryCard :build-id="buildid" />
 
-    <loading-indicator :is-loading="loading">
-      <div class="buildgroup">
-        <table
-          cellspacing="0"
-          class="tabb striped"
-          width="100%"
-        >
-          <thead>
-            <tr class="table-heading1">
-              <td
-                class="center-text botl"
-                colspan="100"
-              >
-                Dynamic Analysis
-              </td>
-            </tr>
-            <tr class="table-heading">
-              <th class="column-header">
-                Name
-              </th>
-              <th class="column-header">
-                Status
-              </th>
-              <th
-                v-for="defecttype in cdash.defecttypes"
-                class="column-header"
-              >
-                {{ defecttype.type }}
-              </th>
-              <th
-                v-if="cdash.displaylabels"
-                class="column-header"
-              >
-                Labels
-              </th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <tr
-              v-for="DA in cdash.dynamicanalyses"
-              align="center"
-            >
-              <td align="left">
-                <a
-                  class="cdash-link"
-                  :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id"
+      <loading-indicator :is-loading="loading">
+        <div class="buildgroup">
+          <table
+            cellspacing="0"
+            class="tabb striped"
+            width="100%"
+          >
+            <thead>
+              <tr class="table-heading1">
+                <td
+                  class="center-text botl"
+                  colspan="100"
                 >
-                  {{ DA.name }}
-                </a>
-              </td>
+                  Dynamic Analysis
+                </td>
+              </tr>
+              <tr class="table-heading">
+                <th class="column-header">
+                  Name
+                </th>
+                <th class="column-header">
+                  Status
+                </th>
+                <th
+                  v-for="defecttype in cdash.defecttypes"
+                  class="column-header"
+                >
+                  {{ defecttype.type }}
+                </th>
+                <th
+                  v-if="cdash.displaylabels"
+                  class="column-header"
+                >
+                  Labels
+                </th>
+              </tr>
+            </thead>
 
-              <td :class="DA.status === 'Passed' ? 'normal' : 'error'">
-                {{ DA.status }}
-              </td>
-
-              <!-- Show how many defects of each type were found for this test -->
-              <td
-                v-for="numdefects in DA.defects"
-                :class="{warning: numdefects > 0}"
+            <tbody>
+              <tr
+                v-for="DA in cdash.dynamicanalyses"
+                align="center"
               >
-                <span v-if="numdefects > 0">
-                  {{ numdefects }}
-                </span>
-              </td>
+                <td align="left">
+                  <a
+                    class="cdash-link"
+                    :href="$baseURL + '/viewDynamicAnalysisFile.php?id=' + DA.id"
+                  >
+                    {{ DA.name }}
+                  </a>
+                </td>
 
-              <!-- Labels -->
-              <td v-if="cdash.displaylabels">
-                {{ DA.labels }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </loading-indicator>
-  </section>
+                <td :class="DA.status === 'Passed' ? 'normal' : 'error'">
+                  {{ DA.status }}
+                </td>
+
+                <!-- Show how many defects of each type were found for this test -->
+                <td
+                  v-for="numdefects in DA.defects"
+                  :class="{warning: numdefects > 0}"
+                >
+                  <span v-if="numdefects > 0">
+                    {{ numdefects }}
+                  </span>
+                </td>
+
+                <!-- Labels -->
+                <td v-if="cdash.displaylabels">
+                  {{ DA.labels }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </loading-indicator>
+    </section>
+  </BuildSidebar>
 </template>
 
 <script>
 import ApiLoader from './shared/ApiLoader';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
 
 export default {
   name: 'ViewDynamicAnalysis',
-  components: {BuildSummaryCard, LoadingIndicator},
+  components: {BuildSidebar, BuildSummaryCard, LoadingIndicator},
 
   props: {
     buildid: {

--- a/resources/js/vue/components/shared/BuildSidebar.vue
+++ b/resources/js/vue/components/shared/BuildSidebar.vue
@@ -1,0 +1,327 @@
+<template>
+  <div
+    class="tw-flex tw-w-full tw-items-start"
+    :data-test="!build ? 'sidebar-loading' : 'sidebar-loaded'"
+  >
+    <aside class="tw-shrink-0 tw-bg-base-200 tw-border tw-border-base-300 tw-rounded-lg tw-overflow-hidden tw-sticky tw-top-[100px] tw-max-h-[calc(100vh-100px)] tw-overflow-y-auto tw-z-10">
+      <nav class="tw-flex tw-flex-col tw-py-2">
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}`"
+          title="Summary"
+          :icon="FA.faCircleInfo"
+          :selected="activeTab === 'summary'"
+          :disabled="summaryDisabled"
+          data-test="sidebar-summary"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/update`"
+          title="Update"
+          :icon="FA.faCodePullRequest"
+          :selected="activeTab === 'update'"
+          :disabled="updateDisabled"
+          data-test="sidebar-update"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/configure`"
+          title="Configure"
+          :icon="FA.faWrench"
+          :selected="activeTab === 'configure'"
+          :disabled="configureDisabled"
+          :badges="configureBadges"
+          data-test="sidebar-configure"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/errors`"
+          title="Build Errors"
+          :icon="FA.faCircleExclamation"
+          :selected="activeTab === 'errors'"
+          :disabled="errorsDisabled"
+          :badges="errorsBadges"
+          data-test="sidebar-build"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/tests`"
+          title="Tests"
+          :icon="FA.faFlask"
+          :selected="activeTab === 'tests'"
+          :disabled="testsDisabled"
+          :badges="testsBadges"
+          data-test="sidebar-tests"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/coverage`"
+          title="Coverage"
+          :icon="FA.faUmbrella"
+          :selected="activeTab === 'coverage'"
+          :disabled="coverageDisabled"
+          data-test="sidebar-coverage"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/dynamic_analysis`"
+          title="Dynamic Analysis"
+          :icon="FA.faBug"
+          :selected="activeTab === 'dynamic_analysis'"
+          :disabled="dynamicAnalysisDisabled"
+          data-test="sidebar-dynamic-analysis"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/files`"
+          title="Uploads"
+          :icon="FA.faFileArrowUp"
+          :selected="activeTab === 'files'"
+          :disabled="filesDisabled"
+          data-test="sidebar-files"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/notes`"
+          title="Notes"
+          :icon="FA.faNoteSticky"
+          :selected="activeTab === 'notes'"
+          :disabled="notesDisabled"
+          data-test="sidebar-notes"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/commands`"
+          title="Instrumentation"
+          :icon="FA.faGaugeHigh"
+          :selected="activeTab === 'instrumentation'"
+          :disabled="commandsDisabled"
+          data-test="sidebar-instrumentation"
+        />
+        <build-sidebar-item
+          :href="`${$baseURL}/builds/${buildId}/targets`"
+          title="Targets"
+          :icon="FA.faBullseye"
+          :selected="activeTab === 'targets'"
+          :disabled="targetsDisabled"
+          data-test="sidebar-targets"
+        />
+      </nav>
+    </aside>
+
+    <main class="tw-flex-grow tw-pl-4 tw-min-w-0">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<script>
+import gql from 'graphql-tag';
+import BuildSidebarItem from './BuildSidebarItem.vue';
+import {
+  faCircleInfo,
+  faCodePullRequest,
+  faWrench,
+  faCircleExclamation,
+  faTriangleExclamation,
+  faFlask,
+  faUmbrella,
+  faBug,
+  faFileArrowUp,
+  faNoteSticky,
+  faGaugeHigh,
+  faBullseye,
+} from '@fortawesome/free-solid-svg-icons';
+
+export default {
+  name: 'BuildSidebar',
+  components: {
+    BuildSidebarItem,
+  },
+  props: {
+    buildId: {
+      type: Number,
+      required: true,
+    },
+    activeTab: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      build: null,
+    };
+  },
+  apollo: {
+    build: {
+      query: gql`
+        query($buildid: ID) {
+          build(id: $buildid) {
+            id
+            updateStep {
+              id
+            }
+            configureWarningsCount
+            configureErrorsCount
+            buildWarningsCount
+            buildErrorsCount
+            passedTestsCount
+            notRunTestsCount
+            failedTestsCount
+            coverage {
+              pageInfo {
+                total
+              }
+            }
+            dynamicAnalyses {
+              pageInfo {
+                total
+              }
+            }
+            files {
+              pageInfo {
+                total
+              }
+            }
+            urls {
+              pageInfo {
+                total
+              }
+            }
+            notes {
+              pageInfo {
+                total
+              }
+            }
+            commands {
+              pageInfo {
+                total
+              }
+            }
+            targets {
+              pageInfo {
+                total
+              }
+            }
+          }
+        }
+      `,
+      variables() {
+        return {
+          buildid: this.buildId,
+        };
+      },
+    },
+  },
+  computed: {
+    FA() {
+      return {
+        faCircleInfo,
+        faCodePullRequest,
+        faWrench,
+        faCircleExclamation,
+        faTriangleExclamation,
+        faFlask,
+        faUmbrella,
+        faBug,
+        faFileArrowUp,
+        faNoteSticky,
+        faGaugeHigh,
+        faBullseye,
+      };
+    },
+    summaryDisabled() {
+      return !this.build;
+    },
+    updateDisabled() {
+      return !this.build || this.build.updateStep === null;
+    },
+    configureDisabled() {
+      return !this.build || (this.build.configureWarningsCount === -1 && this.build.configureErrorsCount === -1);
+    },
+    errorsDisabled() {
+      return !this.build || (this.build.buildWarningsCount === -1 && this.build.buildErrorsCount === -1);
+    },
+    testsDisabled() {
+      return !this.build || (
+        this.build.failedTestsCount + this.build.notRunTestsCount + this.build.passedTestsCount <= 0
+      );
+    },
+    coverageDisabled() {
+      return !this.build || !this.build.coverage || this.build.coverage.pageInfo.total === 0;
+    },
+    dynamicAnalysisDisabled() {
+      return !this.build || !this.build.dynamicAnalyses || this.build.dynamicAnalyses.pageInfo.total === 0;
+    },
+    filesDisabled() {
+      if (!this.build) {
+        return true;
+      }
+      const hasFiles = this.build.files && this.build.files.pageInfo.total > 0;
+      const hasUrls = this.build.urls && this.build.urls.pageInfo.total > 0;
+      return !hasFiles && !hasUrls;
+    },
+    notesDisabled() {
+      return !this.build || !this.build.notes || this.build.notes.pageInfo.total === 0;
+    },
+    commandsDisabled() {
+      return !this.build || !this.build.commands || this.build.commands.pageInfo.total === 0;
+    },
+    targetsDisabled() {
+      return !this.build || !this.build.targets || this.build.targets.pageInfo.total === 0;
+    },
+    errorsBadges() {
+      if (!this.build) {
+        return [];
+      }
+      const badges = [];
+      if (this.build.buildErrorsCount > 0) {
+        badges.push({
+          count: this.build.buildErrorsCount,
+          icon: this.FA.faCircleExclamation,
+          colorClass: 'tw-bg-error',
+          textClass: 'tw-text-error-content',
+        });
+      }
+      if (this.build.buildWarningsCount > 0) {
+        badges.push({
+          count: this.build.buildWarningsCount,
+          icon: this.FA.faTriangleExclamation,
+          colorClass: 'tw-bg-warning',
+          textClass: 'tw-text-warning-content',
+        });
+      }
+      return badges;
+    },
+    configureBadges() {
+      if (!this.build) {
+        return [];
+      }
+      const badges = [];
+      if (this.build.configureErrorsCount > 0) {
+        badges.push({
+          count: this.build.configureErrorsCount,
+          icon: this.FA.faCircleExclamation,
+          colorClass: 'tw-bg-error',
+          textClass: 'tw-text-error-content',
+        });
+      }
+      if (this.build.configureWarningsCount > 0) {
+        badges.push({
+          count: this.build.configureWarningsCount,
+          icon: this.FA.faTriangleExclamation,
+          colorClass: 'tw-bg-warning',
+          textClass: 'tw-text-warning-content',
+        });
+      }
+      return badges;
+    },
+    testsBadges() {
+      if (!this.build) {
+        return [];
+      }
+      const badges = [];
+      if (this.build.failedTestsCount > 0) {
+        badges.push({
+          count: this.build.failedTestsCount,
+          icon: this.FA.faCircleExclamation,
+          colorClass: 'tw-bg-error',
+          textClass: 'tw-text-error-content',
+        });
+      }
+      return badges;
+    },
+  },
+};
+</script>

--- a/resources/js/vue/components/shared/BuildSidebarItem.vue
+++ b/resources/js/vue/components/shared/BuildSidebarItem.vue
@@ -1,0 +1,80 @@
+<template>
+  <component
+    :is="disabled ? 'div' : 'a'"
+    :href="disabled ? undefined : href"
+    class="tw-flex tw-flex-col tw-items-center tw-justify-center tw-p-2 tw-transition-colors tw-text-base-content"
+    :class="{
+      'tw-bg-base-300': selected && !disabled,
+      'hover:tw-bg-base-300 tw-cursor-pointer': !disabled && !selected,
+      'tw-opacity-40 tw-cursor-not-allowed': disabled,
+    }"
+    :title="title"
+  >
+    <div class="tw-relative">
+      <font-awesome-icon
+        :icon="icon"
+        class="tw-w-5 tw-h-5 tw-mb-1"
+      />
+      <div
+        v-if="badges && badges.length > 0"
+        class="tw-absolute -tw-top-1.5 -tw-right-5 tw-flex tw-flex-col tw-gap-0.5 tw-items-center"
+      >
+        <div
+          v-for="(badge, i) in badges"
+          :key="i"
+          class="tw-flex tw-items-center tw-justify-center tw-min-w-[1rem] tw-h-3.5 tw-px-1 tw-text-[8px] tw-font-bold tw-rounded-full tw-gap-0.5"
+          :class="[badge.colorClass, badge.textClass || 'tw-text-white']"
+        >
+          <font-awesome-icon
+            v-if="badge.icon"
+            :icon="badge.icon"
+          />
+          <span>{{ badge.count }}</span>
+        </div>
+      </div>
+    </div>
+    <span
+      class="tw-text-[10px] tw-text-center tw-leading-tight"
+      :class="{'tw-font-bold': selected && !disabled}"
+    >
+      {{ title }}
+    </span>
+  </component>
+</template>
+
+<script>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+export default {
+  name: 'BuildSidebarItem',
+  components: {
+    FontAwesomeIcon,
+  },
+  props: {
+    href: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    icon: {
+      type: Object,
+      required: true,
+    },
+    selected: {
+      type: Boolean,
+      default: false,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    badges: {
+      type: Array,
+      default: () => [],
+    },
+  },
+};
+</script>

--- a/tests/Browser/Pages/BuildSidebarComponentTest.php
+++ b/tests/Browser/Pages/BuildSidebarComponentTest.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use App\Enums\BuildCommandType;
+use App\Enums\TargetType;
+use App\Http\Submission\Traits\UpdatesSiteInformation;
+use App\Models\Build;
+use App\Models\BuildUpdate;
+use App\Models\CoverageFile;
+use App\Models\DynamicAnalysis;
+use App\Models\Note;
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\SiteInformation;
+use App\Models\UploadFile;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\BrowserTestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+
+class BuildSidebarComponentTest extends BrowserTestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use UpdatesSiteInformation;
+
+    private Project $project;
+    private Site $site;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        $this->site = $this->makeSite();
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+    }
+
+    public function tearDown(): void
+    {
+        $this->project->delete();
+        $this->site->delete();
+
+        parent::tearDown();
+    }
+
+    private function assertDisabled(Browser $browser, string $url, string $selector): void
+    {
+        $browser->visit($url)
+            ->waitFor('@sidebar-loaded')
+            ->assertAttributeMissing($selector, 'href');
+    }
+
+    private function assertNotDisabled(Browser $browser, string $url, string $selector, string $expectedLink): void
+    {
+        $browser->visit($url)
+            ->waitFor('@sidebar-loaded')
+            ->assertAttributeContains($selector, 'href', $expectedLink);
+    }
+
+    public function testSummaryItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-summary', "/builds/{$build->id}");
+        });
+    }
+
+    public function testUpdateItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-update');
+
+            /** @var BuildUpdate $update */
+            $update = BuildUpdate::create([
+                'command' => Str::uuid()->toString(),
+                'type' => 'GIT',
+                'status' => Str::uuid()->toString(),
+                'revision' => Str::uuid()->toString(),
+                'priorrevision' => Str::uuid()->toString(),
+                'path' => Str::uuid()->toString(),
+            ]);
+            $build->updateStep()->associate($update)->save();
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-update', "/builds/{$build->id}/update");
+        });
+    }
+
+    public function testConfigureItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-configure');
+
+            $build->configurewarnings = 10;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-configure', "/builds/{$build->id}/configure");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-configure', '10');
+
+            $build->configurewarnings = -1;
+            $build->configureerrors = 5;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-configure', "/builds/{$build->id}/configure");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-configure', '5');
+
+            $build->configurewarnings = 10;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-configure', "/builds/{$build->id}/configure");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-configure', '10')
+                ->assertSeeIn('@sidebar-configure', '5');
+        });
+    }
+
+    public function testBuildItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-build');
+
+            $build->buildwarnings = 10;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-build', "/builds/{$build->id}/errors");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-build', '10');
+
+            $build->buildwarnings = -1;
+            $build->builderrors = 5;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-build', "/builds/{$build->id}/errors");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-build', '5');
+
+            $build->buildwarnings = 10;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-build', "/builds/{$build->id}/errors");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-build', '10')
+                ->assertSeeIn('@sidebar-build', '5');
+        });
+    }
+
+    public function testTestsItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-tests');
+
+            $build->testpassed = 10;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-tests', "/builds/{$build->id}/tests");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertDontSeeIn('@sidebar-tests', '10');
+
+            $build->testpassed = 0;
+            $build->testnotrun = 7;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-tests', "/builds/{$build->id}/tests");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertDontSeeIn('@sidebar-tests', '10');
+
+            $build->testnotrun = 0;
+            $build->testfailed = 5;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-tests', "/builds/{$build->id}/tests");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-tests', '5');
+
+            $build->testpassed = 10;
+            $build->testnotrun = 7;
+            $build->testfailed = 5;
+            $build->save();
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-tests', "/builds/{$build->id}/tests");
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-tests', '5');
+        });
+    }
+
+    public function testCoverageItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-coverage');
+
+            $coverageFile = CoverageFile::firstOrCreate([
+                'fullpath' => Str::uuid()->toString(),
+                'file' => Str::uuid()->toString(),
+                'crc32' => 0,
+            ]);
+            $build->coverageResults()->create([
+                'fileid' => $coverageFile->id,
+                'locuntested' => 10,
+                'loctested' => 10,
+                'branchesuntested' => 0,
+                'branchestested' => 0,
+            ]);
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-coverage', "/builds/{$build->id}/coverage");
+        });
+    }
+
+    public function testDynamicAnalysisItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-dynamic-analysis');
+
+            $build->dynamicAnalyses()->save(DynamicAnalysis::factory()->make());
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-dynamic-analysis', "/builds/{$build->id}/dynamic_analysis");
+        });
+    }
+
+    public function testFilesItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-files');
+
+            $build->uploadedFiles()->attach(
+                UploadFile::create([
+                    'filename' => Str::uuid()->toString(),
+                    'sha1sum' => Str::uuid()->toString(),
+                    'filesize' => 12345,
+                    'isurl' => false,
+                ])
+            );
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-files', "/builds/{$build->id}/files");
+
+            $build->uploadedFiles()->delete();
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-files');
+
+            $build->uploadedFiles()->attach(
+                UploadFile::create([
+                    'filename' => fake()->url(),
+                    'sha1sum' => Str::uuid()->toString(),
+                    'isurl' => true,
+                ])
+            );
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-files', "/builds/{$build->id}/files");
+        });
+    }
+
+    public function testNotesItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-notes');
+
+            $build->notes()->attach(
+                Note::create([
+                    'name' => Str::uuid()->toString(),
+                    'text' => Str::uuid()->toString(),
+                ])
+            );
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-notes', "/builds/{$build->id}/notes");
+        });
+    }
+
+    public function testInstrumentationItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-instrumentation');
+
+            $build->commands()->create([
+                'type' => BuildCommandType::CUSTOM,
+                'starttime' => Carbon::now(),
+                'duration' => 12345,
+                'command' => Str::random(10),
+                'result' => Str::random(10),
+                'source' => Str::random(10),
+                'language' => Str::random(10),
+                'config' => Str::random(10),
+                'workingdirectory' => Str::uuid()->toString(),
+            ]);
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-instrumentation', "/builds/{$build->id}/commands");
+        });
+    }
+
+    public function testTargetsItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-targets');
+
+            $build->targets()->create([
+                'name' => Str::uuid()->toString(),
+                'type' => TargetType::UNKNOWN,
+            ]);
+
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-targets', "/builds/{$build->id}/targets");
+        });
+    }
+}


### PR DESCRIPTION
It's currently difficult to navigate between parts of a build.  This addresses the issue by adding a sidebar to all build pages with a list of links to each step.  I plan to continue this work by overhauling the build summary page in the near future.

<img width="2830" height="1910" alt="image" src="https://github.com/user-attachments/assets/27161351-01fa-4cf4-98a4-e2bae16a952c" />
