### PR TITLE
Fix duplicate date query param on test query next/previous

### DIFF
--- a/app/Http/Controllers/DynamicAnalysisController.php
+++ b/app/Http/Controllers/DynamicAnalysisController.php
@@ -29,7 +29,7 @@ final class DynamicAnalysisController extends AbstractBuildController
             [
                 'build-id' => $buildid,
                 'dynamic-analysis-id' => $fileid,
-                'link' => url("queryTests.php?project={$this->project->Name}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1={$da?->name}&date={$this->date}"),
+                'link' => url("queryTests.php?project={$this->project->Name}&date={$this->date}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1={$da?->name}"),
             ],
         );
     }

--- a/app/cdash/app/Controller/Api/TestOverview.php
+++ b/app/cdash/app/Controller/Api/TestOverview.php
@@ -191,7 +191,7 @@ class TestOverview extends ResultsApi
                 round(($test['failed'] / $total_runs) * 100, 2);
             $test_response['timeoutpercent'] =
                 round(($test['timeout'] / $total_runs) * 100, 2);
-            $test_response['link'] = "queryTests.php?project={$this->project->Name}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1={$name}&date={$this->date}";
+            $test_response['link'] = "queryTests.php?project={$this->project->Name}&date={$this->date}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1={$name}";
             $test_response['totalruns'] = $total_runs;
             $test_response['prettytime'] = time_difference($test['time'], true, '', true);
             $test_response['time'] = $test['time'];

--- a/app/cdash/app/Controller/Api/ViewTest.php
+++ b/app/cdash/app/Controller/Api/ViewTest.php
@@ -690,7 +690,7 @@ class ViewTest extends BuildApi
             'execTime' => time_difference($data['time'], true, '', true),
             'execTimeFull' => (float) $data['time'],
             'details' => $data['details'],
-            'summaryLink' => "queryTests.php?project={$projectname}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=" . urlencode($data['testname']) . "&date={$testdate}",
+            'summaryLink' => "queryTests.php?project={$projectname}&date={$testdate}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=" . urlencode($data['testname']),
             'summary' => 'Summary', /* Default value later replaced by AJAX */
             'detailsLink' => "tests/{$data['buildtestid']}",
         ];

--- a/app/cdash/include/filterdataFunctions.php
+++ b/app/cdash/include/filterdataFunctions.php
@@ -969,6 +969,11 @@ function get_filterurl()
     $filterurl = htmlentities($_GET['filterstring'], ENT_QUOTES);
     // ...but we need ampersands to pass through unescaped, so convert them back.
     $filterurl = str_replace('&amp;', '&', $filterurl);
+
+    // Remove &date= and &limit= from filterurl to avoid duplicates when next/prev links are built.
+    $filterurl = preg_replace('/&date=[^&]*/', '', $filterurl);
+    $filterurl = preg_replace('/&limit=[^&]*/', '', $filterurl);
+
     return $filterurl;
 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13123,6 +13123,12 @@ parameters:
 			path: app/cdash/include/filterdataFunctions.php
 
 		-
+			rawMessage: 'Parameter #3 $subject of function preg_replace expects array<float|int|string>|string, string|null given.'
+			identifier: argument.type
+			count: 1
+			path: app/cdash/include/filterdataFunctions.php
+
+		-
 			rawMessage: Unreachable statement - code above always terminates.
 			identifier: deadCode.unreachable
 			count: 5

--- a/resources/js/angular/services/filters.js
+++ b/resources/js/angular/services/filters.js
@@ -17,7 +17,8 @@ export function filtersSvc() {
     var str = new String(window.location);
     var idx = str.indexOf("&filtercount=", 0);
     if (idx > 0) {
-      return str.substr(idx);
+      var filterstring = str.substr(idx);
+      return filterstring.replace(/&date=[^&]*/, "").replace(/&limit=[^&]*/, "");
     }
     else {
       return "";

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -337,7 +337,7 @@ export default {
           history: {
             value: '',
             text: 'History',
-            href: `${this.$baseURL}/queryTests.php?project=${this.projectName}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${edge.node.name}&date=${DateTime.fromISO(this.buildTime).toISODate()}`,
+            href: `${this.$baseURL}/queryTests.php?project=${this.projectName}&date=${DateTime.fromISO(this.buildTime).toISODate()}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${edge.node.name}`,
           },
           ...this.pinnedMeasurements.reduce((acc, name) => ({
             ...acc,

--- a/resources/js/vue/components/TestDetailsPage.vue
+++ b/resources/js/vue/components/TestDetailsPage.vue
@@ -24,7 +24,7 @@
       <a
         id="summary_link"
         class="tw-link tw-link-hover"
-        :href="`${$baseURL}/queryTests.php?project=${build.project.name}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${test.name}&date=${testingDay}`"
+        :href="`${$baseURL}/queryTests.php?project=${build.project.name}&date=${testingDay}&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=${test.name}`"
       >
         {{ test.name }}
       </a>

--- a/tests/Browser/Pages/TestDetailsPageTest.php
+++ b/tests/Browser/Pages/TestDetailsPageTest.php
@@ -142,7 +142,7 @@ class TestDetailsPageTest extends BrowserTestCase
         $this->build->save();
 
         $this->browse(function (Browser $browser) use ($test): void {
-            $url = url('queryTests.php') . '?project=' . $this->project->name . '&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=' . $test->testname . '&date=' . $this->build->starttime->toDateString();
+            $url = url('queryTests.php') . '?project=' . $this->project->name . '&date=' . $this->build->starttime->toDateString() . '&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=' . $test->testname;
 
             $browser->visit("/tests/{$test->id}")
                 ->waitForLink($test->testname)


### PR DESCRIPTION
The test query page expects the date query parameter to come before the filter parameters.  This causes the next/previous buttons to not work, as described in https://github.com/Kitware/CDash/issues/3719.  Closes https://github.com/Kitware/CDash/issues/3719.