### PR TITLE
Add `NoteFactory`

### DIFF
--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use Database\Factories\NoteFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
@@ -15,6 +17,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  */
 class Note extends Model
 {
+    /** @use HasFactory<NoteFactory> */
+    use HasFactory;
+
     protected $table = 'note';
 
     public $timestamps = false;

--- a/database/factories/NoteFactory.php
+++ b/database/factories/NoteFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Note;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Note>
+ */
+class NoteFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => Str::uuid()->toString(),
+            'text' => Str::uuid()->toString(),
+        ];
+    }
+}

--- a/tests/Browser/Pages/BuildNotesPageTest.php
+++ b/tests/Browser/Pages/BuildNotesPageTest.php
@@ -64,10 +64,7 @@ class BuildNotesPageTest extends BrowserTestCase
 
     private function addNote(): Note
     {
-        $note = Note::create([
-            'name' => Str::uuid()->toString(),
-            'text' => Str::uuid()->toString(),
-        ]);
+        $note = Note::factory()->create();
 
         $this->build->notes()->attach($note);
 

--- a/tests/Browser/Pages/BuildSidebarComponentTest.php
+++ b/tests/Browser/Pages/BuildSidebarComponentTest.php
@@ -348,10 +348,7 @@ class BuildSidebarComponentTest extends BrowserTestCase
             $this->assertDisabled($browser, "/builds/{$build->id}", '@sidebar-notes');
 
             $build->notes()->attach(
-                Note::create([
-                    'name' => Str::uuid()->toString(),
-                    'text' => Str::uuid()->toString(),
-                ])
+                Note::factory()->create()
             );
 
             $this->assertNotDisabled($browser, "/builds/{$build->id}", '@sidebar-notes', "/builds/{$build->id}/notes");

--- a/tests/Feature/GraphQL/NoteTypeTest.php
+++ b/tests/Feature/GraphQL/NoteTypeTest.php
@@ -45,20 +45,9 @@ class NoteTypeTest extends TestCase
         $this->public_project = $this->makePublicProject();
         $this->private_project = $this->makePrivateProject();
 
-        $this->note1 = Note::create([
-            'name' => Str::uuid()->toString(),
-            'text' => Str::uuid()->toString(),
-        ]);
-
-        $this->note2 = Note::create([
-            'name' => Str::uuid()->toString(),
-            'text' => Str::uuid()->toString(),
-        ]);
-
-        $this->note3 = Note::create([
-            'name' => Str::uuid()->toString(),
-            'text' => Str::uuid()->toString(),
-        ]);
+        $this->note1 = Note::factory()->create();
+        $this->note2 = Note::factory()->create();
+        $this->note3 = Note::factory()->create();
 
         $this->public_project->builds()->create([
             'name' => 'build1',


### PR DESCRIPTION
This continues our ongoing effort to generate test data via factories instead of saving models directly.