### PR TITLE
GraphQL: Support single-valued relationship filtering

### DIFF
--- a/app/GraphQL/Directives/FilterDirective.php
+++ b/app/GraphQL/Directives/FilterDirective.php
@@ -56,18 +56,25 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
         $defaultFilterType = $returnType . 'FilterInput';
         $filterName = $this->directiveArgValue('inputType', $defaultFilterType);
 
+        $subFilterableFields = $this->getSubFilterableFieldsForType($documentAST, $argDefinition, $parentType);
+        foreach ($subFilterableFields as $subMultiFilterName) {
+            $subTypeName = Str::before($subMultiFilterName, 'MultiFilterInput');
+            $this->ensureFilterInputTypes($documentAST, $subTypeName, $argDefinition);
+        }
+
         if (
-            $this->getSubFilterableFieldsForType($argDefinition, $parentType) === []
+            $subFilterableFields === []
             || (
                 !($parentField->type instanceof ListTypeNode)
                 && Str::doesntEndWith(ASTHelper::getUnderlyingTypeName($parentField), 'Connection')
             )
-            || $this->getSubFilterableFieldsForType($argDefinition, $documentAST->types[$returnType]) === []
+            || !isset($documentAST->types[$returnType])
+            || $this->getSubFilterableFieldsForType($documentAST, $argDefinition, $documentAST->types[$returnType]) === []
         ) {
             // Don't create a relationship filter input type because this type has no relationships
             $documentAST->setTypeDefinition($this->createMultiFilterInput($multiFilterName, $filterName, null));
         } else {
-            $relatedFieldRelationshipFilterName = Str::replaceEnd('Connection', '', $parentField->type->type->name->value) . 'RelationshipFilterInput';
+            $relatedFieldRelationshipFilterName = Str::replaceEnd('Connection', '', ASTHelper::getUnderlyingTypeName($parentField)) . 'RelationshipFilterInput';
             $documentAST->setTypeDefinition($this->createMultiFilterInput($multiFilterName, $filterName, $relatedFieldRelationshipFilterName));
         }
 
@@ -76,12 +83,12 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
         $relationshipFilterName = $parentType->name->value . 'RelationshipFilterInput';
         if (
             !array_key_exists($relationshipFilterName, $documentAST->types)
-            && $this->getSubFilterableFieldsForType($argDefinition, $parentType) !== []
+            && $subFilterableFields !== []
         ) {
             $documentAST->setTypeDefinition(
                 $this->createRelationshipFilterInput(
                     $relationshipFilterName,
-                    $this->getSubFilterableFieldsForType($argDefinition, $parentType)
+                    $subFilterableFields
                 )
             );
         }
@@ -243,20 +250,102 @@ final class FilterDirective extends BaseDirective implements ArgBuilderDirective
      *
      * @return array<string,string> A mapping of field names to their respective ...MultiFilterInput types
      */
-    private function getSubFilterableFieldsForType(InputValueDefinitionNode $argDefinition, ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode $type): array
+    private function getSubFilterableFieldsForType(DocumentAST $documentAST, InputValueDefinitionNode $argDefinition, ObjectTypeDefinitionNode|InterfaceTypeDefinitionNode $type): array
     {
         $subFilterableFieldNames = [];
         foreach ($type->fields as $field) {
+            // Check for hasMany/Connection style relationships with @filter argument
+            $hasFilterArg = false;
             foreach ($field->arguments as $argument) {
-                if (
-                    ASTHelper::hasDirective($argument, 'filter')
-                    && Str::endsWith(ASTHelper::getUnderlyingTypeName($field), 'Connection')
-                ) {
-                    $subFilterableFieldNames[(string) $field->name->value] = ASTHelper::qualifiedArgType($argDefinition, $field, $type) . 'MultiFilterInput';
+                if (ASTHelper::hasDirective($argument, 'filter')) {
+                    $hasFilterArg = true;
                     break;
+                }
+            }
+
+            if (
+                $hasFilterArg
+                && Str::endsWith(ASTHelper::getUnderlyingTypeName($field), 'Connection')
+            ) {
+                $subFilterableFieldNames[(string) $field->name->value] = ASTHelper::qualifiedArgType($argDefinition, $field, $type) . 'MultiFilterInput';
+                continue;
+            }
+
+            // Check for single-record relationships
+            if (
+                ASTHelper::hasDirective($field, 'belongsTo')
+                || ASTHelper::hasDirective($field, 'hasOne')
+                || ASTHelper::hasDirective($field, 'hasOneThrough')
+                || ASTHelper::hasDirective($field, 'morphOne')
+                || ASTHelper::hasDirective($field, 'morphTo')
+            ) {
+                $typeName = ASTHelper::getUnderlyingTypeName($field);
+                if ($this->isTypeFilterable($documentAST, $typeName)) {
+                    $subFilterableFieldNames[(string) $field->name->value] = $typeName . 'MultiFilterInput';
                 }
             }
         }
         return $subFilterableFieldNames;
+    }
+
+    private function ensureFilterInputTypes(DocumentAST &$documentAST, string $typeName, InputValueDefinitionNode $argDefinition): void
+    {
+        $multiFilterName = $typeName . 'MultiFilterInput';
+        if (array_key_exists($multiFilterName, $documentAST->types)) {
+            return;
+        }
+
+        $type = $documentAST->types[$typeName] ?? null;
+        if (!$type || (!$type instanceof ObjectTypeDefinitionNode && !$type instanceof InterfaceTypeDefinitionNode)) {
+            return;
+        }
+
+        // Avoid infinite recursion by setting a placeholder
+        $documentAST->types[$multiFilterName] = null;
+
+        $subFilterableFields = $this->getSubFilterableFieldsForType($documentAST, $argDefinition, $type);
+
+        $relationshipFilterName = null;
+        if ($subFilterableFields !== []) {
+            $relationshipFilterName = $typeName . 'RelationshipFilterInput';
+            if (!array_key_exists($relationshipFilterName, $documentAST->types)) {
+                // Ensure related types exist
+                foreach ($subFilterableFields as $subMultiFilterName) {
+                    $subTypeName = Str::before($subMultiFilterName, 'MultiFilterInput');
+                    $this->ensureFilterInputTypes($documentAST, $subTypeName, $argDefinition);
+                }
+
+                $documentAST->setTypeDefinition($this->createRelationshipFilterInput($relationshipFilterName, $subFilterableFields));
+            }
+        }
+
+        $filterName = $typeName . 'FilterInput';
+        $documentAST->setTypeDefinition($this->createMultiFilterInput($multiFilterName, $filterName, $relationshipFilterName));
+    }
+
+    private function isTypeFilterable(DocumentAST $documentAST, string $typeName): bool
+    {
+        if (!isset($documentAST->types[$typeName])) {
+            return false;
+        }
+
+        $type = $documentAST->types[$typeName];
+        if (!$type instanceof ObjectTypeDefinitionNode && !$type instanceof InterfaceTypeDefinitionNode) {
+            return false;
+        }
+
+        foreach ($type->fields as $field) {
+            if (ASTHelper::hasDirective($field, 'filterable')) {
+                return true;
+            }
+            // Also check for arguments with @filter
+            foreach ($field->arguments as $argument) {
+                if (ASTHelper::hasDirective($argument, 'filter')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,18 +151,6 @@ parameters:
 			path: app/Exceptions/Handler.php
 
 		-
-			rawMessage: Access to an undefined property GraphQL\Language\AST\ListTypeNode|GraphQL\Language\AST\NamedTypeNode|GraphQL\Language\AST\NonNullTypeNode::$name.
-			identifier: property.notFound
-			count: 1
-			path: app/GraphQL/Directives/FilterDirective.php
-
-		-
-			rawMessage: Access to an undefined property GraphQL\Language\AST\ListTypeNode|GraphQL\Language\AST\NamedTypeNode|GraphQL\Language\AST\NonNullTypeNode::$type.
-			identifier: property.notFound
-			count: 1
-			path: app/GraphQL/Directives/FilterDirective.php
-
-		-
 			rawMessage: 'Generic type Illuminate\Database\Eloquent\Relations\Relation<Illuminate\Database\Eloquent\Model> in PHPDoc tag @param for parameter $builder does not specify all template types of class Illuminate\Database\Eloquent\Relations\Relation: TRelatedModel, TDeclaringModel, TResult'
 			identifier: generics.lessTypes
 			count: 1
@@ -187,15 +175,33 @@ parameters:
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			rawMessage: 'Method App\GraphQL\Directives\FilterDirective::ensureFilterInputTypes() throws checked exception GraphQL\Error\SyntaxError but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 2
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			rawMessage: 'Method App\GraphQL\Directives\FilterDirective::ensureFilterInputTypes() throws checked exception JsonException but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 2
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			rawMessage: 'Method App\GraphQL\Directives\FilterDirective::handleBuilder() never returns Illuminate\Database\Query\Builder so it can be removed from the return type.'
 			identifier: return.unusedType
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
+			rawMessage: 'Only booleans are allowed in a negated boolean, (GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode)|null given.'
+			identifier: booleanNot.exprNotBoolean
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
 			rawMessage: 'Parameter #2 $array of function array_key_exists expects array, array<string, GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode>|GraphQL\Language\AST\NodeList<GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode> given.'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
@@ -211,8 +217,14 @@ parameters:
 			path: app/GraphQL/Directives/FilterDirective.php
 
 		-
-			rawMessage: 'Parameter #2 $type of method App\GraphQL\Directives\FilterDirective::getSubFilterableFieldsForType() expects GraphQL\Language\AST\InterfaceTypeDefinitionNode|GraphQL\Language\AST\ObjectTypeDefinitionNode, GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode given.'
+			rawMessage: 'Parameter #3 $type of method App\GraphQL\Directives\FilterDirective::getSubFilterableFieldsForType() expects GraphQL\Language\AST\InterfaceTypeDefinitionNode|GraphQL\Language\AST\ObjectTypeDefinitionNode, GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode given.'
 			identifier: argument.type
+			count: 1
+			path: app/GraphQL/Directives/FilterDirective.php
+
+		-
+			rawMessage: 'array<string, GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode>|GraphQL\Language\AST\NodeList<GraphQL\Language\AST\Node&GraphQL\Language\AST\TypeDefinitionNode> does not accept null.'
+			identifier: offsetAssign.valueType
 			count: 1
 			path: app/GraphQL/Directives/FilterDirective.php
 

--- a/tests/Feature/GraphQL/FilterTest.php
+++ b/tests/Feature/GraphQL/FilterTest.php
@@ -1127,4 +1127,60 @@ class FilterTest extends TestCase
             ],
         ]);
     }
+
+    public function testFilterByBelongsToRelationship(): void
+    {
+        $site1 = $this->makeSite(['name' => 'site1']);
+        $build1 = $this->projects['public1']->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $site1->id,
+        ]);
+
+        $site2 = $this->makeSite(['name' => 'site2']);
+        $build2 = $this->projects['public1']->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $site2->id,
+        ]);
+
+        $this->actingAs($this->users['admin'])->graphQL('
+            query($sitename: String!, $projectId: ID!) {
+                project(id: $projectId) {
+                    builds(filters: {
+                        has: {
+                            site: {
+                                eq: {
+                                    name: $sitename
+                                }
+                            }
+                        }
+                    }) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+            'sitename' => $site1->name,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => $build1->name,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
Our GraphQL filter system currently only supports multi-valued relationships, e.g., filtering builds with failing tests.  This PR completes the final piece of the core filtering feature, allowing users to filter by single-valued relationships, such as filtering builds by subproject, site, or configure.