### PR TITLE
Hardcode Cypress APP_URL

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,3 @@
-function(set_app_url)
-  if(DEFINED ENV{APP_URL})
-    set(APP_URL "$ENV{APP_URL}" PARENT_SCOPE)
-  elseif(EXISTS ${CDash_SOURCE_DIR}/.env)
-    file(STRINGS ${CDash_SOURCE_DIR}/.env env_vars)
-    foreach(var IN LISTS env_vars)
-      if(var MATCHES "^APP_URL=(.*)$")
-        set(APP_URL "${CMAKE_MATCH_1}" PARENT_SCOPE)
-        break()
-      endif()
-    endforeach()
-  else()
-    set(APP_URL "http://localhost:8080" PARENT_SCOPE)
-  endif()
-endfunction()
-
 add_test(
   NAME php_style_check
   COMMAND ${CMAKE_SOURCE_DIR}/vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes

--- a/tests/cypress/e2e/CMakeLists.txt
+++ b/tests/cypress/e2e/CMakeLists.txt
@@ -1,13 +1,11 @@
 function(add_cypress_e2e_test TestName)
-  set_app_url()
-
   add_test(
     NAME cypress/e2e/${TestName}
     COMMAND ${NPX_EXE} cypress run
       --e2e
       --project ${CDash_SOURCE_DIR}
       --spec ${CDash_SOURCE_DIR}/tests/cypress/e2e/${TestName}.cy.js
-      --config baseUrl=${APP_URL}
+      --config baseUrl=http://localhost:8080
   )
   # Cypress tries to put stuff in our home directory, which doesn't work for /var/www.
   set_tests_properties(cypress/e2e/${TestName} PROPERTIES


### PR DESCRIPTION
Our Cypress tests currently attempt to dynamically set the baseUrl based on the APP_URL config ahead of time.  This doesn't work when the APP_URL changes mid-run.  We already have other mechanisms in place to ensure that Cypress and Dusk tests don't conflict, so this logic is no longer necessary.  I believe this the root cause of much of the recent Cypress test flakiness.