### PR TITLE
Remove project `autoremovemaxbuilds` config option

### DIFF
--- a/app/Console/Commands/AutoRemoveBuilds.php
+++ b/app/Console/Commands/AutoRemoveBuilds.php
@@ -43,7 +43,7 @@ class AutoRemoveBuilds extends Command
 
         $projectname = $this->argument('project');
         $db = new Database();
-        $sql = 'SELECT id, autoremovetimeframe, autoremovemaxbuilds
+        $sql = 'SELECT id, autoremovetimeframe
                 FROM project';
         $args = [];
         if ($projectname !== 'all') {
@@ -69,12 +69,11 @@ class AutoRemoveBuilds extends Command
                 DatabaseCleanupUtils::removeFirstBuilds(
                     $project_array['id'],
                     $project_array['autoremovetimeframe'],
-                    (int) $project_array['autoremovemaxbuilds'],
+                    -1,
                     true // force the autoremove
                 );
                 DatabaseCleanupUtils::removeBuildsGroupwise(
                     (int) $project_array['id'],
-                    (int) $project_array['autoremovemaxbuilds'],
                     true // force the autoremove
                 );
             }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -36,12 +36,8 @@ class Kernel extends ConsoleKernel
             ->hourly()
             ->withoutOverlapping();
 
-        // TODO: This currently runs daily because the autoremovemaxbuilds project setting specifies
-        // the maximum number of builds to be removed per day.  In the future, we should evaluate
-        // whether this setting is meaningful.  Ideally, this job would run more frequently--perhaps
-        // hourly.
         $schedule->job(new PruneBuilds())
-            ->daily()
+            ->hourly()
             ->withoutOverlapping();
 
         $schedule->job(new PruneEmails())

--- a/app/Jobs/PruneBuilds.php
+++ b/app/Jobs/PruneBuilds.php
@@ -23,8 +23,8 @@ class PruneBuilds implements ShouldQueue
     public function handle(): void
     {
         foreach (Project::all() as $project) {
-            DatabaseCleanupUtils::removeFirstBuilds($project->id, $project->autoremovetimeframe, $project->autoremovemaxbuilds);
-            DatabaseCleanupUtils::removeBuildsGroupwise($project->id, $project->autoremovemaxbuilds);
+            DatabaseCleanupUtils::removeFirstBuilds($project->id, $project->autoremovetimeframe, -1);
+            DatabaseCleanupUtils::removeBuildsGroupwise($project->id);
         }
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -39,7 +39,6 @@ use Illuminate\Support\Facades\Auth;
  * @property int $emailmaxchars
  * @property bool $displaylabels
  * @property int $autoremovetimeframe
- * @property int $autoremovemaxbuilds
  * @property int $uploadquota Maximum sum of uploaded file sizes (in bytes)
  * @property int $uploadquotagb Maximum sum of uploaded file sizes (in GiB)
  * @property bool $showcoveragecode
@@ -88,7 +87,6 @@ class Project extends Model
         'emailmaxchars',
         'displaylabels',
         'autoremovetimeframe',
-        'autoremovemaxbuilds',
         'uploadquota',
         'uploadquotagb',
         'showcoveragecode',

--- a/app/Utils/DatabaseCleanupUtils.php
+++ b/app/Utils/DatabaseCleanupUtils.php
@@ -22,7 +22,7 @@ use InvalidArgumentException;
 class DatabaseCleanupUtils
 {
     /** Remove builds by their group-specific auto-remove timeframe setting */
-    public static function removeBuildsGroupwise(int $projectid, int $maxbuilds, bool $force = false): void
+    public static function removeBuildsGroupwise(int $projectid, bool $force = false): void
     {
         if (!$force && !(bool) config('cdash.autoremove_builds')) {
             return;
@@ -53,8 +53,7 @@ class DatabaseCleanupUtils
                               AND build2group.buildid = build.id
                               AND build2group.groupid = ?
                           ORDER BY build.starttime ASC
-                          LIMIT ?
-                      ', [$cutoffdate, $groupid, $maxbuilds]);
+                      ', [$cutoffdate, $groupid]);
 
             foreach ($builds as $build) {
                 $buildids[] = (int) $build->id;

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -73,7 +73,6 @@ class Project
     public $AuthenticateSubmissions = 0;
     public $ShowCoverageCode = 0;
     public $AutoremoveTimeframe = 0;
-    public int $AutoremoveMaxBuilds = 300;
     public $UploadQuota = 0;
     public ?string $LdapFilter = null;
     public ?string $Banner = null;
@@ -131,7 +130,6 @@ class Project
             'authenticatesubmissions' => filter_var($this->AuthenticateSubmissions, FILTER_VALIDATE_BOOLEAN),
             'showcoveragecode' => filter_var($this->ShowCoverageCode, FILTER_VALIDATE_BOOLEAN),
             'autoremovetimeframe' => (int) $this->AutoremoveTimeframe,
-            'autoremovemaxbuilds' => (int) $this->AutoremoveMaxBuilds,
             'uploadquota' => (int) $this->UploadQuota,
             'cvsviewertype' => $this->CvsViewerType,
             'testtimestd' => (int) $this->TestTimeStd,
@@ -212,7 +210,6 @@ class Project
             $this->AuthenticateSubmissions = $project->authenticatesubmissions;
             $this->ShowCoverageCode = $project->showcoveragecode;
             $this->AutoremoveTimeframe = $project->autoremovetimeframe;
-            $this->AutoremoveMaxBuilds = $project->autoremovemaxbuilds;
             $this->UploadQuota = $project->uploadquota;
             $this->CvsViewerType = $project->cvsviewertype;
             $this->TestTimeStd = $project->testtimestd;

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -419,7 +419,6 @@ class KWWebTestCase extends WebTestCase
             }
             // Specify some default settings.
             $settings = [
-                'AutoremoveMaxBuilds' => 500,
                 'AutoremoveTimeframe' => 60,
                 'CoverageThreshold' => 70,
                 'CvsViewerType' => 'github',

--- a/database/migrations/2026_04_28_172937_drop_project_autoremovemaxbuilds_column.php
+++ b/database/migrations/2026_04_28_172937_drop_project_autoremovemaxbuilds_column.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project DROP COLUMN autoremovemaxbuilds');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
-			rawMessage: Cannot access offset 'autoremovemaxbuilds' on mixed.
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: app/Console/Commands/AutoRemoveBuilds.php
-
-		-
 			rawMessage: Cannot access offset 'autoremovetimeframe' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -45,7 +39,7 @@ parameters:
 		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
-			count: 3
+			count: 1
 			path: app/Console/Commands/AutoRemoveBuilds.php
 
 		-
@@ -9706,12 +9700,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Casting to int something that's already int.
-			identifier: cast.useless
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: 'Method CDash\Model\Project::AddLogo() has no return type specified.'
 			identifier: missingType.return
 			count: 1
@@ -15640,19 +15628,19 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::__construct() has parameter $response with no type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::__construct() has parameter $response with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::getSent() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::getSent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::read() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::read() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -15880,7 +15868,7 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::$read has no type specified.
+			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::$read has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -170,15 +170,6 @@
         />
 
         <InputField
-          v-model="form.autoRemoveMaxBuilds"
-          :validation-error="validationErrors?.autoRemoveMaxBuilds?.[0]"
-          label="Maximum Builds Removed Per Day"
-          type="number"
-          min="0"
-          test-id="autoremove-max-builds-input"
-        />
-
-        <InputField
           v-model="form.fileUploadLimit"
           :validation-error="validationErrors?.fileUploadLimit?.[0]"
           label="File Upload Limit (GB)"
@@ -539,7 +530,6 @@ export default {
         emailMaxCharacters: 255,
         displayLabels: true,
         autoRemoveTimeFrame: 0,
-        autoRemoveMaxBuilds: 500,
         fileUploadLimit: 50,
         showCoverageCode: true,
         shareLabelFilters: false,
@@ -584,7 +574,6 @@ export default {
             emailMaxCharacters
             displayLabels
             autoRemoveTimeFrame
-            autoRemoveMaxBuilds
             fileUploadLimit
             showCoverageCode
             shareLabelFilters

--- a/tests/Browser/Pages/ProjectSettingsPageTest.php
+++ b/tests/Browser/Pages/ProjectSettingsPageTest.php
@@ -124,7 +124,6 @@ class ProjectSettingsPageTest extends BrowserTestCase
             ['@display-labels-input', false, 'displaylabels', false, 'checkbox'],
             ['@nightly-time-input', '23:01:01', 'nightlytime', '23:01:01', 'string'],
             ['@autoremove-time-frame-input', 7, 'autoremovetimeframe', 7, 'string'],
-            ['@autoremove-max-builds-input', 100, 'autoremovemaxbuilds', 100, 'string'],
             ['@file-upload-limit-input', 100, 'uploadquota', 107374182400, 'string'],
             ['@home-url-input', $homeurl, 'homeurl', $homeurl, 'string'],
             ['@home-url-input', '', 'homeurl', null, 'string'],

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -204,7 +204,6 @@ class UpdateProjectTest extends TestCase
             ['emailMaxCharacters', 2000, 'emailmaxchars', 2000],
             ['displayLabels', false, 'displaylabels', false],
             ['autoRemoveTimeFrame', 10, 'autoremovetimeframe', 10],
-            ['autoRemoveMaxBuilds', 20, 'autoremovemaxbuilds', 20],
             ['fileUploadLimit', 50, 'uploadquota', 53687091200],
             ['showCoverageCode', false, 'showcoveragecode', false],
             ['shareLabelFilters', false, 'sharelabelfilters', false],

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -162,7 +162,6 @@ class ProjectTypeTest extends TestCase
             ['emailmaxchars', 10, 'emailMaxCharacters', 10],
             ['displaylabels', true, 'displayLabels', true],
             ['displaylabels', false, 'displayLabels', false],
-            ['autoremovemaxbuilds', 10, 'autoRemoveMaxBuilds', 10],
             ['uploadquota', 10737418240, 'fileUploadLimit', 10],
             ['showcoveragecode', true, 'showCoverageCode', true],
             ['showcoveragecode', false, 'showCoverageCode', false],


### PR DESCRIPTION
The `autoremovemaxbuilds` was originally added in the era of daily updates, representing the maximum number of builds to delete per day.  This option is no longer meaningful, and is blocking other improvements to the daily update process.  In addition to removing the `autoremovemaxbuilds` option, this PR also increases the legacy build removal script frequency to hourly instead of daily.