### PR TITLE
Remove mapping for remote worker route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -51,8 +51,6 @@ Route::get('/v1/timeline.php', 'TimelineController@apiTimeline');
 
 Route::get('/v1/testOverview.php', 'TestController@apiTestOverview');
 
-Route::post('/v1/store_upload', 'SubmissionController@storeUploadedFile');
-
 Route::match(['get', 'post', 'delete'], '/v1/expectedbuild.php', 'ExpectedBuildController@apiResponse');
 
 Route::middleware(['auth'])->group(function (): void {


### PR DESCRIPTION
The route mapping for `/api/v1/store_upload` was missed in https://github.com/Kitware/CDash/pull/3614.