### PR TITLE
Move `UpdatesSiteInformation` trait to `SiteService`

### DIFF
--- a/app/Http/Submission/Handlers/BuildHandler.php
+++ b/app/Http/Submission/Handlers/BuildHandler.php
@@ -19,7 +19,6 @@ namespace App\Http\Submission\Handlers;
 
 use App\Enums\BuildCommandType;
 use App\Enums\TargetType;
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build as EloquentBuild;
 use App\Models\BuildCommand;
 use App\Models\BuildCommandOutput;
@@ -28,6 +27,7 @@ use App\Models\Label as EloquentLabel;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\Target;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use Carbon\Carbon;
 use CDash\Collection\BuildCollection;
@@ -51,7 +51,6 @@ use RuntimeException;
 class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {
     use CommitAuthorHandlerTrait;
-    use UpdatesSiteInformation;
 
     private int $StartTimeStamp = -1;
     private int $EndTimeStamp = -1;
@@ -177,7 +176,7 @@ class BuildHandler extends AbstractXmlHandler implements ActionableBuildInterfac
                 $this->BuildName = '(empty)';
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/Http/Submission/Handlers/ConfigureHandler.php
+++ b/app/Http/Submission/Handlers/ConfigureHandler.php
@@ -17,9 +17,9 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use CDash\Collection\BuildCollection;
 use CDash\Collection\SubscriptionBuilderCollection;
@@ -36,8 +36,6 @@ use CDash\Model\Subscriber;
 
 class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInterface
 {
-    use UpdatesSiteInformation;
-
     private int $StartTimeStamp = 0;
     private int $EndTimeStamp = 0;
     private array $Builds = [];
@@ -115,7 +113,7 @@ class ConfigureHandler extends AbstractXmlHandler implements ActionableBuildInte
                 $this->BuildName = '(empty)';
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/Http/Submission/Handlers/CoverageHandler.php
+++ b/app/Http/Submission/Handlers/CoverageHandler.php
@@ -17,10 +17,10 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Services\ProjectService;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use CDash\Model\Build;
 use CDash\Model\Coverage;
@@ -32,8 +32,6 @@ use CDash\Model\SubProject;
 
 class CoverageHandler extends AbstractXmlHandler
 {
-    use UpdatesSiteInformation;
-
     private int $StartTimeStamp;
     private int $EndTimeStamp;
 
@@ -86,7 +84,7 @@ class CoverageHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/Http/Submission/Handlers/CoverageJUnitHandler.php
+++ b/app/Http/Submission/Handlers/CoverageJUnitHandler.php
@@ -17,9 +17,9 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use CDash\Model\Coverage;
 use CDash\Model\CoverageFile;
@@ -29,8 +29,6 @@ use CDash\Model\Project;
 
 class CoverageJUnitHandler extends AbstractXmlHandler
 {
-    use UpdatesSiteInformation;
-
     private int $StartTimeStamp;
     private int $EndTimeStamp;
 
@@ -83,7 +81,7 @@ class CoverageJUnitHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
+++ b/app/Http/Submission/Handlers/DynamicAnalysisHandler.php
@@ -17,10 +17,10 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\DynamicAnalysisDefect;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use CDash\Collection\BuildCollection;
 use CDash\Collection\SubscriptionBuilderCollection;
@@ -38,8 +38,6 @@ use CDash\Model\Subscriber;
 
 class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBuildInterface
 {
-    use UpdatesSiteInformation;
-
     private int $StartTimeStamp;
     private int $EndTimeStamp;
     private string $Checker;
@@ -114,7 +112,7 @@ class DynamicAnalysisHandler extends AbstractXmlHandler implements ActionableBui
             if (empty($this->BuildName)) {
                 $this->BuildName = '(empty)';
             }
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/Http/Submission/Handlers/NoteHandler.php
+++ b/app/Http/Submission/Handlers/NoteHandler.php
@@ -17,9 +17,9 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use App\Utils\NoteCreator;
 use App\Utils\SubmissionUtils;
 use CDash\Model\Project;
@@ -27,8 +27,6 @@ use Illuminate\Support\Facades\Log;
 
 class NoteHandler extends AbstractXmlHandler
 {
-    use UpdatesSiteInformation;
-
     private bool $AdjustStartTime = false;
     private NoteCreator $NoteCreator;
     protected static ?string $schema_file = '/app/Validators/Schemas/Notes.xsd';
@@ -76,7 +74,7 @@ class NoteHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/Http/Submission/Handlers/TestingHandler.php
+++ b/app/Http/Submission/Handlers/TestingHandler.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Submission\Handlers;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\TestMeasurement;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use App\Utils\TestCreator;
 use Carbon\Carbon;
@@ -29,7 +29,6 @@ use CDash\Submission\CommitAuthorHandlerTrait;
 class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterface, CommitAuthorHandlerInterface
 {
     use CommitAuthorHandlerTrait;
-    use UpdatesSiteInformation;
 
     protected static ?string $schema_file = '/app/Validators/Schemas/Test.xsd';
     private int $StartTimeStamp = 0;
@@ -122,7 +121,7 @@ class TestingHandler extends AbstractXmlHandler implements ActionableBuildInterf
             if (empty($this->BuildName)) {
                 $this->BuildName = '(empty)';
             }
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
         } elseif ($name === 'SUBPROJECT') {
             $this->SubProjectName = $attributes['NAME'];
             if (!array_key_exists($this->SubProjectName, $this->SubProjects)) {

--- a/app/Http/Submission/Handlers/TestingJUnitHandler.php
+++ b/app/Http/Submission/Handlers/TestingJUnitHandler.php
@@ -17,17 +17,15 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use App\Utils\TestCreator;
 use CDash\Model\Project;
 
 class TestingJUnitHandler extends AbstractXmlHandler
 {
-    use UpdatesSiteInformation;
-
     private int $StartTimeStamp;
     private int $EndTimeStamp;
     // Should we update the end time of the build?
@@ -95,7 +93,7 @@ class TestingJUnitHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/Http/Submission/Handlers/UploadHandler.php
+++ b/app/Http/Submission/Handlers/UploadHandler.php
@@ -17,10 +17,10 @@ namespace App\Http\Submission\Handlers;
   PURPOSE. See the above copyright notices for more information.
 =========================================================================*/
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\UploadFile;
+use App\Services\SiteService;
 use App\Utils\SubmissionUtils;
 use CDash\Model\Label;
 use CDash\Model\Project;
@@ -45,8 +45,6 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
  */
 class UploadHandler extends AbstractXmlHandler
 {
-    use UpdatesSiteInformation;
-
     private UploadFile $UploadFile;
     private string $TmpFilename = '';
     private $Base64TmpFileWriteHandle = 0;
@@ -106,7 +104,7 @@ class UploadHandler extends AbstractXmlHandler
                 }
             }
 
-            $this->updateSiteInfoIfChanged($this->Site, $siteInformation);
+            SiteService::updateSiteInfoIfChanged($this->Site, $siteInformation);
 
             $this->Build->SiteId = $this->Site->id;
             $this->Build->Name = $attributes['BUILDNAME'];

--- a/app/Services/SiteService.php
+++ b/app/Services/SiteService.php
@@ -1,17 +1,19 @@
 <?php
 
-namespace App\Http\Submission\Traits;
+declare(strict_types=1);
+
+namespace App\Services;
 
 use App\Models\Site;
 use App\Models\SiteInformation;
 
-trait UpdatesSiteInformation
+class SiteService extends AbstractService
 {
     /**
      * Saves a new site information record if $newInformation is different from the most recent
      * information recorded for the site.
      */
-    protected function updateSiteInfoIfChanged(Site $site, SiteInformation $newInformation): void
+    public static function updateSiteInfoIfChanged(Site $site, SiteInformation $newInformation): void
     {
         if ($site->information()->doesntExist()) {
             // No existing information, so save whatever we're given, regardless of whether it's all null.

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -280,8 +280,6 @@ add_feature_test_in_transaction(/Feature/GraphQL/Mutations/ChangeProjectRoleTest
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/RemoveProjectUserTest)
 
-add_feature_test_in_transaction(/Feature/Traits/UpdatesSiteInformationTest)
-
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/ChangeGlobalRoleTest)
 
 add_feature_test_in_transaction(/Feature/GraphQL/Mutations/JoinProjectTest)
@@ -321,6 +319,8 @@ add_feature_test_in_transaction(/Feature/Jobs/PruneEmailsTest)
 add_feature_test_in_transaction(/Feature/Jobs/ComputeCoverageDifferenceTest)
 
 add_feature_test_in_transaction(/Feature/Services/ProjectServiceTest)
+
+add_feature_test_in_transaction(/Feature/Services/SiteServiceTest)
 
 add_feature_test_in_transaction(/Feature/AutoRemoveBuildsCommand)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22999,12 +22999,6 @@ parameters:
 			path: tests/Feature/RouteAccessTest.php
 
 		-
-			rawMessage: 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type'
-			identifier: phpunit.assertEquals
-			count: 6
-			path: tests/Feature/Traits/UpdatesSiteInformationTest.php
-
-		-
 			rawMessage: Cannot access property $admin on App\Models\User|null.
 			identifier: property.nonObject
 			count: 1

--- a/tests/Browser/Pages/BuildBuildPageTest.php
+++ b/tests/Browser/Pages/BuildBuildPageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\BuildError;
 use App\Models\BuildUpdate;
@@ -11,6 +10,7 @@ use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\SubProject;
+use App\Services\SiteService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
@@ -23,7 +23,6 @@ class BuildBuildPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -59,7 +58,7 @@ class BuildBuildPageTest extends BrowserTestCase
         ]);
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildCommentsPageTest.php
+++ b/tests/Browser/Pages/BuildCommentsPageTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Comment;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\User;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -21,7 +21,6 @@ class BuildCommentsPageTest extends BrowserTestCase
     use CreatesProjects;
     use CreatesSites;
     use CreatesUsers;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
@@ -36,7 +35,7 @@ class BuildCommentsPageTest extends BrowserTestCase
         $this->user = $this->makeNormalUser();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildConfigurePageTest.php
+++ b/tests/Browser/Pages/BuildConfigurePageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\BuildConfigure;
 use App\Models\Configure;
@@ -10,6 +9,7 @@ use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\SubProject;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -20,7 +20,6 @@ class BuildConfigurePageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -59,7 +58,7 @@ class BuildConfigurePageTest extends BrowserTestCase
         ]);
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildCoveragePageTest.php
+++ b/tests/Browser/Pages/BuildCoveragePageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Coverage;
 use App\Models\CoverageFile;
@@ -10,6 +9,7 @@ use App\Models\CoverageView;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -20,7 +20,6 @@ class BuildCoveragePageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Build $build;
@@ -33,7 +32,7 @@ class BuildCoveragePageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         /** @var Build $build */
         $build = $this->project->builds()->create([

--- a/tests/Browser/Pages/BuildDynamicAnalysisIdPageTest.php
+++ b/tests/Browser/Pages/BuildDynamicAnalysisIdPageTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\DynamicAnalysis;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -19,7 +19,6 @@ class BuildDynamicAnalysisIdPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
@@ -31,7 +30,7 @@ class BuildDynamicAnalysisIdPageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildFilesPageTest.php
+++ b/tests/Browser/Pages/BuildFilesPageTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\UploadFile;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -18,7 +18,6 @@ class BuildFilesPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -38,7 +37,7 @@ class BuildFilesPageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         /** @var Build $build */
         $build = $this->project->builds()->create([

--- a/tests/Browser/Pages/BuildNotesPageTest.php
+++ b/tests/Browser/Pages/BuildNotesPageTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Note;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
@@ -19,7 +19,6 @@ class BuildNotesPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -39,7 +38,7 @@ class BuildNotesPageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         /** @var Build $build */
         $build = $this->project->builds()->create([

--- a/tests/Browser/Pages/BuildSidebarComponentTest.php
+++ b/tests/Browser/Pages/BuildSidebarComponentTest.php
@@ -4,7 +4,6 @@ namespace Tests\Browser\Pages;
 
 use App\Enums\BuildCommandType;
 use App\Enums\TargetType;
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\BuildUpdate;
 use App\Models\CoverageFile;
@@ -15,6 +14,7 @@ use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\UploadFile;
 use App\Models\User;
+use App\Services\SiteService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
@@ -28,7 +28,6 @@ class BuildSidebarComponentTest extends BrowserTestCase
     use CreatesProjects;
     use CreatesSites;
     use CreatesUsers;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
@@ -41,7 +40,7 @@ class BuildSidebarComponentTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         $this->user = $this->makeNormalUser();
     }

--- a/tests/Browser/Pages/BuildSummaryPageTest.php
+++ b/tests/Browser/Pages/BuildSummaryPageTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -17,7 +17,6 @@ class BuildSummaryPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Site $site;
@@ -29,7 +28,7 @@ class BuildSummaryPageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildTargetsPageTest.php
+++ b/tests/Browser/Pages/BuildTargetsPageTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Browser\Pages;
 
 use App\Enums\TargetType;
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\Target;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -19,7 +19,6 @@ class BuildTargetsPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -34,7 +33,7 @@ class BuildTargetsPageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         /** @var Build $build */
         $build = $this->project->builds()->create([

--- a/tests/Browser/Pages/BuildTestsPageTest.php
+++ b/tests/Browser/Pages/BuildTestsPageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Project;
 use App\Models\Site;
@@ -10,6 +9,7 @@ use App\Models\SiteInformation;
 use App\Models\SubProject;
 use App\Models\Test;
 use App\Models\TestOutput;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -20,7 +20,6 @@ class BuildTestsPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -41,7 +40,7 @@ class BuildTestsPageTest extends BrowserTestCase
         ]);
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/BuildUpdatePageTest.php
+++ b/tests/Browser/Pages/BuildUpdatePageTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\BuildUpdate;
 use App\Models\BuildUpdateFile;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\BrowserTestCase;
@@ -19,7 +19,6 @@ class BuildUpdatePageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
 
@@ -36,7 +35,7 @@ class BuildUpdatePageTest extends BrowserTestCase
         $this->project = $this->makePublicProject();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         $this->update = BuildUpdate::factory()->create();
 

--- a/tests/Browser/Pages/ProjectsPageTest.php
+++ b/tests/Browser/Pages/ProjectsPageTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\User;
+use App\Services\SiteService;
 use Illuminate\Foundation\Testing\DatabaseTruncation;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -22,7 +22,6 @@ class ProjectsPageTest extends BrowserTestCase
     use CreatesSites;
     use CreatesUsers;
     use DatabaseTruncation;
-    use UpdatesSiteInformation;
 
     /**
      * @var array<User>
@@ -41,7 +40,7 @@ class ProjectsPageTest extends BrowserTestCase
         parent::setUp();
 
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
     }
 
     public function tearDown(): void

--- a/tests/Browser/Pages/TestsIdPageTest.php
+++ b/tests/Browser/Pages/TestsIdPageTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Browser\Pages;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Build;
 use App\Models\Image;
 use App\Models\Project;
@@ -10,6 +9,7 @@ use App\Models\Site;
 use App\Models\SiteInformation;
 use App\Models\Test;
 use App\Models\TestOutput;
+use App\Services\SiteService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
@@ -23,7 +23,6 @@ class TestsIdPageTest extends BrowserTestCase
 {
     use CreatesProjects;
     use CreatesSites;
-    use UpdatesSiteInformation;
 
     private Project $project;
     private Build $build;
@@ -35,7 +34,7 @@ class TestsIdPageTest extends BrowserTestCase
 
         $this->project = $this->makePublicProject();
         $this->site = $this->makeSite();
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation([]));
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation([]));
 
         $this->build = $this->project->builds()->create([
             'siteid' => $this->site->id,

--- a/tests/Feature/Services/SiteServiceTest.php
+++ b/tests/Feature/Services/SiteServiceTest.php
@@ -1,20 +1,19 @@
 <?php
 
-namespace Tests\Feature\Traits;
+namespace Tests\Feature\Services;
 
-use App\Http\Submission\Traits\UpdatesSiteInformation;
 use App\Models\Site;
 use App\Models\SiteInformation;
+use App\Services\SiteService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
 use Tests\Traits\CreatesSites;
 
-class UpdatesSiteInformationTest extends TestCase
+class SiteServiceTest extends TestCase
 {
     use CreatesSites;
     use DatabaseTransactions;
-    use UpdatesSiteInformation;
 
     private Site $site;
 
@@ -39,10 +38,10 @@ class UpdatesSiteInformationTest extends TestCase
         $site_information = new SiteInformation([
             'processorclockfrequency' => 1234,
         ]);
-        $this->updateSiteInfoIfChanged($this->site, $site_information);
+        SiteService::updateSiteInfoIfChanged($this->site, $site_information);
 
         $this->site->refresh();
-        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(1234, $this->site->mostRecentInformation?->processorclockfrequency);
     }
 
     public function testUpdatesWhenChangedInformation(): void
@@ -57,10 +56,10 @@ class UpdatesSiteInformationTest extends TestCase
         $site_information = new SiteInformation([
             'processorclockfrequency' => 2345,
         ]);
-        $this->updateSiteInfoIfChanged($this->site, $site_information);
+        SiteService::updateSiteInfoIfChanged($this->site, $site_information);
 
         $this->site->refresh();
-        self::assertEquals(2345, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(2345, $this->site->mostRecentInformation?->processorclockfrequency);
         self::assertCount(2, $this->site->information()->get());
     }
 
@@ -71,15 +70,15 @@ class UpdatesSiteInformationTest extends TestCase
         ]);
         $this->site->refresh();
         self::assertCount(1, $this->site->information()->get());
-        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(1234, $this->site->mostRecentInformation?->processorclockfrequency);
 
         $site_information = new SiteInformation([
             'processorclockfrequency' => 1234,
         ]);
-        $this->updateSiteInfoIfChanged($this->site, $site_information);
+        SiteService::updateSiteInfoIfChanged($this->site, $site_information);
 
         $this->site->refresh();
-        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(1234, $this->site->mostRecentInformation?->processorclockfrequency);
         self::assertCount(1, $this->site->information()->get());
     }
 
@@ -90,18 +89,18 @@ class UpdatesSiteInformationTest extends TestCase
         ]);
         $this->site->refresh();
         self::assertCount(1, $this->site->information()->get());
-        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(1234, $this->site->mostRecentInformation?->processorclockfrequency);
 
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation());
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation());
 
         $this->site->refresh();
-        self::assertEquals(1234, $this->site->mostRecentInformation?->processorclockfrequency);
+        self::assertSame(1234, $this->site->mostRecentInformation?->processorclockfrequency);
         self::assertCount(1, $this->site->information()->get());
     }
 
     public function testCreatesInitialInformationWhenAllNull(): void
     {
-        $this->updateSiteInfoIfChanged($this->site, new SiteInformation());
+        SiteService::updateSiteInfoIfChanged($this->site, new SiteInformation());
 
         $this->site->refresh();
         self::assertCount(1, $this->site->information()->get());


### PR DESCRIPTION
In the time since the `UpdatesSiteInformation` trait was created, CDash has developed a service layer which is a more appropriate location for these kinds of utility methods.  This PR moves the contents of the `UpdatesSiteInformation` trait to a static method in a new `SiteService`.