### PR TITLE
Remove unused BasicBuildAlert GraphQL type

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1108,28 +1108,6 @@ type BuildCommandOutput {
 }
 
 
-"""
-"Basic" alerts are warnings or errors scraped from the build log, as opposed to "rich" alerts which
-come from CTest launchers.  A given build should either have all "basic" alerts or all "rich" alerts.
-Users should take both types into account when querying the alerts for a given build.
-
-https://cmake.org/cmake/help/latest/manual/ctest.1.html#ctest-build-step
-"""
-type BasicBuildAlert {
-  logLine: Int! @rename(attribute: "logline")
-
-  text: String! @rename(attribute: "stdoutput")
-
-  sourceFile: String! @rename(attribute: "sourcefile")
-
-  sourceLine: Int! @rename(attribute: "sourceline")
-
-  preContext: String @rename(attribute: "precontext")
-
-  postContext: String @rename(attribute: "postcontext")
-}
-
-
 type BuildError {
   "Unique primary key."
   id: ID! @filterable


### PR DESCRIPTION
This type is no longer referenced in the schema, and is thus unnecessary.