### PR TITLE
Remove `axios-mock-adapter` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@eslint/js": "^10.0.1",
         "@vue/test-utils": "^2.4.11",
         "@vue/vue3-jest": "^29.2.6",
-        "axios-mock-adapter": "^2.1.0",
         "babel-core": "^7.0.0-bridge.0",
         "cypress": "14.5.3",
         "eslint": "^10.5.0",
@@ -5381,19 +5380,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/axios-mock-adapter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
-      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "is-buffer": "^2.0.5"
-      },
-      "peerDependencies": {
-        "axios": ">= 0.17.0"
-      }
-    },
     "node_modules/axios/node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -10389,29 +10375,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-callable": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@eslint/js": "^10.0.1",
     "@vue/test-utils": "^2.4.11",
     "@vue/vue3-jest": "^29.2.6",
-    "axios-mock-adapter": "^2.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "cypress": "14.5.3",
     "eslint": "^10.5.0",


### PR DESCRIPTION
`axios-mock-adapter` is no longer used, since all of the Jest spec tests which used it to mock Axios requests have been replaced by various forms of browser tests.