### PR TITLE
Use PHP 8.4 as base for Debian container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG DEVELOPMENT_BUILD
 ###############################################################################
 # The base image for regular Debian-based images
 ###############################################################################
-FROM php:8.3-apache-trixie AS cdash-debian-intermediate
+FROM php:8.4-apache-trixie AS cdash-debian-intermediate
 
 ARG BASE_IMAGE
 ARG DEVELOPMENT_BUILD


### PR DESCRIPTION
RedHat hasn't released a PHP 8.4 image yet, so we can't update the minimum PHP version.  Bumping the Debian-based image will allow users of that image to take advantage of speed improvements and give us CI exposure to 8.4.