### PR TITLE
GraphQL: Don't validate URLs on serialization

### DIFF
--- a/app/GraphQL/Scalars/Url.php
+++ b/app/GraphQL/Scalars/Url.php
@@ -25,16 +25,10 @@ final class Url extends ScalarType
 
     /**
      * Serializes an internal value to include in a response.
-     *
-     * @throws InvariantViolation
      */
     public function serialize(mixed $value): string
     {
-        if (!$this->validate($value)) {
-            throw new InvariantViolation("Could not serialize {$value} as URL.");
-        }
-
-        return $this->parseValue($value);
+        return (string) $value;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -459,7 +459,7 @@ parameters:
 		-
 			rawMessage: Cannot cast mixed to string.
 			identifier: cast.string
-			count: 1
+			count: 2
 			path: app/GraphQL/Scalars/Url.php
 
 		-
@@ -471,7 +471,7 @@ parameters:
 		-
 			rawMessage: 'Part $value (mixed) of encapsed string cannot be cast to string.'
 			identifier: encapsedStringPart.nonString
-			count: 2
+			count: 1
 			path: app/GraphQL/Scalars/Url.php
 
 		-

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -120,6 +120,7 @@ class ProjectTypeTest extends TestCase
             ['description', 'abc', 'description', 'abc'],
             ['description', null, 'description', null],
             ['homeurl', 'https://cdash.org', 'homeurl', 'https://cdash.org'],
+            ['homeurl', 'cdash.org', 'homeurl', 'cdash.org'],
             ['homeurl', null, 'homeurl', null],
             ['homeurl', 'https://cdash.org', 'homeUrl', 'https://cdash.org'],
             ['homeurl', null, 'homeUrl', null],


### PR DESCRIPTION
Existing databases may contain incomplete URLs.  This commit removes the validation on URL serialization, meaning that URL-typed GraphQL fields will return any string the database contains.  Validation will still occur when providing a value to a URL field in a mutation.