### PR TITLE
Remove direct dependency on `ramsey/uuid`

### DIFF
--- a/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
+++ b/app/cdash/tests/case/CDash/Lib/Repository/GitHubTest.php
@@ -23,8 +23,8 @@ use Github\Api\Repo;
 use Github\Api\Repository\Statuses;
 use Github\Client;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\MockObject\MockObject;
-use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 
 class GitHubTest extends TestCase
@@ -46,7 +46,7 @@ class GitHubTest extends TestCase
     {
         $sut = $this->setupAuthentication();
         $options = [
-            'commit_hash' => str_replace('-', '', Uuid::uuid4()->toString()),
+            'commit_hash' => str_replace('-', '', Str::uuid()->toString()),
             'context' => 'CDash by Kitware',
             'description' => 'Build suchnsuch from site sonso',
             'state' => 'pending',
@@ -355,7 +355,7 @@ class GitHubTest extends TestCase
     public function testCreateCheck(): void
     {
         $sut = $this->setupAuthentication();
-        $sut->createCheck(str_replace('-', '', Uuid::uuid4()->toString()));
+        $sut->createCheck(str_replace('-', '', Str::uuid()->toString()));
     }
 
     public function testDisablePullRequestComments(): void

--- a/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
+++ b/app/cdash/tests/case/CDash/Service/RepositoryServiceTest.php
@@ -20,8 +20,8 @@ use CDash\Model\Build;
 use CDash\Model\BuildUpdate;
 use CDash\Service\RepositoryService;
 use CDash\Test\CDashTestCase;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\MockObject\MockObject;
-use Ramsey\Uuid\Uuid;
 
 class RepositoryServiceTest extends CDashTestCase
 {
@@ -46,7 +46,7 @@ class RepositoryServiceTest extends CDashTestCase
     {
         $sut = new RepositoryService($this->repository);
 
-        $hash = str_replace('-', '', Uuid::uuid4()->toString());
+        $hash = str_replace('-', '', Str::uuid()->toString());
 
         $buildUpdate = new BuildUpdate();
         $buildUpdate->Revision = $hash;

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "nuwave/lighthouse": "6.65.0",
     "pear/archive_tar": "1.6.0",
     "php-di/php-di": "7.1.1",
-    "ramsey/uuid": "4.9.3",
     "sebastian/diff": "7.0.0",
     "socialiteproviders/github": "4.1.0",
     "socialiteproviders/gitlab": "4.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a1b7f91d881caca6eccb066639b4407",
+    "content-hash": "f74383c4a29e2057c4425b2db055c0c0",
     "packages": [
         {
             "name": "24slides/laravel-saml2",
@@ -12602,5 +12602,5 @@
     "platform-dev": {
         "ext-zip": "*"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`ramsey/uuid` is an important transitive dependency currently listed directly in our `composer.json`.  This PR removes it from our list of direct dependencies, allowing the dependencies which require it to specify their own version constraints.