### PR TITLE
Drop support for SQS queues

### DIFF
--- a/app/Jobs/ProcessSubmission.php
+++ b/app/Jobs/ProcessSubmission.php
@@ -100,13 +100,7 @@ class ProcessSubmission implements ShouldQueue
         // Requeue the file with exponential backoff.
         PendingSubmissions::where('buildid', $this->buildid)->increment('numfiles');
         $delay = ((int) config('cdash.retry_base')) ** $retry_handler->Retries;
-        if (config('queue.default') === 'sqs-fifo') {
-            // Special handling for sqs-fifo, which does not support per-message delays.
-            sleep(10);
-            self::dispatch($this->filename, $this->projectid, $buildid, $this->expected_md5);
-        } else {
-            self::dispatch($this->filename, $this->projectid, $buildid, $this->expected_md5)->delay(now()->addSeconds($delay));
-        }
+        self::dispatch($this->filename, $this->projectid, $buildid, $this->expected_md5)->delay(now()->addSeconds($delay));
 
         return true;
     }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "ext-xsl": "*",
     "ext-zlib": "*",
     "24slides/laravel-saml2": "2.4.2",
-    "aws/aws-sdk-php": "3.374.0",
     "directorytree/ldaprecord-laravel": "3.4.3",
     "guzzlehttp/guzzle": "7.10.0",
     "knplabs/github-api": "3.16.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     "pear/archive_tar": "1.6.0",
     "php-di/php-di": "7.1.1",
     "ramsey/uuid": "4.9.2",
-    "shiftonelabs/laravel-sqs-fifo-queue": "3.0.3",
     "socialiteproviders/github": "4.1.0",
     "socialiteproviders/gitlab": "4.1.0",
     "socialiteproviders/google": "4.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce51472cd2f3809e4a388f9040e2ac7b",
+    "content-hash": "cb3c7d85cafeaf68e788784644b49359",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -137,16 +137,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.374.0",
+            "version": "3.379.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "18525c8cc2a3aa2c1db23ceca5f57c5f8380d9c4"
+                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/18525c8cc2a3aa2c1db23ceca5f57c5f8380d9c4",
-                "reference": "18525c8cc2a3aa2c1db23ceca5f57c5f8380d9c4",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
+                "reference": "a50c3cc2c59f5ebeb56cbe170e6f144034b252b6",
                 "shasum": ""
             },
             "require": {
@@ -228,9 +228,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.374.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.379.0"
             },
-            "time": "2026-03-25T18:05:48+00:00"
+            "time": "2026-04-13T18:11:10+00:00"
         },
         {
             "name": "brick/math",
@@ -6928,16 +6928,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -6987,7 +6987,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7007,7 +7007,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -7265,16 +7265,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -7326,7 +7326,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7346,20 +7346,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -7410,7 +7410,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.35.0"
             },
             "funding": [
                 {
@@ -7430,7 +7430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e12e730eac7411bf24ee5d390dcb42d9",
+    "content-hash": "ce51472cd2f3809e4a388f9040e2ac7b",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -5553,76 +5553,6 @@
                 "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.5"
             },
             "time": "2026-03-13T10:31:56+00:00"
-        },
-        {
-            "name": "shiftonelabs/laravel-sqs-fifo-queue",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/shiftonelabs/laravel-sqs-fifo-queue.git",
-                "reference": "ef10d55db6a93243b8ea3789590f46a0567e44f6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/shiftonelabs/laravel-sqs-fifo-queue/zipball/ef10d55db6a93243b8ea3789590f46a0567e44f6",
-                "reference": "ef10d55db6a93243b8ea3789590f46a0567e44f6",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-sdk-php": "~3.0",
-                "illuminate/queue": ">=9.0",
-                "illuminate/support": ">=9.0",
-                "php": ">=8.0.2",
-                "ramsey/uuid": ">=4.2.2"
-            },
-            "require-dev": {
-                "illuminate/mail": ">=9.0",
-                "illuminate/notifications": ">=9.0",
-                "mockery/mockery": "~1.3",
-                "phpunit/phpunit": "~9.3 || ~10.0",
-                "shiftonelabs/codesniffer-standard": "0.*",
-                "squizlabs/php_codesniffer": "3.*",
-                "vlucas/phpdotenv": "~5.4"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "ShiftOneLabs\\LaravelSqsFifoQueue\\LaravelSqsFifoQueueServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "ShiftOneLabs\\LaravelSqsFifoQueue\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Patrick Carlo-Hickman",
-                    "email": "patrick@shiftonelabs.com"
-                }
-            ],
-            "description": "Adds a Laravel queue driver for Amazon SQS FIFO queues.",
-            "homepage": "https://github.com/shiftonelabs/laravel-sqs-fifo-queue",
-            "keywords": [
-                "aws",
-                "fifo",
-                "illuminate",
-                "laravel",
-                "lumen",
-                "queue",
-                "sqs"
-            ],
-            "support": {
-                "issues": "https://github.com/shiftonelabs/laravel-sqs-fifo-queue/issues",
-                "source": "https://github.com/shiftonelabs/laravel-sqs-fifo-queue"
-            },
-            "time": "2024-09-21T22:48:23+00:00"
         },
         {
             "name": "socialiteproviders/github",
@@ -12578,5 +12508,5 @@
         "ext-xdebug": "*",
         "ext-zip": "*"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/queue.php
+++ b/config/queue.php
@@ -23,7 +23,7 @@ return [
     | is used by your application. A default configuration has been added
     | for each back-end shipped with Laravel. You are free to add more.
     |
-    | Drivers: "sync", "database", "beanstalkd", "sqs", "null"
+    | Drivers: "sync", "database", "null"
     |
     */
 
@@ -37,36 +37,6 @@ return [
             'table' => 'jobs',
             'queue' => 'default',
             'retry_after' => env('QUEUE_TIMEOUT', 2000) + 60,
-        ],
-
-        'beanstalkd' => [
-            'driver' => 'beanstalkd',
-            'host' => 'localhost',
-            'queue' => 'default',
-            'retry_after' => env('QUEUE_TIMEOUT', 2000) + 60,
-        ],
-
-        'sqs' => [
-            'driver' => 'sqs',
-            'key' => env('SQS_KEY', 'your-public-key'),
-            'secret' => env('SQS_SECRET', 'your-secret-key'),
-            'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
-            'queue' => env('SQS_QUEUE', 'your-queue-name'),
-            'region' => env('SQS_REGION', 'us-east-1'),
-        ],
-
-        'sqs-fifo' => [
-            'driver' => 'sqs-fifo',
-            'key' => env('SQS_KEY'),
-            'secret' => env('SQS_SECRET'),
-            'prefix' => env('SQS_FIFO_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
-            'queue' => env('SQS_FIFO_QUEUE', 'default.fifo'),
-            'suffix' => env('SQS_FIFO_SUFFIX'),
-            'region' => env('SQS_REGION', 'us-east-1'),
-            'after_commit' => false,
-            'group' => 'default',
-            'deduplicator' => env('SQS_FIFO_DEDUPLICATOR', 'unique'),
-            'allow_delay' => env('SQS_FIFO_ALLOW_DELAY', false),
         ],
     ],
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24363,7 +24363,7 @@ parameters:
 		-
 			rawMessage: Binary operation "+" between 2000|bool|string and 60 results in an error.
 			identifier: binaryOp.invalid
-			count: 2
+			count: 1
 			path: config/queue.php
 
 		-


### PR DESCRIPTION
Using the database queue allows CDash to have more consistent control over the behavior of the queue.  Given that this isn't a particularly high-performance queue, the database driver is sufficient for all use cases.