### PR TITLE
Remove `tiny-emitter` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "sass": "^1.101.0",
         "sass-loader": "^17.0.0",
         "tailwindcss": "^3.4.17",
-        "tiny-emitter": "^2.1.0",
         "vue": "^3.5.38",
         "vue-echarts": "^8.0.1",
         "vue-loader": "^17.4.2",
@@ -17197,11 +17196,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "sass": "^1.101.0",
     "sass-loader": "^17.0.0",
     "tailwindcss": "^3.4.17",
-    "tiny-emitter": "^2.1.0",
     "vue": "^3.5.38",
     "vue-echarts": "^8.0.1",
     "vue-loader": "^17.4.2",

--- a/resources/js/vue/components/shared/ApiLoader.js
+++ b/resources/js/vue/components/shared/ApiLoader.js
@@ -1,11 +1,4 @@
-import emitter from 'tiny-emitter/instance';
-
 export default {
-  // Replacement emitters for the Vue 2 -> 3 conversion.  TODO: Remove these eventually.
-  // See: https://v3-migration.vuejs.org/breaking-changes/events-api.html#event-bus
-  $on: (...args) => emitter.on(...args),
-  $emit: (...args) => emitter.emit(...args),
-
   loadPageData: function (vm, endpoint_path) {
     vm.start = new Date().getTime();
     vm.$axios
@@ -48,9 +41,6 @@ export default {
         if (document.getElementById('testing-day') && vm.cdash.nightlytime !== undefined) {
           document.getElementById('testing-day').textContent = `| Testing day ${vm.cdash.currentdate} started at ${vm.cdash.nightlytime}`;
         }
-
-        // Let other components know that data has been loaded from the API.
-        this.$emit('api-loaded', vm.cdash);
       })
       .catch(error => {
         console.log(error);


### PR DESCRIPTION
`tiny-emitter` was used to support the migration from Vue 2 to Vue 3, but is no longer necessary because the emitted events are no longer used.