### PR TITLE
Remove `xdebug` from UBI dev image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,6 @@ RUN if [ "$DEVELOPMENT_BUILD" = '1' ]; then \
           --nodocs \
           --noplugins \
           --setopt=install_weak_deps=0 \
-          php-xdebug \
           rsync \
       #> A horrible hack to get a newer version of CMake.  As of the time of this
       #> writing, Red Hat UBI uses CMake 3.20, while our scripts require CMake>=3.22.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "socialiteproviders/pingidentity": "1.0.0"
   },
   "require-dev": {
-    "ext-xdebug": "*",
     "ext-zip": "*",
     "fakerphp/faker": "1.24.1",
     "friendsofphp/php-cs-fixer": "3.95.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a440e9c3517805969dce1b493b02ae64",
+    "content-hash": "3fd0b337121dd9f21857eea6a7847599",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -12580,8 +12580,7 @@
         "ext-zlib": "*"
     },
     "platform-dev": {
-        "ext-xdebug": "*",
         "ext-zip": "*"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Our UBI images recently started failing to build because the `php-xdebug` package is no longer available from `dnf`.  I'm not aware of anyone using xdebug to develop on these images, so this PR removes it for the moment