### PR TITLE
Remove "View SubProjects Link" project config option

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -45,7 +45,6 @@ use Illuminate\Support\Facades\Auth;
  * @property bool $showcoveragecode
  * @property bool $sharelabelfilters
  * @property bool $authenticatesubmissions
- * @property bool $viewsubprojectslink
  * @property ?string $ldapfilter
  * @property ?string $banner
  * @property ?string $logoUrl
@@ -95,7 +94,6 @@ class Project extends Model
         'showcoveragecode',
         'sharelabelfilters',
         'authenticatesubmissions',
-        'viewsubprojectslink',
         'ldapfilter',
         'banner',
         'cmakeprojectroot',
@@ -115,7 +113,6 @@ class Project extends Model
         'showcoveragecode' => 'boolean',
         'sharelabelfilters' => 'boolean',
         'authenticatesubmissions' => 'boolean',
-        'viewsubprojectslink' => 'boolean',
     ];
 
     public const PROJECT_ADMIN = 2;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -70,7 +70,6 @@ class Project
     public $EmailMaxChars = 255;
     public $DisplayLabels = 0;
     public $ShareLabelFilters = 0;
-    public $ViewSubProjectsLink = 0;
     public $AuthenticateSubmissions = 0;
     public $ShowCoverageCode = 0;
     public $AutoremoveTimeframe = 0;
@@ -131,7 +130,6 @@ class Project
             'emailredundantfailures' => filter_var($this->EmailRedundantFailures, FILTER_VALIDATE_BOOLEAN),
             'displaylabels' => filter_var($this->DisplayLabels, FILTER_VALIDATE_BOOLEAN),
             'sharelabelfilters' => filter_var($this->ShareLabelFilters, FILTER_VALIDATE_BOOLEAN),
-            'viewsubprojectslink' => filter_var($this->ViewSubProjectsLink, FILTER_VALIDATE_BOOLEAN),
             'authenticatesubmissions' => filter_var($this->AuthenticateSubmissions, FILTER_VALIDATE_BOOLEAN),
             'showcoveragecode' => filter_var($this->ShowCoverageCode, FILTER_VALIDATE_BOOLEAN),
             'autoremovetimeframe' => (int) $this->AutoremoveTimeframe,
@@ -219,7 +217,6 @@ class Project
             $this->EmailRedundantFailures = (int) $project->emailredundantfailures;
             $this->DisplayLabels = $project->displaylabels;
             $this->ShareLabelFilters = $project->sharelabelfilters;
-            $this->ViewSubProjectsLink = $project->viewsubprojectslink;
             $this->AuthenticateSubmissions = $project->authenticatesubmissions;
             $this->ShowCoverageCode = $project->showcoveragecode;
             $this->AutoremoveTimeframe = $project->autoremovetimeframe;

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -433,7 +433,6 @@ class KWWebTestCase extends WebTestCase
                 'TestTimeStd' => 4,
                 'TestTimeStdThreshold' => 1,
                 'UploadQuota' => 1073741824,
-                'ViewSubProjectsLink' => true,
                 'WarningsFilter' => '',
                 'ErrorsFilter' => '',
             ];

--- a/database/migrations/2026_04_12_214757_drop_project_viewsubprojectslink_column.php
+++ b/database/migrations/2026_04_12_214757_drop_project_viewsubprojectslink_column.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project DROP COLUMN viewsubprojectslink');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -43,7 +43,6 @@ class DatabaseSeeder extends Seeder
     {
         $project = $this->makePublicProject('Trilinos');
         $project->description = 'Submission files donated by the Trilinos project.';
-        $project->viewsubprojectslink = true;
         $project->save();
 
         $files_to_submit = file_get_contents(app_path('/cdash/tests/data/ActualTrilinosSubmission/orderedFileList.txt'));

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -318,12 +318,6 @@ type Project {
   "Forward label filters from index.php to queryTests.php and viewTest.php."
   shareLabelFilters: Boolean! @rename(attribute: "sharelabelfilters")
 
-  """
-  If true and this Project uses SubProjects, show a per-SubProject breakdown by default. If false,
-  CDash will show per-build results instead.
-  """
-  showViewSubProjectsLink: Boolean! @rename(attribute: "viewsubprojectslink")
-
   "Custom text displayed at the top of a project's dashboard."
   banner: String
 
@@ -476,8 +470,6 @@ input UpdateProjectInput @validator {
   showCoverageCode: Boolean @rename(attribute: "showcoveragecode")
 
   shareLabelFilters: Boolean @rename(attribute: "sharelabelfilters")
-
-  showViewSubProjectsLink: Boolean @rename(attribute: "viewsubprojectslink")
 
   banner: String
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10339,12 +10339,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$ViewSubProjectsLink has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$WarningsFilter has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -16147,19 +16141,19 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:803::__construct() has parameter $response with no type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:802::__construct() has parameter $response with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:803::getSent() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:802::getSent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:803::read() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:802::read() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -16387,7 +16381,7 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:803::$read has no type specified.
+			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:802::$read has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -148,15 +148,6 @@
           label="Display Labels"
           test-id="display-labels-input"
         />
-
-        <CheckboxField
-          v-model="form.showViewSubProjectsLink"
-          :validation-error="validationErrors?.showViewSubProjectsLink?.[0]"
-          label="Show View SubProjects Link"
-          description="If this Project uses SubProjects, show a per-SubProject breakdown by default.
-          If unchecked, CDash will show per-build results instead."
-          test-id="view-subprojects-link-input"
-        />
       </FormSection>
 
       <FormSection
@@ -552,7 +543,6 @@ export default {
         fileUploadLimit: 50,
         showCoverageCode: true,
         shareLabelFilters: false,
-        showViewSubProjectsLink: true,
         banner: '',
       },
       validationErrors: {},
@@ -598,7 +588,6 @@ export default {
             fileUploadLimit
             showCoverageCode
             shareLabelFilters
-            showViewSubProjectsLink
             banner
           }
         }

--- a/tests/Browser/Pages/ProjectSettingsPageTest.php
+++ b/tests/Browser/Pages/ProjectSettingsPageTest.php
@@ -122,8 +122,6 @@ class ProjectSettingsPageTest extends BrowserTestCase
             ['@banner-input', '', 'banner', null, 'string'],
             ['@display-labels-input', true, 'displaylabels', true, 'checkbox'],
             ['@display-labels-input', false, 'displaylabels', false, 'checkbox'],
-            ['@view-subprojects-link-input', true, 'viewsubprojectslink', true, 'checkbox'],
-            ['@view-subprojects-link-input', false, 'viewsubprojectslink', false, 'checkbox'],
             ['@nightly-time-input', '23:01:01', 'nightlytime', '23:01:01', 'string'],
             ['@autoremove-time-frame-input', 7, 'autoremovetimeframe', 7, 'string'],
             ['@autoremove-max-builds-input', 100, 'autoremovemaxbuilds', 100, 'string'],

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -208,7 +208,6 @@ class UpdateProjectTest extends TestCase
             ['fileUploadLimit', 50, 'uploadquota', 53687091200],
             ['showCoverageCode', false, 'showcoveragecode', false],
             ['shareLabelFilters', false, 'sharelabelfilters', false],
-            ['showViewSubProjectsLink', false, 'viewsubprojectslink', false],
             ['banner', 'new banner', 'banner', 'new banner'],
         ];
     }

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -168,8 +168,6 @@ class ProjectTypeTest extends TestCase
             ['showcoveragecode', false, 'showCoverageCode', false],
             ['sharelabelfilters', true, 'shareLabelFilters', true],
             ['sharelabelfilters', false, 'shareLabelFilters', false],
-            ['viewsubprojectslink', true, 'showViewSubProjectsLink', true],
-            ['viewsubprojectslink', false, 'showViewSubProjectsLink', false],
             ['banner', 'test', 'banner', 'test'],
             ['banner', null, 'banner', null],
         ];


### PR DESCRIPTION
The `showViewSubProjectsLink` isn't  hooked up to anything anymore, and the feature itself has little value.  A better thought out solution could be implemented in the future if there's sufficient interest.  Interested users are encouraged to file an issue describing their use cases.