### PR TITLE
Convert project role column to enum

### DIFF
--- a/app/GraphQL/Mutations/ChangeProjectRole.php
+++ b/app/GraphQL/Mutations/ChangeProjectRole.php
@@ -61,8 +61,8 @@ final class ChangeProjectRole extends AbstractMutation
 
         $rowsEdited = $userToChange->projects()->updateExistingPivot($project->id, [
             'role' => match ($args['role']) {
-                ProjectRole::USER => Project::PROJECT_USER,
-                ProjectRole::ADMINISTRATOR => Project::PROJECT_ADMIN,
+                ProjectRole::USER => ProjectRole::USER,
+                ProjectRole::ADMINISTRATOR => ProjectRole::ADMINISTRATOR,
             },
         ]);
 

--- a/app/GraphQL/Mutations/CreateProject.php
+++ b/app/GraphQL/Mutations/CreateProject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Services\ProjectService;
 use Illuminate\Support\Facades\Gate;
@@ -25,7 +26,7 @@ class CreateProject
             'emailcategory' => 62,
             'emailsuccess' => false,
             'emailmissingsites' => false,
-            'role' => Project::PROJECT_ADMIN,
+            'role' => ProjectRole::ADMINISTRATOR,
         ]);
 
         $user = auth()->user();

--- a/app/GraphQL/Mutations/JoinProject.php
+++ b/app/GraphQL/Mutations/JoinProject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Mutations;
 
+use App\Enums\ProjectRole;
 use App\Exceptions\GraphQLMutationException;
 use App\Models\Project;
 use App\Models\User;
@@ -39,7 +40,7 @@ final class JoinProject extends AbstractMutation
                 'emailcategory' => 62,
                 'emailsuccess' => false,
                 'emailmissingsites' => false,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         Log::info("User {$user->id} joined project {$project->id}.");

--- a/app/Http/Controllers/ProjectInvitationController.php
+++ b/app/Http/Controllers/ProjectInvitationController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Enums\ProjectRole;
-use App\Models\Project;
 use App\Models\ProjectInvitation;
 use App\Models\User;
 use Exception;
@@ -45,7 +44,7 @@ final class ProjectInvitationController extends AbstractController
             abort(401, 'Cannot accept self-invitation.');
         }
 
-        $role = $user_invite->role === ProjectRole::ADMINISTRATOR ? Project::PROJECT_ADMIN : Project::PROJECT_USER;
+        $role = $user_invite->role === ProjectRole::ADMINISTRATOR ? ProjectRole::ADMINISTRATOR : ProjectRole::USER;
 
         $user->projects()->attach($user_invite->project_id, [
             'role' => $role,

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ProjectRole;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
@@ -138,9 +139,6 @@ class Project extends Model
         'authenticatesubmissions' => false,
     ];
 
-    public const PROJECT_ADMIN = 2;
-    public const PROJECT_USER = 0;
-
     public const ACCESS_PRIVATE = 0;
     public const ACCESS_PUBLIC = 1;
     public const ACCESS_PROTECTED = 2;
@@ -194,7 +192,7 @@ class Project extends Model
     public function basicUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'user2project', 'projectid', 'userid')
-            ->wherePivot('role', self::PROJECT_USER);
+            ->wherePivot('role', ProjectRole::USER);
     }
 
     /**
@@ -205,7 +203,7 @@ class Project extends Model
     public function administrators(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'user2project', 'projectid', 'userid')
-            ->wherePivot('role', self::PROJECT_ADMIN);
+            ->wherePivot('role', ProjectRole::ADMINISTRATOR);
     }
 
     /**

--- a/app/Utils/LdapUtils.php
+++ b/app/Utils/LdapUtils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Utils;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\User;
 use Exception;
@@ -57,7 +58,7 @@ class LdapUtils
             }
 
             if ($matches_ldap_filter && !$relationship_already_exists) {
-                $project->users()->attach($user->id, ['role' => Project::PROJECT_USER]);
+                $project->users()->attach($user->id, ['role' => ProjectRole::USER]);
                 Log::info("Added user $user->email to project $project->name.");
             } elseif (!$matches_ldap_filter && $relationship_already_exists) {
                 $project->users()->detach($user->id);

--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -23,6 +23,7 @@ define('FMT_DATETIMETZ', 'Y-m-d\TH:i:s T');  // date and time with time zone
 define('FMT_DATETIMEMS', 'Y-m-d\TH:i:s.u');  // date and time with milliseconds
 define('FMT_DATETIMEDISPLAY', 'M d, Y - H:i T');  // date and time standard
 
+use App\Enums\ProjectRole;
 use App\Http\Controllers\AbstractController;
 use App\Models\Site;
 use App\Utils\DatabaseCleanupUtils;
@@ -609,8 +610,8 @@ function get_dashboard_JSON($projectname, $date, &$response): void
     $userid = Auth::id();
     if ($userid) {
         $project = App\Models\Project::findOrFail((int) $project->Id);
-        $response['projectrole'] = (int) ($project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? 0);
-        if ($response['projectrole'] === App\Models\Project::PROJECT_ADMIN) {
+        $response['projectrole'] = $project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? ProjectRole::USER;
+        if ($response['projectrole'] === ProjectRole::ADMINISTRATOR) {
             $response['user']['admin'] = 1;
         }
     }

--- a/app/cdash/tests/kwtest/kw_web_tester.php
+++ b/app/cdash/tests/kwtest/kw_web_tester.php
@@ -24,6 +24,7 @@ if (!defined('LARAVEL_START')) {
     define('LARAVEL_START', microtime(true));
 }
 
+use App\Enums\ProjectRole;
 use App\Http\Kernel;
 use App\Models\User;
 use CDash\Model\Project;
@@ -449,7 +450,7 @@ class KWWebTestCase extends WebTestCase
                     'emailcategory' => 126,
                     'emailsuccess' => false,
                     'emailmissingsites' => false,
-                    'role' => App\Models\Project::PROJECT_ADMIN,
+                    'role' => ProjectRole::ADMINISTRATOR,
                 ]);
 
             $projectid = $eloquent_project->id;

--- a/app/cdash/tests/test_authtoken.php
+++ b/app/cdash/tests/test_authtoken.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/cdash_test_case.php';
 
+use App\Enums\ProjectRole;
 use App\Models\AuthToken;
 use App\Models\Project as EloquentProject;
 use App\Models\User;
@@ -60,7 +61,7 @@ class AuthTokenTestCase extends KWWebTestCase
                 'emailcategory' => 126,
                 'emailsuccess' => false,
                 'emailmissingsites' => false,
-                'role' => EloquentProject::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
     }
 

--- a/app/cdash/tests/test_email.php
+++ b/app/cdash/tests/test_email.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\ProjectRole;
 use App\Enums\TestDiffType;
 use App\Models\Site;
 use App\Models\User;
@@ -44,7 +45,7 @@ class EmailTestCase extends KWWebTestCase
         }
 
         $user->projects()->attach($this->project, [
-            'role' => 0,
+            'role' => ProjectRole::USER,
             'emailtype' => 1,
             'emailcategory' => 126,
             'emailsuccess' => 1,
@@ -77,7 +78,7 @@ class EmailTestCase extends KWWebTestCase
                 role,
                 emailtype
             ) VALUES (?, ?, ?, ?)
-        ', [$user->id, $this->project, 0, 0]);
+        ', [$user->id, $this->project, ProjectRole::USER->value, 0]);
     }
 
     public function testSubmissionFirstBuild(): void

--- a/app/cdash/tests/test_issuecreation.php
+++ b/app/cdash/tests/test_issuecreation.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\ProjectRole;
 use App\Models\Project as EloquentProject;
 use App\Models\User;
 use App\Utils\RepositoryUtils;
@@ -96,7 +97,7 @@ class IssueCreationTestCase extends KWWebTestCase
                 'emailcategory' => 126,
                 'emailsuccess' => false,
                 'emailmissingsites' => false,
-                'role' => EloquentProject::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         // Setup subprojects.

--- a/app/cdash/tests/test_projectindb.php
+++ b/app/cdash/tests/test_projectindb.php
@@ -4,6 +4,8 @@
 // After including cdash_test_case.php, subsequent require_once calls are
 // relative to the top of the CDash source tree
 //
+use App\Enums\ProjectRole;
+
 require_once __DIR__ . '/cdash_test_case.php';
 
 class ProjectInDbTestCase extends KWWebTestCase
@@ -63,7 +65,7 @@ class ProjectInDbTestCase extends KWWebTestCase
         $query = 'SELECT userid, role, emailtype, emailcategory FROM user2project WHERE projectid=' . $this->projecttestid;
         $result = $this->db->query($query);
         $expected = ['userid' => 1,
-            'role' => 2,
+            'role' => ProjectRole::ADMINISTRATOR->value,
             'emailtype' => 3,
             'emailcategory' => 126];
         $this->assertEqual($result[0], $expected);

--- a/database/migrations/2026_07_27_221552_project_role_enum.php
+++ b/database/migrations/2026_07_27_221552_project_role_enum.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // We drop the type first in case the database has been truncated previously.
+        DB::statement('DROP TYPE IF EXISTS projectrole');
+        DB::statement("CREATE TYPE projectrole AS ENUM ('USER', 'ADMINISTRATOR')");
+
+        DB::statement('ALTER TABLE user2project ALTER COLUMN role DROP DEFAULT');
+
+        DB::statement("
+            ALTER TABLE user2project
+            ALTER COLUMN role TYPE projectrole
+            USING CASE role
+                WHEN 0 THEN 'USER'::projectrole
+                WHEN 2 THEN 'ADMINISTRATOR'::projectrole
+                ELSE 'USER'::projectrole
+            END
+        ");
+
+        DB::statement("ALTER TABLE user2project ALTER COLUMN role SET DEFAULT 'USER'::projectrole");
+
+        DB::statement("
+            ALTER TABLE project_invitations
+            ALTER COLUMN role TYPE projectrole
+            USING CASE role
+                WHEN 'USER' THEN 'USER'::projectrole
+                WHEN 'ADMINISTRATOR' THEN 'ADMINISTRATOR'::projectrole
+                ELSE 'USER'::projectrole
+            END
+        ");
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15082,19 +15082,19 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::__construct() has parameter $response with no type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::__construct() has parameter $response with no type specified.'
 			identifier: missingType.parameter
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::getSent() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::getSent() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::read() has no return type specified.'
+			rawMessage: 'Method class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::read() has no return type specified.'
 			identifier: missingType.return
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php
@@ -15322,7 +15322,7 @@ parameters:
 			path: app/cdash/tests/kwtest/kw_web_tester.php
 
 		-
-			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:799::$read has no type specified.
+			rawMessage: Property class@anonymous/app/cdash/tests/kwtest/kw_web_tester.php:800::$read has no type specified.
 			identifier: missingType.property
 			count: 1
 			path: app/cdash/tests/kwtest/kw_web_tester.php

--- a/tests/Browser/Pages/ProfilePageTest.php
+++ b/tests/Browser/Pages/ProfilePageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser\Pages;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Support\Str;
@@ -261,7 +262,7 @@ class ProfilePageTest extends BrowserTestCase
     {
         $this->users['admin'] = User::factory()->adminUser()->create();
         $this->projects['project'] = $this->makePublicProject();
-        $this->projects['project']->users()->attach($this->users['admin'], ['role' => Project::PROJECT_USER]);
+        $this->projects['project']->users()->attach($this->users['admin'], ['role' => ProjectRole::USER]);
         $description = Str::uuid()->toString();
 
         $this->browse(function (Browser $browser) use ($description): void {

--- a/tests/Browser/Pages/ProjectMembersPageTest.php
+++ b/tests/Browser/Pages/ProjectMembersPageTest.php
@@ -46,7 +46,7 @@ class ProjectMembersPageTest extends BrowserTestCase
         $this->users[] = $user;
 
         $this->project->users()->attach($user->id, [
-            'role' => $admin ? Project::PROJECT_ADMIN : Project::PROJECT_USER,
+            'role' => $admin ? ProjectRole::ADMINISTRATOR : ProjectRole::USER,
         ]);
 
         return $user;
@@ -82,7 +82,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -105,7 +105,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -152,7 +152,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -176,7 +176,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -276,7 +276,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -301,7 +301,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         self::assertNotContains($this->users['normal']->id, $this->project->administrators()->pluck('id'));
@@ -337,7 +337,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->project
@@ -347,7 +347,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -372,7 +372,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->browse(function (Browser $browser): void {
@@ -396,7 +396,7 @@ class ProjectMembersPageTest extends BrowserTestCase
                     'emailcategory' => 0,
                     'emailsuccess' => true,
                     'emailmissingsites' => true,
-                    'role' => Project::PROJECT_USER,
+                    'role' => ProjectRole::USER,
                 ]);
         }
 

--- a/tests/Browser/Pages/ProjectsPageTest.php
+++ b/tests/Browser/Pages/ProjectsPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser\Pages;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\SiteInformation;
@@ -165,7 +166,7 @@ class ProjectsPageTest extends BrowserTestCase
                     ;
                 });
 
-            $this->projects['project1']->users()->attach($this->users['admin'], ['role' => Project::PROJECT_USER]);
+            $this->projects['project1']->users()->attach($this->users['admin'], ['role' => ProjectRole::USER]);
 
             $browser->loginAs($this->users['admin'])
                 ->visit('/projects')
@@ -300,7 +301,7 @@ class ProjectsPageTest extends BrowserTestCase
                 'submittime' => Carbon::now(),
             ]);
 
-            $project->users()->attach($this->users['admin'], ['role' => Project::PROJECT_USER]);
+            $project->users()->attach($this->users['admin'], ['role' => ProjectRole::USER]);
         }
 
         // The first project created has the lowest ID (first pagination page) and the last has

--- a/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
+++ b/tests/Feature/GraphQL/Mutations/ChangeProjectRoleTest.php
@@ -42,7 +42,7 @@ class ChangeProjectRoleTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->project
@@ -52,7 +52,7 @@ class ChangeProjectRoleTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
     }
 

--- a/tests/Feature/GraphQL/Mutations/CreateAuthenticationTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateAuthenticationTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
+use App\Enums\ProjectRole;
 use App\Models\AuthToken;
 use App\Models\Project;
 use App\Models\User;
@@ -53,10 +54,10 @@ class CreateAuthenticationTokenTest extends TestCase
         return [
             [null, null, false],
             ['normal', null, false],
-            ['normal', Project::PROJECT_USER, true],
-            ['normal', Project::PROJECT_ADMIN, true],
-            ['admin', Project::PROJECT_USER, true],
-            ['admin', Project::PROJECT_ADMIN, true],
+            ['normal', ProjectRole::USER, true],
+            ['normal', ProjectRole::ADMINISTRATOR, true],
+            ['admin', ProjectRole::USER, true],
+            ['admin', ProjectRole::ADMINISTRATOR, true],
             ['admin', null, true],
         ];
     }
@@ -64,7 +65,7 @@ class CreateAuthenticationTokenTest extends TestCase
     #[DataProvider('projectScopedSubmitOnlyTokenCreationPermissionsCases')]
     public function testProjectScopedSubmitOnlyTokenCreationPermissions(
         ?string $user,
-        ?int $projectRole,
+        ?ProjectRole $projectRole,
         bool $canCreateAuthToken,
     ): void {
         $project = $this->makePublicProject();
@@ -225,7 +226,7 @@ class CreateAuthenticationTokenTest extends TestCase
 
         $user = User::factory()->adminUser()->create();
         $project = $this->makePublicProject();
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
 
         self::assertDatabaseEmpty(AuthToken::class);
 
@@ -313,7 +314,7 @@ class CreateAuthenticationTokenTest extends TestCase
     {
         $user = User::factory()->adminUser()->create();
         $project = $this->makePublicProject();
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
 
         self::assertDatabaseEmpty(AuthToken::class);
 

--- a/tests/Feature/GraphQL/Mutations/CreateRepositoryTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateRepositoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
-use App\Models\Project;
+use App\Enums\ProjectRole;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -99,7 +99,7 @@ class CreateRepositoryTest extends TestCase
     {
         $project = $this->makePublicProject();
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
 
         $this->actingAs($user)->graphQL('
             mutation createRepository($input: CreateRepositoryInput!) {
@@ -127,7 +127,7 @@ class CreateRepositoryTest extends TestCase
     {
         $project = $this->makePublicProject();
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
 
         $url = fake()->url();
         $username = Str::uuid()->toString();

--- a/tests/Feature/GraphQL/Mutations/DeleteAuthenticationTokenTest.php
+++ b/tests/Feature/GraphQL/Mutations/DeleteAuthenticationTokenTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
+use App\Enums\ProjectRole;
 use App\Models\AuthToken;
-use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
@@ -152,7 +152,7 @@ class DeleteAuthenticationTokenTest extends TestCase
         ]));
 
         $projectUser = User::factory()->create();
-        $project->users()->attach($projectUser, ['role' => Project::PROJECT_ADMIN]);
+        $project->users()->attach($projectUser, ['role' => ProjectRole::ADMINISTRATOR]);
 
         self::assertDatabaseCount(AuthToken::class, 1);
 
@@ -188,7 +188,7 @@ class DeleteAuthenticationTokenTest extends TestCase
         ]));
 
         $projectUser = User::factory()->create();
-        $project->users()->attach($projectUser, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($projectUser, ['role' => ProjectRole::USER]);
 
         self::assertDatabaseCount(AuthToken::class, 1);
 

--- a/tests/Feature/GraphQL/Mutations/DeleteRepositoryTest.php
+++ b/tests/Feature/GraphQL/Mutations/DeleteRepositoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
-use App\Models\Project;
+use App\Enums\ProjectRole;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -86,7 +86,7 @@ class DeleteRepositoryTest extends TestCase
         $user = User::factory()->create();
         $project = $this->makePublicProject();
         $repository = $project->repositories()->save(Repository::factory()->make());
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
         self::assertInstanceOf(Repository::class, $repository);
 
         self::assertDatabaseCount(Repository::class, 1);
@@ -111,7 +111,7 @@ class DeleteRepositoryTest extends TestCase
         $user = User::factory()->create();
         $project = $this->makePublicProject();
         $repository = $project->repositories()->save(Repository::factory()->make());
-        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
         self::assertInstanceOf(Repository::class, $repository);
 
         self::assertDatabaseCount(Repository::class, 1);

--- a/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/InviteToProjectTest.php
@@ -160,7 +160,7 @@ class InviteToProjectTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->actingAs($this->users['normal'])->graphQL('
@@ -202,7 +202,7 @@ class InviteToProjectTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         $this->actingAs($this->users['normal'])->graphQL('
@@ -252,7 +252,7 @@ class InviteToProjectTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         $this->actingAs($this->users['normal'])->graphQL('
@@ -420,7 +420,7 @@ class InviteToProjectTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->actingAs($this->users['admin'])->graphQL('

--- a/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
+++ b/tests/Feature/GraphQL/Mutations/RemoveProjectUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -47,7 +48,7 @@ class RemoveProjectUserTest extends TestCase
         $this->users[] = $user;
 
         $this->project->users()->attach($user->id, [
-            'role' => $admin ? Project::PROJECT_ADMIN : Project::PROJECT_USER,
+            'role' => $admin ? ProjectRole::ADMINISTRATOR : ProjectRole::USER,
         ]);
 
         return $user;

--- a/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
+++ b/tests/Feature/GraphQL/Mutations/RevokeProjectInvitationTest.php
@@ -154,7 +154,7 @@ class RevokeProjectInvitationTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         self::assertCount(1, $this->project->invitations()->get());
@@ -192,7 +192,7 @@ class RevokeProjectInvitationTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
 
         self::assertCount(1, $this->project->invitations()->get());

--- a/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
+++ b/tests/Feature/GraphQL/Mutations/UpdateProjectTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\GraphQL\Mutations;
 
-use App\Models\Project;
+use App\Enums\ProjectRole;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Config;
@@ -87,7 +87,7 @@ class UpdateProjectTest extends TestCase
         $project = $this->makePublicProject();
         $original_name = $project->name;
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
 
         $this->actingAs($user)->graphQL('
             mutation updateProject($input: UpdateProjectInput!) {
@@ -111,7 +111,7 @@ class UpdateProjectTest extends TestCase
     {
         $project = $this->makePublicProject();
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
 
         $name = Str::uuid()->toString();
         $this->actingAs($user)->graphQL('
@@ -355,7 +355,7 @@ class UpdateProjectTest extends TestCase
             $user = User::factory()->adminUser()->create();
         } elseif ($userRole === 'project_admin') {
             $user = User::factory()->create();
-            $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+            $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
         }
 
         $response = $this->actingAs($user)->graphQL('
@@ -413,7 +413,7 @@ class UpdateProjectTest extends TestCase
             $user = User::factory()->adminUser()->create();
         } elseif ($userRole === 'project_admin') {
             $user = User::factory()->create();
-            $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+            $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
         }
 
         $response = $this->actingAs($user)->graphQL('

--- a/tests/Feature/GraphQL/ProjectTypeTest.php
+++ b/tests/Feature/GraphQL/ProjectTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\TestOutput;
 use App\Models\User;
@@ -58,23 +59,23 @@ class ProjectTypeTest extends TestCase
 
         $this->projects['public1']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_ADMIN]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::ADMINISTRATOR]);
 
         $this->projects['public1']
             ->users()
-            ->attach($this->users['admin']->id, $user2project_data + ['role' => Project::PROJECT_ADMIN]);
+            ->attach($this->users['admin']->id, $user2project_data + ['role' => ProjectRole::ADMINISTRATOR]);
 
         $this->projects['protected2']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::USER]);
 
         $this->projects['private1']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::USER]);
 
         $this->projects['private2']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_ADMIN]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::ADMINISTRATOR]);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/GraphQL/QueryTypeTest.php
+++ b/tests/Feature/GraphQL/QueryTypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Enums\BuildCommandType;
+use App\Enums\ProjectRole;
 use App\Models\AuthToken;
 use App\Models\BuildCommand;
 use App\Models\DynamicAnalysis;
@@ -186,7 +187,7 @@ class QueryTypeTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
         /** @var BuildCommand $command1 */
         $command1 = $project1->builds()->create([
@@ -260,7 +261,7 @@ class QueryTypeTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
         /** @var DynamicAnalysis $da1 */
         $da1 = $project1->builds()->create([
@@ -401,7 +402,7 @@ class QueryTypeTest extends TestCase
         $project1 = $this->makePrivateProject();
         $project1->users()
             ->attach($user->id, [
-                'role' => Project::PROJECT_ADMIN,
+                'role' => ProjectRole::ADMINISTRATOR,
             ]);
         /** @var Test $test1 */
         $test1 = $project1->builds()->create([

--- a/tests/Feature/GraphQL/SiteTypeTest.php
+++ b/tests/Feature/GraphQL/SiteTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\Site;
 use App\Models\User;
@@ -56,11 +57,11 @@ class SiteTypeTest extends TestCase
 
         $this->projects['public1']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::USER]);
 
         $this->projects['private1']
             ->users()
-            ->attach($this->users['normal']->id, $user2project_data + ['role' => Project::PROJECT_USER]);
+            ->attach($this->users['normal']->id, $user2project_data + ['role' => ProjectRole::USER]);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/GraphQL/UserTypeTest.php
+++ b/tests/Feature/GraphQL/UserTypeTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Enums\ProjectRole;
 use App\Models\AuthToken;
-use App\Models\Project;
 use App\Models\User;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -186,22 +186,22 @@ class UserTypeTest extends TestCase
         $privateProject = $this->makePrivateProject();
 
         $projectUser = User::factory()->create();
-        $publicProject->users()->attach($projectUser, ['role' => Project::PROJECT_USER]);
-        $protectedProject->users()->attach($projectUser, ['role' => Project::PROJECT_USER]);
-        $privateProject->users()->attach($projectUser, ['role' => Project::PROJECT_USER]);
+        $publicProject->users()->attach($projectUser, ['role' => ProjectRole::USER]);
+        $protectedProject->users()->attach($projectUser, ['role' => ProjectRole::USER]);
+        $privateProject->users()->attach($projectUser, ['role' => ProjectRole::USER]);
 
         if ($user === 'normal') {
             $user = User::factory()->create();
         } elseif ($user === 'project_member') {
             $user = User::factory()->create();
-            $publicProject->users()->attach($user, ['role' => Project::PROJECT_USER]);
-            $protectedProject->users()->attach($user, ['role' => Project::PROJECT_USER]);
-            $privateProject->users()->attach($user, ['role' => Project::PROJECT_USER]);
+            $publicProject->users()->attach($user, ['role' => ProjectRole::USER]);
+            $protectedProject->users()->attach($user, ['role' => ProjectRole::USER]);
+            $privateProject->users()->attach($user, ['role' => ProjectRole::USER]);
         } elseif ($user === 'project_admin') {
             $user = User::factory()->create();
-            $publicProject->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
-            $protectedProject->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
-            $privateProject->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+            $publicProject->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
+            $protectedProject->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
+            $privateProject->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
         } elseif ($user === 'admin') {
             $user = User::factory()->adminUser()->create();
         } elseif ($user === null) {

--- a/tests/Feature/ProjectInvitationAcceptanceTest.php
+++ b/tests/Feature/ProjectInvitationAcceptanceTest.php
@@ -107,7 +107,7 @@ class ProjectInvitationAcceptanceTest extends TestCase
                 'emailcategory' => 0,
                 'emailsuccess' => true,
                 'emailmissingsites' => true,
-                'role' => Project::PROJECT_USER,
+                'role' => ProjectRole::USER,
             ]);
 
         $this->actingAs($this->users['normal'])

--- a/tests/Feature/ProjectPermissions.php
+++ b/tests/Feature/ProjectPermissions.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -99,7 +100,7 @@ class ProjectPermissions extends TestCase
         DB::table('user2project')->insert([
             'userid' => $this->normal_user->id,
             'projectid' => $this->private_project1->id,
-            'role' => 0,
+            'role' => ProjectRole::USER,
             'emailtype' => 0,
             'emailcategory' => 0,
             'emailsuccess' => 0,

--- a/tests/Feature/UpdateProjectLogoTest.php
+++ b/tests/Feature/UpdateProjectLogoTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Models\Project;
+use App\Enums\ProjectRole;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\UploadedFile;
@@ -63,7 +63,7 @@ class UpdateProjectLogoTest extends TestCase
     {
         $project = $this->makePublicProject();
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_USER]);
+        $project->users()->attach($user, ['role' => ProjectRole::USER]);
 
         $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
             'logo' => UploadedFile::fake()->image('logo.jpg'),
@@ -78,7 +78,7 @@ class UpdateProjectLogoTest extends TestCase
         Storage::fake('public');
         $project = $this->makePublicProject();
         $user = User::factory()->create();
-        $project->users()->attach($user, ['role' => Project::PROJECT_ADMIN]);
+        $project->users()->attach($user, ['role' => ProjectRole::ADMINISTRATOR]);
 
         $response = $this->actingAs($user)->postJson("/projects/{$project->id}/logo", [
             'logo' => UploadedFile::fake()->image('logo.jpg'),


### PR DESCRIPTION
The project role is currently represented as an integer, with constants in app code to refer to magic integer values.  This PR converts the project role column to an enum type so there's no confusion about what the valid values are.  This will be particularly important for my upcoming PR which will add another table which references the project role.