### PR TITLE
Add logging to all GraphQL mutations

### DIFF
--- a/app/GraphQL/Mutations/ChangeGlobalRole.php
+++ b/app/GraphQL/Mutations/ChangeGlobalRole.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Enums\GlobalRole;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
@@ -54,6 +55,8 @@ final class ChangeGlobalRole extends AbstractMutation
 
         $userToChange->admin = $args['role'] === GlobalRole::ADMINISTRATOR;
         $userToChange->save();
+
+        Log::info("User {$user->id} changed global role to {$args['role']->value} for user {$userToChange->id}.");
 
         $this->user = $userToChange;
 

--- a/app/GraphQL/Mutations/ChangeProjectRole.php
+++ b/app/GraphQL/Mutations/ChangeProjectRole.php
@@ -9,6 +9,7 @@ use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
 use Exception;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
@@ -64,6 +65,8 @@ final class ChangeProjectRole extends AbstractMutation
                 ProjectRole::ADMINISTRATOR => Project::PROJECT_ADMIN,
             },
         ]);
+
+        Log::info("User {$user->id} changed role to {$args['role']->value} for user {$userToChange->id} in project {$project->id}.");
 
         if ($rowsEdited !== 1) {
             throw new Exception('Failed to update pivot table with new role.');

--- a/app/GraphQL/Mutations/ClaimSite.php
+++ b/app/GraphQL/Mutations/ClaimSite.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 final class ClaimSite extends AbstractMutation
 {
@@ -35,6 +36,8 @@ final class ClaimSite extends AbstractMutation
         }
 
         $site->maintainers()->syncWithoutDetaching($user);
+
+        Log::info("User {$user->id} claimed site {$site->id}.");
 
         $this->site = $site;
         $this->user = $user;

--- a/app/GraphQL/Mutations/CreateAuthenticationToken.php
+++ b/app/GraphQL/Mutations/CreateAuthenticationToken.php
@@ -10,6 +10,7 @@ use App\Utils\AuthTokenUtil;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class CreateAuthenticationToken extends AbstractMutation
 {
@@ -46,6 +47,13 @@ final class CreateAuthenticationToken extends AbstractMutation
             $args['description'] ?? '',
             $args['expiration'],
         );
+
+        $logMessage = "User {$user->id} created authentication token with scope {$this->token->scope}";
+        if ($this->token->projectid > 0) {
+            $logMessage .= " for project {$this->token->projectid}";
+        }
+
+        Log::info("$logMessage.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/CreateComment.php
+++ b/app/GraphQL/Mutations/CreateComment.php
@@ -8,6 +8,7 @@ use App\Models\Build;
 use App\Models\Comment;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class CreateComment extends AbstractMutation
 {
@@ -40,6 +41,8 @@ final class CreateComment extends AbstractMutation
         ]);
 
         $this->comment = $comment->refresh();
+
+        Log::info("User {$user->id} left comment {$comment->id} on build {$build?->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/CreateGlobalInvitation.php
+++ b/app/GraphQL/Mutations/CreateGlobalInvitation.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
@@ -73,6 +74,8 @@ final class CreateGlobalInvitation extends AbstractMutation
             'invitation_timestamp' => Carbon::now(),
             'password' => Hash::make($password),
         ]);
+
+        Log::info("User {$user->id} invited user {$this->invitedUser->email} with role {$this->invitedUser->role->value}.");
 
         // The email gets sent to the queue, so we have no way to know immediately whether it was sent or not.
         // TODO: We should eventually track whether the email was actually sent.

--- a/app/GraphQL/Mutations/CreatePinnedTestMeasurement.php
+++ b/app/GraphQL/Mutations/CreatePinnedTestMeasurement.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Models\PinnedTestMeasurement;
 use App\Models\Project;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class CreatePinnedTestMeasurement extends AbstractMutation
 {
@@ -34,6 +35,9 @@ final class CreatePinnedTestMeasurement extends AbstractMutation
             'name' => $args['name'],
             'position' => $nextAvailablePosition,
         ]);
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} created pinned test measurement {$this->pinnedTestMeasurement?->id} for project {$project?->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/CreateProject.php
+++ b/app/GraphQL/Mutations/CreateProject.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Models\Project;
 use App\Services\ProjectService;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 class CreateProject
 {
@@ -26,6 +27,9 @@ class CreateProject
             'emailmissingsites' => false,
             'role' => Project::PROJECT_ADMIN,
         ]);
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} created project {$project->id}.");
 
         return $project;
     }

--- a/app/GraphQL/Mutations/CreateRepository.php
+++ b/app/GraphQL/Mutations/CreateRepository.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Models\Project;
 use App\Models\Repository;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class CreateRepository extends AbstractMutation
 {
@@ -33,6 +34,9 @@ final class CreateRepository extends AbstractMutation
             'password' => $args['password'],
             'branch' => $args['branch'],
         ]);
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} created repository {$this->repository?->id} for project {$project?->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/DeleteAuthenticationToken.php
+++ b/app/GraphQL/Mutations/DeleteAuthenticationToken.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Models\AuthToken;
 use App\Utils\AuthTokenUtil;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Log;
 
 final class DeleteAuthenticationToken extends AbstractMutation
 {
@@ -25,6 +26,8 @@ final class DeleteAuthenticationToken extends AbstractMutation
         if ($userid === null || !AuthTokenUtil::deleteToken($token->hash ?? '', $userid)) {
             throw new AuthenticationException('This action is unauthorized.');
         }
+
+        Log::info("User {$userid} deleted authentication token {$args['tokenId']}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/DeletePinnedTestMeasurement.php
+++ b/app/GraphQL/Mutations/DeletePinnedTestMeasurement.php
@@ -6,6 +6,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\PinnedTestMeasurement;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class DeletePinnedTestMeasurement extends AbstractMutation
 {
@@ -21,6 +22,9 @@ final class DeletePinnedTestMeasurement extends AbstractMutation
         Gate::authorize('deletePinnedTestMeasurement', $measurement?->project);
 
         $measurement?->delete();
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} deleted pinned test measurement {$args['id']}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/DeleteRepository.php
+++ b/app/GraphQL/Mutations/DeleteRepository.php
@@ -6,6 +6,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\Repository;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class DeleteRepository extends AbstractMutation
 {
@@ -21,6 +22,9 @@ final class DeleteRepository extends AbstractMutation
         Gate::authorize('deleteRepository', $repository?->project);
 
         $repository?->delete();
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} deleted repository {$args['repositoryId']}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/InviteToProject.php
+++ b/app/GraphQL/Mutations/InviteToProject.php
@@ -12,6 +12,7 @@ use App\Models\ProjectInvitation;
 use App\Models\User;
 use Exception;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -76,6 +77,8 @@ final class InviteToProject extends AbstractMutation
             'role' => $args['role'],  // Note: we assume that anyone who can invite users can assign them any role.
             'invitation_timestamp' => Carbon::now(),
         ]);
+
+        Log::info("User {$user->id} invited user {$args['email']} to project {$project->id} with role {$args['role']->value}.");
 
         // The email gets sent to the queue, so we have no way to know immediately whether it was sent or not.
         // TODO: We should eventually track whether the email was actually sent.

--- a/app/GraphQL/Mutations/JoinProject.php
+++ b/app/GraphQL/Mutations/JoinProject.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 final class JoinProject extends AbstractMutation
 {
@@ -40,6 +41,8 @@ final class JoinProject extends AbstractMutation
                 'emailmissingsites' => false,
                 'role' => Project::PROJECT_USER,
             ]);
+
+        Log::info("User {$user->id} joined project {$project->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/RemoveProjectUser.php
+++ b/app/GraphQL/Mutations/RemoveProjectUser.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 final class RemoveProjectUser extends AbstractMutation
 {
@@ -43,6 +44,8 @@ final class RemoveProjectUser extends AbstractMutation
         }
 
         $project->users()->detach($userToRemove->id);
+
+        Log::info("User {$user->id} removed user {$userToRemove->id} from project {$project->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/RemoveUser.php
+++ b/app/GraphQL/Mutations/RemoveUser.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\User;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class RemoveUser extends AbstractMutation
 {
@@ -28,6 +29,9 @@ final class RemoveUser extends AbstractMutation
         Gate::authorize('delete', $user);
 
         $user->delete();
+
+        $authUser = auth()->user();
+        Log::info("User {$authUser?->id} removed user {$args['userId']}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/RevokeGlobalInvitation.php
+++ b/app/GraphQL/Mutations/RevokeGlobalInvitation.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\GlobalInvitation;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class RevokeGlobalInvitation extends AbstractMutation
 {
@@ -28,6 +29,9 @@ final class RevokeGlobalInvitation extends AbstractMutation
         Gate::authorize('revokeInvitation', $invitation);
 
         $invitation->delete();
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} revoked global invitation for {$invitation->email}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/RevokeProjectInvitation.php
+++ b/app/GraphQL/Mutations/RevokeProjectInvitation.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\ProjectInvitation;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class RevokeProjectInvitation extends AbstractMutation
 {
@@ -28,6 +29,9 @@ final class RevokeProjectInvitation extends AbstractMutation
         Gate::authorize('revokeInvitation', $invitation->project);
 
         $invitation->delete();
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} revoked invitation for user {$invitation->email} to project {$invitation->project_id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/UnclaimSite.php
+++ b/app/GraphQL/Mutations/UnclaimSite.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 final class UnclaimSite extends AbstractMutation
 {
@@ -35,6 +36,8 @@ final class UnclaimSite extends AbstractMutation
         }
 
         $site->maintainers()->detach($user);
+
+        Log::info("User {$user->id} unclaimed site {$site->id}.");
 
         $this->site = $site;
         $this->user = $user;

--- a/app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
+++ b/app/GraphQL/Mutations/UpdatePinnedTestMeasurementOrder.php
@@ -9,6 +9,7 @@ use App\Models\PinnedTestMeasurement;
 use App\Models\Project;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class UpdatePinnedTestMeasurementOrder extends AbstractMutation
 {
@@ -56,6 +57,9 @@ final class UpdatePinnedTestMeasurementOrder extends AbstractMutation
         }
 
         $this->pinnedTestMeasurements = $project?->pinnedTestMeasurements()->orderBy('position')->get();
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} updated pinned test measurement order for project {$project?->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/UpdateProject.php
+++ b/app/GraphQL/Mutations/UpdateProject.php
@@ -6,6 +6,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Models\Project;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 
 final class UpdateProject extends AbstractMutation
 {
@@ -25,6 +26,9 @@ final class UpdateProject extends AbstractMutation
         $project?->update($args);
 
         $this->project = $project;
+
+        $user = auth()->user();
+        Log::info("User {$user?->id} updated project {$project?->id}.");
 
         return $this;
     }

--- a/app/GraphQL/Mutations/UpdateSiteDescription.php
+++ b/app/GraphQL/Mutations/UpdateSiteDescription.php
@@ -7,6 +7,7 @@ namespace App\GraphQL\Mutations;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Site;
 use App\Models\User;
+use Illuminate\Support\Facades\Log;
 
 final class UpdateSiteDescription extends AbstractMutation
 {
@@ -40,6 +41,8 @@ final class UpdateSiteDescription extends AbstractMutation
         unset($newSiteInformation['timestamp']);
         $newSiteInformation['description'] = $args['description'];
         $site->information()->create($newSiteInformation);
+
+        Log::info("User {$user->id} updated description for site {$site->id}.");
 
         $this->site = $site;
 


### PR DESCRIPTION
All mutations are currently untraceable, making debugging difficult.  This PR adds basic logging to each of our existing mutations to resolve this.