### PR TITLE
Bump browser testing default timeout to 120 seconds

### DIFF
--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -25,7 +25,7 @@ abstract class BrowserTestCase extends BaseTestCase
         Dusk::selectorHtmlAttribute('data-test');
 
         Browser::$baseUrl = 'http://website:8080';
-        Browser::$waitSeconds = 20;
+        Browser::$waitSeconds = 120;
     }
 
     /**


### PR DESCRIPTION
Many of our browser tests have been flaky for the last few months.  This PR aims to rule out simple load-induced timeouts as the cause.