### PR TITLE
Fix flaky `SitesIdPageTest`

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1165,7 +1165,7 @@ type Site {
   longitude: String! @filterable
 
   "Every edit of this site's information."
-  information: [SiteInformation!]! @hasMany(type: CONNECTION) @orderBy(column: "timestamp", direction: DESC)
+  information: [SiteInformation!]! @hasMany(type: CONNECTION) @orderBy(column: "timestamp", direction: DESC) @orderBy(column: "id", direction: DESC)
 
   "The most recent information we have about this site."
   # TODO: Figure out how to support the date parameter. Perhaps it would be better to use a scope instead.


### PR DESCRIPTION
`SitesIdPageTest` currently fails a small percentage of the time in CI due to two site descriptions getting the same timestamp at second precision.  This PR resolves the issue by adding a secondary ordering clause to break timestamp ties by ID.