### PR TITLE
Return null when repo type not set in `getRepository`

### DIFF
--- a/resources/js/vue/components/shared/RepositoryIntegrations.js
+++ b/resources/js/vue/components/shared/RepositoryIntegrations.js
@@ -76,7 +76,7 @@ export class GitLab extends Repository {
  * @return ?Repository
  */
 export function getRepository(repositoryType, repositoryUrl, repositoryCmakeProjectRoot) {
-  if (!repositoryUrl) {
+  if (!repositoryUrl || !repositoryType) {
     return null;
   }
 

--- a/tests/Spec/repository-integrations.spec.js
+++ b/tests/Spec/repository-integrations.spec.js
@@ -28,6 +28,31 @@ describe('RepositoryIntegrations', () => {
       const repo = getRepository('bitbucket', 'https://bitbucket.org/foo/bar', '');
       expect(repo).toBeNull();
     });
+
+    it('returns null when repositoryType is null', () => {
+      const repo = getRepository(null, 'https://github.com/foo/bar', '');
+      expect(repo).toBeNull();
+    });
+
+    it('returns null when repositoryType is undefined', () => {
+      const repo = getRepository(undefined, 'https://github.com/foo/bar', '');
+      expect(repo).toBeNull();
+    });
+
+    it('returns null when repositoryType is an empty string', () => {
+      const repo = getRepository('', 'https://github.com/foo/bar', '');
+      expect(repo).toBeNull();
+    });
+
+    it('returns null when repositoryUrl is null', () => {
+      const repo = getRepository('github', null, '');
+      expect(repo).toBeNull();
+    });
+
+    it('returns null when both repositoryUrl and repositoryType are null', () => {
+      const repo = getRepository(null, null, '');
+      expect(repo).toBeNull();
+    });
   });
 
   describe('GitHub', () => {


### PR DESCRIPTION
`getRepository` incorrectly assumes `repositoryType` is always set to a valid value, leading to the error described in https://github.com/Kitware/CDash/issues/3780 when it is not.  This PR fixes the issue by returning null if one or both of the repository URL and type aren't set.  Fixes https://github.com/Kitware/CDash/issues/3780.