### PR TITLE
Return 400 code instead of 500 on missing test details query param

### DIFF
--- a/app/cdash/app/Controller/Api/TestDetails.php
+++ b/app/cdash/app/Controller/Api/TestDetails.php
@@ -17,7 +17,6 @@
 
 namespace CDash\Controller\Api;
 
-use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -54,6 +53,6 @@ class TestDetails extends BuildTestApi
             );
         }
 
-        throw new Exception('fileid query parameter is required');
+        abort(400, 'fileid query parameter is required');
     }
 }


### PR DESCRIPTION
The test details API is now used exclusively to download files, and presents an error message stating as much when the `fileid` query parameter isn't provided.  This message is logged as an error, even though it's a validation issue with the client's request.  This PR changes the response code to 400 to make it more clear what the problem is, and prevent these types of requests from leaving stack traces in the logs.