### PR TITLE
Capture output images on test failure in CI

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -12,8 +12,10 @@ module.exports = defineConfig({
   defaultCommandTimeout: 120000,
   retries: 2,
   e2e: {
-    setupNodeEvents() {
-      // implement node event listeners here
+    setupNodeEvents(on) {
+      on('after:screenshot', (details) => {
+        console.log(`\n<CTestMeasurementFile name="TestImage" type="image/png">${details.path}</CTestMeasurementFile>\n`);
+      });
     },
     baseUrl: 'http://localhost:8080',
     specPattern: 'tests/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
@@ -24,6 +26,11 @@ module.exports = defineConfig({
     specPattern: 'tests/cypress/component/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'tests/cypress/support/component.js',
     indexHtmlFile: 'tests/cypress/support/component-index.html',
+    setupNodeEvents(on) {
+      on('after:screenshot', (details) => {
+        console.log(`\n<CTestMeasurementFile name="TestImage" type="image/png">${details.path}</CTestMeasurementFile>\n`);
+      });
+    },
     devServer: {
       framework: 'vue',
       bundler: 'webpack',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22522,6 +22522,24 @@ parameters:
 			path: tests/Browser/Pages/UsersPageTest.php
 
 		-
+			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::name() from outside its root namespace PHPUnit.'
+			identifier: method.internal
+			count: 1
+			path: tests/BrowserTestCase.php
+
+		-
+			rawMessage: 'Method Tests\BrowserTestCase::captureFailuresFor() has parameter $browsers with generic class Illuminate\Support\Collection but does not specify its types: TKey, TValue'
+			identifier: missingType.generics
+			count: 1
+			path: tests/BrowserTestCase.php
+
+		-
+			rawMessage: 'Parameter #1 $callback of method Illuminate\Support\Collection<(int|string),mixed>::each() expects callable(mixed, int|string): mixed, Closure(Laravel\Dusk\Browser, int): void given.'
+			identifier: argument.type
+			count: 1
+			path: tests/BrowserTestCase.php
+
+		-
 			rawMessage: Access to an undefined property CDash\Model\Build::$Endime.
 			identifier: property.notFound
 			count: 2

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -48,4 +48,29 @@ abstract class BrowserTestCase extends BaseTestCase
             )
         );
     }
+
+    /**
+     * Capture screenshots and console logs for failed tests.
+     *
+     * @param Collection $browsers
+     */
+    protected function captureFailuresFor($browsers): void
+    {
+        $browsers->each(function (Browser $browser, int $key): void {
+            $name = str_replace('\\', '_', static::class) . '_' . $this->name();
+            $screenshotName = 'failure-' . $name . '-' . $key;
+            $browser->screenshot($screenshotName);
+            $browser->storeConsoleLog($screenshotName);
+
+            $screenshotPath = base_path("tests/Browser/screenshots/{$screenshotName}.png");
+            if (file_exists($screenshotPath)) {
+                fwrite(STDOUT, "\n<CTestMeasurementFile name=\"TestImage\" type=\"image/png\">$screenshotPath</CTestMeasurementFile>\n");
+            }
+
+            $consoleLogPath = base_path("tests/Browser/console/{$screenshotName}.log");
+            if (file_exists($consoleLogPath)) {
+                fwrite(STDOUT, "\n<CTestMeasurementFile name=\"ConsoleLog\" type=\"text/plain\">$consoleLogPath</CTestMeasurementFile>\n");
+            }
+        });
+    }
 }


### PR DESCRIPTION
We currently have many flaky tests.  Laravel Dusk and Cypress both create output images on failure, but we currently have no way to access those when CI fails.  This PR addresses that by uploading the images to CDash on failure.