### PR TITLE
Convert all Vue component references to PascalCase

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig([
     },
     rules: {
       'indent': ['error', 2],
+      'vue/component-name-in-template-casing': ['error', 'PascalCase'],
       'vue/no-v-html': 'off',
       'vue/require-v-for-key': 'off',
       'eqeqeq': ['error', 'always'],

--- a/resources/js/vue/components/AdministrationPage.vue
+++ b/resources/js/vue/components/AdministrationPage.vue
@@ -1,22 +1,22 @@
 <template>
   <div class="tw-container tw-mx-auto tw-p-4 tw-max-w-screen-lg">
     <div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-6">
-      <administration-page-card
+      <AdministrationPageCard
         href="/projects/new"
         title="Create Project"
         :icon="FA.faFolderPlus"
       />
-      <administration-page-card
+      <AdministrationPageCard
         href="/users"
         title="Manage Users"
         :icon="FA.faUsers"
       />
-      <administration-page-card
+      <AdministrationPageCard
         href="/authtokens/manage"
         title="Manage Authentication Tokens"
         :icon="FA.faKey"
       />
-      <administration-page-card
+      <AdministrationPageCard
         href="/monitor"
         title="Submission Status"
         :icon="FA.faListCheck"

--- a/resources/js/vue/components/BuildBuildPage.vue
+++ b/resources/js/vue/components/BuildBuildPage.vue
@@ -4,9 +4,9 @@
     active-tab="build"
   >
     <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-      <build-summary-card :build-id="buildId" />
+      <BuildSummaryCard :build-id="buildId" />
 
-      <loading-indicator :is-loading="!build">
+      <LoadingIndicator :is-loading="!build">
         <div
           class="tw-border tw-p-2 tw-rounded-lg tw-flex tw-flex-col tw-gap-2"
           data-test="build-info"
@@ -18,7 +18,7 @@
             <div class="tw-font-bold">
               Compiler
             </div>
-            <code-box :text="build.compilerName" />
+            <CodeBox :text="build.compilerName" />
           </div>
 
           <div
@@ -28,7 +28,7 @@
             <div class="tw-font-bold">
               Compiler Version
             </div>
-            <code-box :text="build.compilerVersion" />
+            <CodeBox :text="build.compilerVersion" />
           </div>
 
           <div
@@ -38,7 +38,7 @@
             <div class="tw-font-bold">
               Generator
             </div>
-            <code-box :text="build.generator" />
+            <CodeBox :text="build.generator" />
           </div>
 
           <div
@@ -48,7 +48,7 @@
             <div class="tw-font-bold">
               Source Directory
             </div>
-            <code-box :text="build.sourceDirectory" />
+            <CodeBox :text="build.sourceDirectory" />
           </div>
 
           <div
@@ -58,7 +58,7 @@
             <div class="tw-font-bold">
               Binary Directory
             </div>
-            <code-box :text="build.binaryDirectory" />
+            <CodeBox :text="build.binaryDirectory" />
           </div>
 
           <div
@@ -68,12 +68,12 @@
             <div class="tw-font-bold">
               Build Command
             </div>
-            <code-box :text="build.command" />
+            <CodeBox :text="build.command" />
           </div>
         </div>
-      </loading-indicator>
+      </LoadingIndicator>
 
-      <loading-indicator :is-loading="!buildWithErrors">
+      <LoadingIndicator :is-loading="!buildWithErrors">
         <div
           v-if="buildWithErrors.children.edges.length > 0"
           class="tw-join tw-join-vertical tw-w-full"
@@ -89,15 +89,15 @@
                 v-if="childBuild.buildErrorsCount > 0"
                 class="tw-badge tw-ml-2 tw-bg-error"
                 :data-test="'errors-' + childBuild.subProject.id"
-              ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ childBuild.buildErrorsCount }}</span>
+              ><FontAwesomeIcon :icon="FA.faCircleExclamation" /> {{ childBuild.buildErrorsCount }}</span>
               <span
                 v-if="childBuild.buildWarningsCount > 0"
                 class="tw-badge tw-ml-1 tw-bg-warning"
                 :data-test="'warnings-' + childBuild.subProject.id"
-              ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ childBuild.buildWarningsCount }}</span>
+              ><FontAwesomeIcon :icon="FA.faTriangleExclamation" /> {{ childBuild.buildWarningsCount }}</span>
             </summary>
             <div class="tw-collapse-content">
-              <build-error-list
+              <BuildErrorList
                 :build-id="parseInt(childBuild.id)"
                 :previous-build-id="buildIdsToPreviousBuildIds[parseInt(childBuild.id)] ?? null"
                 :show-new-errors="showNewErrors"
@@ -110,7 +110,7 @@
           </details>
         </div>
         <div v-else>
-          <build-error-list
+          <BuildErrorList
             :build-id="buildId"
             :previous-build-id="previousBuildId"
             :show-new-errors="showNewErrors"
@@ -120,7 +120,7 @@
             :repository-cmake-project-root="repositoryCmakeProjectRoot"
           />
         </div>
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
@@ -5,7 +5,7 @@
         class="tw-mr-1"
         :class="buildError.type === 'ERROR' ? 'tw-text-error' : 'tw-text-warning'"
       >
-        <font-awesome-icon :icon="buildError.type === 'ERROR' ? FA.faCircleExclamation : FA.faTriangleExclamation" />
+        <FontAwesomeIcon :icon="buildError.type === 'ERROR' ? FA.faCircleExclamation : FA.faTriangleExclamation" />
       </span>
       {{ buildError.type === 'ERROR' ? 'Error' : 'Warning' }}
       <template v-if="buildError.outputFile">
@@ -27,9 +27,9 @@
         class="tw-font-bold tw-cursor-pointer"
         @click="showStdError = !showStdError"
       >
-        Standard Error <font-awesome-icon :icon="showStdError ? FA.faChevronDown : FA.faChevronRight" />
+        Standard Error <FontAwesomeIcon :icon="showStdError ? FA.faChevronDown : FA.faChevronRight" />
       </div>
-      <code-box
+      <CodeBox
         v-if="showStdError"
         :text="buildError.stdError"
         :links="getLinksFromText(buildError.stdError)"
@@ -42,9 +42,9 @@
         data-test="stdout"
         @click="showStdOutput = !showStdOutput"
       >
-        Standard Output <font-awesome-icon :icon="showStdOutput ? FA.faChevronDown : FA.faChevronRight" />
+        Standard Output <FontAwesomeIcon :icon="showStdOutput ? FA.faChevronDown : FA.faChevronRight" />
       </div>
-      <code-box
+      <CodeBox
         v-if="showStdOutput"
         :text="buildError.stdOutput"
         :links="getLinksFromText(buildError.stdOutput)"
@@ -56,9 +56,9 @@
         class="tw-font-bold tw-cursor-pointer"
         @click="showCommand = !showCommand"
       >
-        Command <font-awesome-icon :icon="showCommand ? FA.faChevronDown : FA.faChevronRight" />
+        Command <FontAwesomeIcon :icon="showCommand ? FA.faChevronDown : FA.faChevronRight" />
       </div>
-      <code-box
+      <CodeBox
         v-if="showCommand"
         :text="buildError.command"
       />

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="tw-flex tw-flex-col tw-gap-4">
-    <loading-indicator :is-loading="!build || (!previousBuild && previousBuildId !== null)">
+    <LoadingIndicator :is-loading="!build || (!previousBuild && previousBuildId !== null)">
       <div
         v-if="filteredWarnings.length === 0 && filteredErrors.length === 0"
         class="tw-self-center"
@@ -20,7 +20,7 @@
             :key="buildError.id"
             class="tw-p-2 tw-border-2 tw-rounded-md"
           >
-            <build-error-item
+            <BuildErrorItem
               :build-error="buildError"
               :source-directory="build.sourceDirectory"
               :repository-type="repositoryType"
@@ -44,7 +44,7 @@
             :key="buildWarning.id"
             class="tw-p-2 tw-border-2 tw-rounded-md"
           >
-            <build-error-item
+            <BuildErrorItem
               :build-error="buildWarning"
               :source-directory="build.sourceDirectory"
               :repository-type="repositoryType"
@@ -55,7 +55,7 @@
           </div>
         </div>
       </div>
-    </loading-indicator>
+    </LoadingIndicator>
   </div>
 </template>
 

--- a/resources/js/vue/components/BuildConfigure.vue
+++ b/resources/js/vue/components/BuildConfigure.vue
@@ -4,13 +4,13 @@
     active-tab="configure"
   >
     <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-      <build-summary-card :build-id="buildId" />
+      <BuildSummaryCard :build-id="buildId" />
 
-      <loading-indicator :is-loading="!configures">
+      <LoadingIndicator :is-loading="!configures">
         <div v-if="configures.length === 0">
           No configure found for this build.
         </div>
-        <configure-card
+        <ConfigureCard
           v-else-if="hasSingleConfigure"
           :return-value="configures[0].configure.returnValue"
           :log="configures[0].configure.log"
@@ -31,15 +31,15 @@
                 v-if="configure.configureErrorsCount > 0"
                 class="tw-badge tw-ml-2 tw-bg-red-400"
                 :data-test="'errors-' + configure.subProject.id"
-              ><font-awesome-icon :icon="FA.faCircleExclamation" /> {{ configure.configureErrorsCount }}</span>
+              ><FontAwesomeIcon :icon="FA.faCircleExclamation" /> {{ configure.configureErrorsCount }}</span>
               <span
                 v-if="configure.configureWarningsCount > 0"
                 class="tw-badge tw-ml-1 tw-bg-orange-400"
                 :data-test="'warnings-' + configure.subProject.id"
-              ><font-awesome-icon :icon="FA.faTriangleExclamation" /> {{ configure.configureWarningsCount }}</span>
+              ><FontAwesomeIcon :icon="FA.faTriangleExclamation" /> {{ configure.configureWarningsCount }}</span>
             </summary>
             <div class="tw-collapse-content">
-              <configure-card
+              <ConfigureCard
                 :return-value="configure.configure.returnValue"
                 :log="configure.configure.log"
                 :command="configure.configure.command"
@@ -47,7 +47,7 @@
             </div>
           </details>
         </div>
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildCoveragePage.vue
+++ b/resources/js/vue/components/BuildCoveragePage.vue
@@ -10,7 +10,7 @@
         <span class="tw-font-bold tw-text-xl">
           Coverage Summary
         </span>
-        <loading-indicator :is-loading="!coverage">
+        <LoadingIndicator :is-loading="!coverage">
           <table class="tw-table tw-table-sm tw-w-auto">
             <tbody>
               <tr>
@@ -51,10 +51,10 @@
               </tr>
             </tbody>
           </table>
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
 
-      <filter-builder
+      <FilterBuilder
         filter-type="BuildCoverageFiltersMultiFilterInput"
         primary-record-name="coverage files"
         :initial-filters="initialFilters"
@@ -70,7 +70,7 @@
             data-test="breadcrumbs-back-button"
             @click="currentPrefix = directoryAbovePath(currentPrefix)"
           >
-            <font-awesome-icon :icon="FA.faReply" />
+            <FontAwesomeIcon :icon="FA.faReply" />
             Back
           </button>
           <div
@@ -93,7 +93,7 @@
                   href=""
                   @click.prevent="currentPrefix = currentPrefix.split('/').slice(0, index + 1).join('/') + '/'"
                 >
-                  <font-awesome-icon
+                  <FontAwesomeIcon
                     :icon="FA.faFolder"
                     class="tw-mr-1"
                   />
@@ -103,8 +103,8 @@
             </ul>
           </div>
         </div>
-        <loading-indicator :is-loading="!coverage">
-          <data-table
+        <LoadingIndicator :is-loading="!coverage">
+          <DataTable
             :columns="[
               ...(hasSubProjects ? [{
                 name: 'subProject',
@@ -144,14 +144,14 @@
                 data-test="coverage-directory-link"
                 @click.prevent="currentPrefix += obj.path + '/';"
               >
-                <font-awesome-icon :icon="FA.faFolder" /> {{ obj.path }}
+                <FontAwesomeIcon :icon="FA.faFolder" /> {{ obj.path }}
               </a>
               <a
                 v-else
                 :href="`${$baseURL}/builds/${buildId}/coverage/${obj.fileId}`"
                 data-test="coverage-file-link"
               >
-                <font-awesome-icon :icon="FA.faFile" /> {{ obj.path }}
+                <FontAwesomeIcon :icon="FA.faFile" /> {{ obj.path }}
               </a>
             </template>
             <template #linePercentage="{ props: { text: pct } }">
@@ -170,8 +170,8 @@
                 max="100"
               /> {{ pct }}%
             </template>
-          </data-table>
-        </loading-indicator>
+          </DataTable>
+        </LoadingIndicator>
       </div>
     </div>
   </BuildSidebar>

--- a/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
+++ b/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
@@ -4,9 +4,9 @@
     active-tab="dynamic_analysis"
   >
     <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-      <build-summary-card :build-id="buildId" />
+      <BuildSummaryCard :build-id="buildId" />
 
-      <loading-indicator :is-loading="!dynamicAnalysis">
+      <LoadingIndicator :is-loading="!dynamicAnalysis">
         <div class="tw-border-base-300 tw-bg-base-200 tw-border tw-rounded tw-p-2 tw-flex tw-flex-row tw-w-full tw-gap-1">
           <div class="tw-font-mono tw-link tw-link-hover">
             <a :href="link">
@@ -21,8 +21,8 @@
           <span>{{ status }}</span>
         </div>
 
-        <code-box :text="dynamicAnalysis.log" />
-      </loading-indicator>
+        <CodeBox :text="dynamicAnalysis.log" />
+      </LoadingIndicator>
     </div>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildFilesPage.vue
+++ b/resources/js/vue/components/BuildFilesPage.vue
@@ -13,8 +13,8 @@
         No URLs or files were uploaded for this build.
       </div>
 
-      <loading-indicator :is-loading="!urls">
-        <data-table
+      <LoadingIndicator :is-loading="!urls">
+        <DataTable
           v-if="urls.edges.length > 0"
           :column-groups="[
             {
@@ -32,10 +32,10 @@
           :full-width="true"
           test-id="urls-table"
         />
-      </loading-indicator>
+      </LoadingIndicator>
 
-      <loading-indicator :is-loading="!files">
-        <data-table
+      <LoadingIndicator :is-loading="!files">
+        <DataTable
           v-if="files.edges.length > 0"
           :column-groups="[
             {
@@ -61,7 +61,7 @@
           :full-width="true"
           test-id="files-table"
         />
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildInstrumentationPage.vue
+++ b/resources/js/vue/components/BuildInstrumentationPage.vue
@@ -15,9 +15,9 @@
           @change-filters="filters => changedFilters = filters"
         />
 
-        <loading-indicator :is-loading="!allCommands">
+        <LoadingIndicator :is-loading="!allCommands">
           <CommandFlameChart :commands="formattedChartCommands" />
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
 
       <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
@@ -25,7 +25,7 @@
           Memory
         </h3>
 
-        <loading-indicator :is-loading="!allCommands">
+        <LoadingIndicator :is-loading="!allCommands">
           <LineChart
             v-if="memoryChartData.length > 0"
             y-label="Memory (GB)"
@@ -34,7 +34,7 @@
           <div v-else>
             No data available.
           </div>
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
     </div>
   </BuildSidebar>

--- a/resources/js/vue/components/BuildNotesPage.vue
+++ b/resources/js/vue/components/BuildNotesPage.vue
@@ -60,7 +60,7 @@
                   {{ note.node.name }}
                 </h3>
                 <hr>
-                <code-box
+                <CodeBox
                   :text="note.node.text"
                   :bordered="false"
                 />

--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -7,9 +7,9 @@
       <p>{{ cdash.error }}</p>
     </section>
     <section v-else>
-      <build-summary-card :build-id="buildId" />
+      <BuildSummaryCard :build-id="buildId" />
 
-      <loading-indicator :is-loading="loading">
+      <LoadingIndicator :is-loading="loading">
         <!-- Display link to create bug tracker issue if supported. -->
         <div v-if="cdash.newissueurl">
           <a
@@ -433,7 +433,7 @@
         <br>
 
         <!-- Display comments for this build -->
-        <loading-indicator :is-loading="!comments">
+        <LoadingIndicator :is-loading="!comments">
           <div
             v-if="comments.length > 0 || cdash.user.id > 0"
             class="title-divider"
@@ -444,7 +444,7 @@
           <div v-if="comments.length > 0">
             <div v-for="{node: comment} in comments">
               <b>{{ comment.user.firstname }} {{ comment.user.lastname }}</b> {{ Utils.formatRelativeTimestamp(comment.timestamp) }}
-              <code-box :text="comment.text" />
+              <CodeBox :text="comment.text" />
               <hr>
             </div>
             <br>
@@ -503,7 +503,7 @@
             </div>
             <br>
           </div>
-        </loading-indicator>
+        </LoadingIndicator>
 
         <!-- Graphs -->
         <div class="title-divider">
@@ -618,7 +618,7 @@
           />
         </div>
         <br>
-      </loading-indicator>
+      </LoadingIndicator>
     </section>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -14,11 +14,11 @@
         @change-filters="filters => changedFilters = filters"
       />
 
-      <loading-indicator :is-loading="!build || !targets">
+      <LoadingIndicator :is-loading="!build || !targets">
         <div class="tw-w-full tw-bg-base-100 tw-flex tw-flex-col tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
           <CommandFlameChart :commands="formattedCommands" />
         </div>
-      </loading-indicator>
+      </LoadingIndicator>
 
       <LoadingIndicator :is-loading="!targets">
         <DataTable

--- a/resources/js/vue/components/BuildTestsPage.vue
+++ b/resources/js/vue/components/BuildTestsPage.vue
@@ -6,21 +6,21 @@
     <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
       <BuildSummaryCard :build-id="buildId" />
 
-      <filter-builder
+      <FilterBuilder
         filter-type="BuildTestsFiltersMultiFilterInput"
         primary-record-name="tests"
         :initial-filters="initialFilters"
         :execute-query-link="executeQueryLink"
         @change-filters="filters => changedFilters = filters"
       />
-      <loading-indicator :is-loading="!tests || (onlyDelta && !previousTests && previousBuildId !== null)">
+      <LoadingIndicator :is-loading="!tests || (onlyDelta && !previousTests && previousBuildId !== null)">
         <div
           v-if="onlyDelta && tests && filteredTests.length === 0"
           class="tw-self-center"
         >
           No tests with changed state for this build.
         </div>
-        <data-table
+        <DataTable
           v-if="!onlyDelta || filteredTests.length > 0"
           :columns="[
             ...(hasSubProjects ? [{
@@ -59,7 +59,7 @@
           initial-sort-column="status"
           test-id="tests-table"
         />
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/BuildUpdate/CommitCard.vue
+++ b/resources/js/vue/components/BuildUpdate/CommitCard.vue
@@ -26,7 +26,7 @@
         class="tw-w-1/2"
       />
       <ul class="tw-menu tw-menu-xs tw-bg-base-200 tw-rounded-lg tw-w-1/2">
-        <commit-file-tree-node
+        <CommitFileTreeNode
           v-for="node in fileTree"
           :key="node.name"
           :node="node"

--- a/resources/js/vue/components/BuildUpdate/CommitFileTreeNode.vue
+++ b/resources/js/vue/components/BuildUpdate/CommitFileTreeNode.vue
@@ -5,7 +5,7 @@
         class="tw-truncate"
         :title="node.name"
       >
-        <font-awesome-icon :icon="FA.faFile" />
+        <FontAwesomeIcon :icon="FA.faFile" />
         {{ node.name }}
       </span>
       <span
@@ -23,7 +23,7 @@
         class="tw-truncate"
         :title="node.name"
       >
-        <font-awesome-icon :icon="FA.faFolderOpen" />
+        <FontAwesomeIcon :icon="FA.faFolderOpen" />
         {{ node.name }}
       </summary>
       <ul>

--- a/resources/js/vue/components/BuildUpdatePage.vue
+++ b/resources/js/vue/components/BuildUpdatePage.vue
@@ -4,9 +4,9 @@
     active-tab="update"
   >
     <section class="tw-flex tw-flex-col tw-w-full tw-gap-4">
-      <build-summary-card :build-id="buildId" />
+      <BuildSummaryCard :build-id="buildId" />
 
-      <loading-indicator :is-loading="!update">
+      <LoadingIndicator :is-loading="!update">
         <div>
           <div v-if="update.revision">
             <b>Revision: </b>
@@ -61,9 +61,9 @@
         >
           {{ update.status }}
         </h3>
-      </loading-indicator>
+      </LoadingIndicator>
 
-      <loading-indicator :is-loading="!updateFiles">
+      <LoadingIndicator :is-loading="!updateFiles">
         <div class="tw-flex tw-flex-col tw-gap-4">
           <CommitCard
             v-for="commitFiles in commits"
@@ -72,7 +72,7 @@
             :repository="repository"
           />
         </div>
-      </loading-indicator>
+      </LoadingIndicator>
     </section>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/CreateProjectPage.vue
+++ b/resources/js/vue/components/CreateProjectPage.vue
@@ -9,7 +9,7 @@
         role="alert"
         class="tw-alert tw-alert-error"
       >
-        <font-awesome-icon
+        <FontAwesomeIcon
           :icon="FA.faCircleXmark"
           class="tw-h-6 tw-w-6"
         />
@@ -68,7 +68,7 @@
             >
             <div>
               <span class="tw-label-text">
-                <font-awesome-icon :icon="FA.faEarthAmericas" /> Public
+                <FontAwesomeIcon :icon="FA.faEarthAmericas" /> Public
               </span>
               <div class="tw-text-xs tw-text-neutral-500">
                 Does not require authentication to access.
@@ -87,7 +87,7 @@
             >
             <div>
               <span class="tw-label-text">
-                <font-awesome-icon :icon="FA.faShieldHalved" /> Protected
+                <FontAwesomeIcon :icon="FA.faShieldHalved" /> Protected
               </span>
               <div class="tw-text-xs tw-text-neutral-500">
                 Access limited to authenticated users.
@@ -105,7 +105,7 @@
             >
             <div>
               <span class="tw-label-text">
-                <font-awesome-icon :icon="FA.faLock" /> Private
+                <FontAwesomeIcon :icon="FA.faLock" /> Private
               </span>
               <div class="tw-text-xs tw-text-neutral-500">
                 Requires access to be granted explicitly.

--- a/resources/js/vue/components/ManageAuthTokens.vue
+++ b/resources/js/vue/components/ManageAuthTokens.vue
@@ -1,6 +1,6 @@
 <template>
-  <loading-indicator :is-loading="!authenticationTokens">
-    <data-table
+  <LoadingIndicator :is-loading="!authenticationTokens">
+    <DataTable
       :column-groups="[
         {
           displayName: 'Authentication Tokens',
@@ -58,11 +58,11 @@
           @click="revokeToken(token)"
         >
           Revoke Token
-          <font-awesome-icon :icon="FA.faTrash" />
+          <FontAwesomeIcon :icon="FA.faTrash" />
         </button>
       </template>
-    </data-table>
-  </loading-indicator>
+    </DataTable>
+  </LoadingIndicator>
 </template>
 <script>
 

--- a/resources/js/vue/components/ProfilePage.vue
+++ b/resources/js/vue/components/ProfilePage.vue
@@ -159,7 +159,7 @@
               data-test="create-token-button"
               @click="createAuthenticationToken"
             >
-              <font-awesome-icon :icon="FA.faPlus" /> Create Token
+              <FontAwesomeIcon :icon="FA.faPlus" /> Create Token
             </button>
           </div>
 
@@ -190,7 +190,7 @@
                 data-test="copy-token-button"
                 @click="copyToken"
               >
-                <font-awesome-icon
+                <FontAwesomeIcon
                   v-if="!copied"
                   :icon="FA.faCopy"
                 />
@@ -269,7 +269,7 @@
                   data-test="delete-token-button"
                   @click="deleteAuthenticationToken(token.id)"
                 >
-                  <font-awesome-icon :icon="FA.faTrashCan" />
+                  <FontAwesomeIcon :icon="FA.faTrashCan" />
                 </button>
               </td>
             </tr>

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -86,7 +86,7 @@
             Email
           </div>
           <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
-            <font-awesome-icon :icon="FA.faEnvelope" />
+            <FontAwesomeIcon :icon="FA.faEnvelope" />
             <input
               v-model="inviteMembersModalEmail"
               type="email"
@@ -141,11 +141,11 @@
         <button>Cancel</button>
       </form>
     </dialog>
-    <loading-indicator
+    <LoadingIndicator
       v-if="canInviteUsers"
       :is-loading="!projectInvitations"
     >
-      <data-table
+      <DataTable
         :column-groups="[
           {
             displayName: 'Invitations',
@@ -186,13 +186,13 @@
             data-test="revoke-invitation-button"
             @click="revokeInvitation(invite)"
           >
-            Revoke Invitation <font-awesome-icon :icon="FA.faTrash" />
+            Revoke Invitation <FontAwesomeIcon :icon="FA.faTrash" />
           </button>
         </template>
-      </data-table>
-    </loading-indicator>
-    <loading-indicator :is-loading="!projectAdministrators || !projectUsers">
-      <data-table
+      </DataTable>
+    </LoadingIndicator>
+    <LoadingIndicator :is-loading="!projectAdministrators || !projectUsers">
+      <DataTable
         :column-groups="[
           {
             displayName: 'Members',
@@ -247,12 +247,12 @@
             data-test="remove-user-button"
             @click="removeUser(user)"
           >
-            Remove User <font-awesome-icon :icon="FA.faTrash" />
+            Remove User <FontAwesomeIcon :icon="FA.faTrash" />
           </button>
           <span v-else />
         </template>
-      </data-table>
-    </loading-indicator>
+      </DataTable>
+    </LoadingIndicator>
   </div>
 </template>
 

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -70,7 +70,7 @@
               >
               <div>
                 <span class="tw-label-text">
-                  <font-awesome-icon :icon="FA.faEarthAmericas" /> Public
+                  <FontAwesomeIcon :icon="FA.faEarthAmericas" /> Public
                 </span>
                 <div class="tw-text-xs tw-text-neutral-500">
                   Does not require authentication to access.
@@ -87,7 +87,7 @@
               >
               <div>
                 <span class="tw-label-text">
-                  <font-awesome-icon :icon="FA.faShieldHalved" /> Protected
+                  <FontAwesomeIcon :icon="FA.faShieldHalved" /> Protected
                 </span>
                 <div class="tw-text-xs tw-text-neutral-500">
                   Access limited to authenticated users.
@@ -104,7 +104,7 @@
               >
               <div>
                 <span class="tw-label-text">
-                  <font-awesome-icon :icon="FA.faLock" /> Private
+                  <FontAwesomeIcon :icon="FA.faLock" /> Private
                 </span>
                 <div class="tw-text-xs tw-text-neutral-500">
                   Requires access to be granted explicitly.

--- a/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
+++ b/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
@@ -40,7 +40,7 @@
               data-test="delete-repository-button"
               @click="deleteRepository(repository.id)"
             >
-              <font-awesome-icon :icon="FA.faTrashCan" />
+              <FontAwesomeIcon :icon="FA.faTrashCan" />
             </button>
           </div>
         </div>

--- a/resources/js/vue/components/ProjectSettings/TestMeasurementsTab.vue
+++ b/resources/js/vue/components/ProjectSettings/TestMeasurementsTab.vue
@@ -19,7 +19,7 @@
             class="tw-flex tw-flex-row tw-items-center tw-justify-between tw-p-3 tw-border tw-border-base-300 tw-rounded-lg tw-bg-base-100"
           >
             <div class="tw-flex tw-items-center tw-gap-4 tw-flex-grow">
-              <font-awesome-icon
+              <FontAwesomeIcon
                 :icon="FA.faBars"
                 class="tw-handle tw-cursor-move tw-text-neutral-500"
               />
@@ -32,7 +32,7 @@
               data-test="delete-test-measurement-button"
               @click="deleteTestMeasurement(element.id)"
             >
-              <font-awesome-icon :icon="FA.faTrash" />
+              <FontAwesomeIcon :icon="FA.faTrash" />
             </button>
           </div>
         </template>
@@ -67,7 +67,7 @@
             v-if="createLoading"
             class="tw-loading tw-loading-spinner"
           />
-          <font-awesome-icon :icon="FA.faPlus" />
+          <FontAwesomeIcon :icon="FA.faPlus" />
           Add
         </button>
       </div>
@@ -76,7 +76,7 @@
         class="tw-text-error tw-text-sm"
         data-test="error-message"
       >
-        <font-awesome-icon :icon="FA.faCircleXmark" /> {{ errorMessage }}
+        <FontAwesomeIcon :icon="FA.faCircleXmark" /> {{ errorMessage }}
       </div>
     </div>
 

--- a/resources/js/vue/components/ProjectSitesPage.vue
+++ b/resources/js/vue/components/ProjectSitesPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div data-test="all-sites-table">
-    <loading-indicator :is-loading="!allSites">
-      <data-table
+    <LoadingIndicator :is-loading="!allSites">
+      <DataTable
         :column-groups="[
           {
             displayName: 'All Sites',
@@ -34,7 +34,7 @@
         :rows="formattedSiteRows"
         :full-width="true"
       />
-    </loading-indicator>
+    </LoadingIndicator>
   </div>
 </template>
 

--- a/resources/js/vue/components/ProjectsPage.vue
+++ b/resources/js/vue/components/ProjectsPage.vue
@@ -49,7 +49,7 @@
           Create Project
         </a>
       </div>
-      <loading-indicator :is-loading="projects === null">
+      <LoadingIndicator :is-loading="projects === null">
         <div
           v-if="noProjectsMessage !== null"
           class="tw-italic tw-font-medium tw-text-neutral-500"
@@ -68,7 +68,7 @@
               data-test="projects-table-row"
             >
               <td>
-                <project-logo
+                <ProjectLogo
                   :image-url="project.logoUrl"
                   :project-name="project.name"
                   class="tw-w-8 tw-h-8"
@@ -82,7 +82,7 @@
                     data-test="project-name"
                   >
                     {{ project.name }}
-                    <font-awesome-icon
+                    <FontAwesomeIcon
                       :icon="projectVisibilityToIcon(project.visibility)"
                       class="tw-text-neutral-500"
                     />
@@ -100,13 +100,13 @@
                   v-if="project.mostRecentBuild"
                   class="tw-text-nowrap tw-text-neutral-500"
                 >
-                  <font-awesome-icon :icon="FA.faCalendar" /> {{ DateTime.fromISO(project.mostRecentBuild?.submissionTime).toRelative() }}
+                  <FontAwesomeIcon :icon="FA.faCalendar" /> {{ DateTime.fromISO(project.mostRecentBuild?.submissionTime).toRelative() }}
                 </span>
               </td>
             </tr>
           </tbody>
         </table>
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </div>
 </template>

--- a/resources/js/vue/components/SitesIdPage.vue
+++ b/resources/js/vue/components/SitesIdPage.vue
@@ -8,7 +8,7 @@
         <div class="tw-text-2xl tw-font-black">
           Site Details
         </div>
-        <loading-indicator :is-loading="$apollo.queries.mostRecentInformation.loading">
+        <LoadingIndicator :is-loading="$apollo.queries.mostRecentInformation.loading">
           <template v-if="mostRecentInformation === null">
             No information available for this site.
           </template>
@@ -76,7 +76,7 @@
                       data-test="edit-description-button"
                       @click="editDescription"
                     >
-                      <font-awesome-icon :icon="FA.faPencil" /> Edit
+                      <FontAwesomeIcon :icon="FA.faPencil" /> Edit
                     </button>
                   </div>
                 </div>
@@ -106,13 +106,13 @@
               </div>
             </div>
           </template>
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
       <div class="tw-flex tw-flex-col tw-border tw-rounded tw-p-4">
         <div class="tw-text-2xl tw-font-black">
           Projects
         </div>
-        <loading-indicator :is-loading="!projects">
+        <LoadingIndicator :is-loading="!projects">
           <table
             class="tw-table"
             data-test="site-projects-table"
@@ -133,7 +133,7 @@
               </tr>
             </tbody>
           </table>
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
       <div class="tw-flex tw-flex-col tw-border tw-rounded tw-p-4">
         <div class="tw-flex tw-flex-row">
@@ -159,7 +159,7 @@
             </button>
           </template>
         </div>
-        <loading-indicator :is-loading="!siteMaintainers">
+        <LoadingIndicator :is-loading="!siteMaintainers">
           <table
             class="tw-table"
             data-test="site-maintainers-table"
@@ -175,7 +175,7 @@
               </tr>
             </tbody>
           </table>
-        </loading-indicator>
+        </LoadingIndicator>
       </div>
     </div>
     <div
@@ -185,14 +185,14 @@
       <div class="tw-text-2xl tw-font-black">
         History
       </div>
-      <loading-indicator :is-loading="!site">
+      <LoadingIndicator :is-loading="!site">
         <ul class="tw-timeline tw-timeline-snap-icon tw-timeline-compact tw-timeline-vertical">
           <li
             v-for="(information, index) in deduplicatedInformation"
             data-test="site-history-item"
           >
             <div class="tw-timeline-middle">
-              <font-awesome-icon :icon="FA.faCircleCheck" />
+              <FontAwesomeIcon :icon="FA.faCircleCheck" />
             </div>
             <div class="tw-timeline-end tw-mb-4">
               <time class="tw-font-mono tw-italic tw-text-neutral-500">{{ humanReadableTimestamp(information.node.timestamp) }}</time>
@@ -267,7 +267,7 @@
             <hr>
           </li>
         </ul>
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </div>
 </template>

--- a/resources/js/vue/components/SubProjectDependencies.vue
+++ b/resources/js/vue/components/SubProjectDependencies.vue
@@ -30,8 +30,8 @@
       </span>
     </div>
     <div class="text-center">
-      <loading-indicator :is-loading="graphLoading">
-        <v-chart
+      <LoadingIndicator :is-loading="graphLoading">
+        <VChart
           id="chart_placeholder"
           :option="chartOption"
           autoresize
@@ -39,7 +39,7 @@
           @mouseover="onMouseOver"
           @mouseout="onMouseOut"
         />
-      </loading-indicator>
+      </LoadingIndicator>
     </div>
   </section>
 </template>

--- a/resources/js/vue/components/TestDetailsPage.vue
+++ b/resources/js/vue/components/TestDetailsPage.vue
@@ -3,9 +3,9 @@
     :build-id="buildId"
     active-tab="tests"
   >
-    <build-summary-card :build-id="buildId" />
+    <BuildSummaryCard :build-id="buildId" />
 
-    <loading-indicator :is-loading="!build || !test">
+    <LoadingIndicator :is-loading="!build || !test">
       <div
         id="executiontime"
         class="tw-flex tw-flex-row tw-gap-1"
@@ -159,7 +159,7 @@
         </a>
       </div>
       <div v-if="showcommandline">
-        <code-box
+        <CodeBox
           id="commandline"
           :text="test.command"
         />
@@ -187,7 +187,7 @@
         </a>
       </div>
       <div v-if="showenvironment">
-        <code-box
+        <CodeBox
           id="environment"
           :text="environment"
         />
@@ -238,7 +238,7 @@
       />
       <div id="tooltip" />
 
-      <test-history-plot
+      <TestHistoryPlot
         v-if="graphSelection === 'status'"
         :base-url="$baseURL"
         :project-id="build.project.id"
@@ -249,7 +249,7 @@
 
       <br>
       <b>Test Output</b>
-      <code-box
+      <CodeBox
         id="test_output"
         :text="test.output"
       />
@@ -257,10 +257,10 @@
 
       <div v-for="preformattedMeasurement in preformattedMeasurements">
         <b>{{ preformattedMeasurement.name }}</b>
-        <code-box :text="preformattedMeasurement.value" />
+        <CodeBox :text="preformattedMeasurement.value" />
         <br>
       </div>
-    </loading-indicator>
+    </LoadingIndicator>
   </BuildSidebar>
 </template>
 

--- a/resources/js/vue/components/UsersPage.vue
+++ b/resources/js/vue/components/UsersPage.vue
@@ -35,7 +35,7 @@
               Email
             </div>
             <label class="tw-input tw-input-bordered tw-flex tw-items-center tw-w-full tw-gap-2">
-              <font-awesome-icon :icon="FA.faEnvelope" />
+              <FontAwesomeIcon :icon="FA.faEnvelope" />
               <input
                 v-model="inviteUsersModalEmail"
                 type="email"
@@ -95,11 +95,11 @@
         </form>
       </dialog>
     </div>
-    <loading-indicator
+    <LoadingIndicator
       v-if="canInviteUsers"
       :is-loading="!invitations"
     >
-      <data-table
+      <DataTable
         :column-groups="[
           {
             displayName: 'Invitations',
@@ -140,13 +140,13 @@
             data-test="revoke-invitation-button"
             @click="revokeInvitation(invite)"
           >
-            Revoke Invitation <font-awesome-icon :icon="FA.faTrash" />
+            Revoke Invitation <FontAwesomeIcon :icon="FA.faTrash" />
           </button>
         </template>
-      </data-table>
-    </loading-indicator>
-    <loading-indicator :is-loading="!users">
-      <data-table
+      </DataTable>
+    </LoadingIndicator>
+    <LoadingIndicator :is-loading="!users">
+      <DataTable
         :column-groups="[
           {
             displayName: 'Users',
@@ -214,12 +214,12 @@
             :data-test="'remove-user-button-' + user.id"
             @click="removeUser(user)"
           >
-            Remove User <font-awesome-icon :icon="FA.faTrash" />
+            Remove User <FontAwesomeIcon :icon="FA.faTrash" />
           </button>
           <span v-else />
         </template>
-      </data-table>
-    </loading-indicator>
+      </DataTable>
+    </LoadingIndicator>
   </div>
 </template>
 

--- a/resources/js/vue/components/ViewDynamicAnalysis.vue
+++ b/resources/js/vue/components/ViewDynamicAnalysis.vue
@@ -12,8 +12,8 @@
     >
       <BuildSummaryCard :build-id="buildid" />
 
-      <loading-indicator :is-loading="loading">
-        <data-table
+      <LoadingIndicator :is-loading="loading">
+        <DataTable
           :columns="columns"
           :column-groups="columnGroups"
           :rows="rows"
@@ -21,7 +21,7 @@
           initial-sort-column="status"
           test-id="dynamic-analysis-table"
         />
-      </loading-indicator>
+      </LoadingIndicator>
     </section>
   </BuildSidebar>
 </template>

--- a/resources/js/vue/components/shared/AdministrationPageCard.vue
+++ b/resources/js/vue/components/shared/AdministrationPageCard.vue
@@ -7,7 +7,7 @@
       v-if="icon"
       class="tw-flex-shrink-0 tw-flex tw-items-center tw-justify-center"
     >
-      <font-awesome-icon
+      <FontAwesomeIcon
         :icon="icon"
         class="tw-h-8 tw-w-8 tw-text-black"
       />

--- a/resources/js/vue/components/shared/BuildSidebar.vue
+++ b/resources/js/vue/components/shared/BuildSidebar.vue
@@ -5,7 +5,7 @@
   >
     <aside class="tw-shrink-0 tw-bg-base-200 tw-border tw-border-base-300 tw-rounded-lg tw-overflow-hidden tw-sticky tw-top-[100px] tw-max-h-[calc(100vh-100px)] tw-overflow-y-auto tw-z-10">
       <nav class="tw-flex tw-flex-col tw-py-2">
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}`"
           title="Summary"
           :icon="FA.faCircleInfo"
@@ -13,7 +13,7 @@
           :disabled="summaryDisabled"
           data-test="sidebar-summary"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/update`"
           title="Update"
           :icon="FA.faCodePullRequest"
@@ -21,7 +21,7 @@
           :disabled="updateDisabled"
           data-test="sidebar-update"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/configure`"
           title="Configure"
           :icon="FA.faWrench"
@@ -30,7 +30,7 @@
           :badges="configureBadges"
           data-test="sidebar-configure"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/build`"
           title="Build"
           :icon="FA.faHammer"
@@ -39,7 +39,7 @@
           :badges="errorsBadges"
           data-test="sidebar-build"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/tests`"
           title="Tests"
           :icon="FA.faFlask"
@@ -48,7 +48,7 @@
           :badges="testsBadges"
           data-test="sidebar-tests"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/coverage`"
           title="Coverage"
           :icon="FA.faUmbrella"
@@ -56,7 +56,7 @@
           :disabled="coverageDisabled"
           data-test="sidebar-coverage"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/dynamic_analysis`"
           title="Dynamic Analysis"
           :icon="FA.faBug"
@@ -64,7 +64,7 @@
           :disabled="dynamicAnalysisDisabled"
           data-test="sidebar-dynamic-analysis"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/files`"
           title="Uploads"
           :icon="FA.faFileArrowUp"
@@ -72,7 +72,7 @@
           :disabled="filesDisabled"
           data-test="sidebar-files"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/notes`"
           title="Notes"
           :icon="FA.faNoteSticky"
@@ -80,7 +80,7 @@
           :disabled="notesDisabled"
           data-test="sidebar-notes"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/instrumentation`"
           title="Instrumentation"
           :icon="FA.faGaugeHigh"
@@ -88,7 +88,7 @@
           :disabled="instrumentationDisabled"
           data-test="sidebar-instrumentation"
         />
-        <build-sidebar-item
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/targets`"
           title="Targets"
           :icon="FA.faBullseye"

--- a/resources/js/vue/components/shared/BuildSidebarItem.vue
+++ b/resources/js/vue/components/shared/BuildSidebarItem.vue
@@ -11,7 +11,7 @@
     :title="title"
   >
     <div class="tw-relative">
-      <font-awesome-icon
+      <FontAwesomeIcon
         :icon="icon"
         class="tw-w-5 tw-h-5 tw-mb-1"
       />
@@ -25,7 +25,7 @@
           class="tw-flex tw-items-center tw-justify-center tw-min-w-[1rem] tw-h-3.5 tw-px-1 tw-text-[8px] tw-font-bold tw-rounded-full tw-gap-0.5"
           :class="[badge.colorClass, badge.textClass || 'tw-text-white']"
         >
-          <font-awesome-icon
+          <FontAwesomeIcon
             v-if="badge.icon"
             :icon="badge.icon"
           />

--- a/resources/js/vue/components/shared/BuildSummaryCard.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <loading-indicator :is-loading="!build">
+  <LoadingIndicator :is-loading="!build">
     <details class="tw-collapse tw-collapse-arrow tw-border-base-300 tw-bg-base-200 tw-border tw-group/collapse">
       <summary class="tw-collapse-title">
         <div class="tw-text-lg tw-font-medium tw-truncate tw-text-nowrap group-open/collapse:tw-text-wrap">
@@ -16,23 +16,23 @@
             :href="`${$baseURL}/sites/${build.site.id}`"
             class="tw-truncate"
           >
-            <font-awesome-icon :icon="FA.faComputer" /> {{ build.site.name }}
+            <FontAwesomeIcon :icon="FA.faComputer" /> {{ build.site.name }}
           </a>
           &bull;
           <span
             v-if="build.operatingSystemName"
             class="tw-truncate"
           >
-            <font-awesome-icon
+            <FontAwesomeIcon
               v-if="build.operatingSystemName === 'Windows'"
               :icon="FA.faWindows"
             />
             <!-- TODO: Add more specific Linux types. May require CTest work. -->
-            <font-awesome-icon
+            <FontAwesomeIcon
               v-else-if="build.operatingSystemName === 'Linux'"
               :icon="FA.faLinux"
             />
-            <font-awesome-icon
+            <FontAwesomeIcon
               v-else-if="build.operatingSystemName === 'Darwin' || build.operatingSystemName === 'OSX'"
               :icon="FA.faApple"
             />
@@ -65,36 +65,36 @@
           <div class="tw-flex tw-flex-row tw-gap-4">
             <div class="tw-flex tw-flex-col">
               <div class="tw-bg-white tw-divide-y tw-rounded tw-shadow tw-text-left">
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="Start"
                   :upper-right-text="humanReadableOverallStartTime"
                 />
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="Configure"
                   :upper-right-text="hasConfigure ? humanReadableConfigureDuration : null"
                   :main-text="configureText"
                   :link="hasConfigure ? `${$baseURL}/builds/${build.id}/configure` : null"
                   :highlight-color="configureHighlightColor"
                 />
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="Build"
                   :upper-right-text="hasBuild ? humanReadableBuildDuration : null"
                   :main-text="buildText"
                   :link="hasBuild ? `${$baseURL}/builds/${build.id}` : null"
                   :highlight-color="buildHighlightColor"
                 />
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="Test"
                   :upper-right-text="hasTest ? humanReadableTestDuration : null"
                   :main-text="testText"
                   :link="hasTest ? `${$baseURL}/builds/${build.id}/tests` : null"
                   :highlight-color="testHighlightColor"
                 />
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="End"
                   :upper-right-text="humanReadableOverallEndTime"
                 />
-                <build-summary-card-step-summary
+                <BuildSummaryCardStepSummary
                   upper-left-text="Submitted"
                   :upper-right-text="humanReadableSubmissionTime"
                 />
@@ -127,7 +127,7 @@
               :href="`${$baseURL}/sites/${build.site.id}`"
               class="tw-link tw-link-hover"
             >
-              <font-awesome-icon :icon="FA.faComputer" /> {{ build.site.name }}
+              <FontAwesomeIcon :icon="FA.faComputer" /> {{ build.site.name }}
             </a>
           </div>
           <div class="tw-flex tw-flex-row tw-gap-4">
@@ -291,7 +291,7 @@
         </div>
       </div>
     </details>
-  </loading-indicator>
+  </LoadingIndicator>
 </template>
 
 <script>

--- a/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
@@ -8,7 +8,7 @@
   >
     <div class="tw-text-small tw-font-medium tw-text-neutral-500 tw-flex tw-flex-row tw-gap-2 group-hover:tw-font-bold">
       <div>
-        <font-awesome-icon :icon="FA.faLink" />
+        <FontAwesomeIcon :icon="FA.faLink" />
         {{ upperLeftText }}
       </div>
       <div

--- a/resources/js/vue/components/shared/Charts/FlameChart.vue
+++ b/resources/js/vue/components/shared/Charts/FlameChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chart
+  <VChart
     class="tw-w-full"
     :option="chartOptions"
     :style="{ height: height + 'px' }"

--- a/resources/js/vue/components/shared/Charts/LineChart.vue
+++ b/resources/js/vue/components/shared/Charts/LineChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chart
+  <VChart
     class="tw-w-full tw-h-60"
     :option="chartOption"
     autoresize

--- a/resources/js/vue/components/shared/CommandFlameChart.vue
+++ b/resources/js/vue/components/shared/CommandFlameChart.vue
@@ -16,7 +16,7 @@
         <span class="tw-text-gray-700">{{ type }}</span>
       </div>
     </div>
-    <flame-chart
+    <FlameChart
       class="tw-w-full tw-p-0 tw-flex-grow"
       :data="processedChartData.data"
       :tracks="processedChartData.tracks"
@@ -29,7 +29,7 @@
     />
     <template v-if="selectedCommandId">
       <div class="tw-divider" />
-      <command-info-card :command-id="selectedCommandId" />
+      <CommandInfoCard :command-id="selectedCommandId" />
     </template>
   </div>
 </template>

--- a/resources/js/vue/components/shared/CommandInfoCard.vue
+++ b/resources/js/vue/components/shared/CommandInfoCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <loading-indicator :is-loading="!buildCommand">
+    <LoadingIndicator :is-loading="!buildCommand">
       <div class="tw-font-bold tw-text-lg">
         Details
       </div>
@@ -106,7 +106,7 @@
           </tbody>
         </table>
       </template>
-    </loading-indicator>
+    </LoadingIndicator>
   </div>
 </template>
 

--- a/resources/js/vue/components/shared/ConfigureCard.vue
+++ b/resources/js/vue/components/shared/ConfigureCard.vue
@@ -3,7 +3,7 @@
     <div class="tw-font-bold">
       Configure Command
     </div>
-    <code-box :text="command" />
+    <CodeBox :text="command" />
     <br>
     <div class="tw-flex tw-flex-row tw-gap-1">
       <span class="tw-font-bold">Return Value:</span>
@@ -13,7 +13,7 @@
     <div class="tw-font-bold">
       Configure Log
     </div>
-    <code-box :text="log" />
+    <CodeBox :text="log" />
   </div>
 </template>
 

--- a/resources/js/vue/components/shared/DataTable.vue
+++ b/resources/js/vue/components/shared/DataTable.vue
@@ -27,7 +27,7 @@
           data-cy="column-header"
           @click="toggleSort(column.name)"
         >
-          <font-awesome-icon
+          <FontAwesomeIcon
             v-if="sortable"
             :icon="sortColumn === column.name ? (sortAsc ? FA.faCaretUp : FA.faCaretDown) : FA.faSort"
           />

--- a/resources/js/vue/components/shared/FilterBuilder.vue
+++ b/resources/js/vue/components/shared/FilterBuilder.vue
@@ -4,9 +4,9 @@
       class="table-heading1 tw-font-bold"
       style="font-size: 16px; padding: 6px;"
     >
-      <font-awesome-icon :icon="FA.faFilter" /> Filters
+      <FontAwesomeIcon :icon="FA.faFilter" /> Filters
     </div>
-    <filter-group
+    <FilterGroup
       :type="filterType"
       :primary-record-name="primaryRecordName"
       :initial-filters="initialFilters"
@@ -18,7 +18,7 @@
         class="tw-btn tw-btn-xs"
         :href="executeQueryLink"
       >
-        <font-awesome-icon :icon="FA.faMagnifyingGlass" /> Apply
+        <FontAwesomeIcon :icon="FA.faMagnifyingGlass" /> Apply
       </a>
     </div>
   </div>

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -35,7 +35,7 @@
           @delete="changeRow('deleted', index)"
           @change-filters="newEntry => changeRow(newEntry, index)"
         />
-        <filter-row
+        <FilterRow
           v-else-if="entry !== 'deleted'"
           :fields="availableFields"
           :initial-field="filterRowFromGraphQLFilter(entry).field"
@@ -50,19 +50,19 @@
           class="tw-btn tw-btn-xs"
           @click="addFilter"
         >
-          <font-awesome-icon :icon="FA.faPlus" /> Add Filter
+          <FontAwesomeIcon :icon="FA.faPlus" /> Add Filter
         </button>
         <button
           class="tw-btn tw-btn-xs"
           @click="addGroup"
         >
-          <font-awesome-icon :icon="FA.faBarsStaggered" /> Add Group
+          <FontAwesomeIcon :icon="FA.faBarsStaggered" /> Add Group
         </button>
         <button
           class="tw-btn tw-btn-xs"
           @click="$emit('delete')"
         >
-          <font-awesome-icon :icon="FA.faTrash" /> Delete Group
+          <FontAwesomeIcon :icon="FA.faTrash" /> Delete Group
         </button>
       </div>
     </div>

--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -4,7 +4,7 @@
       class="tw-btn tw-btn-xs"
       @click="$emit('delete')"
     >
-      <font-awesome-icon :icon="FA.faTrash" /> Delete
+      <FontAwesomeIcon :icon="FA.faTrash" /> Delete
     </button>
     <!-- Field chooser -->
     <select
@@ -45,7 +45,7 @@
       type="text"
       class="tw-input tw-input-xs tw-input-bordered tw-w-full"
     >
-    <date-time-selector
+    <DateTimeSelector
       v-else-if="selectedField.type === FilterType.DATETIME"
       v-model="selectedValue"
     />

--- a/resources/js/vue/components/shared/TestHistoryPlot.vue
+++ b/resources/js/vue/components/shared/TestHistoryPlot.vue
@@ -17,7 +17,7 @@
         ›
       </button>
     </div>
-    <loading-indicator :is-loading="!testStatuses" />
+    <LoadingIndicator :is-loading="!testStatuses" />
     <div
       ref="chart"
       class="chart"

--- a/resources/js/vue/components/shared/TimelinePlot.vue
+++ b/resources/js/vue/components/shared/TimelinePlot.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-chart
+  <VChart
     ref="chart"
     class="chart"
     :option="chartOption"


### PR DESCRIPTION
Vue components can be referenced by either their PascalCase or strike-through names, which makes it difficult to search for references.  This PR improves the situation by requiring all components to be referenced by their PascalCase name.