### PR TITLE
Log out after browser tests

### DIFF
--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -28,6 +28,13 @@ abstract class BrowserTestCase extends BaseTestCase
         Browser::$waitSeconds = 20;
     }
 
+    public function tearDown(): void
+    {
+        $this->browse(fn (Browser $browser) => $browser->logout());
+
+        parent::tearDown();
+    }
+
     /**
      * Create the RemoteWebDriver instance.
      */


### PR DESCRIPTION
I suspect some of the flakiness of `CreateProjectPageTest` and `ProfilePageTest` is caused by session conflicts since the browser doesn't guarantee complete isolation between tests.  Logging out after each test will hopefully address these issues.  Note that this is a speculative change, since I'm unable to reproduce the test failures locally.