### PR TITLE
Fix: Allow BaselineImage as alternative to ValidImage

### DIFF
--- a/resources/js/vue/components/TestDetailsPage.vue
+++ b/resources/js/vue/components/TestDetailsPage.vue
@@ -567,7 +567,8 @@ export default {
       const testImages = [];
 
       this.test.testImages.edges.forEach(({ node: image }) => {
-        if (image.role === 'ValidImage') {
+        // BaselineImage is accepted as an alternative to ValidImage for backwards compatibility.
+        if (image.role === 'ValidImage' || image.role === 'BaselineImage') {
           validImages.push(image);
         } else if (image.role === 'TestImage') {
           testImages.push(image);

--- a/tests/Browser/Pages/TestsIdPageTest.php
+++ b/tests/Browser/Pages/TestsIdPageTest.php
@@ -330,10 +330,20 @@ class TestsIdPageTest extends BrowserTestCase
         });
     }
 
+    public static function validImageRoleProvider(): array
+    {
+        return [
+            'ValidImage' => ['ValidImage'],
+            // BaselineImage is accepted as an alternative to ValidImage for backwards compatibility.
+            'BaselineImage' => ['BaselineImage'],
+        ];
+    }
+
     /**
      * @throws RandomException
      */
-    public function testImagesSectionVisibility(): void
+    #[DataProvider('validImageRoleProvider')]
+    public function testImagesSectionVisibility(string $validImageRole): void
     {
         /** @var Test $test */
         $test = $this->createTest([
@@ -367,7 +377,7 @@ class TestsIdPageTest extends BrowserTestCase
                 });
         });
 
-        // Add a ValidImage for interactive comparison
+        // Add a ValidImage (or BaselineImage) for interactive comparison
         $image2 = Image::create([
             'img' => (string) Str::uuid(),
             'extension' => 'png',
@@ -375,14 +385,18 @@ class TestsIdPageTest extends BrowserTestCase
         ]);
         $test->testImages()->create([
             'imgid' => $image2->id,
-            'role' => 'ValidImage',
+            'role' => $validImageRole,
         ]);
 
-        $this->browse(function (Browser $browser) use ($test): void {
+        $this->browse(function (Browser $browser) use ($test, $validImageRole): void {
             $browser->visit("/tests/{$test->id}")
                 ->waitForText($test->testname)
                 ->waitFor('@interactive-image')
-                ->assertVisible('@interactive-image');
+                ->assertVisible('@interactive-image')
+                ->within('@interactive-image', function (Browser $browser) use ($validImageRole): void {
+                    $browser->assertPresent('img[alt="TestImage"]')
+                        ->assertPresent('img[alt="' . $validImageRole . '"]');
+                });
         });
     }
 


### PR DESCRIPTION
As per the docs in `docs/test_measurements.md`, `BaselineImage` should be accepted as an alternative to `ValidImage` for backwards compatibility purposes.  I wasn't aware of this in my recent refactoring efforts, and accidentally removed support for `BaselineImage`.  This PR re-adds it, with appropriate tests.

Fixes https://github.com/Kitware/CDash/issues/3883.