### PR TITLE
Disable line chart animation

### DIFF
--- a/resources/js/vue/components/shared/LineChart.vue
+++ b/resources/js/vue/components/shared/LineChart.vue
@@ -42,6 +42,7 @@ export default {
       let chartData = [];
 
       const baseOption = {
+        animation: false,
         grid: {
           left: '30px',
           right: '20px',


### PR DESCRIPTION
Our Apache eCharts-based LineChart component currently takes a few seconds to fully render.  This PR addresses the undesirable animation, rendering the full chart immediately.