### PR TITLE
Remove jQuery from global Vue bundle

### DIFF
--- a/resources/js/vue/app.js
+++ b/resources/js/vue/app.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import * as Vue from 'vue';
 import axios from 'axios';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
@@ -40,7 +39,7 @@ const app = Vue.createApp({
   },
 });
 
-app.config.globalProperties.$baseURL = $('#app').attr('data-app-url');
+app.config.globalProperties.$baseURL = document.getElementById('app').getAttribute('data-app-url');
 
 axios.defaults.baseURL = app.config.globalProperties.$baseURL;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';


### PR DESCRIPTION
jQuery is currently being imported at the top level of the Vue bundle for a single simple use case.  Removing this single jQuery import reduces the bundle size by 30kb, roughly 15%.  Note that this doesn't mean that CDash no longer uses jQuery.  Pages which require jQuery already include it directly.