### PR TITLE
Add handling for branch coverage information from CTest

### DIFF
--- a/app/Http/Submission/Handlers/CoverageLogHandler.php
+++ b/app/Http/Submission/Handlers/CoverageLogHandler.php
@@ -66,6 +66,17 @@ class CoverageLogHandler extends AbstractXmlHandler
             $this->CurrentCoverageFileLog = new CoverageFileLog();
             $this->CurrentCoverageFile->FullPath = trim($attributes['FULLPATH']);
         } elseif ($name === 'LINE') {
+            if (array_key_exists('BRANCHESTESTED', $attributes) && array_key_exists('BRANCHESUNTESTED', $attributes)) {
+                if ($attributes['BRANCHESTESTED'] > 0 || $attributes['BRANCHESUNTESTED'] > 0) {
+                    $this->CurrentCoverageFileLog->AddBranch(
+                        (int) $attributes['NUMBER'],
+                        (int) $attributes['BRANCHESTESTED'],
+                        (int) $attributes['BRANCHESTESTED'] + (int) $attributes['BRANCHESUNTESTED']
+                    );
+                    $this->CurrentLine = '';
+                    return;
+                }
+            }
             if ($attributes['COUNT'] >= 0) {
                 $this->CurrentCoverageFileLog->AddLine($attributes['NUMBER'], $attributes['COUNT']);
             }

--- a/app/Validators/Schemas/CoverageLog.xsd
+++ b/app/Validators/Schemas/CoverageLog.xsd
@@ -23,6 +23,8 @@
                                 <xs:extension base="xs:string">
                                   <xs:attribute name="Number" type="xs:int" use="required" />
                                   <xs:attribute name="Count" type="xs:int" use="required" />
+                                  <xs:attribute name="BranchesTested" type="xs:int" use="optional"/>
+                                  <xs:attribute name="BranchesUntested" type="xs:int" use="optional"/>
                                 </xs:extension>
                               </xs:simpleContent>
                             </xs:complexType>

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -357,6 +357,8 @@ add_feature_test(/Feature/Submission/Tests/TestXMLTest)
 
 add_feature_test(/Feature/Submission/Tests/BuildXMLTest)
 
+add_feature_test(/Feature/Submission/Tests/CoverageLogXMLTest)
+
 add_browser_test(/Browser/Pages/SitesIdPageTest)
 
 add_browser_test(/Browser/Pages/ProjectSitesPageTest)

--- a/tests/Feature/Submission/Tests/CoverageLogXMLTest.php
+++ b/tests/Feature/Submission/Tests/CoverageLogXMLTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Submission\Tests;
+
+use App\Models\Project;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSubmissions;
+
+class CoverageLogXMLTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSubmissions;
+
+    private Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->project->delete();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test parsing a valid CoverageLog.xml file that contains branch
+     * coverage information in the attributes of each line
+     */
+    public function testBranchCoverage(): void
+    {
+        $this->submitFiles($this->project->name, [
+            base_path(
+                'tests/Feature/Submission/Tests/data/with_branchCoverage.xml'
+            ),
+            base_path(
+                'tests/Feature/Submission/Tests/data/with_LogBranchCoverage.xml'
+            ),
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+              build(id: $id) {
+                coverage {
+                  edges {
+                    node {
+                      branchPercentage
+                      branchesTested
+                      branchesUntested
+                      coveredLines {
+                        lineNumber
+                        branchesHit
+                        totalBranches
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        ', [
+            'id' => $this->project->builds()->firstOrFail()->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'coverage' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'branchPercentage' => 75,
+                                    'branchesTested' => 3,
+                                    'branchesUntested' => 1,
+                                    'coveredLines' => [
+                                        [
+                                            'lineNumber' => 3,
+                                            'branchesHit' => 2,
+                                            'totalBranches' => 2,
+                                        ],
+                                        [
+                                            'lineNumber' => 18,
+                                            'branchesHit' => 1,
+                                            'totalBranches' => 2,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/Submission/Tests/data/with_LogBranchCoverage.xml
+++ b/tests/Feature/Submission/Tests/data/with_LogBranchCoverage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="dummy_test_name"
+  BuildStamp="dummy_stamp"
+  Name="dummy_name"
+  Generator="dummy_generator"
+	>
+	<CoverageLog>
+		<StartDateTime>Apr 01 09:08 EDT</StartDateTime>
+		<StartTime>1775048903</StartTime>
+		<File Name="hello.cxx" FullPath="./hello.cxx">
+			<Report>
+				<Line Number="3" Count="66" BranchesTested="2" BranchesUntested="0"> for (int i =0; i &lt; times; i++) {</Line>
+				<Line Number="18" Count="11" BranchesTested="1" BranchesUntested="1">   if(false)</Line>
+			</Report>
+		</File>
+		<EndDateTime>Apr 01 09:08 EDT</EndDateTime>
+		<EndTime>1775048903</EndTime>
+	</CoverageLog>
+</Site>

--- a/tests/Feature/Submission/Tests/data/with_branchCoverage.xml
+++ b/tests/Feature/Submission/Tests/data/with_branchCoverage.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="dummy_test_name"
+  BuildStamp="dummy_stamp"
+  Name="dummy_name"
+  Generator="dummy_generator"
+	>
+	<Coverage>
+		<StartDateTime>Apr 01 09:08 EDT</StartDateTime>
+		<StartTime>1775048902</StartTime>
+		<File Name="hello.cxx" FullPath="./hello.cxx" Covered="true">
+			<LOCTested>13</LOCTested>
+			<LOCUnTested>5</LOCUnTested>
+			<BranchesTested>3</BranchesTested>
+			<BranchesUnTested>1</BranchesUnTested>
+			<PercentCoverage>72.22</PercentCoverage>
+			<CoverageMetric>0.82</CoverageMetric>
+		</File>
+		<LOCTested>13</LOCTested>
+		<LOCUntested>5</LOCUntested>
+		<LOC>18</LOC>
+		<PercentCoverage>72.22</PercentCoverage>
+		<EndDateTime>Apr 01 09:08 EDT</EndDateTime>
+		<EndTime>1775048903</EndTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Coverage>
+</Site>


### PR DESCRIPTION
When reading the coverage log file, look for incoming "BranchesTested" and "BranchesUntested" attributes on each log line.  If either is greater than 0, add a branch entry to that line.