### PR TITLE
Prefix project URLs with https prefix

### DIFF
--- a/database/migrations/2026_04_09_220225_add_project_url_protocols.php
+++ b/database/migrations/2026_04_09_220225_add_project_url_protocols.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $fields_to_update = [
+            'homeurl',
+            'cvsurl',
+            'bugtrackerurl',
+            'bugtrackernewissueurl',
+            'documentationurl',
+            'testingdataurl',
+        ];
+
+        foreach ($fields_to_update as $field) {
+            DB::update("
+                UPDATE project
+                SET $field = 'https://' || $field
+                WHERE
+                    $field NOT LIKE 'http://%'
+                    AND $field NOT LIKE 'https://%'
+                    AND $field IS NOT NULL
+                    AND length($field) > 0
+            ");
+        }
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
CDash previously performed no validation to ensure that URLs stored in the project table were of the correct form, leading to variety of data cleanliness issues.  This attempts to fix the most common case--the missing http(s):// prefix.

Fixes most of the issues outlined in https://github.com/Kitware/CDash/issues/3625.