### PR TITLE
Make single-method controllers invokable

### DIFF
--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -8,7 +8,7 @@ use Illuminate\View\View;
 
 final class AuthTokenController extends AbstractController
 {
-    public function manage(): View
+    public function __invoke(): View
     {
         return $this->vue('manage-auth-tokens', 'Authentication Tokens');
     }

--- a/app/Http/Controllers/CTestConfigurationController.php
+++ b/app/Http/Controllers/CTestConfigurationController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Response;
 
 final class CTestConfigurationController extends AbstractProjectController
 {
-    public function get(int $id): Response
+    public function __invoke(int $id): Response
     {
         $this->setProjectById($id);
 

--- a/app/Http/Controllers/ExpectedBuildController.php
+++ b/app/Http/Controllers/ExpectedBuildController.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Gate;
 
 final class ExpectedBuildController extends AbstractProjectController
 {
-    public function apiResponse(Request $request): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
         $required_params = ['siteid', 'groupid', 'name', 'type'];
         foreach ($required_params as $param) {

--- a/app/Http/Controllers/FilterController.php
+++ b/app/Http/Controllers/FilterController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\JsonResponse;
 
 final class FilterController extends AbstractController
 {
-    public function getFilterDataArray(): JsonResponse
+    public function __invoke(): JsonResponse
     {
         $page_id = $_GET['page_id'] ?? '';
         $filterdata = get_filterdata_from_request($page_id);

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -12,7 +12,7 @@ final class ImageController extends AbstractController
     /**
      * @throws HttpException
      */
-    public function image(Image $image): StreamedResponse
+    public function __invoke(Image $image): StreamedResponse
     {
         if (Gate::denies('view-image', $image)) {
             abort(404);

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -7,7 +7,7 @@ use Illuminate\View\View;
 
 final class IndexController extends AbstractProjectController
 {
-    public function showIndexPage(): View|RedirectResponse
+    public function __invoke(): View|RedirectResponse
     {
         if (!isset($_GET['project'])) {
             $default_project = config('cdash.default_project');

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -8,7 +8,7 @@ use Illuminate\View\View;
 
 final class ProjectController extends AbstractProjectController
 {
-    public function sites(int $project_id): View
+    public function __invoke(int $project_id): View
     {
         $this->setProjectById($project_id);
 

--- a/app/Http/Controllers/ProjectMembersController.php
+++ b/app/Http/Controllers/ProjectMembersController.php
@@ -10,7 +10,7 @@ use Illuminate\View\View;
 
 final class ProjectMembersController extends AbstractProjectController
 {
-    public function members(int $project_id): View
+    public function __invoke(int $project_id): View
     {
         $this->setProjectById($project_id);
 

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -7,7 +7,7 @@ use Illuminate\View\View;
 
 final class SiteController extends AbstractController
 {
-    public function viewSite(Site $site): View
+    public function __invoke(Site $site): View
     {
         return $this->vue('sites-id-page', $site->name, [
             'site-id' => $site->id,

--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class SubmissionController extends AbstractProjectController
 {
-    public function submit(): Response|JsonResponse
+    public function __invoke(): Response|JsonResponse
     {
         // If we have a POST or PUT we defer to the unparsed submission processor.
         try {

--- a/app/Http/Controllers/SubscribeProjectController.php
+++ b/app/Http/Controllers/SubscribeProjectController.php
@@ -16,7 +16,7 @@ final class SubscribeProjectController extends AbstractProjectController
      *       to a proper Blade template with Laravel-based DB queries eventually.  This contents
      *       this function are originally from subscribeProject.php and have been copied (almost) as-is.
      */
-    public function subscribeProject(): View|RedirectResponse
+    public function __invoke(): View|RedirectResponse
     {
         /** @var User $user */
         $user = Auth::user();

--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -8,7 +8,7 @@ use Illuminate\Http\JsonResponse;
 
 final class TimelineController extends AbstractProjectController
 {
-    public function apiTimeline(): JsonResponse
+    public function __invoke(): JsonResponse
     {
         $this->setProjectByName(request()->input('project', ''));
         $controller = new LegacyTimelineController(Database::getInstance(), $this->project);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -9,7 +9,7 @@ use Illuminate\View\View;
 
 final class UsersController extends AbstractController
 {
-    public function users(): View
+    public function __invoke(): View
     {
         return $this->vue('users-page', 'Users', [
             'can-invite-users' => auth()->user()?->can('createInvitation', GlobalInvitation::class) ?? false,

--- a/app/Http/Controllers/ViewProjectsController.php
+++ b/app/Http/Controllers/ViewProjectsController.php
@@ -11,7 +11,7 @@ use Illuminate\View\View;
 
 final class ViewProjectsController extends AbstractController
 {
-    public function viewProjects(): View|RedirectResponse
+    public function __invoke(): View|RedirectResponse
     {
         $num_public_projects = (int) DB::select('
                                      SELECT COUNT(*) AS c FROM project WHERE public=?

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\ExpectedBuildController;
+use App\Http\Controllers\FilterController;
+use App\Http\Controllers\TimelineController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -19,7 +22,7 @@ Route::get('/v1/testDetails.php', 'TestDetailsController@apiTestDetails');
 
 Route::match(['get', 'post', 'delete'], '/v1/build.php', 'BuildController@restApi');
 
-Route::get('/v1/filterdata.php', 'FilterController@getFilterDataArray');
+Route::get('/v1/filterdata.php', FilterController::class);
 
 Route::get('/v1/viewSubProjects.php', 'SubProjectController@apiViewSubProjects');
 
@@ -39,11 +42,11 @@ Route::get('/v1/buildUpdateGraph.php', 'BuildController@apiBuildUpdateGraph');
 
 Route::get('/v1/overview.php', 'ProjectOverviewController@apiOverview');
 
-Route::get('/v1/timeline.php', 'TimelineController@apiTimeline');
+Route::get('/v1/timeline.php', TimelineController::class);
 
 Route::get('/v1/testOverview.php', 'TestController@apiTestOverview');
 
-Route::match(['get', 'post', 'delete'], '/v1/expectedbuild.php', 'ExpectedBuildController@apiResponse');
+Route::match(['get', 'post', 'delete'], '/v1/expectedbuild.php', ExpectedBuildController::class);
 
 Route::middleware(['auth'])->group(function (): void {
     Route::get('/v1/manageSubProject.php', 'SubProjectController@apiManageSubProject');

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,12 +12,23 @@
 */
 
 use App\Http\Controllers\AdministrationController;
+use App\Http\Controllers\AuthTokenController;
 use App\Http\Controllers\CoverageFileController;
 use App\Http\Controllers\CreateProjectController;
+use App\Http\Controllers\CTestConfigurationController;
 use App\Http\Controllers\GlobalInvitationController;
+use App\Http\Controllers\ImageController;
+use App\Http\Controllers\IndexController;
+use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\ProjectInvitationController;
+use App\Http\Controllers\ProjectMembersController;
 use App\Http\Controllers\ProjectSettingsController;
+use App\Http\Controllers\SiteController;
+use App\Http\Controllers\SubmissionController;
+use App\Http\Controllers\SubscribeProjectController;
 use App\Http\Controllers\UpdateProjectLogoController;
+use App\Http\Controllers\UsersController;
+use App\Http\Controllers\ViewProjectsController;
 use App\Models\DynamicAnalysis;
 use App\Models\Project;
 use App\Models\Test;
@@ -61,12 +72,12 @@ Route::get('ping', function (Response $response) {
     return $response;
 });
 
-Route::get('/index.php', 'IndexController@showIndexPage');
-Route::get('/', 'IndexController@showIndexPage');
+Route::get('/index.php', IndexController::class);
+Route::get('/', IndexController::class);
 
-Route::any('/submit.php', 'SubmissionController@submit');
+Route::any('/submit.php', SubmissionController::class);
 
-Route::get('/image/{image}', 'ImageController@image')
+Route::get('/image/{image}', ImageController::class)
     ->whereNumber('image');
 Route::get('/displayImage.php', function (Request $request) {
     $imgid = $request->query('imgid');
@@ -190,7 +201,7 @@ Route::permanentRedirect('/projects/{id}/edit', url('/projects/{id}/settings'));
 Route::permanentRedirect('/projects/{id}/testmeasurements', url('/projects/{id}/settings'));
 Route::permanentRedirect('/project/{id}/testmeasurements', url('/projects/{id}/settings'));
 
-Route::get('/projects/{id}/ctest_configuration', 'CTestConfigurationController@get')
+Route::get('/projects/{id}/ctest_configuration', CTestConfigurationController::class)
     ->whereNumber('id');
 Route::permanentRedirect('/project/{id}/ctest_configuration', url('/projects/{id}/ctest_configuration'));
 Route::get('/generateCTestConfig.php', function (Request $request) {
@@ -201,7 +212,7 @@ Route::get('/generateCTestConfig.php', function (Request $request) {
     return redirect("/projects/{$projectid}/ctest_configuration", 301);
 });
 
-Route::get('/projects/{project_id}/sites', 'ProjectController@sites')
+Route::get('/projects/{project_id}/sites', ProjectController::class)
     ->whereNumber('project_id');
 Route::get('/viewMap.php', function (Request $request) {
     $project = Project::where('name', $request->query('project'))->first();
@@ -229,7 +240,7 @@ Route::get('/overview.php', 'ProjectOverviewController@overview');
 // TODO: (williamjallen) This should be in the auth section, but needs to be here until we get rid of Protractor..
 Route::get('/manageOverview.php', 'ProjectOverviewController@manageOverview');
 
-Route::match(['get', 'post'], '/projects', 'ViewProjectsController@viewProjects');
+Route::match(['get', 'post'], '/projects', ViewProjectsController::class);
 Route::permanentRedirect('/viewProjects.php', url('/projects'));
 Route::permanentRedirect('/projects/all', url('/projects'));
 
@@ -269,7 +280,7 @@ Route::get('/viewSubProjectDependenciesGraph.php', function (Request $request) {
     return redirect("/projects/{$project}/subprojects/dependencies", 301);
 });
 
-Route::match(['get', 'post'], '/sites/{site}', 'SiteController@viewSite')
+Route::match(['get', 'post'], '/sites/{site}', SiteController::class)
     ->whereNumber('site');
 Route::get('/viewSite.php', function (Request $request) {
     $siteid = $request->query('siteid');
@@ -278,9 +289,9 @@ Route::get('/viewSite.php', function (Request $request) {
 
 Route::get('/manageBuildGroup.php', 'BuildController@manageBuildGroup');
 
-Route::get('/users', 'UsersController@users');
+Route::get('/users', UsersController::class);
 
-Route::get('/projects/{project_id}/members', 'ProjectMembersController@members')
+Route::get('/projects/{project_id}/members', ProjectMembersController::class)
     ->whereNumber('project_id');
 
 Route::get('/invitations/{invitationId}', GlobalInvitationController::class)
@@ -299,8 +310,8 @@ Route::middleware(['auth'])->group(function (): void {
     Route::permanentRedirect('/editUser.php', url('/profile'));
 
     // TODO: (williamjallen) send the POST route to a different function
-    Route::get('/subscribeProject.php', 'SubscribeProjectController@subscribeProject');
-    Route::post('/subscribeProject.php', 'SubscribeProjectController@subscribeProject');
+    Route::get('/subscribeProject.php', SubscribeProjectController::class);
+    Route::post('/subscribeProject.php', SubscribeProjectController::class);
 
     Route::get('/manageProjectRoles.php', function (Request $request) {
         if (!$request->has('projectid')) {
@@ -317,7 +328,7 @@ Route::middleware(['auth'])->group(function (): void {
     Route::middleware(['admin'])->group(function (): void {
         Route::get('/administration', AdministrationController::class);
 
-        Route::get('/authtokens/manage', 'AuthTokenController@manage');
+        Route::get('/authtokens/manage', AuthTokenController::class);
 
         Route::get('/monitor', 'MonitorController@monitor');
         Route::get('/monitor.php', fn () => redirect('/monitor', 301));


### PR DESCRIPTION
Invokable controllers make it easier for static analysis tools to understand how methods are connected to the router.  This PR converts all controllers containing a single method to invokable classes.  Eventually, all controllers should be invokable.