### PR TITLE
Allow querying parent and child builds via GraphQL

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -51,6 +51,7 @@ use Illuminate\Support\Str;
  * @property ?string $binarydirectory
  *
  * @method static Builder<Build> betweenDates(?Carbon $starttime, ?Carbon $endtime)
+ * @method static Builder<Build> onlyParents(bool $onlyParents = true)
  *
  * @mixin Builder<Build>
  */
@@ -162,6 +163,19 @@ class Build extends Model
 
         if ($endtime !== null) {
             $query->where('endtime', '<=', $endtime);
+        }
+    }
+
+    /**
+     * @param Builder<self> $query
+     */
+    public function scopeOnlyParents(Builder $query, bool $onlyParents = true): void
+    {
+        if ($onlyParents) {
+            $query->where(function (Builder $q): void {
+                $q->where('parentid', 0)
+                    ->orWhere('parentid', -1);
+            });
         }
     }
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -288,25 +288,17 @@ class Project extends Model
      */
     public function builds(): HasMany
     {
-        return $this->hasMany(Build::class, 'projectid', 'id')
-            ->where(function ($query): void {
-                $query->where('parentid', 0)
-                    ->orWhere('parentid', -1);
-            });
+        return $this->hasMany(Build::class, 'projectid');
     }
 
     /**
-     * TODO: Share code with builds().  As of Laravel 10, aggregates added to hasMany relations
-     *       with conditional clauses are unsupported/broken.  A reusable scope may be a better approach.
-     *
      * @return HasOne<Build, $this>
      */
     public function mostRecentBuild(): HasOne
     {
         return $this->hasOne(Build::class, 'projectid', 'id')
             ->ofMany(['submittime' => 'max'], function (Builder $query): void {
-                $query->where('parentid', 0)
-                    ->orWhere('parentid', -1);
+                $query->onlyParents();
             });
     }
 

--- a/app/Services/ProjectService.php
+++ b/app/Services/ProjectService.php
@@ -146,6 +146,7 @@ class ProjectService extends AbstractService
 
         $starttime = Project::findOrFail($projectid)
             ->builds()
+            ->onlyParents()
             ->max('starttime');
 
         if ($starttime === null) {

--- a/app/cdash/app/Model/Project.php
+++ b/app/cdash/app/Model/Project.php
@@ -502,7 +502,7 @@ class Project
         }
 
         $project = EloquentProject::findOrFail((int) $this->Id);
-        $num_builds = $project->builds()->count();
+        $num_builds = $project->builds()->onlyParents()->count();
 
         // The +1 here is to account for the build we're currently inserting.
         if ($num_builds < ($max_builds + 1)) {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -359,6 +359,8 @@ type Project {
 
   builds(
     filters: _ @filter
+    "When true (default), only return parent builds. When false, return all builds including child builds."
+    onlyParents: Boolean = true @scope
   ): [Build!]! @hasMany(type: CONNECTION)
 
   """
@@ -366,6 +368,8 @@ type Project {
   """
   buildCount(
     filters: _ @filter(inputType: "BuildFilterInput")
+    "When true (default), only count parent builds. When false, count all builds including child builds."
+    onlyParents: Boolean = true @scope
   ): Int! @count(relation: "builds")
 
   """

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4954,6 +4954,12 @@ parameters:
 			path: app/Models/Project.php
 
 		-
+			rawMessage: 'Call to an undefined method Illuminate\Database\Eloquent\Builder::onlyParents().'
+			identifier: method.notFound
+			count: 1
+			path: app/Models/Project.php
+
+		-
 			rawMessage: Cannot cast mixed to int.
 			identifier: cast.int
 			count: 2

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -1016,6 +1016,198 @@ class ProjectTypeTest extends TestCase
         ]);
     }
 
+    public function testBuildsOnlyParentsArgument(): void
+    {
+        // Create two parent builds
+        $this->projects['public1']->builds()->create([
+            'name' => 'parent1',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'parent2',
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Create a parent build that will serve as the "real" parent for child builds
+        $parent = $this->projects['public1']->builds()->create([
+            'name' => 'parent3',
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Create a child build
+        $this->projects['public1']->builds()->create([
+            'name' => 'child1',
+            'parentid' => $parent->id,
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Default behavior: only parent builds should be returned
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    builds {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            ['node' => ['name' => 'parent1']],
+                            ['node' => ['name' => 'parent2']],
+                            ['node' => ['name' => 'parent3']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        // Explicit onlyParents: true: same as default
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    builds(onlyParents: true) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            ['node' => ['name' => 'parent1']],
+                            ['node' => ['name' => 'parent2']],
+                            ['node' => ['name' => 'parent3']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        // onlyParents: false: all builds including child builds are returned
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    builds(onlyParents: false) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'builds' => [
+                        'edges' => [
+                            ['node' => ['name' => 'parent1']],
+                            ['node' => ['name' => 'parent2']],
+                            ['node' => ['name' => 'parent3']],
+                            ['node' => ['name' => 'child1']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Tests that the buildCount field respects the onlyParents argument.
+     */
+    public function testBuildCountOnlyParentsArgument(): void
+    {
+        // Create two parent builds
+        $this->projects['public1']->builds()->create([
+            'name' => 'parent1',
+            'uuid' => Str::uuid(),
+        ]);
+        $this->projects['public1']->builds()->create([
+            'name' => 'parent2',
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Create a parent build that will serve as the "real" parent for child builds
+        $parent = $this->projects['public1']->builds()->create([
+            'name' => 'parent3',
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Create a child build
+        $this->projects['public1']->builds()->create([
+            'name' => 'child1',
+            'parentid' => $parent->id,
+            'uuid' => Str::uuid(),
+        ]);
+
+        // Default behavior: only parent builds counted
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    buildCount
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'buildCount' => 3,
+                ],
+            ],
+        ]);
+
+        // Explicit onlyParents: true: same as default
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    buildCount(onlyParents: true)
+                }
+            }
+        ', [
+            'projectId' => $this->projects['public1']->id,
+        ])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'buildCount' => 3,
+                ],
+            ],
+        ]);
+
+        // onlyParents: false: all builds counted including child builds
+        $this->graphQL('
+            query($projectId: ID!) {
+                project(id: $projectId) {
+                    buildCount(onlyParents: false)
+                }
+            }
+        ', ['projectId' => $this->projects['public1']->id])->assertExactJson([
+            'data' => [
+                'project' => [
+                    'buildCount' => 4,
+                ],
+            ],
+        ]);
+    }
+
     public function testBuildCountFieldWithFilters(): void
     {
         $this->projects['public1']->builds()->create([


### PR DESCRIPTION
The Project->builds relationship currently only returns the list of parent builds.  That's useful for common usage, but makes it inconvenient to filter by prior instances of a child build.  This PR adds an `onlyParents` boolean parameter to the `builds` and `buildCount` relationships, which allows clients to specify whether to retain the default "parents only" behavior, or whether they'd like to also query child builds.