### PR TITLE
Remove label filter propagation

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -42,7 +42,6 @@ use Illuminate\Support\Facades\Auth;
  * @property int $uploadquota Maximum sum of uploaded file sizes (in bytes)
  * @property int $uploadquotagb Maximum sum of uploaded file sizes (in GiB)
  * @property bool $showcoveragecode
- * @property bool $sharelabelfilters
  * @property bool $authenticatesubmissions
  * @property ?string $ldapfilter
  * @property ?string $banner
@@ -90,7 +89,6 @@ class Project extends Model
         'uploadquota',
         'uploadquotagb',
         'showcoveragecode',
-        'sharelabelfilters',
         'authenticatesubmissions',
         'ldapfilter',
         'banner',
@@ -109,7 +107,6 @@ class Project extends Model
         'displaylabels' => 'boolean',
         'coveragethreshold' => 'integer',
         'showcoveragecode' => 'boolean',
-        'sharelabelfilters' => 'boolean',
         'authenticatesubmissions' => 'boolean',
     ];
 

--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -1350,7 +1350,7 @@ class Index extends ResultsApi
             }
         }
         unset($filters);
-        if ($filter_on_labels && $this->project->ShareLabelFilters) {
+        if ($filter_on_labels) {
             $this->shareLabelFilters = true;
             $this->labelIds = get_label_ids_from_filterdata($this->filterdata);
         }

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -69,7 +69,6 @@ class Project
     public $EmailMaxItems = 5;
     public $EmailMaxChars = 255;
     public $DisplayLabels = 0;
-    public $ShareLabelFilters = 0;
     public $AuthenticateSubmissions = 0;
     public $ShowCoverageCode = 0;
     public $AutoremoveTimeframe = 0;
@@ -126,7 +125,6 @@ class Project
             'emailbrokensubmission' => filter_var($this->EmailBrokenSubmission, FILTER_VALIDATE_BOOLEAN),
             'emailredundantfailures' => filter_var($this->EmailRedundantFailures, FILTER_VALIDATE_BOOLEAN),
             'displaylabels' => filter_var($this->DisplayLabels, FILTER_VALIDATE_BOOLEAN),
-            'sharelabelfilters' => filter_var($this->ShareLabelFilters, FILTER_VALIDATE_BOOLEAN),
             'authenticatesubmissions' => filter_var($this->AuthenticateSubmissions, FILTER_VALIDATE_BOOLEAN),
             'showcoveragecode' => filter_var($this->ShowCoverageCode, FILTER_VALIDATE_BOOLEAN),
             'autoremovetimeframe' => (int) $this->AutoremoveTimeframe,
@@ -206,7 +204,6 @@ class Project
             $this->EmailBrokenSubmission = (int) $project->emailbrokensubmission;
             $this->EmailRedundantFailures = (int) $project->emailredundantfailures;
             $this->DisplayLabels = $project->displaylabels;
-            $this->ShareLabelFilters = $project->sharelabelfilters;
             $this->AuthenticateSubmissions = $project->authenticatesubmissions;
             $this->ShowCoverageCode = $project->showcoveragecode;
             $this->AutoremoveTimeframe = $project->autoremovetimeframe;

--- a/app/cdash/public/api/v1/index.php
+++ b/app/cdash/public/api/v1/index.php
@@ -236,7 +236,6 @@ $response['filterdata'] = $controller->getFilterData();
 $response['filterurl'] = get_filterurl();
 
 $controller->checkForSubProjectFilters();
-$response['sharelabelfilters'] = $controller->shareLabelFilters;
 $response['testfilters'] = $controller->subProjectTestFilters;
 
 $build_data = $controller->getDailyBuilds();

--- a/app/cdash/tests/test_actualtrilinossubmission.php
+++ b/app/cdash/tests/test_actualtrilinossubmission.php
@@ -25,7 +25,7 @@ class ActualTrilinosSubmissionTestCase extends TrilinosSubmissionTestCase
             'EmailBrokenSubmission' => '1',
             'DisplayLabels' => '1',
             'NightlyTime' => '21:00:00 America/New_York',
-            'ShareLabelFilters' => '1'];
+        ];
         return $this->createProject($settings);
     }
 

--- a/app/cdash/tests/test_filtertestlabels.php
+++ b/app/cdash/tests/test_filtertestlabels.php
@@ -28,10 +28,6 @@ class FilterTestLabelsTestCase extends KWWebTestCase
             return 1;
         }
 
-        // Turn this option on.
-        pdo_query("UPDATE project SET sharelabelfilters=TRUE
-                WHERE name='EmailProjectExample'");
-
         // Get the buildid that we just created so we can delete it later.
         $buildids = [];
         $buildid_results = pdo_query(
@@ -90,10 +86,6 @@ class FilterTestLabelsTestCase extends KWWebTestCase
 
         // Delete the build
         DatabaseCleanupUtils::removeBuild($buildid);
-
-        // Turn the option back off.
-        pdo_query("UPDATE project SET sharelabelfilters=FALSE
-                WHERE name='EmailProjectExample'");
 
         if (!$success) {
             $this->fail($error_msg);

--- a/database/migrations/2026_05_13_223707_drop_project_sharelabelfilters_column.php
+++ b/database/migrations/2026_05_13_223707_drop_project_sharelabelfilters_column.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE project DROP COLUMN sharelabelfilters');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -340,9 +340,6 @@ type Project {
   """
   showCoverageCode: Boolean! @rename(attribute: "showcoveragecode")
 
-  "Forward label filters from index.php to queryTests.php and viewTest.php."
-  shareLabelFilters: Boolean! @rename(attribute: "sharelabelfilters")
-
   "Custom text displayed at the top of a project's dashboard."
   banner: String
 
@@ -493,8 +490,6 @@ input UpdateProjectInput @validator {
   fileUploadLimit: Int @rename(attribute: "uploadquotagb")
 
   showCoverageCode: Boolean @rename(attribute: "showcoveragecode")
-
-  shareLabelFilters: Boolean @rename(attribute: "sharelabelfilters")
 
   banner: String
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9874,12 +9874,6 @@ parameters:
 			path: app/cdash/app/Model/Project.php
 
 		-
-			rawMessage: Property CDash\Model\Project::$ShareLabelFilters has no type specified.
-			identifier: missingType.property
-			count: 1
-			path: app/cdash/app/Model/Project.php
-
-		-
 			rawMessage: Property CDash\Model\Project::$ShowCoverageCode has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -18912,7 +18906,7 @@ parameters:
 				04/01/2023
 			'''
 			identifier: function.deprecated
-			count: 3
+			count: 1
 			path: app/cdash/tests/test_filtertestlabels.php
 
 		-

--- a/resources/js/angular/controllers/index.js
+++ b/resources/js/angular/controllers/index.js
@@ -220,13 +220,6 @@ export function IndexController($scope, $rootScope, $location, $http, $filter, $
       $scope.pageChanged($scope.cdash.buildgroups[i]);
     }
 
-    // Check for label filters
-    $scope.cdash.extrafilterurl = '';
-    if ($scope.cdash.sharelabelfilters) {
-      $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
-      $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
-    }
-
     // Read simple/advanced view cookie setting.
     var advanced_cookie = $.cookie('cdash_'+$scope.cdash.projectname+'_advancedview');
     var show_time_columns = 0;

--- a/resources/js/angular/controllers/queryTests.js
+++ b/resources/js/angular/controllers/queryTests.js
@@ -33,12 +33,6 @@ export function QueryTestsController($scope, $rootScope, $filter, apiLoader, fil
     $scope.finishSetup = function() {
       // Hide test output context by default.
       $scope.cdash.showmatchingoutput = false;
-
-      // Check for label filters
-      $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
-      if ($scope.cdash.extrafilterurl) {
-        $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
-      }
       $scope.cdash.builds = $filter('orderBy')($scope.cdash.builds, $scope.orderByFields);
       $scope.pageChanged();
     };

--- a/resources/js/angular/controllers/viewTest.js
+++ b/resources/js/angular/controllers/viewTest.js
@@ -37,11 +37,6 @@ export function ViewTestController($scope, $rootScope, $http, $filter, $q, apiLo
 
     apiLoader.loadPageData($scope, 'api/v1/viewTest.php');
     $scope.finishSetup = function() {
-      // Check for label filters
-      $scope.cdash.extrafilterurl = filters.getLabelString($scope.cdash.filterdata);
-      if ($scope.cdash.extrafilterurl) {
-        $scope.cdash.querytestfilters = $scope.cdash.extrafilterurl;
-      }
       $scope.cdash.tests = $filter('orderBy')($scope.cdash.tests, $scope.orderByFields);
       $scope.setPage(1);
     };

--- a/resources/js/angular/views/partials/build.html
+++ b/resources/js/angular/views/partials/build.html
@@ -332,10 +332,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'warning': build.test.notrun > 0, 'normal': build.test.notrun == 0}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.nnotrundiffp > 0 || build.test.nnotrundiffn > 0}">
-    <a class="cdash-link" ng-href="{{ !cdash.testfilters && !cdash.extrafilterurl ? 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D' : 'viewTest.php?onlynotrun&buildid=' + build.id + cdash.testfilters + cdash.extrafilterurl }}">
+    <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D' }}">
       {{::build.test.notrun}}
     </a>
-    <a ng-if="::build.test.nnotrundiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.nnotrundiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
       +{{::build.test.nnotrundiffp}}
     </a>
     <span ng-if="::build.test.nnotrundiffn > 0" class="sub">-{{::build.test.nnotrundiffn}}</span>
@@ -345,10 +345,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'error': build.test.fail > 0, 'normal': build.test.fail < 1}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.nfaildiffp > 0 || build.test.nfaildiffn > 0}">
-    <a class="cdash-link" ng-href="{{ !cdash.testfilters && !cdash.extrafilterurl ? 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D' : 'viewTest.php?onlyfailed&buildid=' + build.id + cdash.testfilters + cdash.extrafilterurl }}">
+    <a class="cdash-link" ng-href="{{'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
       {{::build.test.fail}}
     </a>
-    <a ng-if="::build.test.nfaildiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.nfaildiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
       +{{::build.test.nfaildiffp}}
     </a>
     <span ng-if="::build.test.nfaildiffn > 0" class="sub">
@@ -360,10 +360,10 @@
 <td ng-if="::buildgroup.hastestdata" align="center" ng-class="::{'normal': build.test.pass > -1}">
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.test.npassdiffp > 0 || build.test.npassdiffn > 0}">
-    <a class="cdash-link" ng-href="{{ !cdash.testfilters && !cdash.extrafilterurl ? 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22PASSED%22%7D%7D%5D%7D' : 'viewTest.php?onlypassed&buildid=' + build.id + cdash.testfilters + cdash.extrafilterurl }}">
+    <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22PASSED%22%7D%7D%5D%7D' }}">
       {{::build.test.pass}}
     </a>
-    <a ng-if="::build.test.npassdiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+    <a ng-if="::build.test.npassdiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
       +{{::build.test.npassdiffp}}
     </a>
 
@@ -379,10 +379,10 @@
   <div ng-if="::build.hastest"
        ng-class="::{'valuewithsub': build.build.test.ntimediffp > 0 || build.test.ntimediffn > 0}">
     <div ng-if="::build.test.timestatus > 0">
-      <a class="cdash-link" ng-href="{{ !cdash.testfilters && !cdash.extrafilterurl ? 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22timeStatusCategory%22%3A%22FAILED%22%7D%7D%5D%7D' : 'viewTest.php?onlytimestatus&buildid=' + build.id + cdash.testfilters + cdash.extrafilterurl }}">
+      <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22timeStatusCategory%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
         {{::build.test.timestatus}}
       </a>
-      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">
@@ -392,7 +392,7 @@
 
     <span ng-if="::build.test.timestatus">
       {{::build.test.time}}
-      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.testfilters}}{{::cdash.extrafilterurl}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.testfilters}}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -532,7 +532,6 @@ export default {
         autoRemoveTimeFrame: 0,
         fileUploadLimit: 50,
         showCoverageCode: true,
-        shareLabelFilters: false,
         banner: '',
       },
       validationErrors: {},
@@ -576,7 +575,6 @@ export default {
             autoRemoveTimeFrame
             fileUploadLimit
             showCoverageCode
-            shareLabelFilters
             banner
           }
         }

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -206,7 +206,6 @@ class UpdateProjectTest extends TestCase
             ['autoRemoveTimeFrame', 10, 'autoremovetimeframe', 10],
             ['fileUploadLimit', 50, 'uploadquota', 53687091200],
             ['showCoverageCode', false, 'showcoveragecode', false],
-            ['shareLabelFilters', false, 'sharelabelfilters', false],
             ['banner', 'new banner', 'banner', 'new banner'],
         ];
     }

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -165,8 +165,6 @@ class ProjectTypeTest extends TestCase
             ['uploadquota', 10737418240, 'fileUploadLimit', 10],
             ['showcoveragecode', true, 'showCoverageCode', true],
             ['showcoveragecode', false, 'showCoverageCode', false],
-            ['sharelabelfilters', true, 'shareLabelFilters', true],
-            ['sharelabelfilters', false, 'shareLabelFilters', false],
             ['banner', 'test', 'banner', 'test'],
             ['banner', null, 'banner', null],
         ];

--- a/tests/cypress/e2e/filter-labels.cy.js
+++ b/tests/cypress/e2e/filter-labels.cy.js
@@ -1,37 +1,4 @@
 describe('filterLabels', () => {
-  it('passes filters to the viewTest page', () => {
-    cy.visit('index.php?project=Trilinos&date=2011-07-22');
-    cy.get('a').contains('Windows_NT-MSVC10-SERIAL_DEBUG_DEV').click();
-    cy.url().should('contain', 'index.php?project=Trilinos&parentid=12');
-
-    // first, verify the expected number of builds
-    cy.get('#numbuilds').should('contain', 'Number of SubProjects: 36');
-    // note: A maximum of 10 builds are displayed at a time
-    cy.get('tbody').find('tr').should('have.length', 10);
-
-    // apply filter parameters
-    cy.get('#settings').click();
-    cy.get('#label_showfilters').click();
-    cy.get('#id_field1').select('Label');
-    cy.get('#id_compare1').select('contains');
-    cy.get('#id_value1').type('ra');
-    cy.get('input[name="apply"]').click();
-
-    // make sure the expected number of builds are displayed
-    cy.get('#numbuilds').should('contain', 'Number of SubProjects: 5');
-    cy.get('tbody').find('tr').should('have.length', 5);
-
-    // next, click on a specific test
-    cy.get('tbody').find('tr').eq(3).find('td').eq(7).as('failing_test');
-    cy.get('@failing_test').should('contain', '10');
-    cy.get('@failing_test').find('a').click();
-    cy.url().should('contain', 'viewTest.php?onlyfailed&buildid=13&filtercount=1&showfilters=1&field1=label&compare1=63&value1=ra');
-
-    // make sure the expected number of tests are displayed
-    cy.get('#viewTestTable').find('tbody').find('tr').should('have.length', 10);
-  });
-
-
   it('inserts new filters in the right order', () => {
     cy.visit('index.php?project=Trilinos&date=2011-07-22&showfilters=1');
 


### PR DESCRIPTION
CDash currently supports the ability to propagate label filters from the index page to viewTest.php.  This functionality is fundamentally broken in all but the most simple case, since extracting only the label filters is not logically equivalent to the full original filters.  This PR removes the feature entirely.  In the future, there's an opportunity to add something which fills roughly the same niche: allowing users to select a subset of subprojects to display, which can be propagated to other pages automatically.