### PR TITLE
Refactor: use `whereKey` instead of `where('id', ...)`

### DIFF
--- a/app/GraphQL/Mutations/RemoveProjectUser.php
+++ b/app/GraphQL/Mutations/RemoveProjectUser.php
@@ -38,7 +38,7 @@ final class RemoveProjectUser extends AbstractMutation
                 $userToRemove->id !== $user->id
                 && $user->cannot('removeUser', $project)
             )
-            || !$project->users()->where('id', $userToRemove->id)->exists()
+            || !$project->users()->whereKey($userToRemove->id)->exists()
         ) {
             throw new GraphQLMutationException('This action is unauthorized.');
         }

--- a/app/Http/Controllers/ProjectInvitationController.php
+++ b/app/Http/Controllers/ProjectInvitationController.php
@@ -35,7 +35,7 @@ final class ProjectInvitationController extends AbstractController
             abort(401, 'Membership is managed by LDAP for this project.');
         }
 
-        if ($user->projects()->where('id', $user_invite->project_id)->exists()) {
+        if ($user->projects()->whereKey($user_invite->project_id)->exists()) {
             $user_invite->deleteOrFail();
             abort(401, 'You are already registered for this project.');
         }

--- a/app/Http/Controllers/TestDetailsController.php
+++ b/app/Http/Controllers/TestDetailsController.php
@@ -44,7 +44,7 @@ final class TestDetailsController extends AbstractBuildController
             abort(400, 'A valid test was not specified.');
         }
 
-        $buildtest = Test::where('id', '=', $buildtestid)->first();
+        $buildtest = Test::whereKey($buildtestid)->first();
         if ($buildtest === null) {
             // Create a dummy project object to prevent information leakage between different error cases
             $project = new Project();

--- a/app/Http/Submission/Handlers/BazelJSONHandler.php
+++ b/app/Http/Submission/Handlers/BazelJSONHandler.php
@@ -652,7 +652,7 @@ class BazelJSONHandler extends AbstractSubmissionHandler
         if (array_key_exists('', $this->Builds)) {
             $this->ParentBuild = $this->Builds[''];
             unset($this->Builds['']);
-            \App\Models\Build::where('id', $this->ParentBuild->Id)->update(['parentid' => Build::PARENT_BUILD]);
+            \App\Models\Build::whereKey($this->ParentBuild->Id)->update(['parentid' => Build::PARENT_BUILD]);
             $this->ParentBuild->SetParentId(Build::PARENT_BUILD);
         }
 

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -34,7 +34,7 @@ class ProjectPolicy
         }
 
         // Private projects can only be viewed by members who are explicitly added.
-        if ($project->public === Project::ACCESS_PRIVATE && $project->users()->where('id', $user->id)->exists()) {
+        if ($project->public === Project::ACCESS_PRIVATE && $project->users()->whereKey($user->id)->exists()) {
             return true;
         }
 
@@ -68,7 +68,7 @@ class ProjectPolicy
         }
 
         // Users can edit projects they administer
-        if ($project->administrators()->where('id', $user->id)->exists()) {
+        if ($project->administrators()->whereKey($user->id)->exists()) {
             return true;
         }
 
@@ -83,7 +83,7 @@ class ProjectPolicy
         }
 
         // Can't change the role for users who aren't in the project...
-        if (!$project->users()->where('id', $userToChange->id)->exists()) {
+        if (!$project->users()->whereKey($userToChange->id)->exists()) {
             return false;
         }
 
@@ -133,12 +133,12 @@ class ProjectPolicy
             return false;
         }
 
-        return !$project->users()->where('id', $currentUser->id)->exists();
+        return !$project->users()->whereKey($currentUser->id)->exists();
     }
 
     public function leave(User $currentUser, Project $project): bool
     {
-        return !$this->isLdapControlledMembership($project) && $project->users()->where('id', $currentUser->id)->exists();
+        return !$this->isLdapControlledMembership($project) && $project->users()->whereKey($currentUser->id)->exists();
     }
 
     public function createPinnedTestMeasurement(User $currentUser, Project $project): bool
@@ -168,12 +168,12 @@ class ProjectPolicy
 
     public function createAuthToken(User $currentUser, Project $project): bool
     {
-        return $currentUser->admin || $project->users()->where('id', $currentUser->id)->exists();
+        return $currentUser->admin || $project->users()->whereKey($currentUser->id)->exists();
     }
 
     public function createCoverageDiff(User $user, Project $project): bool
     {
-        return $user->admin || $project->users()->where('id', $user->id)->exists();
+        return $user->admin || $project->users()->whereKey($user->id)->exists();
     }
 
     private function isLdapControlledMembership(Project $project): bool

--- a/app/cdash/app/Model/Build.php
+++ b/app/cdash/app/Model/Build.php
@@ -319,7 +319,7 @@ class Build
             return false;
         }
 
-        return EloquentBuild::where('id', $this->Id)->update([
+        return EloquentBuild::whereKey($this->Id)->update([
             'endtime' => $end_time,
         ]) > 0;
     }
@@ -684,7 +684,7 @@ class Build
             return false;
         }
 
-        return EloquentBuild::where('id', $this->Id)->exists();
+        return EloquentBuild::whereKey($this->Id)->exists();
     }
 
     public function Save()
@@ -811,7 +811,7 @@ class Build
         $this->SetParentId($this->LookupParentBuildId());
         $this->UpdateParentTestNumbers($newFailed, $newNotRun, $newPassed);
 
-        EloquentBuild::where('id', $this->Id)->update([
+        EloquentBuild::whereKey($this->Id)->update([
             'testnotrun' => $numberTestsNotRun,
             'testfailed' => $numberTestsFailed,
             'testpassed' => $numberTestsPassed,
@@ -1225,7 +1225,7 @@ class Build
             }
         }
 
-        return EloquentBuild::where('id', $this->Id)->update([
+        return EloquentBuild::whereKey($this->Id)->update([
             'testtimestatusfailed' => $testtimestatusfailed,
         ]) > 0;
     }
@@ -1656,7 +1656,7 @@ class Build
             return;
         }
 
-        EloquentBuild::where('id', (int) $this->Id)->update([
+        EloquentBuild::whereKey((int) $this->Id)->update([
             'configurewarnings' => $numWarnings,
         ]);
     }
@@ -1668,7 +1668,7 @@ class Build
             return;
         }
 
-        EloquentBuild::where('id', (int) $this->Id)->update([
+        EloquentBuild::whereKey((int) $this->Id)->update([
             'configureerrors' => $numErrors,
         ]);
 
@@ -1762,7 +1762,7 @@ class Build
 
         DB::transaction(function () use ($field, $duration, $update_parent): void {
             // Update duration of specified step for this build.
-            EloquentBuild::where('id', $this->Id)
+            EloquentBuild::whereKey($this->Id)
                 ->increment("{$field}duration", $duration);
 
             if (!$update_parent) {
@@ -1773,7 +1773,7 @@ class Build
             $this->SetParentId($this->LookupParentBuildId());
             if ($this->ParentId > 0) {
                 // Update duration of specified step for this build.
-                EloquentBuild::where('id', $this->ParentId)
+                EloquentBuild::whereKey($this->ParentId)
                     ->increment("{$field}duration", $duration);
             }
         }, 5);
@@ -1825,7 +1825,7 @@ class Build
     /** Set (or unset) the done bit in the database for this build. */
     public function MarkAsDone(bool $done): void
     {
-        EloquentBuild::where('id', $this->Id)->update([
+        EloquentBuild::whereKey($this->Id)->update([
             'done' => $done,
         ]);
     }
@@ -2152,7 +2152,7 @@ class Build
 
         // Add the subproject relationship if necessary.
         if ($this->SubProjectId) {
-            EloquentBuild::where('id', $this->Id)->update(['subprojectid' => $this->SubProjectId]);
+            EloquentBuild::whereKey($this->Id)->update(['subprojectid' => $this->SubProjectId]);
         }
     }
 

--- a/app/cdash/app/Model/Image.php
+++ b/app/cdash/app/Model/Image.php
@@ -50,7 +50,7 @@ class Image
     /** Check if exists */
     private function Exists(): bool
     {
-        $model = EloquentImage::where('id', (int) $this->Id)
+        $model = EloquentImage::whereKey((int) $this->Id)
             ->orWhere('checksum', $this->Checksum)
             ->first();
         if ($model === null) {

--- a/app/cdash/app/Model/SubProject.php
+++ b/app/cdash/app/Model/SubProject.php
@@ -420,7 +420,7 @@ class SubProject
         // If the dependency already exists, exit early
         $dependency_exists = EloquentSubProject::findOrFail($this->Id)
             ->children()
-            ->where('id', $subprojectid)
+            ->whereKey($subprojectid)
             ->exists();
         if ($dependency_exists) {
             return;

--- a/app/cdash/app/Model/SubProjectGroup.php
+++ b/app/cdash/app/Model/SubProjectGroup.php
@@ -249,7 +249,7 @@ class SubProjectGroup
         // Make sure there's only one default group per project.
         if ($this->IsDefault) {
             EloquentSubProjectGroup::where('projectid', $this->ProjectId)
-                ->where('id', '!=', $this->Id)
+                ->whereKeyNot($this->Id)
                 ->update([
                     'is_default' => 0,
                 ]);

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -16,7 +16,7 @@ if (isset($project)) {
 
     $currentDateString = Carbon::parse($eloquentProject->builds()->max('starttime'))->toDateString();
 
-    $userInProject = auth()->user() !== null && $eloquentProject->users()->where('id', auth()->user()->id)->exists();
+    $userInProject = auth()->user() !== null && $eloquentProject->users()->whereKey(auth()->user()->id)->exists();
 }
 
 $showHeaderNav = isset($build);

--- a/routes/web.php
+++ b/routes/web.php
@@ -228,7 +228,7 @@ Route::permanentRedirect('/test/{id}', url('/tests/{id}'));
 Route::get('/testDetails.php', function (Request $request) {
     $buildid = $request->query('build');
     $testid = $request->query('test');
-    $buildtest = Test::where('buildid', $buildid)->where('id', $testid)->first();
+    $buildtest = Test::where('buildid', $buildid)->whereKey($testid)->first();
     if ($buildtest !== null) {
         return redirect("/tests/{$buildtest->id}", 301);
     }


### PR DESCRIPTION
`whereKey` is cleaner and more maintainable because there's a single source of truth about what the primary key column is.