### PR TITLE
Fix flaky `ProjectSettingsPageTest`

### DIFF
--- a/tests/Browser/Pages/ProjectSettingsPageTest.php
+++ b/tests/Browser/Pages/ProjectSettingsPageTest.php
@@ -307,8 +307,9 @@ class ProjectSettingsPageTest extends BrowserTestCase
                 ->waitFor('@test-measurements-tab-link')
                 ->click('@test-measurements-tab-link')
                 ->whenAvailable('@test-measurements-tab', function (Browser $browser) use ($m1, $m2): void {
-                    $browser->assertSee('No pinned test measurements yet.')
+                    $browser->waitForText('No pinned test measurements yet.')
                         ->type('@new-test-measurement-input', $m1)
+                        ->waitFor('@add-test-measurement-button')
                         ->click('@add-test-measurement-button')
                         ->waitForText($m1)
                         ->assertDontSee('No pinned test measurements yet.')


### PR DESCRIPTION
This test has been flaky in CI since it was added, although with a relatively low failure rate.  The failure rate significantly increased on https://github.com/Kitware/CDash/pull/3807 for unknown reasons.  This PR addresses the race condition causing the flaky behavior.