### PR TITLE
Link to project configuration pages from new settings page

### DIFF
--- a/resources/js/vue/components/ProjectSettingsPage.vue
+++ b/resources/js/vue/components/ProjectSettingsPage.vue
@@ -11,6 +11,7 @@
           @click="currentSection = 'general'"
         >General</a>
       </li>
+
       <li>
         <a
           :class="{'tw-active': currentSection === 'integrations'}"
@@ -18,6 +19,31 @@
           @click="currentSection = 'integrations'"
         >Integrations</a>
       </li>
+
+      <li>
+        <a
+          :href="`${$baseURL}/manageBuildGroup.php?projectid=${projectId}`"
+        >Build Groups</a>
+      </li>
+
+      <li>
+        <a
+          :href="`${$baseURL}/projects/${projectId}/testmeasurements`"
+        >Test Measurements</a>
+      </li>
+
+      <li>
+        <a
+          :href="`${$baseURL}/manageSubProject.php?projectid=${projectId}`"
+        >SubProject Groups</a>
+      </li>
+
+      <li>
+        <a
+          :href="`${$baseURL}/manageOverview.php?projectid=${projectId}`"
+        >Overview Configuration</a>
+      </li>
+
       <li>
         <a
           :href="`${$baseURL}/projects/${projectId}/ctest_configuration`"


### PR DESCRIPTION
Each of the project configuration pages will eventually be merged into the new project settings page.  This commit adds them as links in the project settings page sidebar to make the process of overhauling each one more seamless.