### PR TITLE
Add route caching

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,20 @@ php artisan lighthouse:cache
 if $DEVELOPMENT; then
   # Wipe the cache in case we're coming from a non-dev install
   php artisan config:clear
+  php artisan route:clear
 else
   php artisan config:cache
+
+  # Cache routes if we are at the root path (e.g., https://example.com)
+  # but not if we are in a subdirectory (e.g., https://example.com/cdash).
+  # Laravel does not support route caching when the app is hosted in a subdirectory.
+  APP_URL=$(php artisan config:show app.url)
+  SLASH_COUNT=$(echo "$APP_URL" | grep -o "/" | wc -l)
+  if [[ "$SLASH_COUNT" -eq 2 ]]; then
+    php artisan route:cache
+  else
+    php artisan route:clear
+  fi
 fi
 
 if $INITIAL_DOCKER_INSTALL; then


### PR DESCRIPTION
Laravel recommends enabling route caching for production apps.  Unfortunately, route caching does not work for apps hosted from a subdirectory, which led to it being removed in https://github.com/Kitware/CDash/pull/2276.  Local testing shows a roughly 40% improvement in baseline request handling time with route caching enabled.  This PR re-adds route caching, but only for CDash instances hosted at the root path, allowing virtually all CDash instances to benefit from this performance improvement while continuing to support CDash-in-a-subdirectory instances.