### PR TITLE
Add `createComment` GraphQL mutation

### DIFF
--- a/app/GraphQL/Mutations/CreateComment.php
+++ b/app/GraphQL/Mutations/CreateComment.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\Build;
+use App\Models\Comment;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Gate;
+
+final class CreateComment extends AbstractMutation
+{
+    public ?Comment $comment = null;
+
+    /**
+     * @param array{
+     *     buildId: string,
+     *     text: string,
+     * } $args
+     *
+     * @throws AuthenticationException
+     */
+    public function __invoke(null $_, array $args): self
+    {
+        $user = auth()->user();
+        if ($user === null) {
+            throw new AuthenticationException('This action is unauthorized.');
+        }
+
+        $build = Build::find((int) $args['buildId']);
+
+        Gate::authorize('view', $build);
+
+        /** @var Comment $comment */
+        $comment = $build->comments()->create([
+            'userid' => $user->id,
+            'text' => $args['text'],
+            'status' => Comment::STATUS_NORMAL,
+        ]);
+
+        $this->comment = $comment->refresh();
+
+        return $this;
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -311,6 +311,8 @@ add_feature_test_in_transaction(/Feature/GraphQL/GlobalInvitationTypeTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/RemoveUserTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateCommentTest)
+
 add_feature_test_in_transaction(/Feature/Jobs/PruneBuildsTest)
 
 add_feature_test_in_transaction(/Feature/Jobs/PruneEmailsTest)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -157,6 +157,25 @@ type Mutation {
    2. A system administrator
   """
   deleteAuthenticationToken(input: DeleteAuthenticationTokenInput! @spread): DeleteAuthenticationTokenMutationPayload! @field(resolver: "DeleteAuthenticationToken")
+
+  "Create a new comment."
+  createComment(input: CreateCommentInput! @spread): CreateCommentMutationPayload! @field(resolver: "CreateComment")
+}
+
+input CreateCommentInput {
+  "The build to associate the comment with."
+  buildId: ID!
+
+  "Comment body."
+  text: String!
+}
+
+type CreateCommentMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
+
+  "The newly created comment."
+  comment: Comment
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,6 +271,18 @@ parameters:
 			path: app/GraphQL/Mutations/CreateAuthenticationToken.php
 
 		-
+			rawMessage: 'Cannot call method comments() on App\Models\Build|null.'
+			identifier: method.nonObject
+			count: 1
+			path: app/GraphQL/Mutations/CreateComment.php
+
+		-
+			rawMessage: 'Parameter #2 $args (array{buildId: string, text: string}) of method App\GraphQL\Mutations\CreateComment::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/GraphQL/Mutations/CreateComment.php
+
+		-
 			rawMessage: 'Parameter #1 $args (array{email: string, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\CreateGlobalInvitation::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
 			identifier: method.childParameterType
 			count: 1

--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -563,16 +563,16 @@
                 title="graph"
               >
               <a
-                id="toggle_note"
+                id="toggle_comments"
                 class="tw-link tw-link-hover"
-                @click="toggleNote()"
+                @click="toggleComments()"
               >
                 Add a comment to this Build
               </a>
             </div>
             <div
-              v-show="showNote"
-              id="new_note_div"
+              v-show="showComments"
+              id="new_comment_div"
             >
               <table>
                 <tbody>
@@ -580,8 +580,8 @@
                     <td><b>Comment:</b></td>
                     <td>
                       <textarea
-                        id="note_text"
-                        v-model="cdash.noteText"
+                        id="comment_text"
+                        v-model="commentText"
                         class="tw-textarea tw-textarea-bordered"
                         cols="50"
                         rows="5"
@@ -592,12 +592,12 @@
                     <td />
                     <td>
                       <button
-                        id="add_note"
+                        id="add_comment"
                         class="tw-btn"
-                        :disabled="!cdash.noteText"
-                        @click="addNote()"
+                        :disabled="!commentText"
+                        @click="addComment()"
                       >
-                        Add Note
+                        Add Comment
                       </button>
                     </td>
                   </tr>
@@ -782,12 +782,14 @@ export default {
       loading: true,
       errored: false,
 
+      commentText: '',
+
       // Booleans controlling whether a section should be displayed or not.
       showErrorGraph: false,
       showTestGraph: false,
       showTimeGraph: false,
       showWarningGraph: false,
-      showNote: false,
+      showComments: false,
 
       // Graph data.
       graphLoading: false,
@@ -856,10 +858,6 @@ export default {
   },
 
   methods: {
-    postSetup: function () {
-      this.cdash.noteStatus = '0';
-    },
-
     loadGraphData: function(graphType) {
       this.graphLoading = true;
       this.$axios
@@ -1062,23 +1060,37 @@ export default {
       }, 1);
     },
 
-    toggleNote: function() {
-      this.showNote = !this.showNote;
+    toggleComments: function() {
+      this.showComments = !this.showComments;
     },
 
-    addNote: function() {
-      this.$axios
-        .post('/api/v1/addUserNote.php', {
-          buildid: this.cdash.build.id,
-          Status: this.cdash.noteStatus,
-          AddNote: this.cdash.noteText,
+    addComment: function() {
+      this.$apollo
+        .mutate({
+          mutation: gql`
+            mutation createComment($input: CreateCommentInput!) {
+              createComment(input: $input) {
+                comment {
+                  id
+                }
+              }
+            }
+          `,
+          variables: {
+            input: {
+              buildId: this.buildId,
+              text: this.commentText,
+            },
+          },
         })
         .then(() => {
-          // Add the newly created note to our list.
+          // Add the newly created comment to our list.
           this.$apollo.queries.comments.refetch();
+          this.commentText = '';
+          this.showComments = false;
         })
         .catch(error => {
-        // Display the error.
+          // Display the error.
           this.cdash.error = error;
           console.log(error);
         });
@@ -1086,14 +1098,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-
-.dart th, .dart td {
-  padding: 3px 7px;
-}
-
-.pre-wrap {
-  white-space: pre-wrap;
-}
-</style>

--- a/tests/Feature/GraphQL/Mutations/CreateCommentTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateCommentTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Models\Build;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesUsers;
+
+class CreateCommentTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    public function testCreateComment(): void
+    {
+        $project = $this->makePublicProject();
+
+        /** @var Build $build */
+        $build = $project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $user = $this->makeNormalUser();
+
+        $text = Str::uuid()->toString();
+        $response = $this->actingAs($user)->graphQL('
+            mutation CreateComment($input: CreateCommentInput!) {
+                createComment(input: $input) {
+                    comment {
+                        text
+                        user {
+                            id
+                        }
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'buildId' => $build->id,
+                'text' => $text,
+            ],
+        ]);
+
+        $response->assertExactJson([
+            'data' => [
+                'createComment' => [
+                    'comment' => [
+                        'text' => $text,
+                        'user' => [
+                            'id' => (string) $user->id,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('comments', [
+            'buildid' => $build->id,
+            'userid' => $user->id,
+            'text' => $text,
+        ]);
+    }
+
+    public function testCreateCommentUnauthenticated(): void
+    {
+        $project = $this->makePublicProject();
+
+        /** @var Build $build */
+        $build = $project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->graphQL('
+            mutation CreateComment($input: CreateCommentInput!) {
+                createComment(input: $input) {
+                    comment {
+                        id
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'buildId' => $build->id,
+                'text' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        $this->assertDatabaseEmpty('comments');
+    }
+
+    public function testCreateCommentUnauthorizedForBuild(): void
+    {
+        $project = $this->makePrivateProject();
+
+        /** @var Build $build */
+        $build = $project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $user = $this->makeNormalUser();
+        $this->actingAs($user)->graphQL('
+            mutation CreateComment($input: CreateCommentInput!) {
+                createComment(input: $input) {
+                    comment {
+                        id
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'buildId' => $build->id,
+                'text' => Str::uuid()->toString(),
+            ],
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        $this->assertDatabaseEmpty('comments');
+    }
+}


### PR DESCRIPTION
This PR switches the build summary comments section to use a new `createComment` GraphQL mutation to create comments instead of the legacy API.  The `/api/v1/addUserNote.php` endpoint will be removed in a forthcoming PR.