### PR TITLE
Disallow expensive pages via robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /api/
+Disallow: /builds/
+Disallow: /tests/
+Disallow: /queryTests.php
+Disallow: /testOverview.php


### PR DESCRIPTION
Scrapers frequently target expensive pages such as `testOverview.php`, and pages which are not meaningful to index such as `/tests/<id>` and `/builds/<id>/*`, which adds significant load to public-facing CDash instances.  This attempts to address the issue by requesting that bots not index these pages.