### PR TITLE
Move build comments to dedicated page

### DIFF
--- a/app/Http/Controllers/BuildController.php
+++ b/app/Http/Controllers/BuildController.php
@@ -127,6 +127,16 @@ final class BuildController extends AbstractBuildController
         ]);
     }
 
+    public function comments(int $build_id): View
+    {
+        $this->setBuildById($build_id);
+
+        return $this->vue('build-comments-page', 'Comments', [
+            'build-id' => $this->build->Id,
+            'user-id' => Auth::id() ?? 0,
+        ]);
+    }
+
     public function update(int $build_id): View
     {
         $this->setBuildById($build_id);

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -429,6 +429,8 @@ add_browser_test(/Browser/Pages/BuildDynamicAnalysisIdPageTest)
 
 add_browser_test(/Browser/Pages/BuildSummaryPageTest)
 
+add_browser_test(/Browser/Pages/BuildCommentsPageTest)
+
 add_browser_test(/Browser/Pages/BuildSidebarComponentTest)
 
 add_browser_test(/Browser/Pages/ProjectSettingsPageTest)

--- a/resources/js/angular/views/partials/build.html
+++ b/resources/js/angular/views/partials/build.html
@@ -91,7 +91,7 @@
     <!-- Display the note icon -->
     <a class="cdash-link" name="Build Notes" id="buildnote_{{::build.id}}"
        ng-if="::build.buildnotes > 0"
-       ng-href="builds/{{::build.id}}">
+       ng-href="builds/{{::build.id}}/comments">
       <span class="glyphicon glyphicon-comment" style="color: #337ab7; margin-right: 4px;"></span>
     </a>
 

--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -29,6 +29,7 @@ const app = Vue.createApp({
     BuildFilesPage: Vue.defineAsyncComponent(() => import('./components/BuildFilesPage.vue')),
     BuildTargetsPage: Vue.defineAsyncComponent(() => import('./components/BuildTargetsPage.vue')),
     BuildInstrumentationPage: Vue.defineAsyncComponent(() => import('./components/BuildInstrumentationPage.vue')),
+    BuildCommentsPage: Vue.defineAsyncComponent(() => import('./components/BuildCommentsPage.vue')),
     BuildBuildPage: Vue.defineAsyncComponent(() => import('./components/BuildBuildPage.vue')),
     CoverageFilePage: Vue.defineAsyncComponent(() => import('./components/CoverageFilePage.vue')),
     BuildCoveragePage: Vue.defineAsyncComponent(() => import('./components/BuildCoveragePage.vue')),

--- a/resources/js/vue/components/BuildCommentsPage.vue
+++ b/resources/js/vue/components/BuildCommentsPage.vue
@@ -1,0 +1,213 @@
+<template>
+  <BuildSidebar
+    :build-id="buildId"
+    active-tab="comments"
+  >
+    <div class="tw-flex tw-flex-col tw-w-full tw-gap-4">
+      <BuildSummaryCard :build-id="buildId" />
+
+      <div class="tw-border tw-border-base-300 tw-bg-base-100 tw-rounded-md">
+        <div class="tw-p-4">
+          <div class="tw-flex tw-items-center tw-justify-between tw-mb-4">
+            <h2 class="tw-text-lg tw-font-bold">
+              Comments ({{ comments ? comments.length : 0 }})
+            </h2>
+          </div>
+
+          <LoadingIndicator :is-loading="!comments">
+            <div
+              v-if="comments && comments.length > 0"
+              class="tw-flex tw-flex-col tw-gap-2"
+              data-test="comments-list"
+            >
+              <div
+                v-for="{node: comment} in comments"
+                :key="comment.id"
+                class="tw-p-3 tw-border tw-rounded-md tw-bg-base-100"
+                :class="Number(comment.user.id) === userId ? 'tw-border-primary' : 'tw-border-base-300'"
+                data-test="comment-item"
+              >
+                <div class="tw-flex tw-items-center tw-justify-between tw-mb-1">
+                  <div class="tw-flex tw-items-center tw-gap-2">
+                    <span class="tw-font-bold">{{ comment.user.firstname }} {{ comment.user.lastname }}</span>
+                    <span
+                      v-if="Number(comment.user.id) === userId"
+                      class="tw-badge tw-badge-primary tw-badge-sm"
+                    >You</span>
+                  </div>
+                  <time class="tw-text-xs tw-opacity-50">{{ Utils.formatRelativeTimestamp(comment.timestamp) }}</time>
+                </div>
+                <CodeBox
+                  :text="comment.text"
+                  :bordered="false"
+                  class="tw-bg-transparent tw-p-0"
+                />
+              </div>
+            </div>
+            <div
+              v-else
+              class="tw-text-center tw-py-4 tw-opacity-50"
+              data-test="no-comments-message"
+            >
+              No comments yet.
+            </div>
+          </LoadingIndicator>
+
+          <div
+            v-if="userId > 0"
+            class="tw-divider tw-my-2"
+          />
+
+          <div
+            v-if="userId > 0"
+            class="tw-mt-2"
+          >
+            <h3 class="tw-text-sm tw-font-bold tw-mb-2">
+              Add a comment
+            </h3>
+            <textarea
+              v-model="commentText"
+              data-test="comment-text"
+              class="tw-textarea tw-textarea-bordered tw-w-full tw-textarea-sm"
+              rows="3"
+              placeholder="Write your comment here..."
+            />
+            <div class="tw-flex tw-justify-end tw-mt-2">
+              <button
+                data-test="add-comment"
+                class="tw-btn tw-btn-primary tw-btn-sm"
+                :disabled="!commentText || submitting"
+                @click="addComment()"
+              >
+                <span
+                  v-if="submitting"
+                  class="tw-loading tw-loading-spinner tw-loading-xs"
+                />
+                Post Comment
+              </button>
+            </div>
+          </div>
+          <div
+            v-else
+            class="tw-mt-4 tw-p-4 tw-bg-base-200 tw-rounded-md tw-text-sm tw-text-center tw-text-base-content/70"
+          >
+            Please <a
+              :href="$baseURL + '/login'"
+              class="tw-link tw-link-primary tw-font-bold"
+            >log in</a> to add a comment.
+          </div>
+        </div>
+      </div>
+    </div>
+  </BuildSidebar>
+</template>
+
+<script>
+import BuildSummaryCard from './shared/BuildSummaryCard.vue';
+import BuildSidebar from './shared/BuildSidebar.vue';
+import LoadingIndicator from './shared/LoadingIndicator.vue';
+import CodeBox from './shared/CodeBox.vue';
+import gql from 'graphql-tag';
+import Utils from './shared/Utils';
+
+export default {
+  name: 'BuildCommentsPage',
+
+  components: {
+    BuildSummaryCard,
+    BuildSidebar,
+    LoadingIndicator,
+    CodeBox,
+  },
+
+  props: {
+    buildId: {
+      type: Number,
+      required: true,
+    },
+    userId: {
+      type: Number,
+      default: 0,
+    },
+  },
+
+  data() {
+    return {
+      commentText: '',
+      submitting: false,
+    };
+  },
+
+  computed: {
+    Utils() {
+      return Utils;
+    },
+  },
+
+  apollo: {
+    comments: {
+      query: gql`
+        query($buildId: ID) {
+          build(id: $buildId) {
+            id
+            comments {
+              edges {
+                node {
+                  id
+                  text
+                  timestamp
+                  user {
+                    id
+                    firstname
+                    lastname
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      update: data => data?.build?.comments?.edges,
+      variables() {
+        return {
+          buildId: this.buildId,
+        };
+      },
+    },
+  },
+
+  methods: {
+    addComment() {
+      this.submitting = true;
+      this.$apollo
+        .mutate({
+          mutation: gql`
+            mutation createComment($input: CreateCommentInput!) {
+              createComment(input: $input) {
+                comment {
+                  id
+                }
+              }
+            }
+          `,
+          variables: {
+            input: {
+              buildId: this.buildId,
+              text: this.commentText,
+            },
+          },
+        })
+        .then(() => {
+          this.$apollo.queries.comments.refetch();
+          this.commentText = '';
+          this.submitting = false;
+        })
+        .catch(error => {
+          console.error(error);
+          this.submitting = false;
+          alert('Failed to add comment. Please try again.');
+        });
+    },
+  },
+};
+</script>

--- a/resources/js/vue/components/BuildSummary.vue
+++ b/resources/js/vue/components/BuildSummary.vue
@@ -418,79 +418,6 @@
         </table>
         <br>
 
-        <!-- Display comments for this build -->
-        <LoadingIndicator :is-loading="!comments">
-          <div
-            v-if="comments.length > 0 || cdash.user.id > 0"
-            class="title-divider"
-          >
-            Comments ({{ comments.length }})
-          </div>
-
-          <div v-if="comments.length > 0">
-            <div v-for="{node: comment} in comments">
-              <b>{{ comment.user.firstname }} {{ comment.user.lastname }}</b> {{ Utils.formatRelativeTimestamp(comment.timestamp) }}
-              <CodeBox :text="comment.text" />
-              <hr>
-            </div>
-            <br>
-          </div>
-
-          <div v-if="cdash.user.id > 0">
-            <!-- Add Comments -->
-            <div class="tw-flex tw-flex-row">
-              <img
-                width="20"
-                height="20"
-                :src="$baseURL + '/img/document.png'"
-                title="graph"
-              >
-              <a
-                id="toggle_comments"
-                class="tw-link tw-link-hover"
-                @click="toggleComments()"
-              >
-                Add a comment to this Build
-              </a>
-            </div>
-            <div
-              v-show="showComments"
-              id="new_comment_div"
-            >
-              <table>
-                <tbody>
-                  <tr>
-                    <td><b>Comment:</b></td>
-                    <td>
-                      <textarea
-                        id="comment_text"
-                        v-model="commentText"
-                        class="tw-textarea tw-textarea-bordered"
-                        cols="50"
-                        rows="5"
-                      />
-                    </td>
-                  </tr>
-                  <tr>
-                    <td />
-                    <td>
-                      <button
-                        id="add_comment"
-                        class="tw-btn"
-                        :disabled="!commentText"
-                        @click="addComment()"
-                      >
-                        Add Comment
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <br>
-          </div>
-        </LoadingIndicator>
-
         <!-- Graphs -->
         <div class="tw-border tw-border-base-300 tw-rounded-lg tw-overflow-hidden">
           <div class="tw-flex tw-items-center tw-justify-between tw-px-3 tw-py-1 tw-bg-base-200">
@@ -521,7 +448,6 @@ import {
   faLink,
 } from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
-import CodeBox from './shared/CodeBox.vue';
 import LoadingIndicator from './shared/LoadingIndicator.vue';
 import BuildSummaryCard from './shared/BuildSummaryCard.vue';
 import BuildSidebar from './shared/BuildSidebar.vue';
@@ -532,7 +458,7 @@ import { DateTime, Duration } from 'luxon';
 
 export default {
   name: 'BuildSummary',
-  components: {BuildTimeChart, BuildSummaryCard, LoadingIndicator, CodeBox, BuildSidebar, FontAwesomeIcon},
+  components: {BuildTimeChart, BuildSummaryCard, LoadingIndicator, BuildSidebar, FontAwesomeIcon},
 
   props: {
     projectId: {
@@ -572,11 +498,6 @@ export default {
       cdash: {},
       loading: true,
       errored: false,
-
-      commentText: '',
-
-      // Booleans controlling whether a section should be displayed or not.
-      showComments: false,
     };
   },
 
@@ -711,36 +632,6 @@ export default {
         this.loading = false;
       },
     },
-    comments: {
-      query: gql`
-        query($buildId: ID) {
-          build(id: $buildId) {
-            id
-            comments {
-              edges {
-                node {
-                  id
-                  text
-                  timestamp
-                  user {
-                    id
-                    firstname
-                    lastname
-                  }
-                }
-              }
-            }
-          }
-        }
-      `,
-      update: data => data?.build?.comments?.edges,
-      variables() {
-        return {
-          buildId: this.buildId,
-        };
-      },
-    },
-
     buildHistory: {
       query: gql`
         query($projectId: ID, $filters: ProjectBuildsFiltersMultiFilterInput, $onlyParents: Boolean) {
@@ -836,41 +727,6 @@ export default {
   },
 
   methods: {
-    toggleComments: function() {
-      this.showComments = !this.showComments;
-    },
-
-    addComment: function() {
-      this.$apollo
-        .mutate({
-          mutation: gql`
-            mutation createComment($input: CreateCommentInput!) {
-              createComment(input: $input) {
-                comment {
-                  id
-                }
-              }
-            }
-          `,
-          variables: {
-            input: {
-              buildId: this.buildId,
-              text: this.commentText,
-            },
-          },
-        })
-        .then(() => {
-          // Add the newly created comment to our list.
-          this.$apollo.queries.comments.refetch();
-          this.commentText = '';
-          this.showComments = false;
-        })
-        .catch(error => {
-          // Display the error.
-          this.cdash.error = error;
-          console.log(error);
-        });
-    },
   },
 };
 </script>

--- a/resources/js/vue/components/shared/BuildSidebar.vue
+++ b/resources/js/vue/components/shared/BuildSidebar.vue
@@ -14,6 +14,15 @@
           data-test="sidebar-summary"
         />
         <BuildSidebarItem
+          :href="`${$baseURL}/builds/${buildId}/comments`"
+          title="Comments"
+          :icon="FA.faComments"
+          :selected="activeTab === 'comments'"
+          :disabled="commentsDisabled"
+          :badges="commentsBadges"
+          data-test="sidebar-comments"
+        />
+        <BuildSidebarItem
           :href="`${$baseURL}/builds/${buildId}/update`"
           title="Update"
           :icon="FA.faCodePullRequest"
@@ -122,6 +131,7 @@ import {
   faNoteSticky,
   faGaugeHigh,
   faBullseye,
+  faComments,
 } from '@fortawesome/free-solid-svg-icons';
 
 export default {
@@ -154,6 +164,11 @@ export default {
         query($buildid: ID) {
           build(id: $buildid) {
             id
+            comments {
+              pageInfo {
+                total
+              }
+            }
             updateStep {
               id
             }
@@ -226,9 +241,13 @@ export default {
         faNoteSticky,
         faGaugeHigh,
         faBullseye,
+        faComments,
       };
     },
     summaryDisabled() {
+      return !this.build;
+    },
+    commentsDisabled() {
       return !this.build;
     },
     updateDisabled() {
@@ -267,6 +286,16 @@ export default {
     },
     targetsDisabled() {
       return !this.build || !this.build.targets || this.build.targets.pageInfo.total === 0;
+    },
+    commentsBadges() {
+      if (!this.build || !this.build.comments || this.build.comments.pageInfo.total === 0) {
+        return [];
+      }
+      return [{
+        count: this.build.comments.pageInfo.total,
+        colorClass: 'tw-bg-info',
+        textClass: 'tw-text-info-content',
+      }];
     },
     errorsBadges() {
       if (!this.build) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,8 @@ Route::get('/displayImage.php', function (Request $request) {
 
 Route::get('/builds/{id}', 'BuildController@summary')
     ->whereNumber('id');
+Route::get('/builds/{id}/comments', 'BuildController@comments')
+    ->whereNumber('id');
 Route::permanentRedirect('/build/{id}', url('/builds/{id}'));
 Route::get('/buildSummary.php', function (Request $request) {
     $buildid = $request->query('buildid');

--- a/tests/Browser/Pages/BuildCommentsPageTest.php
+++ b/tests/Browser/Pages/BuildCommentsPageTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use App\Http\Submission\Traits\UpdatesSiteInformation;
+use App\Models\Build;
+use App\Models\Comment;
+use App\Models\Project;
+use App\Models\Site;
+use App\Models\SiteInformation;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Dusk\Browser;
+use Tests\BrowserTestCase;
+use Tests\Traits\CreatesProjects;
+use Tests\Traits\CreatesSites;
+use Tests\Traits\CreatesUsers;
+
+class BuildCommentsPageTest extends BrowserTestCase
+{
+    use CreatesProjects;
+    use CreatesSites;
+    use CreatesUsers;
+    use UpdatesSiteInformation;
+
+    private Project $project;
+    private Site $site;
+    private User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->project = $this->makePublicProject();
+
+        $this->user = $this->makeNormalUser();
+
+        $this->site = $this->makeSite();
+        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+    }
+
+    public function tearDown(): void
+    {
+        $this->project->delete();
+        $this->site->delete();
+        $this->user->delete();
+
+        parent::tearDown();
+    }
+
+    public function testLoggedOutUserCanSeeCommentsButNotAdd(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        /** @var Comment $comment */
+        $comment = $build->comments()->save(Comment::factory()->make([
+            'userid' => $this->user->id,
+        ]));
+
+        $this->browse(function (Browser $browser) use ($comment, $build): void {
+            $browser->visit("/builds/{$build->id}/comments")
+                ->waitForText($comment->text)
+                ->assertSee($this->user->firstname)
+                ->assertSee($this->user->lastname)
+                ->assertMissing('@comment-text')
+                ->assertMissing('@add-comment')
+                ->assertSee('log in to add a comment')
+            ;
+        });
+    }
+
+    public function testAddComment(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $commentText = 'This is a test comment ' . Str::random(10);
+
+        $this->browse(function (Browser $browser) use ($build, $commentText): void {
+            $browser->loginAs($this->user)
+                ->visit("/builds/{$build->id}/comments")
+                ->waitFor('@comment-text')
+                ->assertPresent('@comment-text')
+                ->assertPresent('@add-comment')
+                ->type('@comment-text', $commentText)
+                ->click('@add-comment')
+                ->waitForText($commentText)
+                ->assertSee($this->user->firstname)
+                ->assertSee($this->user->lastname)
+            ;
+        });
+    }
+
+    public function testNoComments(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $browser->visit("/builds/{$build->id}/comments")
+                ->waitFor('@no-comments-message')
+                ->assertSee('No comments yet.')
+                ->assertMissing('@comments-list');
+        });
+    }
+}

--- a/tests/Browser/Pages/BuildSidebarComponentTest.php
+++ b/tests/Browser/Pages/BuildSidebarComponentTest.php
@@ -14,21 +14,25 @@ use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\UploadFile;
+use App\Models\User;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesSites;
+use Tests\Traits\CreatesUsers;
 
 class BuildSidebarComponentTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
+    use CreatesUsers;
     use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
+    private User $user;
 
     public function setUp(): void
     {
@@ -38,12 +42,15 @@ class BuildSidebarComponentTest extends BrowserTestCase
 
         $this->site = $this->makeSite();
         $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+
+        $this->user = $this->makeNormalUser();
     }
 
     public function tearDown(): void
     {
         $this->project->delete();
         $this->site->delete();
+        $this->user->delete();
 
         parent::tearDown();
     }
@@ -73,6 +80,29 @@ class BuildSidebarComponentTest extends BrowserTestCase
 
         $this->browse(function (Browser $browser) use ($build): void {
             $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-summary', "/builds/{$build->id}");
+        });
+    }
+
+    public function testCommentsItem(): void
+    {
+        /** @var Build $build */
+        $build = $this->project->builds()->create([
+            'siteid' => $this->site->id,
+            'name' => Str::uuid()->toString(),
+            'uuid' => Str::uuid()->toString(),
+        ]);
+
+        $this->browse(function (Browser $browser) use ($build): void {
+            $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-comments', "/builds/{$build->id}/comments");
+
+            $build->comments()->create([
+                'userid' => $this->user->id,
+                'text' => 'test comment',
+            ]);
+
+            $browser->visit("/builds/{$build->id}")
+                ->waitFor('@sidebar-loaded')
+                ->assertSeeIn('@sidebar-comments', '1');
         });
     }
 

--- a/tests/Browser/Pages/BuildSummaryPageTest.php
+++ b/tests/Browser/Pages/BuildSummaryPageTest.php
@@ -4,36 +4,29 @@ namespace Tests\Browser\Pages;
 
 use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
-use App\Models\Comment;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
-use App\Models\User;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
 use Tests\Traits\CreatesProjects;
 use Tests\Traits\CreatesSites;
-use Tests\Traits\CreatesUsers;
 
 class BuildSummaryPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use CreatesUsers;
     use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
-    private User $user;
 
     public function setUp(): void
     {
         parent::setUp();
 
         $this->project = $this->makePublicProject();
-
-        $this->user = $this->makeNormalUser();
 
         $this->site = $this->makeSite();
         $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
@@ -87,29 +80,6 @@ class BuildSummaryPageTest extends BrowserTestCase
                 ->assertAttributeContains('@build-history-link', 'href', 'value2=' . $buildName)
                 ->assertAttributeContains('@build-history-link', 'href', 'value3=' . $buildType)
                 ->assertAttributeContains('@build-history-link', 'href', 'value4=' . $startTime)
-            ;
-        });
-    }
-
-    public function testShowsComments(): void
-    {
-        /** @var Build $build */
-        $build = $this->project->builds()->create([
-            'siteid' => $this->site->id,
-            'name' => Str::uuid()->toString(),
-            'uuid' => Str::uuid()->toString(),
-        ]);
-
-        /** @var Comment $comment */
-        $comment = $build->comments()->save(Comment::factory()->make([
-            'userid' => $this->user->id,
-        ]));
-
-        $this->browse(function (Browser $browser) use ($comment, $build): void {
-            $browser->visit("/builds/{$build->id}")
-                ->waitForText($comment->text)
-                ->assertSee($this->user->firstname)
-                ->assertSee($this->user->lastname)
             ;
         });
     }


### PR DESCRIPTION
Comments are currently displayed on the build summary page.  With the recent shift in focus for the build summary page, it no longer makes sense to display the comments there.  This PR moves the comments to a dedicated page, freeing up space on the build summary page for more charts and summary cards.

<img width="2834" height="1928" alt="image" src="https://github.com/user-attachments/assets/992497a3-a1fb-4c46-b689-123b46029074" />
