### PR TITLE
Allow changing user roles for LDAP-managed projects

### DIFF
--- a/app/Http/Controllers/ProjectMembersController.php
+++ b/app/Http/Controllers/ProjectMembersController.php
@@ -22,6 +22,7 @@ final class ProjectMembersController extends AbstractProjectController
         return $this->vue('project-members-page', 'Members', [
             'project-id' => $this->project->Id,
             'user-id' => $user?->id,
+            'can-update' => $user?->can('update', $eloquentProject) ?? false,
             'can-invite-users' => $user?->can('inviteUser', $eloquentProject) ?? false,
             'can-remove-users' => $user?->can('removeUser', $eloquentProject) ?? false,
             'can-join-project' => $user?->can('join', $eloquentProject) ?? false,

--- a/resources/js/vue/components/ProjectMembersPage.vue
+++ b/resources/js/vue/components/ProjectMembersPage.vue
@@ -220,7 +220,7 @@
       >
         <template #role="{ props: { user: user, value: role } }">
           <select
-            v-if="canInviteUsers && parseInt(user.id) !== parseInt(userId)"
+            v-if="canUpdate && parseInt(user.id) !== parseInt(userId)"
             class="tw-select tw-select-bordered tw-w-full tw-select-sm"
             data-test="role-select"
             @change="changeUserRole($event, user)"
@@ -285,6 +285,11 @@ export default {
 
     userId: {
       type: [Number, null],
+      required: true,
+    },
+
+    canUpdate: {
+      type: Boolean,
       required: true,
     },
 


### PR DESCRIPTION
It's currently impossible to change user roles in LDAP-managed projects via the UI.  In light of https://github.com/Kitware/CDash/pull/3880, there is no longer a reason for this to be prohibited.  This PR changes the behavior to allow project and global administrators to change user roles for LDAP-managed projects.