### PR TITLE
Add `build` relationship to `Test` GraphQL type

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -967,6 +967,8 @@ type Test {
 
   output: String @with(relation: "testOutput")
 
+  build: Build! @belongsTo
+
   testMeasurements(
     filters: _ @filter
   ): [TestMeasurement!]! @hasMany

--- a/tests/Feature/GraphQL/TestTypeTest.php
+++ b/tests/Feature/GraphQL/TestTypeTest.php
@@ -133,6 +133,58 @@ class TestTypeTest extends TestCase
         ]);
     }
 
+    public function testBuildRelationship(): void
+    {
+        $build = $this->project->builds()->create([
+            'name' => 'build1',
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $build->tests()->create([
+            'testname' => 'test1',
+            'status' => 'passed',
+            'outputid' => $this->test_output->id,
+        ]);
+
+        $this->graphQL('
+            query build($id: ID) {
+                build(id: $id) {
+                    tests {
+                        edges {
+                            node {
+                                name
+                                build {
+                                    id
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            'id' => $build->id,
+        ])->assertExactJson([
+            'data' => [
+                'build' => [
+                    'tests' => [
+                        'edges' => [
+                            [
+                                'node' => [
+                                    'name' => 'test1',
+                                    'build' => [
+                                        'id' => (string) $build->id,
+                                        'name' => 'build1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     /**
      * @return array<array<string>>
      */


### PR DESCRIPTION
Adding a `build` relationship to the `Test` type allows users to filter the list of tests added in #3808 by build attributes.