### PR TITLE
Change default builds per build group from 10 to 50

### DIFF
--- a/resources/js/angular/controllers/index.js
+++ b/resources/js/angular/controllers/index.js
@@ -128,7 +128,7 @@ export function IndexController($scope, $rootScope, $location, $http, $filter, $
       if(num_per_page_cookie) {
         $scope.cdash.buildgroups[i].pagination.numPerPage = parseInt(num_per_page_cookie);
       } else {
-        $scope.cdash.buildgroups[i].pagination.numPerPage = 10;
+        $scope.cdash.buildgroups[i].pagination.numPerPage = 50;
       }
 
       // Setup sorting.

--- a/resources/js/angular/controllers/queryTests.js
+++ b/resources/js/angular/controllers/queryTests.js
@@ -12,7 +12,7 @@ export function QueryTestsController($scope, $rootScope, $filter, apiLoader, fil
     if(num_per_page_cookie) {
       $scope.pagination.numPerPage = parseInt(num_per_page_cookie);
     } else {
-      $scope.pagination.numPerPage = 25;
+      $scope.pagination.numPerPage = 50;
     }
 
     // Hide filters by default.

--- a/resources/js/angular/controllers/testOverview.js
+++ b/resources/js/angular/controllers/testOverview.js
@@ -35,7 +35,7 @@ export function TestOverviewController($scope, $rootScope, $filter, apiLoader, f
     if(num_per_page_cookie) {
       $scope.pagination.numPerPage = parseInt(num_per_page_cookie);
     } else {
-      $scope.pagination.numPerPage = 10;
+      $scope.pagination.numPerPage = 50;
     }
 
     apiLoader.loadPageData($scope, 'api/v1/testOverview.php');

--- a/tests/cypress/e2e/query-tests.cy.js
+++ b/tests/cypress/e2e/query-tests.cy.js
@@ -49,6 +49,6 @@ describe('query tests', () => {
     // load the page and verify the expected number of tests.
     cy.visit(expected_url);
     cy.get('#numtests').should('contain', 'Query  Tests: 126 matches');
-    cy.get('#queryTestsTable').find('tbody').find('tr').should('have.length', 25);
+    cy.get('#queryTestsTable').find('tbody').find('tr').should('have.length', 50);
   });
 });


### PR DESCRIPTION
As discussed in https://github.com/Kitware/CDash/issues/3715, a default of 10 builds per build group is insufficient for many projects.  This low limit was set in an era when AngularJS rendering for the full page was extremely slow.  This is no longer an issue, and it now makes sense to increase the default number of builds per build group.  I have somewhat arbitrarily chosen 50 as the new default for all types of pagination across the site.  I plan to make further improvements to this in the next ~6-12 months as part of the transition to Vue.