### PR TITLE
Implement test delta in new tests page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -121,7 +121,7 @@ final class BuildController extends AbstractBuildController
         ]);
     }
 
-    public function tests(int $build_id): View
+    public function tests(Request $request, int $build_id): View
     {
         $this->setBuildById($build_id);
 
@@ -129,14 +129,24 @@ final class BuildController extends AbstractBuildController
 
         $eloquent_project = Project::findOrFail((int) $this->project->Id);
 
-        return $this->vue('build-tests-page', 'Tests', [
+        $params = [
             'build-id' => $this->build->Id,
             'show-test-time-status' => (bool) $eloquent_project->showtesttime,
             'project-name' => $eloquent_project->name,
             'build-time' => Carbon::parse($this->build->StartTime)->toIso8601String(),
             'initial-filters' => $filters,
             'pinned-measurements' => $eloquent_project->pinnedTestMeasurements()->orderBy('position')->pluck('name')->toArray(),
-        ]);
+        ];
+
+        if ($request->has('onlydelta')) {
+            $params['only-delta'] = true;
+            $previousBuildId = $this->build->GetPreviousBuildId();
+            if ($previousBuildId > 0) {
+                $params['previous-build-id'] = $previousBuildId;
+            }
+        }
+
+        return $this->vue('build-tests-page', 'Tests', $params);
     }
 
     public function coverage(int $build_id): View

--- a/resources/js/angular/views/partials/build.html
+++ b/resources/js/angular/views/partials/build.html
@@ -335,7 +335,7 @@
     <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D' }}">
       {{::build.test.notrun}}
     </a>
-    <a ng-if="::build.test.nnotrundiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
+    <a ng-if="::build.test.nnotrundiffp > 0" class="sup cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?onlydelta&filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22NOT_RUN%22%7D%7D%5D%7D' }}">
       +{{::build.test.nnotrundiffp}}
     </a>
     <span ng-if="::build.test.nnotrundiffn > 0" class="sub">-{{::build.test.nnotrundiffn}}</span>
@@ -348,7 +348,7 @@
     <a class="cdash-link" ng-href="{{'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
       {{::build.test.fail}}
     </a>
-    <a ng-if="::build.test.nfaildiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
+    <a ng-if="::build.test.nfaildiffp > 0" class="sup cdash-link" ng-href="{{'builds/' + build.id + '/tests?onlydelta&filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
       +{{::build.test.nfaildiffp}}
     </a>
     <span ng-if="::build.test.nfaildiffn > 0" class="sub">
@@ -363,7 +363,7 @@
     <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22PASSED%22%7D%7D%5D%7D' }}">
       {{::build.test.pass}}
     </a>
-    <a ng-if="::build.test.npassdiffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
+    <a ng-if="::build.test.npassdiffp > 0" class="sup cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?onlydelta&filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22PASSED%22%7D%7D%5D%7D' }}">
       +{{::build.test.npassdiffp}}
     </a>
 
@@ -382,7 +382,7 @@
       <a class="cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22timeStatusCategory%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
         {{::build.test.timestatus}}
       </a>
-      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::build.id}}{{::cdash.testfilters}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?onlydelta&filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22timeStatusCategory%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">
@@ -392,7 +392,7 @@
 
     <span ng-if="::build.test.timestatus">
       {{::build.test.time}}
-      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="viewTest.php?onlydelta&buildid={{::buildid}}{{::cdash.testfilters}}">
+      <a ng-if="::build.test.ntimediffp > 0" class="sup cdash-link" ng-href="{{ 'builds/' + build.id + '/tests?onlydelta&filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22timeStatusCategory%22%3A%22FAILED%22%7D%7D%5D%7D' }}">
         +{{::build.test.ntimediffp}}
       </a>
       <span ng-if="::build.test.ntimediffn > 0" class="sub">

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -13,8 +13,15 @@
         :execute-query-link="executeQueryLink"
         @change-filters="filters => changedFilters = filters"
       />
-      <loading-indicator :is-loading="!tests">
+      <loading-indicator :is-loading="!tests || (onlyDelta && !previousTests && previousBuildId !== null)">
+        <div
+          v-if="onlyDelta && tests && filteredTests.length === 0"
+          class="tw-self-center"
+        >
+          No tests with changed state for this build.
+        </div>
         <data-table
+          v-if="!onlyDelta || filteredTests.length > 0"
           :columns="[
             ...(hasSubProjects ? [{
               name: 'subProject',
@@ -67,6 +74,63 @@ import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import BuildSidebar from './shared/BuildSidebar.vue';
 import {DateTime} from 'luxon';
 
+const TEST_QUERY = gql`
+  query(
+    $buildid: ID,
+    $filters: BuildTestsFiltersMultiFilterInput,
+    $measurementFilters: TestTestMeasurementsFiltersMultiFilterInput,
+  ) {
+    build(id: $buildid) {
+      id
+      tests(filters: $filters, first: 1000000) {
+        edges {
+          node {
+            id
+            name
+            status
+            details
+            runningTime
+            timeStatusCategory
+            testMeasurements(filters: $measurementFilters) {
+              id
+              name
+              value
+            }
+          }
+        }
+      }
+      children(first: 100000) {
+        edges {
+          node {
+            id
+            tests(filters: $filters, first: 1000000) {
+              edges {
+                node {
+                  id
+                  name
+                  status
+                  details
+                  runningTime
+                  timeStatusCategory
+                  testMeasurements(filters: $measurementFilters) {
+                    id
+                    name
+                    value
+                  }
+                }
+              }
+            }
+            subProject {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export default {
   name: 'BuildTestsPage',
 
@@ -109,68 +173,28 @@ export default {
       type: Array,
       required: true,
     },
+
+    onlyDelta: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    previousBuildId: {
+      type: [Number, null],
+      required: false,
+      default: null,
+    },
   },
 
   apollo: {
     tests: {
-      query: gql`
-        query(
-          $buildid: ID,
-          $filters: BuildTestsFiltersMultiFilterInput,
-          $measurementFilters: TestTestMeasurementsFiltersMultiFilterInput,
-        ) {
-          build(id: $buildid) {
-            id
-            tests(filters: $filters, first: 1000000) {
-              edges {
-                node {
-                  id
-                  name
-                  status
-                  details
-                  runningTime
-                  timeStatusCategory
-                  testMeasurements(filters: $measurementFilters) {
-                    id
-                    name
-                    value
-                  }
-                }
-              }
-            }
-            children(first: 100000) {
-              edges {
-                node {
-                  id
-                  tests(filters: $filters, first: 1000000) {
-                    edges {
-                      node {
-                        id
-                        name
-                        status
-                        details
-                        runningTime
-                        timeStatusCategory
-                        testMeasurements(filters: $measurementFilters) {
-                          id
-                          name
-                          value
-                        }
-                      }
-                    }
-                  }
-                  subProject {
-                    id
-                    name
-                  }
-                }
-              }
-            }
-          }
-        }
-      `,
+      query: TEST_QUERY,
       update: (data) => {
-        let tests = [...data.build.tests.edges];
+        let tests = data.build.tests.edges.map((test) => ({
+          ...test,
+          subProject: '',
+        }));
         data.build.children.edges.forEach((child) => {
           tests = tests.concat(
             child.node.tests.edges.map((test) => ({
@@ -195,6 +219,41 @@ export default {
         };
       },
     },
+
+    previousTests: {
+      query: TEST_QUERY,
+      update: (data) => {
+        let tests = data.build.tests.edges.map((test) => ({
+          ...test,
+          subProject: '',
+        }));
+        data.build.children.edges.forEach((child) => {
+          tests = tests.concat(
+            child.node.tests.edges.map((test) => ({
+              ...test,
+              subProject: child.node.subProject.name,
+            })),
+          );
+        });
+        return tests;
+      },
+      variables() {
+        return {
+          buildid: this.previousBuildId,
+          filters: this.initialFilters,
+          measurementFilters: {
+            any: this.pinnedMeasurements.map((name) => ({
+              eq: {
+                name: name,
+              },
+            })),
+          },
+        };
+      },
+      skip() {
+        return !this.onlyDelta || this.previousBuildId === null;
+      },
+    },
   },
 
   data() {
@@ -204,8 +263,33 @@ export default {
   },
 
   computed: {
+    filteredTests() {
+      if (!this.onlyDelta) {
+        return this.tests;
+      }
+
+      if (!this.tests) {
+        return [];
+      }
+
+      if (!this.previousTests) {
+        return [];
+      }
+
+      const previousTestsMap = new Map(this.previousTests.map(test => [
+        `${test.subProject}:${test.node.name}`,
+        test.node.status,
+      ]));
+
+      return this.tests.filter(test => {
+        const key = `${test.subProject}:${test.node.name}`;
+        const previousStatus = previousTestsMap.get(key);
+        return previousStatus !== test.node.status;
+      });
+    },
+
     hasSubProjects() {
-      return this.tests?.some((element) => element.subProject) ?? false;
+      return this.filteredTests?.some((element) => element.subProject) ?? false;
     },
 
     pinnedMeasurementColumns() {
@@ -216,11 +300,15 @@ export default {
     },
 
     executeQueryLink() {
-      return `${window.location.origin}${window.location.pathname}?filters=${encodeURIComponent(JSON.stringify(this.changedFilters))}`;
+      let link = `${window.location.origin}${window.location.pathname}?filters=${encodeURIComponent(JSON.stringify(this.changedFilters))}`;
+      if (this.onlyDelta) {
+        link += '&onlydelta';
+      }
+      return link;
     },
 
     formattedTestRows() {
-      return this.tests?.map(edge => {
+      return this.filteredTests?.map(edge => {
         return {
           name: {
             value: edge.node.name,

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -386,4 +386,142 @@ class BuildTestsPageTest extends BrowserTestCase
             ;
         });
     }
+
+    public function testOnlyDelta(): void
+    {
+        /** @var Build $previous_build */
+        $previous_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => 'test-build',
+            'uuid' => Str::uuid()->toString(),
+            'starttime' => '2025-01-01 10:00:00',
+            'type' => 'Experimental',
+        ]);
+
+        /** @var Test $previous_test_failed */
+        $previous_test_failed = $previous_build->tests()->create([
+            'testname' => 'failed-before',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $previous_test_passed */
+        $previous_test_passed = $previous_build->tests()->create([
+            'testname' => 'passed-before',
+            'status' => 'passed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $previous_test_to_be_fixed */
+        $previous_test_to_be_fixed = $previous_build->tests()->create([
+            'testname' => 'fixed-test',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $previous_test_stayed_passed */
+        $previous_test_stayed_passed = $previous_build->tests()->create([
+            'testname' => 'stayed-passed',
+            'status' => 'passed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Build $current_build */
+        $current_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => 'test-build',
+            'uuid' => Str::uuid()->toString(),
+            'starttime' => '2025-01-01 11:00:00',
+            'type' => 'Experimental',
+        ]);
+
+        /** @var Test $current_test_failed_again */
+        $current_test_failed_again = $current_build->tests()->create([
+            'testname' => 'failed-before',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $current_test_newly_failed */
+        $current_test_newly_failed = $current_build->tests()->create([
+            'testname' => 'passed-before',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $current_test_entirely_new_failed */
+        $current_test_entirely_new_failed = $current_build->tests()->create([
+            'testname' => 'new-failed',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $current_test_fixed */
+        $current_test_fixed = $current_build->tests()->create([
+            'testname' => 'fixed-test',
+            'status' => 'passed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Test $current_test_stayed_passed */
+        $current_test_stayed_passed = $current_build->tests()->create([
+            'testname' => 'stayed-passed',
+            'status' => 'passed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($current_build, $current_test_failed_again, $current_test_newly_failed, $current_test_entirely_new_failed, $current_test_fixed, $current_test_stayed_passed): void {
+            $browser->visit("/builds/{$current_build->id}/tests?onlydelta")
+                ->waitFor('@tests-table')
+                ->assertDontSeeIn('@tests-table', $current_test_failed_again->testname)
+                ->assertSeeIn('@tests-table', $current_test_newly_failed->testname)
+                ->assertSeeIn('@tests-table', $current_test_entirely_new_failed->testname)
+                ->assertSeeIn('@tests-table', $current_test_fixed->testname)
+                ->assertDontSeeIn('@tests-table', $current_test_stayed_passed->testname)
+            ;
+        });
+    }
+
+    public function testOnlyDeltaNoResults(): void
+    {
+        /** @var Build $previous_build */
+        $previous_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => 'test-build',
+            'uuid' => Str::uuid()->toString(),
+            'starttime' => '2025-01-01 10:00:00',
+            'type' => 'Experimental',
+        ]);
+
+        /** @var Test $previous_test_failed */
+        $previous_test_failed = $previous_build->tests()->create([
+            'testname' => 'failed-before',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        /** @var Build $current_build */
+        $current_build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => 'test-build',
+            'uuid' => Str::uuid()->toString(),
+            'starttime' => '2025-01-01 11:00:00',
+            'type' => 'Experimental',
+        ]);
+
+        /** @var Test $current_test_failed_again */
+        $current_test_failed_again = $current_build->tests()->create([
+            'testname' => 'failed-before',
+            'status' => 'failed',
+            'outputid' => $this->testOutput->id,
+        ]);
+
+        $this->browse(function (Browser $browser) use ($current_build): void {
+            $browser->visit("/builds/{$current_build->id}/tests?onlydelta")
+                ->waitForText('No tests with changed state for this build.')
+                ->assertSee('No tests with changed state for this build.')
+                ->assertMissing('@tests-table')
+            ;
+        });
+    }
 }


### PR DESCRIPTION
The legacy `viewTest.php` page supports an `onlydelta` query parameter which shows only the tests for which the status changed between the previous and current builds.  That functionality is used to implement the positive superscripts on the builds page.  This PR brings the same functionality to the new build tests page, paving the way for the imminent deletion of the legacy page.