### PR TITLE
Republish Lighthouse configuration

### DIFF
--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -20,6 +20,7 @@ use Nuwave\Lighthouse\Schema\Directives\SpreadDirective;
 use Nuwave\Lighthouse\Schema\Directives\TransformArgsDirective;
 use Nuwave\Lighthouse\Schema\Directives\TrimDirective;
 use Nuwave\Lighthouse\Subscriptions\SubscriptionRouter;
+use Nuwave\Lighthouse\Tracing\ApolloTracing\ApolloTracing;
 use Nuwave\Lighthouse\Validation\ValidateDirective;
 
 return [
@@ -146,15 +147,70 @@ return [
         'enable' => env('LIGHTHOUSE_QUERY_CACHE_ENABLE', true),
 
         /*
+         * Configures which mechanism to use for the query cache.
+         * - store: use an external shared cache through a Laravel cache store like Redis or Memcached
+         * - opcache: store parsed queries in PHP files on the local filesystem to leverage OPcache
+         * - hybrid: leverage OPcache, but use a shared cache store when local files are not found
+         */
+        'mode' => env('LIGHTHOUSE_QUERY_CACHE_MODE', 'hybrid'),
+
+        /*
+         * Specifies the path where the PHP files are stored when using opcache or hybrid mode.
+         * The given path must be a folder, as every query will produce its own file.
+         */
+        'opcache_path' => env('LIGHTHOUSE_QUERY_CACHE_OPCACHE_PATH', base_path('bootstrap/cache')),
+
+        /*
          * Allows using a specific cache store, uses the app's default if set to null.
+         * Not relevant when using opcache mode.
          */
         'store' => env('LIGHTHOUSE_QUERY_CACHE_STORE', null),
 
         /*
          * Duration in seconds the query should remain cached, null means forever.
+         * Not relevant when using opcache mode.
          */
         'ttl' => env('LIGHTHOUSE_QUERY_CACHE_TTL', 24 * 60 * 60),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Cache
+    |--------------------------------------------------------------------------
+    |
+    | Caches the result of validating queries to boost performance on subsequent requests.
+    |
+    */
+
+    'validation_cache' => [
+        /*
+         * Setting to true enables validation caching.
+         */
+        'enable' => env('LIGHTHOUSE_VALIDATION_CACHE_ENABLE', true),
+
+        /*
+         * Allows using a specific cache store, uses the app's default if set to null.
+         */
+        'store' => env('LIGHTHOUSE_VALIDATION_CACHE_STORE', null),
+
+        /*
+         * Duration in seconds the validation result should remain cached, null means forever.
+         */
+        'ttl' => env('LIGHTHOUSE_VALIDATION_CACHE_TTL', 24 * 60 * 60),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Parse source location
+    |--------------------------------------------------------------------------
+    |
+    | Should the source location be included in the AST nodes resulting from query parsing?
+    | Setting this to `false` improves performance, but omits the key `locations` from errors,
+    | see https://spec.graphql.org/October2021/#sec-Errors.Error-result-format.
+    |
+    */
+
+    'parse_source_location' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -322,8 +378,10 @@ return [
     | Transactional Mutations
     |--------------------------------------------------------------------------
     |
-    | If set to true, built-in directives that mutate models will be
-    | wrapped in a transaction to ensure atomicity.
+    | If set to true, the execution of built-in directives that mutate models
+    | will be wrapped in a transaction to ensure atomicity.
+    | The transaction is committed after the root field resolves,
+    | thus errors in nested fields do not cause a rollback.
     |
     */
 
@@ -405,6 +463,11 @@ return [
         'storage_ttl' => env('LIGHTHOUSE_SUBSCRIPTION_STORAGE_TTL', null),
 
         /*
+         * Encrypt subscription channels by prefixing their names with "private-encrypted-"?
+         */
+        'encrypted_channels' => env('LIGHTHOUSE_SUBSCRIPTION_ENCRYPTED', false),
+
+        /*
          * Default subscription broadcaster.
          */
         'broadcaster' => env('LIGHTHOUSE_BROADCASTER', 'pusher'),
@@ -416,15 +479,20 @@ return [
             'log' => [
                 'driver' => 'log',
             ],
-            'pusher' => [
-                'driver' => 'pusher',
-                'routes' => SubscriptionRouter::class . '@pusher',
-                'connection' => 'pusher',
-            ],
             'echo' => [
                 'driver' => 'echo',
                 'connection' => env('LIGHTHOUSE_SUBSCRIPTION_REDIS_CONNECTION', 'default'),
                 'routes' => SubscriptionRouter::class . '@echoRoutes',
+            ],
+            'pusher' => [
+                'driver' => 'pusher',
+                'connection' => 'pusher',
+                'routes' => SubscriptionRouter::class . '@pusher',
+            ],
+            'reverb' => [
+                'driver' => 'pusher',
+                'connection' => 'reverb',
+                'routes' => SubscriptionRouter::class . '@reverb',
             ],
         ],
 
@@ -474,5 +542,28 @@ return [
          * Location of resolver classes when resolving the `_entities` field.
          */
         'entities_resolver_namespace' => 'App\\GraphQL\\Entities',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tracing
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for tracing support.
+    |
+    */
+
+    'tracing' => [
+        /*
+         * Driver used for tracing.
+         *
+         * Accepts the fully qualified class name of a class that implements Nuwave\Lighthouse\Tracing\Tracing.
+         * Lighthouse provides:
+         * - Nuwave\Lighthouse\Tracing\ApolloTracing\ApolloTracing::class
+         * - Nuwave\Lighthouse\Tracing\FederatedTracing\FederatedTracing::class
+         *
+         * In Lighthouse v7 the default will be changed to 'Nuwave\Lighthouse\Tracing\FederatedTracing\FederatedTracing::class'.
+         */
+        'driver' => ApolloTracing::class,
     ],
 ];


### PR DESCRIPTION
Configuration files in the Laravel ecosystem frequently change from release to release, with defaults for backwards compatibility with older configurations.  This PR republishes the configuration file for Lighthouse, allowing us to enable validation caching, and to take advantage of opcache-based query caching.  The rest of the changes are boilerplate.

In theory, enabling the validation cache should improve performance for high-traffic instances, but it's hard to estimate how beneficial these changes will be without testing them in the wild.  In local testing, I observed a ~20% improvement in query processing overhead.