### PR TITLE
Add test output deletion trigger function

### DIFF
--- a/app/Utils/DatabaseCleanupUtils.php
+++ b/app/Utils/DatabaseCleanupUtils.php
@@ -11,7 +11,6 @@ use App\Models\Configure;
 use App\Models\CoverageFile;
 use App\Models\Image;
 use App\Models\Note;
-use App\Models\TestOutput;
 use App\Models\UploadFile;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
@@ -156,12 +155,6 @@ class DatabaseCleanupUtils
         })->delete();
 
         Image::whereHas('tests.build', function (Builder $query) use ($buildids): void {
-            $query->whereIn('build.id', $buildids);
-        })->whereDoesntHave('tests.build', function (Builder $query) use ($buildids): void {
-            $query->whereNotIn('build.id', $buildids);
-        })->delete();
-
-        TestOutput::whereHas('tests.build', function (Builder $query) use ($buildids): void {
             $query->whereIn('build.id', $buildids);
         })->whereDoesntHave('tests.build', function (Builder $query) use ($buildids): void {
             $query->whereNotIn('build.id', $buildids);

--- a/database/migrations/2026_07_02_162459_build2test_testoutput_trigger.php
+++ b/database/migrations/2026_07_02_162459_build2test_testoutput_trigger.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // When build2test rows are deleted, remove any testoutput rows that are
+        // no longer referenced by any remaining build2test row.  A statement-level
+        // trigger with a transition table is used so that bulk deletes are handled
+        // efficiently in a single pass.
+        DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE FUNCTION delete_unreferenced_testoutput() RETURNS trigger AS $$
+                BEGIN
+                    DELETE FROM testoutput
+                    WHERE id IN (SELECT DISTINCT outputid FROM deleted_build2test)
+                    AND NOT EXISTS (
+                        SELECT 1 FROM build2test WHERE build2test.outputid = testoutput.id
+                    );
+                    RETURN NULL;
+                END;
+                $$ LANGUAGE plpgsql;
+            SQL);
+
+        DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE TRIGGER build2test_delete_testoutput
+                AFTER DELETE ON build2test
+                REFERENCING OLD TABLE AS deleted_build2test
+                FOR EACH STATEMENT
+                EXECUTE FUNCTION delete_unreferenced_testoutput();
+            SQL);
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
Our current build-focused deletion process is inherently slow for test output deletion because the database cannot efficiently determine the set of tests sharing the same output, but not being part of the builds being deleted.  This PR attempts to resolve the issue by creating a delete trigger on the build2test table.  When tests are deleted, the trigger deletes related testoutput rows if those rows are not shared with other tests.  This approach completely avoids needing to go through the builds relation.