### PR TITLE
Retain project role when users re-added to project via LDAP

### DIFF
--- a/app/Models/ProjectRoleHistory.php
+++ b/app/Models/ProjectRoleHistory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ProjectRole;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $projectid
+ * @property int $userid
+ * @property ProjectRole|null $role
+ * @property Carbon $timestamp
+ * @property Project $project
+ * @property User $user
+ *
+ * @mixin Builder<ProjectRoleHistory>
+ */
+class ProjectRoleHistory extends Model
+{
+    protected $table = 'project_role_history';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'projectid',
+        'userid',
+        'role',
+        'timestamp',
+    ];
+
+    protected $casts = [
+        'projectid' => 'integer',
+        'userid' => 'integer',
+        'role' => ProjectRole::class,
+        'timestamp' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Project, $this>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'projectid');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'userid');
+    }
+}

--- a/app/Utils/LdapUtils.php
+++ b/app/Utils/LdapUtils.php
@@ -6,6 +6,7 @@ namespace App\Utils;
 
 use App\Enums\ProjectRole;
 use App\Models\Project;
+use App\Models\ProjectRoleHistory;
 use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Log;
@@ -58,8 +59,16 @@ class LdapUtils
             }
 
             if ($matches_ldap_filter && !$relationship_already_exists) {
-                $project->users()->attach($user->id, ['role' => ProjectRole::USER]);
-                Log::info("Added user $user->email to project $project->name.");
+                // Find the most recent role for this user and project.
+                $previous_role = ProjectRoleHistory::where('projectid', $project->id)
+                    ->where('userid', $user->id)
+                    ->whereNotNull('role')
+                    ->latest('timestamp')
+                    ->latest('id')
+                    ->value('role') ?? ProjectRole::USER;
+
+                $project->users()->attach($user->id, ['role' => $previous_role]);
+                Log::info("Added user $user->email to project $project->name with role $previous_role->name.");
             } elseif (!$matches_ldap_filter && $relationship_already_exists) {
                 $project->users()->detach($user->id);
                 Log::info("Removed user $user->email from project $project->name.");

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -314,6 +314,8 @@ add_feature_test_in_transaction(/Feature/GraphQL/Mutations/CreateCoverageDiffMut
 
 add_feature_test_in_transaction(/Feature/Jobs/PruneBuildsTest)
 
+add_feature_test_in_transaction(/Feature/Database/ProjectRoleHistoryTest)
+
 add_feature_test_in_transaction(/Feature/Jobs/PruneEmailsTest)
 
 add_feature_test_in_transaction(/Feature/Jobs/ComputeCoverageDifferenceTest)

--- a/database/migrations/2026_07_28_175356_project_role_history.php
+++ b/database/migrations/2026_07_28_175356_project_role_history.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('
+            CREATE TABLE IF NOT EXISTS project_role_history (
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                projectid bigint REFERENCES project(id) ON DELETE CASCADE NOT NULL,
+                userid bigint REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+                role projectrole,
+                timestamp timestamp(3) with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+
+        DB::statement("
+            CREATE OR REPLACE FUNCTION log_project_role_change() RETURNS TRIGGER AS $$
+            BEGIN
+                IF (TG_OP = 'DELETE') THEN
+                    -- Only log if the project and user still exist.
+                    -- If they are being deleted, the history rows would be cascaded.
+                    IF EXISTS (SELECT 1 FROM project WHERE id = OLD.projectid) AND
+                       EXISTS (SELECT 1 FROM users WHERE id = OLD.userid) THEN
+                        INSERT INTO project_role_history (projectid, userid, role)
+                        VALUES (OLD.projectid, OLD.userid, NULL);
+                    END IF;
+                    RETURN OLD;
+                ELSIF (TG_OP = 'UPDATE') THEN
+                    IF (OLD.role IS DISTINCT FROM NEW.role) THEN
+                        INSERT INTO project_role_history (projectid, userid, role)
+                        VALUES (NEW.projectid, NEW.userid, NEW.role);
+                    END IF;
+                    RETURN NEW;
+                ELSIF (TG_OP = 'INSERT') THEN
+                    INSERT INTO project_role_history (projectid, userid, role)
+                    VALUES (NEW.projectid, NEW.userid, NEW.role);
+                    RETURN NEW;
+                END IF;
+                RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+        ");
+
+        DB::statement('
+            CREATE TRIGGER project_role_history_trigger
+            AFTER INSERT OR UPDATE OR DELETE ON user2project
+            FOR EACH ROW EXECUTE FUNCTION log_project_role_change();
+        ');
+    }
+
+    public function down(): void
+    {
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5143,6 +5143,12 @@ parameters:
 			path: app/Utils/DatabaseCleanupUtils.php
 
 		-
+			rawMessage: Cannot access property $name on mixed.
+			identifier: property.nonObject
+			count: 1
+			path: app/Utils/LdapUtils.php
+
+		-
 			rawMessage: Property App\Utils\NoteCreator::$buildid has no type specified.
 			identifier: missingType.property
 			count: 1
@@ -22840,9 +22846,21 @@ parameters:
 			path: tests/Feature/Jobs/ComputeCoverageDifferenceTest.php
 
 		-
+			rawMessage: Access to an undefined property Illuminate\Database\Eloquent\Relations\Pivot::$role.
+			identifier: property.notFound
+			count: 3
+			path: tests/Feature/LdapIntegration.php
+
+		-
 			rawMessage: Cannot access offset 0 on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 49
+			count: 52
+			path: tests/Feature/LdapIntegration.php
+
+		-
+			rawMessage: 'Cannot access property $pivot on (App\Models\User&object{pivot: Illuminate\Database\Eloquent\Relations\Pivot})|null.'
+			identifier: property.nonObject
+			count: 3
 			path: tests/Feature/LdapIntegration.php
 
 		-

--- a/tests/Feature/Database/ProjectRoleHistoryTest.php
+++ b/tests/Feature/Database/ProjectRoleHistoryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature\Database;
+
+use App\Enums\ProjectRole;
+use App\Models\ProjectRoleHistory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Tests\Traits\CreatesProjects;
+
+class ProjectRoleHistoryTest extends TestCase
+{
+    use CreatesProjects;
+    use DatabaseTransactions;
+
+    public function testTriggerLogsInsert(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $history = ProjectRoleHistory::firstOrFail();
+        $this->assertTrue($history->user->is($user));
+        $this->assertTrue($history->project->is($project));
+        $this->assertEquals(ProjectRole::USER, $history->role);
+    }
+
+    public function testTriggerLogsUpdate(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $project->users()->updateExistingPivot($user->id, ['role' => ProjectRole::ADMINISTRATOR]);
+
+        $this->assertEquals(2, ProjectRoleHistory::count());
+        $history = ProjectRoleHistory::latest('id')->firstOrFail();
+        $this->assertTrue($history->user->is($user));
+        $this->assertTrue($history->project->is($project));
+        $this->assertEquals(ProjectRole::ADMINISTRATOR, $history->role);
+    }
+
+    public function testTriggerLogsDelete(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $project->users()->detach($user->id);
+
+        $this->assertEquals(2, ProjectRoleHistory::count());
+        $history = ProjectRoleHistory::latest('id')->firstOrFail();
+        $this->assertTrue($history->user->is($user));
+        $this->assertTrue($history->project->is($project));
+        $this->assertNull($history->role);
+    }
+
+    public function testTriggerDoesNotLogUpdateWithoutRoleChange(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $project->users()->updateExistingPivot($user->id, ['emailtype' => 1]);
+
+        $this->assertEquals(1, ProjectRoleHistory::count());
+    }
+
+    public function testTriggerDoesNotCrashOnProjectDelete(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $this->assertEquals(1, ProjectRoleHistory::count());
+
+        $project->delete();
+
+        // ProjectRoleHistory should be empty because of ON DELETE CASCADE.
+        $this->assertEquals(0, ProjectRoleHistory::count());
+    }
+
+    public function testTriggerDoesNotCrashOnUserDelete(): void
+    {
+        $project = $this->makePublicProject();
+        $user = User::factory()->create();
+
+        $project->users()->attach($user->id, [
+            'role' => ProjectRole::USER,
+            'emailtype' => 0,
+            'emailcategory' => 0,
+            'emailsuccess' => 0,
+            'emailmissingsites' => 0,
+        ]);
+
+        $this->assertEquals(1, ProjectRoleHistory::count());
+
+        $user->delete();
+
+        // ProjectRoleHistory should be empty because of ON DELETE CASCADE.
+        $this->assertEquals(0, ProjectRoleHistory::count());
+    }
+}

--- a/tests/Feature/LdapIntegration.php
+++ b/tests/Feature/LdapIntegration.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\ProjectRole;
 use App\Models\Project;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -434,5 +435,40 @@ class LdapIntegration extends TestCase
         $this->projects['only_group_1']->save();
 
         $this->artisan('ldap:sync_projects');
+    }
+
+    public function testRolesAreRestoredFromHistory(): void
+    {
+        // Create the user in the database
+        $this->post('/login', [
+            'email' => $this->users['group_1_only_1']->getAttribute('uid')[0],
+            'password' => $this->users['group_1_only_1']->getAttribute('userpassword')[0],
+        ])->assertRedirect('/');
+
+        $user = \App\Models\User::where(['email' => $this->users['group_1_only_1']->getAttribute('uid')[0]])->firstOrFail();
+        $project = $this->projects['only_group_1'];
+
+        // Initial sync should add the user as a USER
+        $this->artisan('ldap:sync_projects');
+        $this->assertEquals(ProjectRole::USER->value, $project->users()->withPivot('role')->where('userid', $user->id)->first()->pivot->role);
+
+        // Elevate the user to ADMINISTRATOR
+        $project->users()->updateExistingPivot($user->id, ['role' => ProjectRole::ADMINISTRATOR]);
+        $this->assertEquals(ProjectRole::ADMINISTRATOR->value, $project->users()->withPivot('role')->where('userid', $user->id)->first()->pivot->role);
+
+        // Change the LDAP filter so the user is removed
+        $project->ldapfilter = '(uid=nonexistent)';
+        $project->save();
+        $this->artisan('ldap:sync_projects');
+        $this->assertNotContains($user->email, $project->users()->pluck('email'));
+
+        // Change the LDAP filter back so the user is added again
+        $project->ldapfilter = '(uid=*group_1*)';
+        $project->save();
+        $this->artisan('ldap:sync_projects');
+
+        // Verify the user was added back with their previous role (ADMINISTRATOR)
+        $this->assertContains($user->email, $project->users()->pluck('email'));
+        $this->assertEquals(ProjectRole::ADMINISTRATOR->value, $project->users()->withPivot('role')->where('userid', $user->id)->first()->pivot->role);
     }
 }


### PR DESCRIPTION
CDash currently adds all LDAP-controlled project members at the most basic user level, with no ability to have admins for LDAP-managed projects.  Users who are added as project admins by direct database manipulation have their admin status revoked if the LDAP server fails temporarily.  This PR adds an "audit log" of sorts, storing the history of project membership.  The log is used to restore users at their previous access level when regaining access to an LDAP-managed project.