### PR TITLE
Standardize GraphQL mutation error handling

### DIFF
--- a/app/Exceptions/GraphQLMutationException.php
+++ b/app/Exceptions/GraphQLMutationException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use GraphQL\Error\ClientAware;
+
+class GraphQLMutationException extends Exception implements ClientAware
+{
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+}

--- a/app/GraphQL/Mutations/ChangeGlobalRole.php
+++ b/app/GraphQL/Mutations/ChangeGlobalRole.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Enums\GlobalRole;
+use App\Exceptions\GraphQLMutationException;
 use App\Models\User;
-use Exception;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -21,9 +21,10 @@ final class ChangeGlobalRole extends AbstractMutation
      *     role: GlobalRole,
      * } $args
      *
+     * @throws GraphQLMutationException
      * @throws ValidationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         Validator::make($args, [
             'userId' => [
@@ -39,23 +40,23 @@ final class ChangeGlobalRole extends AbstractMutation
         $user = auth()->user();
         if ($user === null) {
             // This should never happen, but we handle the case anyway to make PHPStan happy.
-            throw new Exception('Attempt to invite user when not signed in.');
+            throw new GraphQLMutationException('Attempt to invite user when not signed in.');
         }
 
         $userToChange = User::find((int) $args['userId']);
         if ($userToChange === null) {
-            $this->message = 'Cannot change role for user which does not exist.';
-            return;
+            throw new GraphQLMutationException('Cannot change role for user which does not exist.');
         }
 
         if ($user->cannot('changeRole', $userToChange)) {
-            $this->message = 'Insufficient permissions.';
-            return;
+            throw new GraphQLMutationException('Insufficient permissions.');
         }
 
         $userToChange->admin = $args['role'] === GlobalRole::ADMINISTRATOR;
         $userToChange->save();
 
         $this->user = $userToChange;
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/ChangeProjectRole.php
+++ b/app/GraphQL/Mutations/ChangeProjectRole.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Enums\ProjectRole;
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\ValidationException;
 
 final class ChangeProjectRole extends AbstractMutation
 {
@@ -24,9 +24,10 @@ final class ChangeProjectRole extends AbstractMutation
      *     role: ProjectRole,
      * } $args
      *
-     * @throws ValidationException
+     * @throws GraphQLMutationException
+     * @throws Exception
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         Validator::make($args, [
             'userId' => [
@@ -44,20 +45,17 @@ final class ChangeProjectRole extends AbstractMutation
         /** @var ?User $user */
         $user = auth()->user();
         if ($user === null) {
-            // This should never happen, but we handle the case anyway to make PHPStan happy.
-            throw new Exception('Attempt to invite user when not signed in.');
+            throw new GraphQLMutationException('Attempt to invite user when not signed in.');
         }
 
         $userToChange = User::find((int) $args['userId']);
         if ($userToChange === null) {
-            $this->message = 'Cannot change role for user which does not exist.';
-            return;
+            throw new GraphQLMutationException('Cannot change role for user which does not exist.');
         }
 
         $project = Project::find((int) $args['projectId']);
         if ($project === null || $user->cannot('changeUserRole', [$project, $userToChange])) {
-            $this->message = 'This action is unauthorized.';
-            return;
+            throw new GraphQLMutationException('This action is unauthorized.');
         }
 
         $rowsEdited = $userToChange->projects()->updateExistingPivot($project->id, [
@@ -73,5 +71,7 @@ final class ChangeProjectRole extends AbstractMutation
 
         $this->user = $userToChange;
         $this->project = $project;
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/ClaimSite.php
+++ b/app/GraphQL/Mutations/ClaimSite.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
 
@@ -15,25 +16,29 @@ final class ClaimSite extends AbstractMutation
     /** @param array{
      *     siteId: int
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         /** @var ?User $user */
         $user = auth()->user();
 
         if ($user === null) {
-            abort(401, 'Authentication required to claim sites.');
+            throw new GraphQLMutationException('Authentication required to claim sites.');
         }
 
         $site = Site::find((int) $args['siteId']);
 
         if ($site === null) {
-            abort(404, 'Requested site not found.');
+            throw new GraphQLMutationException('Requested site not found.');
         }
 
         $site->maintainers()->syncWithoutDetaching($user);
 
         $this->site = $site;
         $this->user = $user;
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/CreateGlobalInvitation.php
+++ b/app/GraphQL/Mutations/CreateGlobalInvitation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Enums\GlobalRole;
+use App\Exceptions\GraphQLMutationException;
 use App\Mail\InvitedToCdash;
 use App\Models\GlobalInvitation;
 use App\Models\User;
@@ -26,9 +27,10 @@ final class CreateGlobalInvitation extends AbstractMutation
      *     role: GlobalRole,
      * } $args
      *
+     * @throws GraphQLMutationException
      * @throws Exception
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         // This field might not reset when testing since the same mocked request is reused.
         $this->invitedUser = null;
@@ -47,20 +49,19 @@ final class CreateGlobalInvitation extends AbstractMutation
         /** @var ?User $user */
         $user = auth()->user();
         if ($user === null) {
-            // This should never happen, but we handle the case anyway to make PHPStan happy.
-            throw new Exception('Attempt to invite user when not signed in.');
+            throw new GraphQLMutationException('Attempt to invite user when not signed in.');
         }
 
         if ($user->cannot('createInvitation', GlobalInvitation::class)) {
-            abort(401, 'This action is unauthorized.');
+            throw new GraphQLMutationException('This action is unauthorized.');
         }
 
         if (GlobalInvitation::where('email', $args['email'])->exists()) {
-            abort(400, 'Duplicate invitations are not allowed.');
+            throw new GraphQLMutationException('Duplicate invitations are not allowed.');
         }
 
         if (User::where('email', $args['email'])->exists()) {
-            abort(401, 'User is already a member of this instance.');
+            throw new GraphQLMutationException('User is already a member of this instance.');
         }
 
         $password = Str::password();
@@ -76,5 +77,7 @@ final class CreateGlobalInvitation extends AbstractMutation
         // The email gets sent to the queue, so we have no way to know immediately whether it was sent or not.
         // TODO: We should eventually track whether the email was actually sent.
         Mail::to($args['email'])->send(new InvitedToCdash($this->invitedUser, $password));
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/CreatePinnedTestMeasurement.php
+++ b/app/GraphQL/Mutations/CreatePinnedTestMeasurement.php
@@ -18,7 +18,7 @@ final class CreatePinnedTestMeasurement extends AbstractMutation
      *     name: string,
      * } $args
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $project = Project::find((int) $args['projectId']);
         Gate::authorize('createPinnedTestMeasurement', $project);
@@ -34,5 +34,7 @@ final class CreatePinnedTestMeasurement extends AbstractMutation
             'name' => $args['name'],
             'position' => $nextAvailablePosition,
         ]);
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/DeletePinnedTestMeasurement.php
+++ b/app/GraphQL/Mutations/DeletePinnedTestMeasurement.php
@@ -14,12 +14,14 @@ final class DeletePinnedTestMeasurement extends AbstractMutation
      *     id: int,
      * } $args
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $measurement = PinnedTestMeasurement::find((int) $args['id']);
 
         Gate::authorize('deletePinnedTestMeasurement', $measurement?->project);
 
         $measurement?->delete();
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/InviteToProject.php
+++ b/app/GraphQL/Mutations/InviteToProject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Mutations;
 
 use App\Enums\ProjectRole;
+use App\Exceptions\GraphQLMutationException;
 use App\Mail\InvitedToProject;
 use App\Models\Project;
 use App\Models\ProjectInvitation;
@@ -26,9 +27,10 @@ final class InviteToProject extends AbstractMutation
      *     role: ProjectRole,
      * } $args
      *
+     * @throws GraphQLMutationException
      * @throws Exception
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         // This field might not reset when testing since the same mocked request is reused.
         $this->invitedUser = null;
@@ -56,18 +58,15 @@ final class InviteToProject extends AbstractMutation
 
         $project = isset($args['projectId']) ? Project::find((int) $args['projectId']) : null;
         if ($project === null || $user->cannot('inviteUser', $project)) {
-            $this->message = 'This action is unauthorized.';
-            return;
+            throw new GraphQLMutationException('This action is unauthorized.');
         }
 
         if (ProjectInvitation::where(['email' => $args['email'], 'project_id' => $args['projectId']])->exists()) {
-            $this->message = 'Duplicate invitations are not allowed.';
-            return;
+            throw new GraphQLMutationException('Duplicate invitations are not allowed.');
         }
 
         if ($project->users()->where('email', $args['email'])->exists()) {
-            $this->message = 'User is already a member of this project.';
-            return;
+            throw new GraphQLMutationException('User is already a member of this project.');
         }
 
         $this->invitedUser = ProjectInvitation::create([
@@ -81,5 +80,7 @@ final class InviteToProject extends AbstractMutation
         // The email gets sent to the queue, so we have no way to know immediately whether it was sent or not.
         // TODO: We should eventually track whether the email was actually sent.
         Mail::to($args['email'])->send(new InvitedToProject($this->invitedUser));
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/JoinProject.php
+++ b/app/GraphQL/Mutations/JoinProject.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
-use Exception;
 
 final class JoinProject extends AbstractMutation
 {
@@ -15,9 +15,9 @@ final class JoinProject extends AbstractMutation
      *     projectId: int,
      * } $args
      *
-     * @throws Exception
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         /** @var ?User $user */
         $user = auth()->user();
@@ -28,7 +28,7 @@ final class JoinProject extends AbstractMutation
             || $project === null
             || $user->cannot('join', $project)
         ) {
-            abort(401, 'This action is unauthorized.');
+            throw new GraphQLMutationException('This action is unauthorized.');
         }
 
         $project
@@ -40,5 +40,7 @@ final class JoinProject extends AbstractMutation
                 'emailmissingsites' => false,
                 'role' => Project::PROJECT_USER,
             ]);
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/RemoveProjectUser.php
+++ b/app/GraphQL/Mutations/RemoveProjectUser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
 
@@ -14,8 +15,10 @@ final class RemoveProjectUser extends AbstractMutation
      *     userId: int,
      *     projectId: int,
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         /** @var ?User $user */
         $user = auth()->user();
@@ -36,9 +39,11 @@ final class RemoveProjectUser extends AbstractMutation
             )
             || !$project->users()->where('id', $userToRemove->id)->exists()
         ) {
-            abort(401, 'This action is unauthorized.');
+            throw new GraphQLMutationException('This action is unauthorized.');
         }
 
         $project->users()->detach($userToRemove->id);
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/RemoveUser.php
+++ b/app/GraphQL/Mutations/RemoveUser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 
@@ -13,17 +14,21 @@ final class RemoveUser extends AbstractMutation
      * @param array{
      *     userId: int,
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $user = User::find((int) $args['userId']);
 
         if ($user === null) {
-            abort(404, 'User does not exist.');
+            throw new GraphQLMutationException('User does not exist.');
         }
 
         Gate::authorize('delete', $user);
 
         $user->delete();
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/RevokeGlobalInvitation.php
+++ b/app/GraphQL/Mutations/RevokeGlobalInvitation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\GlobalInvitation;
 use Illuminate\Support\Facades\Gate;
 
@@ -13,17 +14,21 @@ final class RevokeGlobalInvitation extends AbstractMutation
      * @param array{
      *     invitationId: int,
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $invitation = GlobalInvitation::find((int) $args['invitationId']);
 
         if ($invitation === null) {
-            abort(400, 'Invitation does not exist.');
+            throw new GraphQLMutationException('Invitation does not exist.');
         }
 
         Gate::authorize('revokeInvitation', $invitation);
 
         $invitation->delete();
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/RevokeProjectInvitation.php
+++ b/app/GraphQL/Mutations/RevokeProjectInvitation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\ProjectInvitation;
 use Illuminate\Support\Facades\Gate;
 
@@ -13,18 +14,21 @@ final class RevokeProjectInvitation extends AbstractMutation
      * @param array{
      *     invitationId: int,
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $invitation = ProjectInvitation::find((int) $args['invitationId']);
 
         if ($invitation === null) {
-            $this->message = 'Invitation does not exist.';
-            return;
+            throw new GraphQLMutationException('Invitation does not exist.');
         }
 
         Gate::authorize('revokeInvitation', $invitation->project);
 
         $invitation->delete();
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/UnclaimSite.php
+++ b/app/GraphQL/Mutations/UnclaimSite.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
 
@@ -15,25 +16,29 @@ final class UnclaimSite extends AbstractMutation
     /** @param array{
      *     siteId: int
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         /** @var ?User $user */
         $user = auth()->user();
 
         if ($user === null) {
-            abort(401, 'Authentication required to unclaim sites.');
+            throw new GraphQLMutationException('Authentication required to unclaim sites.');
         }
 
         $site = Site::find((int) $args['siteId']);
 
         if ($site === null) {
-            abort(404, 'Requested site not found.');
+            throw new GraphQLMutationException('Requested site not found.');
         }
 
         $site->maintainers()->detach($user);
 
         $this->site = $site;
         $this->user = $user;
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
+++ b/app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\PinnedTestMeasurement;
 use App\Models\Project;
-use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 
@@ -20,8 +20,10 @@ final class UpdatePinnedTestMeasurementOrder extends AbstractMutation
      *     projectId: int,
      *     pinnedTestMeasurementIds: array<int>,
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         $project = Project::find((int) $args['projectId']);
         Gate::authorize('updatePinnedTestMeasurementOrder', $project);
@@ -30,15 +32,15 @@ final class UpdatePinnedTestMeasurementOrder extends AbstractMutation
         $newOrder = collect($args['pinnedTestMeasurementIds']);
 
         if ($projectMeasurementIds->diff($newOrder)->isNotEmpty()) {
-            throw new Exception('IDs for all PinnedTestMeasurements must be provided.');
+            throw new GraphQLMutationException('IDs for all PinnedTestMeasurements must be provided.');
         }
 
         if ($newOrder->count() !== $projectMeasurementIds->count()) {
-            throw new Exception('Provided set cannot contain duplicate IDs.');
+            throw new GraphQLMutationException('Provided set cannot contain duplicate IDs.');
         }
 
         if ($newOrder->isEmpty()) {
-            throw new Exception("Can't order an empty set.");
+            throw new GraphQLMutationException("Can't order an empty set.");
         }
 
         // We start at the previous maximum ID + 1 to guarantee that there are never any conflicts.
@@ -54,5 +56,7 @@ final class UpdatePinnedTestMeasurementOrder extends AbstractMutation
         }
 
         $this->pinnedTestMeasurements = $project?->pinnedTestMeasurements()->orderBy('position')->get();
+
+        return $this;
     }
 }

--- a/app/GraphQL/Mutations/UpdateSiteDescription.php
+++ b/app/GraphQL/Mutations/UpdateSiteDescription.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
 
@@ -15,20 +16,22 @@ final class UpdateSiteDescription extends AbstractMutation
      *     siteId: int,
      *     description: string
      * } $args
+     *
+     * @throws GraphQLMutationException
      */
-    protected function mutate(array $args): void
+    public function __invoke(null $_, array $args): self
     {
         /** @var ?User $user */
         $user = auth()->user();
 
         if ($user === null) {
-            abort(401, 'Authentication required to edit site descriptions.');
+            throw new GraphQLMutationException('Authentication required to edit site descriptions.');
         }
 
         $site = Site::find((int) $args['siteId']);
 
         if ($site === null) {
-            abort(404, 'Requested site not found.');
+            throw new GraphQLMutationException('Requested site not found.');
         }
 
         $newSiteInformation = $site->mostRecentInformation?->getAttributes() ?? [];
@@ -39,5 +42,7 @@ final class UpdateSiteDescription extends AbstractMutation
         $site->information()->create($newSiteInformation);
 
         $this->site = $site;
+
+        return $this;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -337,7 +337,7 @@ parameters:
 			path: app/GraphQL/Mutations/InviteToProject.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{projectId: int}) of method App\GraphQL\Mutations\JoinProject::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{projectId: int}) of method App\GraphQL\Mutations\JoinProject::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/JoinProject.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -391,7 +391,7 @@ parameters:
 			path: app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{projectId: int, pinnedTestMeasurementIds: array<int>}) of method App\GraphQL\Mutations\UpdatePinnedTestMeasurementOrder::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{projectId: int, pinnedTestMeasurementIds: array<int>}) of method App\GraphQL\Mutations\UpdatePinnedTestMeasurementOrder::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -361,7 +361,7 @@ parameters:
 			path: app/GraphQL/Mutations/RevokeGlobalInvitation.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{invitationId: int}) of method App\GraphQL\Mutations\RevokeProjectInvitation::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{invitationId: int}) of method App\GraphQL\Mutations\RevokeProjectInvitation::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/RevokeProjectInvitation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -319,7 +319,7 @@ parameters:
 			path: app/GraphQL/Mutations/DeleteAuthenticationToken.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{id: int}) of method App\GraphQL\Mutations\DeletePinnedTestMeasurement::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{id: int}) of method App\GraphQL\Mutations\DeletePinnedTestMeasurement::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/DeletePinnedTestMeasurement.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -349,7 +349,7 @@ parameters:
 			path: app/GraphQL/Mutations/RemoveProjectUser.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{userId: int}) of method App\GraphQL\Mutations\RemoveUser::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{userId: int}) of method App\GraphQL\Mutations\RemoveUser::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/RemoveUser.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -283,7 +283,7 @@ parameters:
 			path: app/GraphQL/Mutations/CreateComment.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{email: string, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\CreateGlobalInvitation::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{email: string, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\CreateGlobalInvitation::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/CreateGlobalInvitation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -331,7 +331,7 @@ parameters:
 			path: app/GraphQL/Mutations/DeleteRepository.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{email: string, projectId: int, role: App\Enums\ProjectRole}) of method App\GraphQL\Mutations\InviteToProject::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{email: string, projectId: int, role: App\Enums\ProjectRole}) of method App\GraphQL\Mutations\InviteToProject::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/InviteToProject.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -409,7 +409,7 @@ parameters:
 			path: app/GraphQL/Mutations/UpdateProject.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{siteId: int, description: string}) of method App\GraphQL\Mutations\UpdateSiteDescription::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{siteId: int, description: string}) of method App\GraphQL\Mutations\UpdateSiteDescription::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/UpdateSiteDescription.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -355,7 +355,7 @@ parameters:
 			path: app/GraphQL/Mutations/RemoveUser.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{invitationId: int}) of method App\GraphQL\Mutations\RevokeGlobalInvitation::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{invitationId: int}) of method App\GraphQL\Mutations\RevokeGlobalInvitation::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/RevokeGlobalInvitation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -343,7 +343,7 @@ parameters:
 			path: app/GraphQL/Mutations/JoinProject.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{userId: int, projectId: int}) of method App\GraphQL\Mutations\RemoveProjectUser::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{userId: int, projectId: int}) of method App\GraphQL\Mutations\RemoveProjectUser::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/RemoveProjectUser.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,7 +241,7 @@ parameters:
 			path: app/GraphQL/Directives/FilterableDirective.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{userId: int, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\ChangeGlobalRole::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{userId: int, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\ChangeGlobalRole::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/ChangeGlobalRole.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -247,7 +247,7 @@ parameters:
 			path: app/GraphQL/Mutations/ChangeGlobalRole.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{userId: int, projectId: int, role: App\Enums\ProjectRole}) of method App\GraphQL\Mutations\ChangeProjectRole::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{userId: int, projectId: int, role: App\Enums\ProjectRole}) of method App\GraphQL\Mutations\ChangeProjectRole::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/ChangeProjectRole.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -295,7 +295,7 @@ parameters:
 			path: app/GraphQL/Mutations/CreatePinnedTestMeasurement.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{projectId: int, name: string}) of method App\GraphQL\Mutations\CreatePinnedTestMeasurement::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{projectId: int, name: string}) of method App\GraphQL\Mutations\CreatePinnedTestMeasurement::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/CreatePinnedTestMeasurement.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -367,7 +367,7 @@ parameters:
 			path: app/GraphQL/Mutations/RevokeProjectInvitation.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{siteId: int}) of method App\GraphQL\Mutations\UnclaimSite::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{siteId: int}) of method App\GraphQL\Mutations\UnclaimSite::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/UnclaimSite.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -253,7 +253,7 @@ parameters:
 			path: app/GraphQL/Mutations/ChangeProjectRole.php
 
 		-
-			rawMessage: 'Parameter #1 $args (array{siteId: int}) of method App\GraphQL\Mutations\ClaimSite::mutate() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::mutate()'
+			rawMessage: 'Parameter #2 $args (array{siteId: int}) of method App\GraphQL\Mutations\ClaimSite::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
 			path: app/GraphQL/Mutations/ClaimSite.php

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -518,7 +518,7 @@ export default {
             projectId: $projectId
             role: $role
           }) {
-            message
+            __typename
           }
         }`,
         variables: {
@@ -543,7 +543,6 @@ export default {
             projectId: $projectId
             role: $role
           }) {
-            message
             invitedUser {
               id
               email
@@ -564,10 +563,6 @@ export default {
         },
         updateQueries: {
           projectInvitations(prev, { mutationResult }) {
-            if (mutationResult.data.inviteToProject.message !== null) {
-              return prev;
-            }
-
             const data = JSON.parse(JSON.stringify(prev));
             data.project.invitations.edges.push({
               __typename: 'ProjectInvitationEdge',
@@ -578,17 +573,13 @@ export default {
             return data;
           },
         },
-      }).then((mutationResult) => {
-        if (mutationResult.data.inviteToProject.message !== null) {
-          this.inviteMembersModalError = mutationResult.data.inviteToProject.message;
-        }
-        else {
-          // eslint-disable-next-line no-undef
-          invite_members_modal.close();
-          this.inviteMembersModalEmail = '';
-          this.inviteMembersModalRole = this.USER_TYPES.USER;
-        }
+      }).then(() => {
+        // eslint-disable-next-line no-undef
+        invite_members_modal.close();
+        this.inviteMembersModalEmail = '';
+        this.inviteMembersModalRole = this.USER_TYPES.USER;
       }).catch((error) => {
+        this.inviteMembersModalError = error.message;
         console.error(error);
       });
     },
@@ -599,7 +590,7 @@ export default {
           revokeProjectInvitation(input: {
             invitationId: $invitationId
           }) {
-            message
+            __typename
           }
         }`,
         variables: {
@@ -630,7 +621,7 @@ export default {
             userId: $userId
             projectId: $projectId
           }) {
-            message
+            __typename
           }
         }`,
         variables: {
@@ -660,16 +651,16 @@ export default {
           joinProject(input: {
             projectId: $projectId
           }) {
-            message
+            __typename
           }
         }`,
         variables: {
           projectId: this.projectId,
         },
-      }).catch((error) => {
-        console.error(error);
       }).then(() => {
         window.location.reload();
+      }).catch((error) => {
+        console.error(error);
       });
     },
 
@@ -680,17 +671,17 @@ export default {
             userId: $userId
             projectId: $projectId
           }) {
-            message
+            __typename
           }
         }`,
         variables: {
           userId: this.userId,
           projectId: this.projectId,
         },
-      }).catch((error) => {
-        console.error(error);
       }).then(() => {
         window.location.reload();
+      }).catch((error) => {
+        console.error(error);
       });
     },
   },

--- a/tests/Feature/GraphQL/Mutations/ChangeGlobalRoleTest.php
+++ b/tests/Feature/GraphQL/Mutations/ChangeGlobalRoleTest.php
@@ -119,14 +119,8 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::ADMINISTRATOR,
-        ])->assertExactJson([
-            'data' => [
-                'changeGlobalRole' => [
-                    'message' => 'Insufficient permissions.',
-                    'user' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeGlobalRole', null)
+            ->assertGraphQLErrorMessage('Insufficient permissions.');
 
         self::assertFalse($this->users['normal']->refresh()->admin);
     }
@@ -150,14 +144,8 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeGlobalRole' => [
-                    'message' => 'Insufficient permissions.',
-                    'user' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeGlobalRole', null)
+            ->assertGraphQLErrorMessage('Insufficient permissions.');
 
         self::assertTrue($this->users['admin']->refresh()->admin);
     }
@@ -179,14 +167,8 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => 123456789,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeGlobalRole' => [
-                    'message' => 'Cannot change role for user which does not exist.',
-                    'user' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeGlobalRole', null)
+            ->assertGraphQLErrorMessage('Cannot change role for user which does not exist.');
     }
 
     public function testAnonymousUserCannotChangeRole(): void
@@ -208,14 +190,8 @@ class ChangeGlobalRoleTest extends TestCase
         ', [
             'userId' => $this->users['admin']->id,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeGlobalRole' => [
-                    'message' => 'Attempt to invite user when not signed in.',
-                    'user' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeGlobalRole', null)
+            ->assertGraphQLErrorMessage('Attempt to invite user when not signed in.');
 
         self::assertTrue($this->users['admin']->refresh()->admin);
     }

--- a/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
+++ b/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
@@ -190,15 +190,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectAdmin']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'This action is unauthorized.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -233,15 +226,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::ADMINISTRATOR,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'This action is unauthorized.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -276,15 +262,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['admin']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'This action is unauthorized.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -319,15 +298,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['nonmemberUser']->id,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'This action is unauthorized.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -362,15 +334,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => 12345678,
             'projectId' => $this->project->id,
             'role' => ProjectRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'Cannot change role for user which does not exist.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('Cannot change role for user which does not exist.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));
@@ -405,15 +370,8 @@ class ChangeProjectRoleTest extends TestCase
             'userId' => $this->users['projectMember']->id,
             'projectId' => 12345678,
             'role' => ProjectRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'changeProjectRole' => [
-                    'message' => 'This action is unauthorized.',
-                    'user' => null,
-                    'project' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.changeProjectRole', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertNotContains($this->users['admin']->id, $this->project->users()->pluck('id'));
         self::assertContains($this->users['projectMember']->id, $this->project->basicUsers()->pluck('id'));

--- a/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateGlobalInvitationTest.php
@@ -139,14 +139,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -179,14 +173,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'Attempt to invite user when not signed in.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('Attempt to invite user when not signed in.');
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -244,14 +232,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'Duplicate invitations are not allowed.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('Duplicate invitations are not allowed.');
 
         self::assertCount(1, GlobalInvitation::all());
         Mail::assertQueued(InvitedToCdash::class, 1);
@@ -292,14 +274,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'The email must be a valid email address.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('The email must be a valid email address.');
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -326,14 +302,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $this->users['normal']->email,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'User is already a member of this instance.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('User is already a member of this instance.');
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();
@@ -368,14 +338,8 @@ class CreateGlobalInvitationTest extends TestCase
         ', [
             'email' => $email,
             'role' => GlobalRole::USER,
-        ])->assertExactJson([
-            'data' => [
-                'createGlobalInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty(GlobalInvitation::all());
         Mail::assertNothingQueued();

--- a/tests/Feature/GraphQL/Mutations/CreatePinnedTestMeasurementTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreatePinnedTestMeasurementTest.php
@@ -35,14 +35,8 @@ class CreatePinnedTestMeasurementTest extends TestCase
                 'projectId' => 1234567,
                 'name' => $name,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'createPinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                    'pinnedTestMeasurement' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createPinnedTestMeasurement', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty(PinnedTestMeasurement::all());
     }
@@ -67,14 +61,8 @@ class CreatePinnedTestMeasurementTest extends TestCase
                 'projectId' => $project->id,
                 'name' => $name,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'createPinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                    'pinnedTestMeasurement' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createPinnedTestMeasurement', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty(PinnedTestMeasurement::all());
     }
@@ -100,14 +88,8 @@ class CreatePinnedTestMeasurementTest extends TestCase
                 'projectId' => $project->id,
                 'name' => $name,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'createPinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                    'pinnedTestMeasurement' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.createPinnedTestMeasurement', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty(PinnedTestMeasurement::all());
     }

--- a/tests/Feature/GraphQL/Mutations/DeletePinnedTestMeasurementTest.php
+++ b/tests/Feature/GraphQL/Mutations/DeletePinnedTestMeasurementTest.php
@@ -29,13 +29,7 @@ class DeletePinnedTestMeasurementTest extends TestCase
             'input' => [
                 'id' => 123456789,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'deletePinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testFailsWhenNoUser(): void
@@ -58,13 +52,8 @@ class DeletePinnedTestMeasurementTest extends TestCase
             'input' => [
                 'id' => $measurement->id,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'deletePinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
         self::assertDatabaseHas(PinnedTestMeasurement::class, ['id' => $measurement->id]);
     }
 
@@ -89,13 +78,8 @@ class DeletePinnedTestMeasurementTest extends TestCase
             'input' => [
                 'id' => $measurement->id,
             ],
-        ])->assertExactJson([
-            'data' => [
-                'deletePinnedTestMeasurement' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertGraphQLErrorMessage('This action is unauthorized.');
+
         self::assertDatabaseHas(PinnedTestMeasurement::class, ['id' => $measurement->id]);
     }
 
@@ -126,7 +110,8 @@ class DeletePinnedTestMeasurementTest extends TestCase
                     'message' => null,
                 ],
             ],
-        ]);
+        ])->assertGraphQLErrorFree();
+
         self::assertEmpty(PinnedTestMeasurement::all());
     }
 }

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -141,14 +141,8 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -187,14 +181,8 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -285,14 +273,8 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();
@@ -319,14 +301,8 @@ class InviteToProjectTest extends TestCase
             'email' => fake()->unique()->email(),
             'projectId' => 1234567,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         Mail::assertNothingQueued();
     }
@@ -386,14 +362,8 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'Duplicate invitations are not allowed.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('Duplicate invitations are not allowed.');
 
         self::assertCount(1, $this->project->invitations()->get());
         Mail::assertQueued(InvitedToProject::class, 1);
@@ -434,14 +404,8 @@ class InviteToProjectTest extends TestCase
             'email' => $email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'The email must be a valid email address.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('The email must be a valid email address.');
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -477,14 +441,8 @@ class InviteToProjectTest extends TestCase
             'email' => $this->users['normal']->email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'User is already a member of this project.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('User is already a member of this project.');
 
         self::assertEmpty($this->project->invitations()->get());
     }
@@ -515,14 +473,8 @@ class InviteToProjectTest extends TestCase
             'email' => $this->users['normal']->email,
             'projectId' => $this->project->id,
             'role' => 'USER',
-        ])->assertExactJson([
-            'data' => [
-                'inviteToProject' => [
-                    'message' => 'This action is unauthorized.',
-                    'invitedUser' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.inviteToProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project->invitations()->get());
         Mail::assertNothingQueued();

--- a/tests/Feature/GraphQL/Mutations/JoinProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/JoinProjectTest.php
@@ -102,13 +102,8 @@ class JoinProjectTest extends TestCase
             }
         ', [
             'projectId' => $this->project?->id,
-        ])->assertExactJson([
-            'data' => [
-                'joinProject' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.joinProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project?->users()->get());
     }
@@ -129,13 +124,8 @@ class JoinProjectTest extends TestCase
             }
         ', [
             'projectId' => $this->project->id,
-        ])->assertExactJson([
-            'data' => [
-                'joinProject' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.joinProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertEmpty($this->project->users()->get());
     }
@@ -154,12 +144,7 @@ class JoinProjectTest extends TestCase
             }
         ', [
             'projectId' => 123456789,
-        ])->assertExactJson([
-            'data' => [
-                'joinProject' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.joinProject', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -115,13 +115,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         $this->assertProjectMember($userToDelete);
     }
@@ -144,13 +139,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         $this->assertProjectMember($userToDelete);
     }
@@ -233,13 +223,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         $this->assertProjectMember($userToDelete);
     }
@@ -263,13 +248,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $this->users['normal']->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertTrue($this->users['normal']->refresh()->exists());
     }
@@ -290,13 +270,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => 123456789,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testHandlesMissingProject(): void
@@ -316,13 +291,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => 123456789,
             'userId' => $this->users['normal']->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
     }
 
     public function testCannotDeleteProjectMembersIfManagedByLdap(): void
@@ -348,13 +318,8 @@ class RemoveProjectUserTest extends TestCase
         ', [
             'projectId' => $this->project->id,
             'userId' => $userToDelete->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeProjectUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeProjectUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         $this->assertProjectMember($userToDelete);
     }

--- a/tests/Feature/GraphQL/Mutations/RemoveUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveUserTest.php
@@ -73,13 +73,9 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
         self::assertContains($this->users['normal']->id, User::pluck('id'));
     }
 
@@ -96,13 +92,9 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
         self::assertContains($this->users['admin']->id, User::pluck('id'));
     }
 
@@ -119,13 +111,9 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => $this->users['admin']->id,
-        ])->assertExactJson([
-            'data' => [
-                'removeUser' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeUser', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
         self::assertContains($this->users['admin']->id, User::pluck('id'));
     }
 
@@ -141,12 +129,7 @@ class RemoveUserTest extends TestCase
             }
         ', [
             'userId' => 123456789,
-        ])->assertExactJson([
-            'data' => [
-                'removeUser' => [
-                    'message' => 'User does not exist.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.removeUser', null)
+            ->assertGraphQLErrorMessage('User does not exist.');
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeGlobalInvitationTest.php
@@ -109,13 +109,8 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertExactJson([
-            'data' => [
-                'revokeGlobalInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertTrue($invitation->refresh()->exists());
     }
@@ -143,13 +138,8 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertExactJson([
-            'data' => [
-                'revokeGlobalInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertTrue($invitation->refresh()->exists());
     }
@@ -166,12 +156,7 @@ class RevokeGlobalInvitationTest extends TestCase
             }
         ', [
             'invitationId' => 1234567,
-        ])->assertExactJson([
-            'data' => [
-                'revokeGlobalInvitation' => [
-                    'message' => 'Invitation does not exist.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeGlobalInvitation', null)
+            ->assertGraphQLErrorMessage('Invitation does not exist.');
     }
 }

--- a/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
@@ -104,13 +104,8 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertExactJson([
-            'data' => [
-                'revokeProjectInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeProjectInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -137,13 +132,8 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertExactJson([
-            'data' => [
-                'revokeProjectInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeProjectInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -180,13 +170,8 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => $invitation->id,
-        ])->assertExactJson([
-            'data' => [
-                'revokeProjectInvitation' => [
-                    'message' => 'This action is unauthorized.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeProjectInvitation', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertCount(1, $this->project->invitations()->get());
     }
@@ -246,12 +231,7 @@ class RevokeProjectInvitationTest extends TestCase
             }
         ', [
             'invitationId' => 1234567,
-        ])->assertExactJson([
-            'data' => [
-                'revokeProjectInvitation' => [
-                    'message' => 'Invitation does not exist.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.revokeProjectInvitation', null)
+            ->assertGraphQLErrorMessage('Invitation does not exist.');
     }
 }

--- a/tests/Feature/GraphQL/Mutations/UpdatePinnedTestMeasurementOrderTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdatePinnedTestMeasurementOrderTest.php
@@ -45,14 +45,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project1->id,
                 'pinnedTestMeasurementIds' => [$measurement2->id],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => 'IDs for all PinnedTestMeasurements must be provided.',
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage('IDs for all PinnedTestMeasurements must be provided.');
     }
 
     public function testFailsWhenMissingIds(): void
@@ -85,14 +79,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project->id,
                 'pinnedTestMeasurementIds' => [$measurement1->id],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => 'IDs for all PinnedTestMeasurements must be provided.',
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage('IDs for all PinnedTestMeasurements must be provided.');
 
         self::assertSame(1, $measurement1->fresh()?->position);
         self::assertSame(2, $measurement2->fresh()?->position);
@@ -119,14 +107,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project->id,
                 'pinnedTestMeasurementIds' => [],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => "Can't order an empty set.",
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage("Can't order an empty set.");
     }
 
     public function testFailsWhenAnonymousUser(): void
@@ -153,14 +135,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project->id,
                 'pinnedTestMeasurementIds' => [$measurement->id],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => 'This action is unauthorized.',
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertSame(1, $measurement->fresh()?->position);
     }
@@ -190,14 +166,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project->id,
                 'pinnedTestMeasurementIds' => [$measurement->id],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => 'This action is unauthorized.',
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
 
         self::assertSame(1, $measurement->fresh()?->position);
     }
@@ -228,14 +198,8 @@ class UpdatePinnedTestMeasurementOrderTest extends TestCase
                 'projectId' => $project->id,
                 'pinnedTestMeasurementIds' => [$measurement->id, $measurement->id],
             ],
-        ])->assertExactJson([
-            'data' => [
-                'updatePinnedTestMeasurementOrder' => [
-                    'message' => 'Provided set cannot contain duplicate IDs.',
-                    'pinnedTestMeasurements' => null,
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updatePinnedTestMeasurementOrder', null)
+            ->assertGraphQLErrorMessage('Provided set cannot contain duplicate IDs.');
 
         self::assertSame(1, $measurement->fresh()?->position);
     }

--- a/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateSiteDescriptionTest.php
@@ -56,14 +56,8 @@ class UpdateSiteDescriptionTest extends TestCase
         ', [
             'siteid' => 123456789,
             'description' => Str::uuid()->toString(),
-        ])->assertExactJson([
-            'data' => [
-                'updateSiteDescription' => [
-                    'site' => null,
-                    'message' => 'Requested site not found.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updateSiteDescription', null)
+            ->assertGraphQLErrorMessage('Requested site not found.');
 
         self::assertEmpty($this->site->information()->get());
     }
@@ -87,14 +81,8 @@ class UpdateSiteDescriptionTest extends TestCase
         ', [
             'siteid' => $this->site->id,
             'description' => Str::uuid()->toString(),
-        ])->assertExactJson([
-            'data' => [
-                'updateSiteDescription' => [
-                    'site' => null,
-                    'message' => 'Authentication required to edit site descriptions.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.updateSiteDescription', null)
+            ->assertGraphQLErrorMessage('Authentication required to edit site descriptions.');
 
         self::assertEmpty($this->site->information()->get());
     }

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -1076,15 +1076,8 @@ class SiteTypeTest extends TestCase
             }
         ', [
             'siteid' => $this->sites['site1']->id,
-        ])->assertExactJson([
-            'data' => [
-                'claimSite' => [
-                    'user' => null,
-                    'site' => null,
-                    'message' => 'Authentication required to claim sites.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.claimSite', null)
+            ->assertGraphQLErrorMessage('Authentication required to claim sites.');
     }
 
     public function testClaimSiteMutationRejectsInvalidSiteId(): void
@@ -1105,15 +1098,8 @@ class SiteTypeTest extends TestCase
             }
         ', [
             'siteid' => 123456789,
-        ])->assertExactJson([
-            'data' => [
-                'claimSite' => [
-                    'user' => null,
-                    'site' => null,
-                    'message' => 'Requested site not found.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.claimSite', null)
+            ->assertGraphQLErrorMessage('Requested site not found.');
     }
 
     public function testClaimSiteMutationAcceptsValidRequest(): void

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -1216,15 +1216,8 @@ class SiteTypeTest extends TestCase
             }
         ', [
             'siteid' => $this->sites['site1']->id,
-        ])->assertExactJson([
-            'data' => [
-                'unclaimSite' => [
-                    'user' => null,
-                    'site' => null,
-                    'message' => 'Authentication required to unclaim sites.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.unclaimSite', null)
+            ->assertGraphQLErrorMessage('Authentication required to unclaim sites.');
     }
 
     public function testUnclaimSiteMutationRejectsInvalidSiteId(): void
@@ -1245,15 +1238,8 @@ class SiteTypeTest extends TestCase
             }
         ', [
             'siteid' => 123456789,
-        ])->assertExactJson([
-            'data' => [
-                'unclaimSite' => [
-                    'user' => null,
-                    'site' => null,
-                    'message' => 'Requested site not found.',
-                ],
-            ],
-        ]);
+        ])->assertJsonPath('data.unclaimSite', null)
+            ->assertGraphQLErrorMessage('Requested site not found.');
     }
 
     public function testUnclaimSiteMutationAcceptsValidRequest(): void


### PR DESCRIPTION
Our GraphQL mutations currently use a combination of thrown and caught exceptions, lighthouse-php error handling, and a `messages` data field used as an error field.  This PR switches everything to report proper GraphQL errors where appropriate, allowing clients to process errors using built-in error handling mechanisms.