### PR TITLE
Drop repository password length constraint

### DIFF
--- a/database/migrations/2026_04_27_125711_drop_repository_password_length_limit.php
+++ b/database/migrations/2026_04_27_125711_drop_repository_password_length_limit.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE repositories ALTER COLUMN password TYPE text');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
The repository password column is used for GitHub app tokens.  GitHub [recently announced](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/) a switch to a JWT approach, which will result in much longer tokens.  This drops our length constraint on the password column to accommodate these longer tokens.