### PR TITLE
Re-add "remember me" login page checkbox

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22867,12 +22867,6 @@ parameters:
 			path: tests/Feature/LoginAndRegistration.php
 
 		-
-			rawMessage: Using nullsafe property access on non-nullable type App\Models\User. Use -> instead.
-			identifier: nullsafe.neverNull
-			count: 1
-			path: tests/Feature/LoginAndRegistration.php
-
-		-
 			rawMessage: '''
 				Call to deprecated method forceRootUrl() of class Illuminate\Routing\UrlGenerator:
 				Use useOrigin

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -59,6 +59,10 @@
                                 </span>
                         @endif
                     </label>
+                    <label class="tw-label tw-cursor-pointer tw-justify-start tw-gap-2">
+                        <input type="checkbox" name="remember" value="1" {{ old('remember') ? 'checked' : '' }} class="tw-checkbox" />
+                        <span class="tw-label-text">Remember me</span>
+                    </label>
                     <button class="tw-btn tw-btn-block tw-mt-2" type="submit">Sign In</button>
                 </form>
             @endif

--- a/tests/Feature/LoginAndRegistration.php
+++ b/tests/Feature/LoginAndRegistration.php
@@ -81,11 +81,49 @@ class LoginAndRegistration extends TestCase
 
         // Verify that users can login with their username and password.
         $response = $this->post('/login', [
-            'email' => $this->user?->email,
+            'email' => $this->user->email,
             'password' => '12345',
         ]);
         $this->assertModelExists($this->user);
         $this->assertAuthenticatedAs($this->user);
+    }
+
+    public function testLoginFormHasRememberMe(): void
+    {
+        // Verify that the login form displays a "remember me" checkbox.
+        $response = $this->get('/login');
+        $response->assertOk();
+        $response->assertSeeText('Remember me');
+        $response->assertSee('name="remember"', false);
+    }
+
+    public function testUserCanLoginWithRememberMe(): void
+    {
+        $this->user = $this->makeNormalUser(password: '12345');
+        $this->assertModelExists($this->user);
+
+        // Verify that logging in with "remember me" checked sets the recaller cookie.
+        $response = $this->post('/login', [
+            'email' => $this->user->email,
+            'password' => '12345',
+            'remember' => '1',
+        ]);
+        $this->assertAuthenticatedAs($this->user);
+        $response->assertCookie(Auth::guard()->getRecallerName());
+    }
+
+    public function testUserCanLoginWithoutRememberMe(): void
+    {
+        $this->user = $this->makeNormalUser(password: '12345');
+        $this->assertModelExists($this->user);
+
+        // Verify that logging in without "remember me" does not set the recaller cookie.
+        $response = $this->post('/login', [
+            'email' => $this->user->email,
+            'password' => '12345',
+        ]);
+        $this->assertAuthenticatedAs($this->user);
+        $response->assertCookieMissing(Auth::guard()->getRecallerName());
     }
 
     public function testUserCannotLoginWithIncorrectCredentials(): void


### PR DESCRIPTION
https://github.com/Kitware/CDash/pull/3313 unintentionally removed the "remember me" functionality.  This PR restores it.  Closes https://github.com/Kitware/CDash/issues/3708.