### PR TITLE
ENH: Finalize GitHub check-run after watchdog timeout when Done.xml never arrives

### DIFF
--- a/app/cdash/app/Lib/Repository/GitHub.php
+++ b/app/cdash/app/Lib/Repository/GitHub.php
@@ -225,7 +225,7 @@ class GitHub implements RepositoryInterface
     {
         $stmt = $this->db->prepare('
             SELECT b.id, b.name, b.builderrors, b.configureerrors, b.testfailed,
-                   b.done, b.starttime, bp.properties
+                   b.done, b.starttime, b.endtime, bp.properties
             FROM build b
             JOIN buildupdate bu ON bu.id = b.updateid
             LEFT JOIN buildproperties bp ON bp.buildid = b.id
@@ -446,6 +446,18 @@ class GitHub implements RepositoryInterface
                 $icon = ':white_check_mark:';
                 $msg = 'success';
                 $this->numPassed++;
+            } elseif ($this->isBuildStale($row)) {
+                // CDash never received a Done.xml for this build, but
+                // enough time has elapsed since it started/ended that we
+                // assume the submitter crashed before its final
+                // ctest_submit(PARTS Done) call. Treat the build as
+                // complete for check-run purposes so the GitHub PR is
+                // not blocked indefinitely. The web UI still shows
+                // done=0 so a maintainer can investigate the missing
+                // submission.
+                $icon = ':white_check_mark:';
+                $msg = 'success (stale: no Done.xml)';
+                $this->numPassed++;
             } else {
                 // Build hasn't finished reporting yet.
                 $icon = ':hourglass_flowing_sand:';
@@ -460,6 +472,50 @@ class GitHub implements RepositoryInterface
         }
         $build_summary = "[$build_name]($build_url) | $icon | [$msg]($details_url)";
         return $build_summary;
+    }
+
+    /**
+     * Watchdog: decide whether a build with done=0 has nonetheless been
+     * idle long enough that the GitHub check-run should be finalized.
+     *
+     * A misbehaving CTest submitter can leave a build in done=0 forever
+     * (e.g., the dashboard wrapper crashes after submitting Test.xml
+     * but before submitting Done.xml). Without a watchdog, the
+     * resulting GitHub check-run stays in_progress indefinitely and
+     * blocks merge for projects that gate on the `CDash` check.
+     *
+     * The threshold is configurable via cdash.github_check_stale_minutes
+     * (default: 240 minutes). Setting it to 0 disables the watchdog.
+     *
+     * @param array<string, int|string> $row
+     */
+    public function isBuildStale(array $row): bool
+    {
+        $threshold_minutes = (int) config('cdash.github_check_stale_minutes', 240);
+        if ($threshold_minutes <= 0) {
+            return false;
+        }
+
+        // Prefer endtime when CTest reported a build end (the most
+        // common stuck-in_progress shape: build ran to completion but
+        // Done.xml never arrived). Fall back to starttime when endtime
+        // is empty.
+        $reference = '';
+        if (!empty($row['endtime']) && (string) $row['endtime'] !== '1980-01-01 00:00:00') {
+            $reference = (string) $row['endtime'];
+        } elseif (!empty($row['starttime']) && (string) $row['starttime'] !== '1980-01-01 00:00:00') {
+            $reference = (string) $row['starttime'];
+        }
+        if ($reference === '') {
+            return false;
+        }
+
+        $reference_ts = strtotime($reference);
+        if ($reference_ts === false) {
+            return false;
+        }
+
+        return (time() - $reference_ts) >= ($threshold_minutes * 60);
     }
 
     /**

--- a/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -18,6 +18,7 @@
 use App\Utils\RepositoryUtils;
 use CDash\Lib\Repository\GitHub;
 use CDash\Model\Project;
+use DateTime;
 use Github\Api\Apps;
 use Github\Api\Repo;
 use Github\Api\Repository\Statuses;
@@ -145,6 +146,57 @@ class GitHubTest extends TestCase
         $actual = $sut->getCheckSummaryForBuildRow($build_row);
         $expected = $common . ":white_check_mark: | [success]($summary_url)";
         $this::assertEquals($expected, $actual);
+    }
+
+    public function testStaleBuildIsTreatedAsSuccess(): void
+    {
+        // Regression test for the stuck-`in_progress` GitHub check-run
+        // bug: a build with done=0 whose reference timestamp is older
+        // than cdash.github_check_stale_minutes must be reported as
+        // completed-success so the merge gate is unblocked.
+        $this->project->expects($this::once())
+            ->method('GetRepositories')
+            ->willReturn([]);
+        $sut = new GitHub($this->project);
+
+        $summary_url = "$this->baseUrl/builds/99999";
+        $common = "[my build]($summary_url) | ";
+
+        // 4 hour 5 minute window: longer than the default 240-minute
+        // threshold, comfortably outside any plausible real CI run.
+        $stale_endtime = (new DateTime('-245 minutes'))->format('Y-m-d H:i:s');
+        $build_row = [
+            'name' => 'my build',
+            'id' => 99999,
+            'properties' => '',
+            'configureerrors' => 0,
+            'builderrors' => 0,
+            'testfailed' => 0,
+            'done' => 0,
+            'starttime' => $stale_endtime,
+            'endtime' => $stale_endtime,
+        ];
+        $actual = $sut->getCheckSummaryForBuildRow($build_row);
+        $expected = $common . ":white_check_mark: | [success (stale: no Done.xml)]($summary_url)";
+        $this::assertEquals($expected, $actual);
+
+        // A fresh build with done=0 must remain pending (default 240 min).
+        $fresh_endtime = (new DateTime('-1 minute'))->format('Y-m-d H:i:s');
+        $build_row['starttime'] = $fresh_endtime;
+        $build_row['endtime'] = $fresh_endtime;
+        $actual = $sut->getCheckSummaryForBuildRow($build_row);
+        $expected = $common . ":hourglass_flowing_sand: | [pending]($summary_url)";
+        $this::assertEquals($expected, $actual);
+
+        // Setting cdash.github_check_stale_minutes=0 disables the
+        // watchdog and restores the legacy behaviour.
+        config(['cdash.github_check_stale_minutes' => 0]);
+        $build_row['starttime'] = $stale_endtime;
+        $build_row['endtime'] = $stale_endtime;
+        $actual = $sut->getCheckSummaryForBuildRow($build_row);
+        $expected = $common . ":hourglass_flowing_sand: | [pending]($summary_url)";
+        $this::assertEquals($expected, $actual);
+        config(['cdash.github_check_stale_minutes' => 240]);
     }
 
     /**

--- a/config/cdash.php
+++ b/config/cdash.php
@@ -39,6 +39,14 @@ return [
     'delete_old_subprojects' => env('DELETE_OLD_SUBPROJECTS', true),
     'github_always_pass' => env('GITHUB_ALWAYS_PASS', false),
     'github_app_id' => env('GITHUB_APP_ID', null),
+    /*
+     * Watchdog timeout (in minutes) after which a GitHub check-run for a
+     * build with done=0 is finalized as success even though Done.xml has
+     * not been received. Set to 0 to disable the watchdog and preserve
+     * the legacy behaviour of waiting indefinitely. See
+     * \CDash\Lib\Repository\GitHub::isBuildStale().
+     */
+    'github_check_stale_minutes' => env('CDASH_GITHUB_CHECK_STALE_MINUTES', 240),
     'github_private_key' => env('GITHUB_PRIVATE_KEY', null),
     'github_webhook_secret' => env('GITHUB_WEBHOOK_SECRET', null),
     'large_text_limit' => env('LARGE_TEXT_LIMIT', 0),


### PR DESCRIPTION
Adds a configurable watchdog so that a `CDash` GitHub check-run no longer stays `in_progress` indefinitely when a build's `Done.xml` never arrives. Closes #3669.

Default threshold is **240 minutes (4 hours)** — well outside any plausible real CI run. Setting `CDASH_GITHUB_CHECK_STALE_MINUTES=0` disables the watchdog and preserves the legacy behaviour.

<details>
<summary>Why</summary>

`getCheckSummaryForBuildRow()` currently only marks a build "passed" when `b.done = 1`, which is set exclusively by `DoneHandler.php` on `Done.xml` receipt. Any CI failure between the data-bearing submissions and `ctest_submit(PARTS Done)` leaves the GitHub check-run permanently `in_progress` even though CDash has all the data it needs. This regularly bites projects whose dashboard wrappers exit non-zero on warning-fatal conditions (e.g. ITK's `itk_common.cmake`'s `ci_completed_successfully` against the six Azure DevOps pipelines and three ARMBUILD GHA runners).

ITK has been temporarily working around this with an external GitHub Actions shadow check ([InsightSoftwareConsortium/ITK#6146](https://github.com/InsightSoftwareConsortium/ITK/pull/6146)); this PR fixes the root cause so that workaround can be retired.

Full root-cause analysis is in the linked issue (#3669).

</details>

<details>
<summary>What changed</summary>

| File | Change |
|---|---|
| `app/cdash/app/Lib/Repository/GitHub.php` | New `isBuildStale()` helper. `getCheckSummaryForBuildRow()` now reports stale builds (`done=0` AND reference timestamp older than threshold) as `success (stale: no Done.xml)` instead of pending. `getBuildRowsForCheck()` SELECT extended with `b.endtime`. |
| `config/cdash.php` | New `github_check_stale_minutes` knob (default `240`, env override `CDASH_GITHUB_CHECK_STALE_MINUTES`). |
| `app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php` | New `testStaleBuildIsTreatedAsSuccess()` covering: stale build → success; fresh build → pending; threshold=0 → legacy behaviour preserved. |

Reference timestamp preference order: `b.endtime` (when CTest reported a build end — the most common stuck shape), falling back to `b.starttime`. Both are sanity-checked against the CDash sentinel `1980-01-01 00:00:00`.

The build's web UI is unchanged: `done=0` is still visible so a maintainer can investigate the missing `Done.xml`. Only the GitHub check-run is short-circuited to a green conclusion.

</details>

<details>
<summary>Backward compatibility</summary>

* Existing `getCheckSummaryForBuildRow` unit tests pass unchanged: their fixture rows have no `endtime` / `starttime`, so `isBuildStale()` returns `false` and the original pending path is taken.
* Sites that prefer the historical wait-forever behaviour can set `CDASH_GITHUB_CHECK_STALE_MINUTES=0`.
* `cdash.github_always_pass` (the existing all-builds-always-success escape hatch) is unaffected and remains the higher-level override.

</details>

<!--
provenance: claude-code session 2026-04-26
linked_issue: Kitware/CDash#3669
itk_workaround_pr: InsightSoftwareConsortium/ITK#6146
default_threshold_minutes: 240
config_env_var: CDASH_GITHUB_CHECK_STALE_MINUTES
files_touched:
  - app/cdash/app/Lib/Repository/GitHub.php (isBuildStale + endtime in SELECT)
  - app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php (new test)
  - config/cdash.php (new knob)
post_merge_action: ITK can drop the cdash-bypass GitHub Actions shadow check (PR #6146).
-->