### PR TITLE
Add selected vue-eslint rules from "uncategorized" list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig([
       'vue/no-duplicate-class-names': 'error',
       'vue/no-empty-component-block': 'error',
       'vue/no-import-compiler-macros': 'error',
+      'vue/no-ref-object-reactivity-loss': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig([
       'vue/prefer-prop-type-boolean-first': 'error',
       'vue/prefer-separate-static-class': 'error',
       'vue/prefer-single-event-payload': 'error',
+      'vue/prefer-v-model': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default defineConfig([
       'vue/no-undef-components': 'error',
       'vue/no-undef-directives': 'error',
       'vue/no-undef-properties': 'off', // Disabled until Apollo properties are addressed
+      'vue/no-unsupported-features': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig([
       'vue/no-template-target-blank': 'error',
       'vue/no-this-in-before-route-enter': 'error',
       'vue/no-undef-components': 'error',
+      'vue/no-undef-directives': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig([
       'vue/component-name-in-template-casing': ['error', 'PascalCase'],
       'vue/no-v-html': 'off',
       'vue/require-v-for-key': 'off',
+      'vue/match-component-import-name': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig([
       'vue/match-component-import-name': 'error',
       'vue/no-duplicate-class-names': 'error',
       'vue/no-empty-component-block': 'error',
+      'vue/no-import-compiler-macros': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,13 @@ export default defineConfig([
       'vue/no-useless-mustaches': 'error',
       'vue/no-useless-v-bind': 'error',
       'vue/padding-line-between-blocks': 'error',
+      'vue/padding-lines-in-component-definition': ['error', {
+        betweenOptions: 'always',
+        withinOption: {
+          apollo: 'ignore',
+        },
+        groupSingleLineProperties: true,
+      }],
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig([
       'vue/no-v-html': 'off',
       'vue/require-v-for-key': 'off',
       'vue/match-component-import-name': 'error',
+      'vue/no-duplicate-class-names': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig([
       'vue/no-unused-properties': 'error',
       'vue/no-unused-refs': 'error',
       'vue/no-use-v-else-with-v-for': 'error',
+      'vue/no-useless-mustaches': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,7 @@ export default defineConfig([
       'vue/no-unsupported-features': 'error',
       'vue/no-unused-emit-declarations': 'error',
       'vue/no-unused-properties': 'error',
+      'vue/no-unused-refs': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default defineConfig([
       'vue/require-v-for-key': 'off',
       'vue/match-component-import-name': 'error',
       'vue/no-duplicate-class-names': 'error',
+      'vue/no-empty-component-block': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig([
       'vue/no-this-in-before-route-enter': 'error',
       'vue/no-undef-components': 'error',
       'vue/no-undef-directives': 'error',
+      'vue/no-undef-properties': 'off', // Disabled until Apollo properties are addressed
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig([
       'vue/no-root-v-if': 'error',
       'vue/no-template-target-blank': 'error',
       'vue/no-this-in-before-route-enter': 'error',
+      'vue/no-undef-components': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig([
       'vue/no-use-v-else-with-v-for': 'error',
       'vue/no-useless-mustaches': 'error',
       'vue/no-useless-v-bind': 'error',
+      'vue/padding-line-between-blocks': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig([
       }],
       'vue/prefer-prop-type-boolean-first': 'error',
       'vue/prefer-separate-static-class': 'error',
+      'vue/prefer-single-event-payload': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig([
       'vue/no-setup-props-reactivity-loss': 'error',
       'vue/no-root-v-if': 'error',
       'vue/no-template-target-blank': 'error',
+      'vue/no-this-in-before-route-enter': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig([
       'vue/prefer-v-model': 'error',
       'vue/require-emit-validator': 'error',
       'vue/require-name-property': 'error',
+      'vue/slot-name-casing': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,7 @@ export default defineConfig([
       'vue/prefer-separate-static-class': 'error',
       'vue/prefer-single-event-payload': 'error',
       'vue/prefer-v-model': 'error',
+      'vue/require-emit-validator': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,7 @@ export default defineConfig([
       'vue/no-unused-refs': 'error',
       'vue/no-use-v-else-with-v-for': 'error',
       'vue/no-useless-mustaches': 'error',
+      'vue/no-useless-v-bind': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig([
       'vue/no-empty-component-block': 'error',
       'vue/no-import-compiler-macros': 'error',
       'vue/no-ref-object-reactivity-loss': 'error',
+      'vue/no-root-v-if': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig([
       'vue/no-ref-object-reactivity-loss': 'error',
       'vue/no-setup-props-reactivity-loss': 'error',
       'vue/no-root-v-if': 'error',
+      'vue/no-template-target-blank': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig([
       'vue/prefer-single-event-payload': 'error',
       'vue/prefer-v-model': 'error',
       'vue/require-emit-validator': 'error',
+      'vue/require-name-property': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig([
       'vue/no-undef-properties': 'off', // Disabled until Apollo properties are addressed
       'vue/no-unsupported-features': 'error',
       'vue/no-unused-emit-declarations': 'error',
+      'vue/no-unused-properties': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,5 +93,5 @@ export default defineConfig([
         ...globals.node,
       },
     },
-  }
+  },
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig([
       'vue/no-empty-component-block': 'error',
       'vue/no-import-compiler-macros': 'error',
       'vue/no-ref-object-reactivity-loss': 'error',
+      'vue/no-setup-props-reactivity-loss': 'error',
       'vue/no-root-v-if': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig([
       'vue/no-undef-directives': 'error',
       'vue/no-undef-properties': 'off', // Disabled until Apollo properties are addressed
       'vue/no-unsupported-features': 'error',
+      'vue/no-unused-emit-declarations': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,7 @@ export default defineConfig([
         groupSingleLineProperties: true,
       }],
       'vue/prefer-prop-type-boolean-first': 'error',
+      'vue/prefer-separate-static-class': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig([
       'vue/no-unused-emit-declarations': 'error',
       'vue/no-unused-properties': 'error',
       'vue/no-unused-refs': 'error',
+      'vue/no-use-v-else-with-v-for': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig([
         },
         groupSingleLineProperties: true,
       }],
+      'vue/prefer-prop-type-boolean-first': 'error',
       'eqeqeq': ['error', 'always'],
       'arrow-spacing': ['error'],
       'block-spacing': ['error'],

--- a/resources/js/vue/components/AdministrationPage.vue
+++ b/resources/js/vue/components/AdministrationPage.vue
@@ -38,9 +38,11 @@ import {
 
 export default {
   name: 'AdministrationPage',
+
   components: {
     AdministrationPageCard,
   },
+
   computed: {
     FA() {
       return {

--- a/resources/js/vue/components/BuildBuildPage.vue
+++ b/resources/js/vue/components/BuildBuildPage.vue
@@ -160,6 +160,8 @@ const BUILD_ERRORS_QUERY = gql`
 `;
 
 export default {
+  name: 'BuildBuildPage',
+
   components: {
     CodeBox,
     BuildErrorList,

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorItem.vue
@@ -106,6 +106,7 @@ import {getRepository} from '../shared/RepositoryIntegrations';
 import 'core-js/actual/regexp/escape';
 
 export default {
+  name: 'BuildErrorItem',
   components: {FontAwesomeIcon, CodeBox},
 
   props: {

--- a/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
+++ b/resources/js/vue/components/BuildBuildPage/BuildErrorList.vue
@@ -120,6 +120,7 @@ const BUILD_QUERY = gql`
 `;
 
 export default {
+  name: 'BuildErrorList',
   components: {BuildErrorItem, LoadingIndicator},
 
   props: {

--- a/resources/js/vue/components/BuildConfigure.vue
+++ b/resources/js/vue/components/BuildConfigure.vue
@@ -66,6 +66,7 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
   components: {FontAwesomeIcon, ConfigureCard, LoadingIndicator, BuildSummaryCard, BuildSidebar},
+
   props: {
     buildId: {
       type: Number,

--- a/resources/js/vue/components/BuildConfigure.vue
+++ b/resources/js/vue/components/BuildConfigure.vue
@@ -65,6 +65,7 @@ import {
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
+  name: 'BuildConfigure',
   components: {FontAwesomeIcon, ConfigureCard, LoadingIndicator, BuildSummaryCard, BuildSidebar},
 
   props: {

--- a/resources/js/vue/components/BuildCoveragePage.vue
+++ b/resources/js/vue/components/BuildCoveragePage.vue
@@ -189,6 +189,7 @@ import {faFile} from '@fortawesome/free-regular-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
+  name: 'BuildCoveragePage',
   components: {FontAwesomeIcon, FilterBuilder, LoadingIndicator, DataTable, BuildSummaryCard, BuildSidebar},
 
   props: {

--- a/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
+++ b/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
@@ -39,6 +39,7 @@ import {
 import CodeBox from './shared/CodeBox.vue';
 
 export default {
+  name: 'BuildDynamicAnalysisIdPage',
   components: {CodeBox, LoadingIndicator, BuildSummaryCard, BuildSidebar},
 
   props: {

--- a/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
+++ b/resources/js/vue/components/BuildDynamicAnalysisIdPage.vue
@@ -40,6 +40,7 @@ import CodeBox from './shared/CodeBox.vue';
 
 export default {
   components: {CodeBox, LoadingIndicator, BuildSummaryCard, BuildSidebar},
+
   props: {
     buildId: {
       type: Number,

--- a/resources/js/vue/components/BuildFilesPage.vue
+++ b/resources/js/vue/components/BuildFilesPage.vue
@@ -74,6 +74,7 @@ import BuildSidebar from './shared/BuildSidebar.vue';
 import gql from 'graphql-tag';
 
 export default {
+  name: 'BuildFilesPage',
   components: {LoadingIndicator, DataTable, BuildSummaryCard, BuildSidebar},
 
   props: {

--- a/resources/js/vue/components/BuildInstrumentationPage.vue
+++ b/resources/js/vue/components/BuildInstrumentationPage.vue
@@ -51,6 +51,8 @@ import { DateTime, Duration } from 'luxon';
 import LineChart from './shared/Charts/LineChart.vue';
 
 export default {
+  name: 'BuildInstrumentationPage',
+
   components: {
     LineChart,
     CommandFlameChart,

--- a/resources/js/vue/components/BuildTargetsPage.vue
+++ b/resources/js/vue/components/BuildTargetsPage.vue
@@ -66,6 +66,8 @@ import { DateTime, Duration } from 'luxon';
 import Utils from './shared/Utils';
 
 export default {
+  name: 'BuildTargetsPage',
+
   components: {
     CommandFlameChart,
     FilterBuilder,

--- a/resources/js/vue/components/BuildUpdate/CommitCard.vue
+++ b/resources/js/vue/components/BuildUpdate/CommitCard.vue
@@ -45,6 +45,7 @@ import CommitFileTreeNode from './CommitFileTreeNode.vue';
 
 export default {
   components: {CodeBox, CommitFileTreeNode},
+
   props: {
     commitFiles: {
       type: Array,

--- a/resources/js/vue/components/BuildUpdate/CommitCard.vue
+++ b/resources/js/vue/components/BuildUpdate/CommitCard.vue
@@ -44,6 +44,7 @@ import CodeBox from '../shared/CodeBox.vue';
 import CommitFileTreeNode from './CommitFileTreeNode.vue';
 
 export default {
+  name: 'CommitCard',
   components: {CodeBox, CommitFileTreeNode},
 
   props: {

--- a/resources/js/vue/components/BuildUpdate/CommitFileTreeNode.vue
+++ b/resources/js/vue/components/BuildUpdate/CommitFileTreeNode.vue
@@ -46,6 +46,7 @@ import {faFolderOpen, faFile} from '@fortawesome/free-regular-svg-icons';
 export default {
   name: 'CommitFileTreeNode',
   components: {FontAwesomeIcon},
+
   props: {
     node: {
       type: Object,
@@ -56,6 +57,7 @@ export default {
       required: true,
     },
   },
+
   computed: {
     FA() {
       return {

--- a/resources/js/vue/components/BuildUpdatePage.vue
+++ b/resources/js/vue/components/BuildUpdatePage.vue
@@ -10,24 +10,28 @@
         <div>
           <div v-if="update.revision">
             <b>Revision: </b>
+            <!-- eslint-disable-next-line vue/no-undef-components -->
             <tt v-if="repository">
               <a
                 class="tw-link tw-link-hover tw-link-info"
                 :href="revisionUrl"
               >{{ update.revision }}</a>
             </tt>
+            <!-- eslint-disable-next-line vue/no-undef-components -->
             <tt v-else>
               {{ update.revision }}
             </tt>
           </div>
           <div v-if="update.priorRevision">
             <b>Prior Revision: </b>
+            <!-- eslint-disable-next-line vue/no-undef-components -->
             <tt v-if="repository">
               <a
                 class="tw-link tw-link-hover tw-link-info"
                 :href="repository?.getCommitUrl(update.priorRevision) ?? ''"
               >{{ update.priorRevision }}</a>
             </tt>
+            <!-- eslint-disable-next-line vue/no-undef-components -->
             <tt v-else>
               {{ update.priorRevision }}
             </tt>

--- a/resources/js/vue/components/CoverageFilePage.vue
+++ b/resources/js/vue/components/CoverageFilePage.vue
@@ -37,6 +37,7 @@ import CoverageViewer from './shared/CoverageViewer.vue';
 import BuildSidebar from './shared/BuildSidebar.vue';
 
 export default {
+  name: 'CoverageFilePage',
   components: {BuildSidebar, CoverageViewer, LoadingIndicator, BuildSummaryCard},
 
   props: {

--- a/resources/js/vue/components/CreateProjectPage.vue
+++ b/resources/js/vue/components/CreateProjectPage.vue
@@ -154,6 +154,7 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import gql from 'graphql-tag';
 
 export default {
+  name: 'CreateProjectPage',
   components: {FontAwesomeIcon},
 
   props: {

--- a/resources/js/vue/components/ManageAuthTokens.vue
+++ b/resources/js/vue/components/ManageAuthTokens.vue
@@ -64,6 +64,7 @@
     </DataTable>
   </LoadingIndicator>
 </template>
+
 <script>
 
 import DataTable from './shared/DataTable.vue';

--- a/resources/js/vue/components/Monitor.vue
+++ b/resources/js/vue/components/Monitor.vue
@@ -34,6 +34,7 @@
     </p>
   </section>
 </template>
+
 <script>
 import ApiLoader from './shared/ApiLoader';
 import TimelinePlot from './shared/TimelinePlot';

--- a/resources/js/vue/components/Monitor.vue
+++ b/resources/js/vue/components/Monitor.vue
@@ -21,10 +21,14 @@
     <p>
       Note: Detailed information about submission failures can be found in the CDash logs.<br>
       <span v-if="'log_directory' in cdash">
-        Log files can be found in: <tt>{{ cdash.log_directory }}</tt>
+        Log files can be found in:
+        <!-- eslint-disable-next-line vue/no-undef-components -->
+        <tt>{{ cdash.log_directory }}</tt>
       </span>
       <span v-else>
-        This CDash instance uses a non-standard logging configuration.  Check your <tt>LOG_CHANNEL</tt>
+        This CDash instance uses a non-standard logging configuration.  Check your
+        <!-- eslint-disable-next-line vue/no-undef-components -->
+        <tt>LOG_CHANNEL</tt>
         environment setting for more information.
       </span>
     </p>

--- a/resources/js/vue/components/ProfilePage.vue
+++ b/resources/js/vue/components/ProfilePage.vue
@@ -300,12 +300,14 @@ import { faTrashCan, faPlus, faCopy } from '@fortawesome/free-solid-svg-icons';
 
 export default {
   name: 'ProfilePage',
+
   components: {
     InputField,
     SelectField,
     FormSection,
     FontAwesomeIcon,
   },
+
   props: {
     user: {
       type: Object,

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -307,11 +307,6 @@ export default {
     },
   },
 
-  setup(props) {
-    // Basic sanity checks...
-    console.assert(!(props.canJoinProject && props.canLeaveProject));
-  },
-
   data() {
     const user_types = Object.freeze({
       USER: 'USER',

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -269,6 +269,8 @@ import {
 import { DateTime } from 'luxon';
 
 export default {
+  name: 'ProjectMembersPage',
+
   components: {
     DataTable,
     LoadingIndicator,

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -481,6 +481,8 @@ import TabContent from './TabContent.vue';
 import LoadingIndicator from '../shared/LoadingIndicator.vue';
 
 export default {
+  name: 'GeneralTab',
+
   components: {
     LoadingIndicator,
     TabContent, SelectField, CheckboxField, TextAreaField, InputField, FontAwesomeIcon, FormSection},

--- a/resources/js/vue/components/ProjectSettings/GeneralTab.vue
+++ b/resources/js/vue/components/ProjectSettings/GeneralTab.vue
@@ -484,6 +484,7 @@ export default {
   components: {
     LoadingIndicator,
     TabContent, SelectField, CheckboxField, TextAreaField, InputField, FontAwesomeIcon, FormSection},
+
   props: {
     projectId: {
       type: Number,

--- a/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
+++ b/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
@@ -122,6 +122,8 @@ import {
 import LoadingIndicator from '../shared/LoadingIndicator.vue';
 
 export default {
+  name: 'IntegrationsTab',
+
   components: {
     LoadingIndicator,
     FontAwesomeIcon,

--- a/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
+++ b/resources/js/vue/components/ProjectSettings/IntegrationsTab.vue
@@ -128,6 +128,7 @@ export default {
     InputField,
     TabContent,
   },
+
   props: {
     projectId: {
       type: Number,

--- a/resources/js/vue/components/ProjectSettings/TabContent.vue
+++ b/resources/js/vue/components/ProjectSettings/TabContent.vue
@@ -12,6 +12,8 @@
 
 <script>
 export default {
+  name: 'TabContent',
+
   props: {
     title: {
       type: String,

--- a/resources/js/vue/components/ProjectSettings/TestMeasurementsTab.vue
+++ b/resources/js/vue/components/ProjectSettings/TestMeasurementsTab.vue
@@ -107,6 +107,8 @@ import TabContent from './TabContent.vue';
 import InputField from '../shared/FormInputs/InputField.vue';
 
 export default {
+  name: 'TestMeasurementsTab',
+
   components: {
     LoadingIndicator,
     TabContent,

--- a/resources/js/vue/components/ProjectSettingsPage.vue
+++ b/resources/js/vue/components/ProjectSettingsPage.vue
@@ -78,6 +78,7 @@ import TestMeasurementsTab from './ProjectSettings/TestMeasurementsTab.vue';
 
 export default {
   components: {GeneralTab,IntegrationsTab,TestMeasurementsTab},
+
   props: {
     projectId: {
       type: Number,

--- a/resources/js/vue/components/ProjectSettingsPage.vue
+++ b/resources/js/vue/components/ProjectSettingsPage.vue
@@ -77,6 +77,7 @@ import IntegrationsTab from './ProjectSettings/IntegrationsTab.vue';
 import TestMeasurementsTab from './ProjectSettings/TestMeasurementsTab.vue';
 
 export default {
+  name: 'ProjectSettingsPage',
   components: {GeneralTab,IntegrationsTab,TestMeasurementsTab},
 
   props: {

--- a/resources/js/vue/components/ProjectSitesPage.vue
+++ b/resources/js/vue/components/ProjectSitesPage.vue
@@ -45,6 +45,8 @@ import gql from 'graphql-tag';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 
 export default {
+  name: 'ProjectSitesPage',
+
   components: {
     LoadingIndicator,
     DataTable,

--- a/resources/js/vue/components/ProjectsPage.vue
+++ b/resources/js/vue/components/ProjectsPage.vue
@@ -150,6 +150,7 @@ const PROJECT_LIST_QUERY = `
 `;
 
 export default {
+  name: 'ProjectsPage',
   components: {FontAwesomeIcon, ProjectLogo, LoadingIndicator},
 
   props: {

--- a/resources/js/vue/components/SitesIdPage.vue
+++ b/resources/js/vue/components/SitesIdPage.vue
@@ -342,6 +342,8 @@ const SITE_INFORMATION_QUERY = gql`
 `;
 
 export default {
+  name: 'SitesIdPage',
+
   components: {
     LoadingIndicator,
     FontAwesomeIcon,

--- a/resources/js/vue/components/TestDetailsPage.vue
+++ b/resources/js/vue/components/TestDetailsPage.vue
@@ -227,6 +227,7 @@
         v-show="rawdatalink != ''"
         :href="rawdatalink"
         target="_blank"
+        rel="noopener noreferrer"
       >
         View Graph Data as JSON
       </a>

--- a/resources/js/vue/components/UsersPage.vue
+++ b/resources/js/vue/components/UsersPage.vue
@@ -236,6 +236,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default {
+  name: 'UsersPage',
+
   components: {
     DataTable,
     LoadingIndicator,

--- a/resources/js/vue/components/ViewDynamicAnalysis.vue
+++ b/resources/js/vue/components/ViewDynamicAnalysis.vue
@@ -35,6 +35,7 @@ import DataTable from './shared/DataTable.vue';
 
 export default {
   name: 'ViewDynamicAnalysis',
+
   components: {
     BuildSidebar,
     BuildSummaryCard,

--- a/resources/js/vue/components/shared/AdministrationPageCard.vue
+++ b/resources/js/vue/components/shared/AdministrationPageCard.vue
@@ -26,9 +26,11 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 
 export default {
   name: 'AdministrationPageCard',
+
   components: {
     FontAwesomeIcon,
   },
+
   props: {
     href: {
       type: String,

--- a/resources/js/vue/components/shared/BuildSidebar.vue
+++ b/resources/js/vue/components/shared/BuildSidebar.vue
@@ -125,9 +125,11 @@ import {
 
 export default {
   name: 'BuildSidebar',
+
   components: {
     BuildSidebarItem,
   },
+
   props: {
     buildId: {
       type: Number,
@@ -138,11 +140,13 @@ export default {
       default: '',
     },
   },
+
   data() {
     return {
       build: null,
     };
   },
+
   apollo: {
     build: {
       query: gql`
@@ -204,6 +208,7 @@ export default {
       },
     },
   },
+
   computed: {
     FA() {
       return {

--- a/resources/js/vue/components/shared/BuildSidebarItem.vue
+++ b/resources/js/vue/components/shared/BuildSidebarItem.vue
@@ -47,9 +47,11 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 export default {
   name: 'BuildSidebarItem',
+
   components: {
     FontAwesomeIcon,
   },
+
   props: {
     href: {
       type: String,

--- a/resources/js/vue/components/shared/BuildSummaryCard.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCard.vue
@@ -309,6 +309,7 @@ import {
 import Utils from './Utils';
 
 export default {
+  name: 'BuildSummaryCard',
   components: {BuildSummaryCardStepSummary, LoadingIndicator, FontAwesomeIcon},
 
   props: {

--- a/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
+++ b/resources/js/vue/components/shared/BuildSummaryCardStepSummary.vue
@@ -58,6 +58,7 @@ import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import {faLink} from '@fortawesome/free-solid-svg-icons';
 
 export default {
+  name: 'BuildSummaryCardStepSummary',
   components: {FontAwesomeIcon},
 
   props: {

--- a/resources/js/vue/components/shared/Charts/FlameChart.vue
+++ b/resources/js/vue/components/shared/Charts/FlameChart.vue
@@ -30,9 +30,11 @@ use([
 
 export default {
   name: 'FlameChart',
+
   components: {
     VChart,
   },
+
   props: {
     data: {
       type: Array,
@@ -63,7 +65,9 @@ export default {
       required: true,
     },
   },
+
   emits: ['click'],
+
   computed: {
     chartOptions() {
       return {

--- a/resources/js/vue/components/shared/Charts/FlameChart.vue
+++ b/resources/js/vue/components/shared/Charts/FlameChart.vue
@@ -66,6 +66,7 @@ export default {
     },
   },
 
+  // eslint-disable-next-line vue/require-emit-validator
   emits: ['click'],
 
   computed: {

--- a/resources/js/vue/components/shared/Charts/LineChart.vue
+++ b/resources/js/vue/components/shared/Charts/LineChart.vue
@@ -28,6 +28,7 @@ use([
 
 export default {
   name: 'LineChart',
+
   components: {
     VChart,
   },

--- a/resources/js/vue/components/shared/CodeBox.vue
+++ b/resources/js/vue/components/shared/CodeBox.vue
@@ -19,6 +19,7 @@ import { AnsiUp } from 'ansi_up';
 
 export default {
   name: 'CodeBox',
+
   props: {
     text: {
       type: String,

--- a/resources/js/vue/components/shared/CommandFlameChart.vue
+++ b/resources/js/vue/components/shared/CommandFlameChart.vue
@@ -41,10 +41,12 @@ import Utils from './Utils';
 
 export default {
   name: 'CommandFlameChart',
+
   components: {
     CommandInfoCard,
     FlameChart,
   },
+
   props: {
     /**
      * An array of command objects. Each object is expected to have the following properties:
@@ -66,6 +68,7 @@ export default {
       required: true,
     },
   },
+
   data() {
     return {
       colors: {
@@ -82,6 +85,7 @@ export default {
       selectedCommandId: null,
     };
   },
+
   computed: {
     processedChartData() {
       if (!this.commands || this.commands.length === 0) {
@@ -159,6 +163,7 @@ export default {
       return (this.commandBarHeight + this.commandBarSpacing) * numtracks + 60;
     },
   },
+
   methods: {
     getTooltipElement(params) {
       if (!params.data.value || !Array.isArray(params.data.value)) {

--- a/resources/js/vue/components/shared/CommandInfoCard.vue
+++ b/resources/js/vue/components/shared/CommandInfoCard.vue
@@ -118,6 +118,7 @@ import Utils from './Utils';
 
 export default {
   components: {LoadingIndicator},
+
   props: {
     commandId: {
       type: Number,

--- a/resources/js/vue/components/shared/CommandInfoCard.vue
+++ b/resources/js/vue/components/shared/CommandInfoCard.vue
@@ -117,6 +117,7 @@ import { DateTime } from 'luxon';
 import Utils from './Utils';
 
 export default {
+  name: 'CommandInfoCard',
   components: {LoadingIndicator},
 
   props: {

--- a/resources/js/vue/components/shared/ConfigureCard.vue
+++ b/resources/js/vue/components/shared/ConfigureCard.vue
@@ -22,6 +22,7 @@ import CodeBox from './CodeBox.vue';
 
 export default {
   components: {CodeBox},
+
   props: {
     command: {
       type: String,

--- a/resources/js/vue/components/shared/ConfigureCard.vue
+++ b/resources/js/vue/components/shared/ConfigureCard.vue
@@ -21,6 +21,7 @@
 import CodeBox from './CodeBox.vue';
 
 export default {
+  name: 'ConfigureCard',
   components: {CodeBox},
 
   props: {

--- a/resources/js/vue/components/shared/CoverageViewer.vue
+++ b/resources/js/vue/components/shared/CoverageViewer.vue
@@ -76,7 +76,9 @@ export default {
     file: { type: String, required: true },
     coverageLines: { type: Array, required: true },
   },
+
   data: () => ({ view: null }),
+
   computed: {
     coverageMap() {
       const map = {};
@@ -88,6 +90,7 @@ export default {
       return map;
     },
   },
+
   watch: {
     coverageMap: {
       handler(newMap) {
@@ -98,6 +101,7 @@ export default {
       immediate: true,
     },
   },
+
   mounted() {
     class CoverageGutterMarker extends GutterMarker {
       constructor(coverage) {
@@ -159,6 +163,7 @@ export default {
       parent: this.$refs.editor,
     });
   },
+
   beforeUnmount() {
     if (this.view) {
       this.view.destroy();

--- a/resources/js/vue/components/shared/CoverageViewer.vue
+++ b/resources/js/vue/components/shared/CoverageViewer.vue
@@ -72,6 +72,8 @@ function buildDecorations(coverageMap, doc) {
 }
 
 export default {
+  name: 'CoverageViewer',
+
   props: {
     file: { type: String, required: true },
     coverageLines: { type: Array, required: true },

--- a/resources/js/vue/components/shared/DataTable.vue
+++ b/resources/js/vue/components/shared/DataTable.vue
@@ -95,6 +95,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default {
+  name: 'DataTable',
+
   components: {
     FontAwesomeIcon,
   },

--- a/resources/js/vue/components/shared/DateTimeSelector.vue
+++ b/resources/js/vue/components/shared/DateTimeSelector.vue
@@ -102,6 +102,7 @@ export default {
     },
   },
 
+  // eslint-disable-next-line vue/require-emit-validator
   emits: ['update:modelValue'],
 
   data() {

--- a/resources/js/vue/components/shared/DateTimeSelector.vue
+++ b/resources/js/vue/components/shared/DateTimeSelector.vue
@@ -94,13 +94,16 @@ import { DateTime } from 'luxon';
 
 export default {
   name: 'DateTimeSelector',
+
   props: {
     modelValue: {
       type: String,
       default: '',
     },
   },
+
   emits: ['update:modelValue'],
+
   data() {
     let dt = DateTime.fromISO(this.modelValue, { setZone: true });
     if (!dt.isValid) {
@@ -117,6 +120,7 @@ export default {
       lastEmittedValue: this.modelValue,
     };
   },
+
   computed: {
     yearOptions() {
       const currentYear = DateTime.now().year;
@@ -162,6 +166,7 @@ export default {
       });
     },
   },
+
   watch: {
     year() {
       this.clampDay();
@@ -198,9 +203,11 @@ export default {
       }
     },
   },
+
   mounted() {
     this.updateDateTime();
   },
+
   methods: {
     getOffsetString(offsetHours) {
       return `UTC${offsetHours === 0 ? '' : (offsetHours > 0 ? '+' : '') + offsetHours}`;

--- a/resources/js/vue/components/shared/FilterBuilder.vue
+++ b/resources/js/vue/components/shared/FilterBuilder.vue
@@ -77,6 +77,7 @@ export default {
   },
 
   emits: [
+    // eslint-disable-next-line vue/require-emit-validator
     'changeFilters',
   ],
 

--- a/resources/js/vue/components/shared/FilterBuilder.vue
+++ b/resources/js/vue/components/shared/FilterBuilder.vue
@@ -34,6 +34,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default {
+  name: 'FilterBuilder',
   components: { FilterGroup, FontAwesomeIcon },
 
   props: {

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -121,6 +121,8 @@ const AVAILABLE_FILTERS = Object.freeze({
 });
 
 export default {
+  name: 'FilterGroup',
+
   components: { FontAwesomeIcon, FilterRow },
 
   props: {

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -149,7 +149,9 @@ export default {
   },
 
   emits: [
+    // eslint-disable-next-line vue/require-emit-validator
     'changeFilters',
+    // eslint-disable-next-line vue/require-emit-validator
     'delete',
   ],
 

--- a/resources/js/vue/components/shared/FilterGroup.vue
+++ b/resources/js/vue/components/shared/FilterGroup.vue
@@ -122,7 +122,6 @@ const AVAILABLE_FILTERS = Object.freeze({
 
 export default {
   name: 'FilterGroup',
-
   components: { FontAwesomeIcon, FilterRow },
 
   props: {

--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -99,7 +99,9 @@ export default {
   },
 
   emits: [
+    // eslint-disable-next-line vue/require-emit-validator
     'changeFilters',
+    // eslint-disable-next-line vue/require-emit-validator
     'delete',
   ],
 

--- a/resources/js/vue/components/shared/FilterRow.vue
+++ b/resources/js/vue/components/shared/FilterRow.vue
@@ -73,6 +73,7 @@ import DateTimeSelector from './DateTimeSelector.vue';
 import {FilterField, FilterType} from './Filters/FilterUtils';
 
 export default {
+  name: 'FilterRow',
   components: {FontAwesomeIcon, DateTimeSelector},
 
   props: {

--- a/resources/js/vue/components/shared/FormSection.vue
+++ b/resources/js/vue/components/shared/FormSection.vue
@@ -11,6 +11,8 @@
 
 <script>
 export default {
+  name: 'FormSection',
+
   props: {
     title: {
       type: String,

--- a/resources/js/vue/components/shared/LoadingIndicator.vue
+++ b/resources/js/vue/components/shared/LoadingIndicator.vue
@@ -13,6 +13,8 @@
 
 <script>
 export default {
+  name: 'LoadingIndicator',
+
   props: {
     isLoading: {
       type: Boolean,

--- a/resources/js/vue/components/shared/ProjectLogo.vue
+++ b/resources/js/vue/components/shared/ProjectLogo.vue
@@ -19,6 +19,8 @@
 <script>
 
 export default {
+  name: 'ProjectLogo',
+
   props: {
     projectName: {
       type: String,

--- a/resources/js/vue/components/shared/TimelinePlot.vue
+++ b/resources/js/vue/components/shared/TimelinePlot.vue
@@ -36,9 +36,11 @@ use([
 
 export default {
   name: 'TimelinePlot',
+
   components: {
     VChart,
   },
+
   props: {
     plotData: {
       type: Object,
@@ -57,6 +59,7 @@ export default {
       required: true,
     },
   },
+
   computed: {
     chartOption() {
       if (!this.plotData || !Array.isArray(this.plotData)) {
@@ -166,6 +169,7 @@ export default {
       return option;
     },
   },
+
   methods: {
     onClick(params) {
       if (params.data && params.data[2]) {

--- a/resources/js/vue/components/shared/TimelinePlot.vue
+++ b/resources/js/vue/components/shared/TimelinePlot.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable vue/no-unused-refs -->
   <VChart
     ref="chart"
     class="chart"
@@ -7,6 +8,7 @@
     autoresize
     @click="onClick"
   />
+  <!-- eslint-enable vue/no-unused-refs -->
 </template>
 
 <script>


### PR DESCRIPTION
Vue-eslint provides several rulesets, which we already used, in addition to a list of ["uncategorized"](https://eslint.vuejs.org/rules/#uncategorized) rules I was not previously aware of.  This PR adds a selection of those rules to our configuration.  I plan to expand on this in the near future by strengthening other parts of our eslint configuration.