### PR TITLE
Fix build group deletion

### DIFF
--- a/app/cdash/app/Model/BuildGroup.php
+++ b/app/cdash/app/Model/BuildGroup.php
@@ -369,7 +369,7 @@ class BuildGroup
                 ])->first();
             }
 
-            $newGroup?->builds()->attach($oldbuild);
+            $newGroup?->builds()->syncWithoutDetaching($oldbuild);
         }
 
         // We delete the buildgroup


### PR DESCRIPTION
Build group deletion currently fails if a build is assigned to two groups, including the default "Experimental" group.  This PR resolves the issue switching from an insert to an upsert operation while moving builds out of the deleted group.