### PR TITLE
Add patch coverage API

### DIFF
--- a/app/GraphQL/Mutations/CreateCoverageDiff.php
+++ b/app/GraphQL/Mutations/CreateCoverageDiff.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations;
+
+use App\Exceptions\GraphQLMutationException;
+use App\Jobs\ComputeCoverageDifference;
+use App\Models\Build;
+use App\Models\Project;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+
+final class CreateCoverageDiff extends AbstractMutation
+{
+    /**
+     * @param array{
+     *     baseBuildId: int,
+     *     compareBuildId: int,
+     * } $args
+     *
+     * @throws GraphQLMutationException
+     */
+    public function __invoke(null $_, array $args): self
+    {
+        $baseBuild = Build::find((int) $args['baseBuildId']);
+        $compareBuild = Build::find((int) $args['compareBuildId']);
+
+        Gate::authorize('createCoverageDiff', $baseBuild->project ?? new Project());
+
+        if ($baseBuild === null || $compareBuild === null || $baseBuild->projectid !== $compareBuild->projectid) {
+            throw new GraphQLMutationException('Builds must belong to the same project.');
+        }
+
+        ComputeCoverageDifference::dispatch($baseBuild, $compareBuild);
+
+        Log::info('User ' . auth()->id() . " queued coverage diff for builds {$baseBuild->id} and {$compareBuild->id}.");
+
+        return $this;
+    }
+}

--- a/app/GraphQL/Validators/CreateCoverageDiffInputValidator.php
+++ b/app/GraphQL/Validators/CreateCoverageDiffInputValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Validators;
+
+use Nuwave\Lighthouse\Validation\Validator;
+
+final class CreateCoverageDiffInputValidator extends Validator
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'baseBuildId' => [
+                'required',
+            ],
+            'compareBuildId' => [
+                'required',
+                'different:baseBuildId',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'compareBuildId.different' => 'The base and compare builds must be different.',
+        ];
+    }
+}

--- a/app/Jobs/ComputeCoverageDifference.php
+++ b/app/Jobs/ComputeCoverageDifference.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Build;
+use App\Models\CoverageDiff;
+use App\Models\CoverageLine;
+use App\Models\CoverageView;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+
+class ComputeCoverageDifference implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+
+    public function __construct(
+        public Build $baseBuild,
+        public Build $compareBuild,
+    ) {
+        if ($this->baseBuild->projectid !== $this->compareBuild->projectid) {
+            throw new InvalidArgumentException('Builds must belong to the same project.');
+        }
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $basePaths = $this->baseBuild->coverage()->pluck('fullpath');
+        $comparePaths = $this->compareBuild->coverage()->pluck('fullpath');
+        /** @var Collection<int, string> $allPaths */
+        $allPaths = $basePaths->merge($comparePaths)->unique()->sort()->values();
+
+        $coverageDiff = CoverageDiff::updateOrCreate(
+            [
+                'basebuildid' => $this->baseBuild->id,
+                'comparebuildid' => $this->compareBuild->id,
+            ],
+            [
+                'coveredlinesadded' => 0,
+                'coveredlinesremoved' => 0,
+                'coveredlinesuncovered' => 0,
+                'uncoveredlinesadded' => 0,
+                'uncoveredlinesremoved' => 0,
+                'uncoveredlinescovered' => 0,
+            ]
+        );
+
+        foreach ($allPaths->chunk(100) as $batch) {
+            $baseViews = $this->baseBuild->coverage()
+                ->whereIn('fullpath', $batch)
+                ->get()
+                ->keyBy('fullpath');
+            $compareViews = $this->compareBuild->coverage()
+                ->whereIn('fullpath', $batch)
+                ->get()
+                ->keyBy('fullpath');
+
+            foreach ($batch as $path) {
+                /** @var CoverageView|null $baseView */
+                $baseView = $baseViews->get((string) $path);
+                /** @var CoverageView|null $compareView */
+                $compareView = $compareViews->get((string) $path);
+                $this->computeFileDiff($baseView, $compareView, $coverageDiff);
+            }
+        }
+
+        $coverageDiff->save();
+    }
+
+    /**
+     * Compute the coverage diff between two coverage files.
+     */
+    private function computeFileDiff(?CoverageView $cv1, ?CoverageView $cv2, CoverageDiff $coverageDiff): void
+    {
+        if ($cv1 === null && $cv2 === null) {
+            return;
+        }
+
+        if ($cv1 === null) {
+            // File added in compare build
+            if ($cv2 !== null) {
+                foreach ($cv2->coveredLines as $line) {
+                    if ($line->isCovered) {
+                        $coverageDiff->coveredlinesadded++;
+                    } else {
+                        $coverageDiff->uncoveredlinesadded++;
+                    }
+                }
+            }
+            return;
+        }
+
+        if ($cv2 === null) {
+            // File removed in compare build
+            foreach ($cv1->coveredLines as $line) {
+                if ($line->isCovered) {
+                    $coverageDiff->coveredlinesremoved++;
+                } else {
+                    $coverageDiff->uncoveredlinesremoved++;
+                }
+            }
+            return;
+        }
+
+        /** @var Collection<int, CoverageLine> $cl1 */
+        $cl1 = collect($cv1->coveredLines)->keyBy('lineNumber');
+        /** @var Collection<int, CoverageLine> $cl2 */
+        $cl2 = collect($cv2->coveredLines)->keyBy('lineNumber');
+
+        $differ = new Differ(new UnifiedDiffOutputBuilder());
+
+        // Files are 1-indexed, with the first line being line 1.
+        $file1Line = 1;
+        $file2Line = 1;
+        foreach ($differ->diffToArray($cv1->file ?? '', $cv2->file ?? '') as [$lineText, $status]) {
+            $line1 = $cl1->get($file1Line);
+            $line2 = $cl2->get($file2Line);
+
+            switch ($status) {
+                case Differ::OLD:  // Line is shared between both files
+                    if ($line1 !== null && $line1->isCovered && $line2 !== null && !$line2->isCovered) {
+                        $coverageDiff->coveredlinesuncovered++;
+                    } elseif ($line1 !== null && !$line1->isCovered && $line2 !== null && $line2->isCovered) {
+                        $coverageDiff->uncoveredlinescovered++;
+                    } elseif ($line1 !== null && $line2 === null) {
+                        // We consider a line to be added if it was previously not executable, and now is executable.
+                        // The reverse is also true: a line is removed if it was previously executable, and now is not executable.
+                        if ($line1->isCovered) {
+                            $coverageDiff->coveredlinesremoved++;
+                        } else {
+                            $coverageDiff->uncoveredlinesremoved++;
+                        }
+                    } elseif ($line1 === null && $line2 !== null) {
+                        if ($line2->isCovered) {
+                            $coverageDiff->coveredlinesadded++;
+                        } else {
+                            $coverageDiff->uncoveredlinesadded++;
+                        }
+                    }
+
+                    $file1Line++;
+                    $file2Line++;
+                    break;
+                case Differ::ADDED:  // Line exists in file 2 but not file 1
+                    if ($line2 !== null) {
+                        if ($line2->isCovered) {
+                            $coverageDiff->coveredlinesadded++;
+                        } else {
+                            $coverageDiff->uncoveredlinesadded++;
+                        }
+                    }
+
+                    $file2Line++;
+                    break;
+                case Differ::REMOVED:  // Line exists in file 1 but not file 2
+                    if ($line1 !== null) {
+                        if ($line1->isCovered) {
+                            $coverageDiff->coveredlinesremoved++;
+                        } else {
+                            $coverageDiff->uncoveredlinesremoved++;
+                        }
+                    }
+
+                    $file1Line++;
+                    break;
+                default:
+                    throw new Exception('Invalid Differ status: ' . $status);
+            }
+        }
+    }
+}

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -274,6 +274,14 @@ class Build extends Model
     }
 
     /**
+     * @return HasMany<CoverageDiff, $this>
+     */
+    public function coverageDiffs(): HasMany
+    {
+        return $this->hasMany(CoverageDiff::class, 'comparebuildid');
+    }
+
+    /**
      * @return BelongsToMany<Label, $this>
      */
     public function labels(): BelongsToMany

--- a/app/Models/CoverageDiff.php
+++ b/app/Models/CoverageDiff.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $basebuildid
+ * @property int $comparebuildid
+ * @property int $coveredlinesadded
+ * @property int $coveredlinesremoved
+ * @property int $coveredlinesuncovered
+ * @property int $uncoveredlinesadded
+ * @property int $uncoveredlinesremoved
+ * @property int $uncoveredlinescovered
+ *
+ * @mixin Builder<CoverageDiff>
+ */
+class CoverageDiff extends Model
+{
+    protected $table = 'coveragediff';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'basebuildid',
+        'comparebuildid',
+        'coveredlinesadded',
+        'coveredlinesremoved',
+        'coveredlinesuncovered',
+        'uncoveredlinesadded',
+        'uncoveredlinesremoved',
+        'uncoveredlinescovered',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'basebuildid' => 'integer',
+        'comparebuildid' => 'integer',
+        'coveredlinesadded' => 'integer',
+        'coveredlinesremoved' => 'integer',
+        'coveredlinesuncovered' => 'integer',
+        'uncoveredlinesadded' => 'integer',
+        'uncoveredlinesremoved' => 'integer',
+        'uncoveredlinescovered' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Build, $this>
+     */
+    public function baseBuild(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'basebuildid');
+    }
+
+    /**
+     * @return BelongsTo<Build, $this>
+     */
+    public function compareBuild(): BelongsTo
+    {
+        return $this->belongsTo(Build::class, 'comparebuildid');
+    }
+}

--- a/app/Models/CoverageLine.php
+++ b/app/Models/CoverageLine.php
@@ -4,11 +4,14 @@ namespace App\Models;
 
 readonly class CoverageLine
 {
+    public bool $isCovered;
+
     public function __construct(
         public int $lineNumber,
         public ?int $timesHit = null,
         public ?int $totalBranches = null,
         public ?int $branchesHit = null,
     ) {
+        $this->isCovered = ($this->timesHit !== null && $this->timesHit > 0) || ($this->branchesHit !== null && $this->branchesHit > 0);
     }
 }

--- a/app/Models/CoverageView.php
+++ b/app/Models/CoverageView.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property ?string $fullpath
  * @property ?string $file
  * @property ?string $log
+ * @property CoverageLine[] $coveredLines
  *
  * @mixin Builder<CoverageView>
  */
@@ -64,12 +65,17 @@ class CoverageView extends Model
     {
         return Attribute::make(
             get: function (mixed $value, array $attributes): array {
-                if ($attributes['log'] === null) {
+                if (($attributes['log'] ?? null) === null) {
+                    return [];
+                }
+
+                $log = str($attributes['log'])->rtrim(';');
+                if ($log->isEmpty()) {
                     return [];
                 }
 
                 $lines = [];
-                foreach (str($attributes['log'])->rtrim(';')->explode(';') as $line_str) {
+                foreach ($log->explode(';') as $line_str) {
                     $line_str = str($line_str);
 
                     $hasBranches = $line_str->startsWith('b');

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -171,6 +171,11 @@ class ProjectPolicy
         return $currentUser->admin || $project->users()->where('id', $currentUser->id)->exists();
     }
 
+    public function createCoverageDiff(User $user, Project $project): bool
+    {
+        return $user->admin || $project->users()->where('id', $user->id)->exists();
+    }
+
     private function isLdapControlledMembership(Project $project): bool
     {
         // If a LDAP filter has been specified and LDAP is enabled, CDash controls the entire members list.

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -242,6 +242,8 @@ add_feature_test_in_transaction(/Feature/GraphQL/CommentTypeTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/RepositoryTypeTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/CoverageDiffTypeTest)
+
 add_feature_test_in_transaction(/Feature/RouteAccessTest)
 
 add_feature_test_in_transaction(/Feature/Monitor)
@@ -310,9 +312,13 @@ add_feature_test_in_transaction(/Feature/GraphQL/Mutations/RemoveUserTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateCommentTest)
 
+add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateCoverageDiffMutationTest)
+
 add_feature_test_in_transaction(/Feature/Jobs/PruneBuildsTest)
 
 add_feature_test_in_transaction(/Feature/Jobs/PruneEmailsTest)
+
+add_feature_test_in_transaction(/Feature/Jobs/ComputeCoverageDifferenceTest)
 
 add_feature_test_in_transaction(/Feature/Services/ProjectServiceTest)
 

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "pear/archive_tar": "1.6.0",
     "php-di/php-di": "7.1.1",
     "ramsey/uuid": "4.9.2",
+    "sebastian/diff": "7.0.0",
     "socialiteproviders/github": "4.1.0",
     "socialiteproviders/gitlab": "4.1.0",
     "socialiteproviders/google": "4.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9b4ef9bf557ef89e9c3fc7e2f90285e",
+    "content-hash": "690e8e517f2879e982c535839b0906c2",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -5553,6 +5553,73 @@
                 "source": "https://github.com/robrichards/xmlseclibs/tree/3.1.5"
             },
             "time": "2026-03-13T10:31:56+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "socialiteproviders/github",
@@ -11623,73 +11690,6 @@
             "time": "2025-02-07T04:55:25+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:46+00:00"
-        },
-        {
             "name": "sebastian/environment",
             "version": "8.1.0",
             "source": {
@@ -12574,5 +12574,5 @@
         "ext-xdebug": "*",
         "ext-zip": "*"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/migrations/2026_05_19_214851_create_coveragediff_table.php
+++ b/database/migrations/2026_05_19_214851_create_coveragediff_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('
+            CREATE TABLE coveragediff (
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                basebuildid bigint REFERENCES build(id) ON DELETE CASCADE NOT NULL,
+                comparebuildid bigint REFERENCES build(id) ON DELETE CASCADE NOT NULL,
+                coveredlinesadded bigint NOT NULL,
+                coveredlinesremoved bigint NOT NULL,
+                coveredlinesuncovered bigint NOT NULL,
+                uncoveredlinesadded bigint NOT NULL,
+                uncoveredlinesremoved bigint NOT NULL,
+                uncoveredlinescovered bigint NOT NULL,
+                CONSTRAINT basebuildid_comparebuildid_unique UNIQUE (basebuildid, comparebuildid)
+            )
+        ');
+
+        DB::statement('CREATE INDEX ON coveragediff (comparebuildid, basebuildid)');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -166,6 +166,9 @@ type Mutation {
 
   "Create a new comment."
   createComment(input: CreateCommentInput! @spread): CreateCommentMutationPayload! @field(resolver: "CreateComment")
+
+  "Compute patch coverage between two builds."
+  createCoverageDiff(input: CreateCoverageDiffInput! @spread): CreateCoverageDiffMutationPayload! @field(resolver: "CreateCoverageDiff")
 }
 
 input CreateCommentInput {
@@ -182,6 +185,17 @@ type CreateCommentMutationPayload implements MutationPayloadInterface {
 
   "The newly created comment."
   comment: Comment
+}
+
+
+input CreateCoverageDiffInput @validator {
+  baseBuildId: ID!
+  compareBuildId: ID!
+}
+
+type CreateCoverageDiffMutationPayload implements MutationPayloadInterface {
+  "Optional error message."
+  message: String
 }
 
 
@@ -879,6 +893,8 @@ type Build {
     filters: _ @filter
   ): [Coverage!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
 
+  coverageDiffs: [CoverageDiff!]! @hasMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+
   """
   Get the percentage of lines covered in all files starting with the provided path.
   Automatically trims leading slashes and dots.  Returns null if the directory does
@@ -1314,6 +1330,31 @@ type Coverage @model(class: "App\\Models\\CoverageView") {
   labels(
     filters: _ @filter
   ): [Label!]! @belongsToMany(type: CONNECTION) @orderBy(column: "id", direction: DESC)
+}
+
+
+"""
+Difference in coverage between two builds.
+"""
+type CoverageDiff {
+  "Unique primary key."
+  id: ID!
+
+  baseBuild: Build! @belongsTo
+
+  compareBuild: Build! @belongsTo
+
+  coveredLinesAdded: Int! @rename(attribute: "coveredlinesadded")
+
+  coveredLinesRemoved: Int! @rename(attribute: "coveredlinesremoved")
+
+  coveredLinesUncovered: Int! @rename(attribute: "coveredlinesuncovered")
+
+  uncoveredLinesAdded: Int! @rename(attribute: "uncoveredlinesadded")
+
+  uncoveredLinesRemoved: Int! @rename(attribute: "uncoveredlinesremoved")
+
+  uncoveredLinesCovered: Int! @rename(attribute: "uncoveredlinescovered")
 }
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -289,6 +289,12 @@ parameters:
 			path: app/GraphQL/Mutations/CreateComment.php
 
 		-
+			rawMessage: 'Parameter #2 $args (array{baseBuildId: int, compareBuildId: int}) of method App\GraphQL\Mutations\CreateCoverageDiff::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
+			identifier: method.childParameterType
+			count: 1
+			path: app/GraphQL/Mutations/CreateCoverageDiff.php
+
+		-
 			rawMessage: 'Parameter #2 $args (array{email: string, role: App\Enums\GlobalRole}) of method App\GraphQL\Mutations\CreateGlobalInvitation::__invoke() should be contravariant with parameter $args (array<string, mixed>) of method App\GraphQL\Mutations\AbstractMutation::__invoke()'
 			identifier: method.childParameterType
 			count: 1
@@ -23885,6 +23891,15 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Feature/GraphQL/SiteTypeTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method coverageResults() of class App\Models\Build:
+				07/27/2025 Use this relation only to edit the underlying coverage table.  Use coverage() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: tests/Feature/Jobs/ComputeCoverageDifferenceTest.php
 
 		-
 			rawMessage: Cannot access offset 0 on mixed.

--- a/tests/Feature/GraphQL/CoverageDiffTypeTest.php
+++ b/tests/Feature/GraphQL/CoverageDiffTypeTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\CoverageDiff;
+use App\Models\Project;
+use App\Models\Site;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+
+class CoverageDiffTypeTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use DatabaseTransactions;
+
+    private Project $project;
+    private Site $site;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->project = $this->makePublicProject();
+        $this->site = $this->makeSite();
+    }
+
+    public function testQueryCoverageDiffFields(): void
+    {
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $coverageDiff = CoverageDiff::create([
+            'basebuildid' => $baseBuild->id,
+            'comparebuildid' => $compareBuild->id,
+            'coveredlinesadded' => 10,
+            'coveredlinesremoved' => 5,
+            'coveredlinesuncovered' => 2,
+            'uncoveredlinesadded' => 8,
+            'uncoveredlinesremoved' => 3,
+            'uncoveredlinescovered' => 4,
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    coverageDiffs {
+                        edges {
+                            node {
+                                id
+                                baseBuild {
+                                    name
+                                }
+                                compareBuild {
+                                    name
+                                }
+                                coveredLinesAdded
+                                coveredLinesRemoved
+                                coveredLinesUncovered
+                                uncoveredLinesAdded
+                                uncoveredLinesRemoved
+                                uncoveredLinesCovered
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $compareBuild->id,
+        ])
+            ->assertGraphQLErrorFree()
+            ->assertExactJson([
+                'data' => [
+                    'build' => [
+                        'coverageDiffs' => [
+                            'edges' => [
+                                [
+                                    'node' => [
+                                        'id' => (string) $coverageDiff->id,
+                                        'baseBuild' => [
+                                            'name' => $baseBuild->name,
+                                        ],
+                                        'compareBuild' => [
+                                            'name' => $compareBuild->name,
+                                        ],
+                                        'coveredLinesAdded' => 10,
+                                        'coveredLinesRemoved' => 5,
+                                        'coveredLinesUncovered' => 2,
+                                        'uncoveredLinesAdded' => 8,
+                                        'uncoveredLinesRemoved' => 3,
+                                        'uncoveredLinesCovered' => 4,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+
+    public function testQueryMultipleCoverageDiffs(): void
+    {
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $baseBuild1 = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $baseBuild2 = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        CoverageDiff::create([
+            'basebuildid' => $baseBuild1->id,
+            'comparebuildid' => $compareBuild->id,
+            'coveredlinesadded' => 1,
+            'coveredlinesremoved' => 0,
+            'coveredlinesuncovered' => 0,
+            'uncoveredlinesadded' => 0,
+            'uncoveredlinesremoved' => 0,
+            'uncoveredlinescovered' => 0,
+        ]);
+
+        CoverageDiff::create([
+            'basebuildid' => $baseBuild2->id,
+            'comparebuildid' => $compareBuild->id,
+            'coveredlinesadded' => 2,
+            'coveredlinesremoved' => 0,
+            'coveredlinesuncovered' => 0,
+            'uncoveredlinesadded' => 0,
+            'uncoveredlinesremoved' => 0,
+            'uncoveredlinescovered' => 0,
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    coverageDiffs {
+                        edges {
+                            node {
+                                baseBuild {
+                                    name
+                                }
+                                coveredLinesAdded
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $compareBuild->id,
+        ])
+            ->assertGraphQLErrorFree()
+            ->assertExactJson([
+                'data' => [
+                    'build' => [
+                        'coverageDiffs' => [
+                            'edges' => [
+                                [
+                                    'node' => [
+                                        'baseBuild' => [
+                                            'name' => $baseBuild2->name,
+                                        ],
+                                        'coveredLinesAdded' => 2,
+                                    ],
+                                ],
+                                [
+                                    'node' => [
+                                        'baseBuild' => [
+                                            'name' => $baseBuild1->name,
+                                        ],
+                                        'coveredLinesAdded' => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+    }
+}

--- a/tests/Feature/GraphQL/Mutations/CreateCoverageDiffMutationTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateCoverageDiffMutationTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Mutations;
+
+use App\Jobs\ComputeCoverageDifference;
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+use Tests\Traits\CreatesUsers;
+
+class CreateCoverageDiffMutationTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use CreatesUsers;
+    use DatabaseTransactions;
+
+    private Project $project;
+    private User $user;
+    private Site $site;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->project = $this->makePublicProject();
+        $this->user = $this->makeNormalUser();
+        $this->site = $this->makeSite();
+    }
+
+    private function coverageDiffMutation(): string
+    {
+        return '
+            mutation createCoverageDiff($input: CreateCoverageDiffInput!) {
+                createCoverageDiff(input: $input) {
+                    message
+                }
+            }
+        ';
+    }
+
+    public function testCreateCoverageDiffMutation(): void
+    {
+        Queue::fake();
+
+        $this->project->users()->attach($this->user->id);
+
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $compareBuild->id,
+                ],
+            ])
+            ->assertGraphQLErrorFree();
+
+        Queue::assertPushed(ComputeCoverageDifference::class, fn ($job) => $job->baseBuild->id === $baseBuild->id && $job->compareBuild->id === $compareBuild->id);
+    }
+
+    public function testCreateCoverageDiffFailsDifferentProjects(): void
+    {
+        Queue::fake();
+
+        $this->project->users()->attach($this->user->id);
+
+        $project2 = $this->makePublicProject();
+
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $project2->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $compareBuild->id,
+                ],
+            ])
+            ->assertGraphQLErrorMessage('Builds must belong to the same project.');
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffFailsUnauthorized(): void
+    {
+        Queue::fake();
+
+        $privateProject = $this->makePrivateProject();
+        $baseBuild = $privateProject->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+        $compareBuild = $privateProject->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $compareBuild->id,
+                ],
+            ])
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffFailsBuildNotFound(): void
+    {
+        Queue::fake();
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => 99999,
+                    'compareBuildId' => 100000,
+                ],
+            ])
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffAdminBuildNotFound(): void
+    {
+        Queue::fake();
+
+        // Admins bypass the null-project policy check, so they proceed to the
+        // same-project validation which fails when the builds do not exist.
+        $this->actingAs($this->makeAdminUser())
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => 999,
+                    'compareBuildId' => 1000,
+                ],
+            ])
+            ->assertGraphQLErrorMessage('Builds must belong to the same project.');
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffFailsSameBuild(): void
+    {
+        Queue::fake();
+
+        $this->project->users()->attach($this->user->id);
+
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $baseBuild->id,
+                ],
+            ])
+            ->assertGraphQLValidationKeys(['input.compareBuildId']);
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffAdminSuccess(): void
+    {
+        Queue::fake();
+
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->makeAdminUser())
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $compareBuild->id,
+                ],
+            ])
+            ->assertGraphQLErrorFree();
+
+        Queue::assertPushed(ComputeCoverageDifference::class);
+    }
+
+    public function testCreateCoverageDiffNonMemberPublicProjectFails(): void
+    {
+        Queue::fake();
+
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->actingAs($this->user)
+            ->graphQL($this->coverageDiffMutation(), [
+                'input' => [
+                    'baseBuildId' => $baseBuild->id,
+                    'compareBuildId' => $compareBuild->id,
+                ],
+            ])
+            ->assertGraphQLErrorMessage('This action is unauthorized.');
+
+        Queue::assertNotPushed(ComputeCoverageDifference::class);
+    }
+}

--- a/tests/Feature/Jobs/ComputeCoverageDifferenceTest.php
+++ b/tests/Feature/Jobs/ComputeCoverageDifferenceTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ComputeCoverageDifference;
+use App\Models\Build;
+use App\Models\CoverageDiff;
+use App\Models\CoverageFile;
+use App\Models\Project;
+use App\Models\Site;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+
+class ComputeCoverageDifferenceTest extends TestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use DatabaseTransactions;
+
+    private Project $project;
+    private Site $site;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->project = $this->makePublicProject();
+        $this->site = $this->makeSite();
+    }
+
+    /**
+     * Helper to create coverage data for a build.
+     */
+    private function createCoverage(Build $build, string $path, string $content, string $log): void
+    {
+        $coverageFile = CoverageFile::create([
+            'fullpath' => $path,
+            'file' => $content,
+            'crc32' => crc32($content),
+        ]);
+
+        $build->coverageResults()->create([
+            'fileid' => $coverageFile->id,
+            'loctested' => 0,
+            'locuntested' => 0,
+            'branchestested' => 0,
+            'branchesuntested' => 0,
+            'functionstested' => 0,
+            'functionsuntested' => 0,
+        ]);
+
+        DB::insert('
+            INSERT INTO coveragefilelog (buildid, fileid, log) VALUES(?, ?, ?)
+        ', [
+            $build->id,
+            $coverageFile->id,
+            $log,
+        ]);
+    }
+
+    /**
+     * Helper to setup builds, run the job and return the diff.
+     */
+    private function setupBuildsAndRun(callable $setup): CoverageDiff
+    {
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $compareBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $setup($baseBuild, $compareBuild);
+
+        ComputeCoverageDifference::dispatch($baseBuild, $compareBuild);
+
+        $diff = CoverageDiff::where('basebuildid', $baseBuild->id)
+            ->where('comparebuildid', $compareBuild->id)
+            ->first();
+
+        $this->assertNotNull($diff);
+        return $diff;
+    }
+
+    /**
+     * Helper to assert all coverage diff counters.
+     */
+    private function assertCoverageDiff(
+        CoverageDiff $diff,
+        int $coveredLinesAdded = 0,
+        int $uncoveredLinesAdded = 0,
+        int $coveredLinesRemoved = 0,
+        int $uncoveredLinesRemoved = 0,
+        int $coveredLinesUncovered = 0,
+        int $uncoveredLinesCovered = 0,
+    ): void {
+        $this->assertSame($coveredLinesAdded, $diff->coveredlinesadded);
+        $this->assertSame($uncoveredLinesAdded, $diff->uncoveredlinesadded);
+        $this->assertSame($coveredLinesRemoved, $diff->coveredlinesremoved);
+        $this->assertSame($uncoveredLinesRemoved, $diff->uncoveredlinesremoved);
+        $this->assertSame($coveredLinesUncovered, $diff->coveredlinesuncovered);
+        $this->assertSame($uncoveredLinesCovered, $diff->uncoveredlinescovered);
+    }
+
+    public function testIdenticalFiles(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($base, 'shared.php', "line1\nline2\n", '1:1;2:0;');
+            $this->createCoverage($compare, 'shared.php', "line1\nline2\n", '1:1;2:0;');
+        });
+
+        $this->assertCoverageDiff($diff);
+    }
+
+    public function testCoverageChange(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            // line 1: covered -> uncovered
+            // line 2: uncovered -> covered
+            $this->createCoverage($base, 'coverage_change.php', "line1\nline2\n", '1:1;2:0;');
+            $this->createCoverage($compare, 'coverage_change.php', "line1\nline2\n", '1:0;2:1;');
+        });
+
+        $this->assertCoverageDiff($diff, coveredLinesUncovered: 1, uncoveredLinesCovered: 1);
+    }
+
+    public function testLinesAddedAsExecutable(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            // Base: line 1 executable, line 2 NOT executable
+            // Compare: line 1 executable, line 2 executable (covered)
+            $this->createCoverage($base, 'line_added.php', "line1\nline2\n", '1:1;');
+            $this->createCoverage($compare, 'line_added.php', "line1\nline2\n", '1:1;2:1;');
+        });
+
+        $this->assertCoverageDiff($diff, coveredLinesAdded: 1);
+    }
+
+    public function testLinesRemovedAsExecutable(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            // Base: line 1 executable, line 2 executable (covered)
+            // Compare: line 1 executable, line 2 NOT executable
+            $this->createCoverage($base, 'line_removed.php', "line1\nline2\n", '1:1;2:1;');
+            $this->createCoverage($compare, 'line_removed.php', "line1\nline2\n", '1:1;');
+        });
+
+        $this->assertCoverageDiff($diff, coveredLinesRemoved: 1);
+    }
+
+    public function testContentChangeWithLineShifts(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            // Base: line 1, line 2
+            // Compare: line 1, line 1.5, line 2
+            $this->createCoverage($base, 'content_change.php', "line1\nline2\n", '1:1;2:1;');
+            $this->createCoverage($compare, 'content_change.php', "line1\nline1.5\nline2\n", '1:1;2:1;3:1;');
+        });
+
+        $this->assertCoverageDiff($diff, coveredLinesAdded: 1);
+    }
+
+    public function testFileRemoved(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($base, 'only_base.php', "line1\n", '1:1;');
+        });
+
+        $this->assertCoverageDiff($diff, coveredLinesRemoved: 1);
+    }
+
+    public function testFileAdded(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($compare, 'only_compare.php', "line1\n", '1:0;');
+        });
+
+        $this->assertCoverageDiff($diff, uncoveredLinesAdded: 1);
+    }
+
+    public function testConstructThrowsOnDifferentProjects(): void
+    {
+        $project2 = $this->makePublicProject();
+        $baseBuild = $this->project->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+        $compareBuild = $project2->builds()->create([
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+            'siteid' => $this->site->id,
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Builds must belong to the same project.');
+
+        new ComputeCoverageDifference($baseBuild, $compareBuild);
+    }
+
+    public function testBatching(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            for ($i = 0; $i < 101; $i++) {
+                $this->createCoverage($base, "file{$i}.php", 'content', '1:1;');
+                $this->createCoverage($compare, "file{$i}.php", 'content', '1:0;');
+            }
+        });
+
+        // Each file has 1 covered -> uncovered change. Total 101.
+        $this->assertCoverageDiff($diff, coveredLinesUncovered: 101);
+    }
+
+    public function testMultipleFilesAdded(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($compare, 'added1.php', "line1\n", '1:1;');
+            $this->createCoverage($compare, 'added2.php', "line1\nline2\n", '1:1;2:0;');
+        });
+
+        // added1: 1 covered added
+        // added2: 1 covered added, 1 uncovered added
+        // Total: 2 covered added, 1 uncovered added
+        $this->assertCoverageDiff($diff, coveredLinesAdded: 2, uncoveredLinesAdded: 1);
+    }
+
+    public function testMultipleFilesRemoved(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($base, 'removed1.php', "line1\n", '1:1;');
+            $this->createCoverage($base, 'removed2.php', "line1\nline2\n", '1:1;2:0;');
+        });
+
+        // removed1: 1 covered removed
+        // removed2: 1 covered removed, 1 uncovered removed
+        // Total: 2 covered removed, 1 uncovered removed
+        $this->assertCoverageDiff($diff, coveredLinesRemoved: 2, uncoveredLinesRemoved: 1);
+    }
+
+    public function testMixedAdditionsAndRemovals(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($base, 'removed.php', "line1\n", '1:1;');
+            $this->createCoverage($compare, 'added.php', "line1\n", '1:0;');
+            $this->createCoverage($base, 'shared.php', "line1\n", '1:1;');
+            $this->createCoverage($compare, 'shared.php', "line1\n", '1:0;');
+        });
+
+        // removed.php: 1 covered removed
+        // added.php: 1 uncovered added
+        // shared.php: 1 covered -> uncovered (coveredLinesUncovered: 1)
+        $this->assertCoverageDiff(
+            $diff,
+            uncoveredLinesAdded: 1,
+            coveredLinesRemoved: 1,
+            coveredLinesUncovered: 1
+        );
+    }
+
+    public function testFileAddedWithNoExecutableLines(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($compare, 'no_exec_added.php', "comment\n", '');
+        });
+
+        $this->assertCoverageDiff($diff);
+    }
+
+    public function testFileRemovedWithNoExecutableLines(): void
+    {
+        $diff = $this->setupBuildsAndRun(function ($base, $compare): void {
+            $this->createCoverage($base, 'no_exec_removed.php', "comment\n", '');
+        });
+
+        $this->assertCoverageDiff($diff);
+    }
+}


### PR DESCRIPTION
This PR adds a `CoverageDiff` GraphQL type and `createCoverageDiff` mutation which accepts two build IDs and creates a summary of the coverage diff between them.  In the future, this patch coverage summary can be expanded by storing the actual diff, not just a summary of the diff.  Another potential future improvement is to display this summary data in the UI somewhere.  For now, this feature is available via the API only, and is meant for use in CI workflows.