### PR TITLE
Linkify build error output

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -41,6 +41,8 @@ final class BuildController extends AbstractBuildController
 
         $params = [
             'build-id' => $this->build->Id,
+            'repository-type' => $this->project->CvsViewerType,
+            'repository-url' => $this->project->CvsUrl,
         ];
 
         $onlyNewErrors = $request->has('onlydeltap');

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "autoprefixer": "^10.4.24",
         "axios": "^1.13",
         "bootstrap": "^4.6.2",
+        "core-js": "^3.49.0",
         "d3": "^3.5.17",
         "daisyui": "^4.12.23",
         "echarts": "^6.0.0",
@@ -96,6 +97,7 @@
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.9.tgz",
       "integrity": "sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -179,6 +181,7 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
       "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -1919,6 +1922,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1942,6 +1946,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2210,6 +2215,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
       "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -4923,6 +4929,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4992,6 +4999,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5364,6 +5372,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -5397,6 +5406,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -5919,6 +5929,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6562,6 +6573,17 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.33.2",
@@ -7363,7 +7385,8 @@
     "node_modules/d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg=="
+      "integrity": "sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg==",
+      "peer": true
     },
     "node_modules/daisyui": {
       "version": "4.12.23",
@@ -7969,6 +7992,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -8082,6 +8106,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9626,6 +9651,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -10699,6 +10725,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -12594,7 +12621,8 @@
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
     },
     "node_modules/jquery-ui-dist": {
       "version": "1.13.3",
@@ -12703,6 +12731,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -14515,6 +14544,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15891,6 +15921,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17154,6 +17185,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17672,6 +17704,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",
@@ -17710,7 +17743,6 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -17735,7 +17767,6 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -17951,6 +17982,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17998,6 +18030,7 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "autoprefixer": "^10.4.24",
     "axios": "^1.13",
     "bootstrap": "^4.6.2",
+    "core-js": "^3.49.0",
     "d3": "^3.5.17",
     "daisyui": "^4.12.23",
     "echarts": "^6.0.0",

--- a/resources/js/vue/components/BuildBuildPage.vue
+++ b/resources/js/vue/components/BuildBuildPage.vue
@@ -102,6 +102,8 @@
                 :previous-build-id="buildIdsToPreviousBuildIds[parseInt(childBuild.id)] ?? null"
                 :show-new-errors="showNewErrors"
                 :show-fixed-errors="showFixedErrors"
+                :repository-type="repositoryType"
+                :repository-url="repositoryUrl"
               />
             </div>
           </details>
@@ -112,6 +114,8 @@
             :previous-build-id="previousBuildId"
             :show-new-errors="showNewErrors"
             :show-fixed-errors="showFixedErrors"
+            :repository-type="repositoryType"
+            :repository-url="repositoryUrl"
           />
         </div>
       </loading-indicator>
@@ -185,6 +189,16 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+
+    repositoryType: {
+      type: [String, null],
+      required: true,
+    },
+
+    repositoryUrl: {
+      type: [String, null],
+      required: true,
     },
   },
 

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
@@ -32,6 +32,7 @@
       <code-box
         v-if="showStdError"
         :text="buildError.stdError"
+        :links="getLinksFromText(buildError.stdError)"
       />
     </div>
 
@@ -46,6 +47,7 @@
       <code-box
         v-if="showStdOutput"
         :text="buildError.stdOutput"
+        :links="getLinksFromText(buildError.stdOutput)"
       />
     </div>
 
@@ -100,6 +102,8 @@ import {
   faTriangleExclamation,
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
+import {getRepository} from '../shared/RepositoryIntegrations';
+import 'core-js/actual/regexp/escape';
 
 export default {
   components: {FontAwesomeIcon, CodeBox},
@@ -108,6 +112,27 @@ export default {
     buildError: {
       type: Object,
       required: true,
+    },
+
+    sourceDirectory: {
+      type: [String, null],
+      required: true,
+    },
+
+    repositoryType: {
+      type: [String, null],
+      required: true,
+    },
+
+    repositoryUrl: {
+      type: [String, null],
+      required: true,
+    },
+
+    revision: {
+      type: String,
+      required: false,
+      default: undefined,
     },
   },
 
@@ -136,6 +161,36 @@ export default {
      */
     shouldShowStringByDefault(str) {
       return [...str.matchAll(/\r\n|\r|\n/g).take(21)].length <= 20;
+    },
+
+    getLinksFromText(text) {
+      if (!text || !this.repositoryType || !this.repositoryUrl) {
+        return new Map();
+      }
+
+      const regexPrefixes = [
+        ...(this.sourceDirectory ? [`${RegExp.escape(this.sourceDirectory)}/`] : []),
+        `${RegExp.escape('/.../')}[^/]+/`, // CTest includes the repository name in the path.
+      ];
+
+      const matches = text.match(new RegExp(`(${regexPrefixes.join('|')})[^:]*:[0-9]+:[0-9]+`, 'g'));
+      const repository = getRepository(this.repositoryType, this.repositoryUrl);
+
+      if (!repository || !matches) {
+        return new Map();
+      }
+
+      return new Map(
+        matches.map((match) => {
+          let filePath = match.replace(new RegExp(`(${regexPrefixes.join('|')})`), '');
+          filePath = filePath.split(':')[0]; // Trim off the line:col anchor.
+
+          return [
+            match,
+            repository.getFileUrl(this.revision ?? 'main', filePath),
+          ];
+        }),
+      );
     },
   },
 };

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
@@ -20,7 +20,13 @@
             :key="buildError.id"
             class="tw-p-2 tw-border-2 tw-rounded-md"
           >
-            <build-error-item :build-error="buildError" />
+            <build-error-item
+              :build-error="buildError"
+              :source-directory="build.sourceDirectory"
+              :repository-type="repositoryType"
+              :repository-url="repositoryUrl"
+              :revision="build.updateStep?.revision"
+            />
           </div>
         </div>
       </div>
@@ -37,7 +43,13 @@
             :key="buildWarning.id"
             class="tw-p-2 tw-border-2 tw-rounded-md"
           >
-            <build-error-item :build-error="buildWarning" />
+            <build-error-item
+              :build-error="buildWarning"
+              :source-directory="build.sourceDirectory"
+              :repository-type="repositoryType"
+              :repository-url="repositoryUrl"
+              :revision="build.updateStep?.revision"
+            />
           </div>
         </div>
       </div>
@@ -82,6 +94,7 @@ const BUILD_QUERY = gql`
   query($buildid: ID) {
     build(id: $buildid) {
       id
+      sourceDirectory
       buildWarnings: buildErrors(filters: {
         eq: {
           type: WARNING
@@ -95,6 +108,10 @@ const BUILD_QUERY = gql`
         }
       }, first: 100000) {
         ${BUILD_ERROR_FIELDS}
+      }
+      updateStep {
+        id
+        revision
       }
     }
   }
@@ -125,6 +142,16 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+
+    repositoryType: {
+      type: [String, null],
+      required: true,
+    },
+
+    repositoryUrl: {
+      type: [String, null],
+      required: true,
     },
   },
 

--- a/resources/js/vue/components/shared/CodeBox.vue
+++ b/resources/js/vue/components/shared/CodeBox.vue
@@ -2,8 +2,16 @@
   <pre
     class="tw-font-mono tw-bg-gray-100 tw-p-2 tw-whitespace-pre-wrap tw-break-all tw-overflow-hidden"
     :class="{ 'tw-border': bordered, 'tw-rounded': bordered }"
-    v-html="ansiText"
-  />
+  ><template
+    v-for="segment in textSegments"
+  ><a
+    v-if="segment.href"
+    class="tw-link tw-link-hover tw-link-info"
+    :href="segment.href"
+  >{{ segment.text }}</a><span
+    v-else
+    v-html="segment.text"
+  /></template></pre>
 </template>
 
 <script>
@@ -21,12 +29,71 @@ export default {
       type: Boolean,
       default: true,
     },
+
+    /**
+     * An map of the form { string => href }.  Strings matching a key in this map will be linkified.
+     */
+    links: {
+      type: Map,
+      required: false,
+      default: undefined,
+    },
   },
 
   computed: {
     ansiText() {
       const escapedText = String(this.text).replace(/\[NON-XML-CHAR-0x1B\]/g, '\x1B') ?? '';
       return (new AnsiUp).ansi_to_html(escapedText);
+    },
+
+    textSegments() {
+      if (!this.links) {
+        return [
+          {
+            text: this.ansiText,
+          },
+        ];
+      }
+
+      let segments = [
+        {
+          text: this.ansiText,
+        },
+      ];
+      for (const [stringToMatch, linkTo] of this.links) {
+        const newSegments = [];
+        segments.forEach(({ text, href }) => {
+          if (href) {
+            // Don't attempt to split existing links.
+            newSegments.push({
+              text,
+              href,
+            });
+            return;
+          }
+
+          let isFirstElement = true;
+          text.split(stringToMatch).forEach((newSegment) => {
+            if (!isFirstElement) {
+              // Add a link between two text chunks.  Don't add a link before the first chunk.
+              newSegments.push({
+                text: stringToMatch,
+                href: linkTo,
+              });
+            }
+
+            newSegments.push({
+              text: newSegment,
+            });
+
+            isFirstElement = false;
+          });
+        });
+
+        segments = newSegments;
+      }
+
+      return segments;
     },
   },
 };

--- a/tests/Browser/Pages/BuildBuildPageTest.php
+++ b/tests/Browser/Pages/BuildBuildPageTest.php
@@ -5,6 +5,7 @@ namespace Tests\Browser\Pages;
 use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\BuildError;
+use App\Models\BuildUpdate;
 use App\Models\Label;
 use App\Models\Project;
 use App\Models\Site;
@@ -325,6 +326,117 @@ class BuildBuildPageTest extends BrowserTestCase
                 ->assertDontSee($buildError1->stdoutput)
                 ->click('@stdout')
                 ->assertSee($buildError1->stdoutput)
+            ;
+        });
+    }
+
+    public function testLinksToMainBranchWhenRepositoryConfiguredAndNoUpdateStep(): void
+    {
+        $this->project->cvsviewertype = 'github';
+        $this->project->cvsurl = 'https://example.com/org/repo';
+        $this->project->save();
+
+        $stdOutPart1 = Str::uuid()->toString();
+        $stdOutPart2 = Str::uuid()->toString();
+        $sourceDirectory = '/absolute/path/to/source';
+        $filePath = $sourceDirectory . '/foo/bar.cpp:10:20';
+
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'sourcedirectory' => $sourceDirectory,
+        ]);
+
+        $build->buildErrors()->save(BuildError::factory()->make([
+            'stdoutput' => $stdOutPart1 . $filePath . $stdOutPart2,
+        ]));
+
+        $this->browse(function (Browser $browser) use ($filePath, $stdOutPart2, $stdOutPart1, $build): void {
+            $browser->visit("/builds/{$build->id}/build")
+                ->waitForText('1 ERROR')
+                ->assertSee($stdOutPart1)
+                ->assertSee($stdOutPart2)
+                ->assertSeeLink($filePath)
+                ->assertPresent('a[href="https://example.com/org/repo/blob/main/foo/bar.cpp"]')
+            ;
+        });
+    }
+
+    public function testLinksToUpdateRevisionWhenRepositoryConfiguredAndHasUpdateStep(): void
+    {
+        $this->project->cvsviewertype = 'github';
+        $this->project->cvsurl = 'https://example.com/org/repo';
+        $this->project->save();
+
+        $stdOutPart1 = Str::uuid()->toString();
+        $stdOutPart2 = Str::uuid()->toString();
+        $sourceDirectory = '/absolute/path/to/source';
+        $filePath = $sourceDirectory . '/foo/bar.cpp:10:20';
+
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'sourcedirectory' => $sourceDirectory,
+        ]);
+
+        $build->buildErrors()->save(BuildError::factory()->make([
+            'stdoutput' => $stdOutPart1 . $filePath . $stdOutPart2,
+        ]));
+
+        /** @var BuildUpdate $update */
+        $update = BuildUpdate::create([
+            'command' => Str::uuid()->toString(),
+            'type' => 'GIT',
+            'status' => Str::uuid()->toString(),
+            'revision' => Str::uuid()->toString(),
+            'priorrevision' => Str::uuid()->toString(),
+            'path' => Str::uuid()->toString(),
+        ]);
+        $build->updateStep()->associate($update)->save();
+
+        $this->browse(function (Browser $browser) use ($update, $filePath, $stdOutPart2, $stdOutPart1, $build): void {
+            $browser->visit("/builds/{$build->id}/build")
+                ->waitForText('1 ERROR')
+                ->assertSee($stdOutPart1)
+                ->assertSee($stdOutPart2)
+                ->assertSeeLink($filePath)
+                ->assertPresent('a[href="https://example.com/org/repo/blob/' . $update->revision . '/foo/bar.cpp"]')
+            ;
+        });
+    }
+
+    public function testLinkifiesCorrectlyWhenNoSourceDirectoryProvided(): void
+    {
+        $this->project->cvsviewertype = 'github';
+        $this->project->cvsurl = 'https://example.com/org/repo';
+        $this->project->save();
+
+        $stdOutPart1 = Str::uuid()->toString();
+        $stdOutPart2 = Str::uuid()->toString();
+        $filePath = '/.../repository/foo/bar.cpp:10:20';
+
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $build->buildErrors()->save(BuildError::factory()->make([
+            'stdoutput' => $stdOutPart1 . $filePath . ':' . $stdOutPart2,
+        ]));
+
+        $this->browse(function (Browser $browser) use ($filePath, $stdOutPart2, $stdOutPart1, $build): void {
+            $browser->visit("/builds/{$build->id}/build")
+                ->waitForText('1 ERROR')
+                ->assertSee($stdOutPart1)
+                ->assertSee($stdOutPart2)
+                ->assertSeeLink($filePath)
+                ->assertPresent('a[href="https://example.com/org/repo/blob/main/foo/bar.cpp"]')
             ;
         });
     }

--- a/tests/Spec/test-details.spec.js
+++ b/tests/Spec/test-details.spec.js
@@ -129,11 +129,11 @@ lines`);
   // Verify colorized/escaped output.
   const test_output = component.find('#test_output');
   const spans = test_output.findAll('span');
-  expect(spans.length).toBe(2);
-  expect(spans.at(0).attributes('style')).toBe('color:rgb(0,187,0)');
-  expect(spans.at(0).text()).toBe('Hello world!');
-  expect(spans.at(1).attributes('style')).toBe('color:rgb(255,85,85)');
-  expect(spans.at(1).text()).toBe('<script type="text/javascript">console.log("MALICIOUS JAVASCRIPT!!!");</script>');
+  expect(spans.length).toBe(3);
+  expect(spans.at(1).attributes('style')).toBe('color:rgb(0,187,0)');
+  expect(spans.at(1).text()).toBe('Hello world!');
+  expect(spans.at(2).attributes('style')).toBe('color:rgb(255,85,85)');
+  expect(spans.at(2).text()).toBe('<script type="text/javascript">console.log("MALICIOUS JAVASCRIPT!!!");</script>');
 
   // Verify links.
   const summary_link = component.find('#summary_link');

--- a/tests/cypress/component/code-box.cy.js
+++ b/tests/cypress/component/code-box.cy.js
@@ -30,4 +30,51 @@ describe('CodeBox', () => {
       });
     });
   });
+
+  it('renders matching strings as links when links prop is provided', () => {
+    const code = 'See issue example-com and issue example-org for details.';
+    const links = new Map([
+      ['example-com', 'https://example.com'],
+      ['example-org', 'https://example.org'],
+    ]);
+
+    cy.mount(CodeBox, {
+      props: {
+        text: code,
+        links: links,
+      },
+    });
+
+    cy.get('a').should('have.length', 2);
+
+    cy.contains('a', 'example-com')
+      .should('have.attr', 'href', 'https://example.com')
+      .should('have.class', 'tw-link tw-link-hover tw-link-info');
+
+    cy.contains('a', 'example-org')
+      .should('have.attr', 'href', 'https://example.org')
+      .should('have.class', 'tw-link tw-link-hover tw-link-info');
+
+    cy.contains('See issue').should('exist');
+    cy.contains('and issue').should('exist');
+    cy.contains('for details.').should('exist');
+  });
+
+  it('handles multiple instances of the same link correctly', () => {
+    const code = 'Duplicate example and example';
+    const links = new Map([
+      ['example', 'https://example.com'],
+    ]);
+
+    cy.mount(CodeBox, {
+      props: {
+        text: code,
+        links: links,
+      },
+    });
+
+    cy.get('a').should('have.length', 2);
+    cy.get('a').eq(0).should('have.attr', 'href', 'https://example.com');
+    cy.get('a').eq(1).should('have.attr', 'href', 'https://example.com');
+  });
 });


### PR DESCRIPTION
This PR re-adds automatic source file link creation in build error stderr and stdout.  Source files are detected by matching strings starting with the absolute source directory and ending with a line:column anchor.  If an update was provided, links to the file in the correct commit are generated.  Otherwise, we fall back to a default `main` branch.