### PR TITLE
Adjust XML schema for instrumentation changes

### DIFF
--- a/app/Validators/Schemas/Build.xsd
+++ b/app/Validators/Schemas/Build.xsd
@@ -123,6 +123,7 @@
                                               <xs:element maxOccurs="unbounded" ref="Outputs"/>
                                             </xs:choice>
                                           </xs:sequence>
+                                          <xs:attribute name="cmakeContent" use="optional"/>
                                           <xs:attribute name="command" use="required"/>
                                           <xs:attribute name="workingDir" use="required"/>
                                           <xs:attribute name="config" use="required"/>
@@ -131,7 +132,7 @@
                                           <xs:attribute name="result" use="required"/>
                                           <xs:attribute name="source" use="required"/>
                                           <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                                          <xs:attribute name="version" use="optional" type="xs:integer"/>
                                         </xs:complexType>
                                       </xs:element>
                                       <xs:element name="Link">
@@ -142,6 +143,7 @@
                                               <xs:element maxOccurs="unbounded" ref="Outputs"/>
                                             </xs:choice>
                                           </xs:sequence>
+                                          <xs:attribute name="cmakeContent" use="optional"/>
                                           <xs:attribute name="command" use="required"/>
                                           <xs:attribute name="workingDir" use="required"/>
                                           <xs:attribute name="config" use="required"/>
@@ -149,7 +151,7 @@
                                           <xs:attribute name="language" use="required"/>
                                           <xs:attribute name="result" use="required"/>
                                           <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                                          <xs:attribute name="version" use="optional" type="xs:integer"/>
                                         </xs:complexType>
                                       </xs:element>
                                     </xs:choice>
@@ -173,12 +175,13 @@
                               <xs:sequence>
                                 <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
                               </xs:sequence>
+                              <xs:attribute name="cmakeContent" use="optional"/>
                               <xs:attribute name="command" use="required"/>
                               <xs:attribute name="workingDir" use="required"/>
                               <xs:attribute name="duration" use="required" type="xs:integer"/>
                               <xs:attribute name="result" use="required"/>
                               <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="optional" type="xs:integer"/>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CmakeInstall">
@@ -186,12 +189,13 @@
                               <xs:sequence>
                                 <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
                               </xs:sequence>
+                              <xs:attribute name="cmakeContent" use="optional"/>
                               <xs:attribute name="command" use="required"/>
                               <xs:attribute name="workingDir" use="required"/>
                               <xs:attribute name="duration" use="required" type="xs:integer"/>
                               <xs:attribute name="result" use="required"/>
                               <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="optional" type="xs:integer"/>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="Custom">
@@ -202,12 +206,13 @@
                                   <xs:element maxOccurs="unbounded" ref="Outputs"/>
                                 </xs:choice>
                               </xs:sequence>
+                              <xs:attribute name="cmakeContent" use="optional"/>
                               <xs:attribute name="command" use="required"/>
                               <xs:attribute name="workingDir" use="required"/>
                               <xs:attribute name="duration" use="required" type="xs:integer"/>
                               <xs:attribute name="result" use="required"/>
                               <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="optional" type="xs:integer"/>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="Install">
@@ -215,12 +220,13 @@
                               <xs:sequence>
                                 <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
                               </xs:sequence>
+                              <xs:attribute name="cmakeContent" use="optional"/>
                               <xs:attribute name="command" use="required"/>
                               <xs:attribute name="workingDir" use="required"/>
                               <xs:attribute name="duration" use="required" type="xs:integer"/>
                               <xs:attribute name="result" use="required"/>
                               <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                              <xs:attribute name="version" use="required" type="xs:integer"/>
+                              <xs:attribute name="version" use="optional" type="xs:integer"/>
                             </xs:complexType>
                           </xs:element>
                         </xs:choice>

--- a/app/Validators/Schemas/Configure.xsd
+++ b/app/Validators/Schemas/Configure.xsd
@@ -55,7 +55,7 @@
                           <xs:attribute name="duration" use="required" type="xs:integer"/>
                           <xs:attribute name="result" use="required"/>
                           <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                          <xs:attribute name="version" use="optional"  type="xs:integer"/>
+                          <xs:attribute name="version" use="optional" type="xs:integer"/>
                         </xs:complexType>
                       </xs:element>
                     </xs:choice>

--- a/app/Validators/Schemas/Configure.xsd
+++ b/app/Validators/Schemas/Configure.xsd
@@ -35,12 +35,13 @@
                           <xs:sequence>
                             <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
                           </xs:sequence>
+                          <xs:attribute name="cmakeContent" use="optional"/>
                           <xs:attribute name="command" use="required"/>
                           <xs:attribute name="workingDir" use="required"/>
                           <xs:attribute name="duration" use="required" type="xs:integer"/>
                           <xs:attribute name="result" use="required"/>
                           <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                          <xs:attribute name="version" use="optional" type="xs:integer"/>
                         </xs:complexType>
                       </xs:element>
                       <xs:element name="Configure">
@@ -48,12 +49,13 @@
                           <xs:sequence>
                             <xs:element maxOccurs="unbounded" ref="NamedMeasurement"/>
                           </xs:sequence>
+                          <xs:attribute name="cmakeContent" use="optional"/>
                           <xs:attribute name="command" use="required"/>
                           <xs:attribute name="workingDir" use="required"/>
                           <xs:attribute name="duration" use="required" type="xs:integer"/>
                           <xs:attribute name="result" use="required"/>
                           <xs:attribute name="timeStart" use="required" type="xs:integer"/>
-                          <xs:attribute name="version" use="required" type="xs:integer"/>
+                          <xs:attribute name="version" use="optional"  type="xs:integer"/>
                         </xs:complexType>
                       </xs:element>
                     </xs:choice>

--- a/tests/Feature/SubmissionValidation.php
+++ b/tests/Feature/SubmissionValidation.php
@@ -51,6 +51,7 @@ class SubmissionValidation extends TestCase
         $this::assertTrue($this->submit('valid_Configure1.xml'), 'Submission of valid_Configure1.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Configure2.xml'), 'Submission of valid_Configure2.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Build.xml'), 'Submission of valid_Build.xml was not successful when it should have passed.');
+        $this::assertTrue($this->submit('valid_instrumentation_Build.xml'), 'Submission of valid_instrumentation_Build.xml was not successful when it should have passed.');
     }
 
     /** Check that error messages are logged but submission succeeds
@@ -64,6 +65,7 @@ class SubmissionValidation extends TestCase
         $this::assertTrue($this->submit('valid_Configure1.xml'), 'Submission of valid_Configure1.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Configure2.xml'), 'Submission of valid_Configure2.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Build.xml'), 'Submission of valid_Build.xml was not successful when it should have passed.');
+        $this::assertTrue($this->submit('valid_instrumentation_Build.xml'), 'Submission of valid_instrumentation_Build.xml was not successful when it should have passed.');
     }
 
     /** Check that error messages are logged but submission succeeds
@@ -77,6 +79,7 @@ class SubmissionValidation extends TestCase
         $this::assertTrue($this->submit('valid_Configure1.xml'), 'Submission of valid_Configure1.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Configure2.xml'), 'Submission of valid_Configure2.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Build.xml'), 'Submission of valid_Build.xml was not successful when it should have passed.');
+        $this::assertTrue($this->submit('valid_instrumentation_Build.xml'), 'Submission of valid_instrumentation_Build.xml was not successful when it should have passed.');
     }
 
     /** Check that the submission is dependent upon passing validation
@@ -90,6 +93,7 @@ class SubmissionValidation extends TestCase
         $this::assertTrue($this->submit('valid_Configure1.xml'), 'Submission of valid_Configure1.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Configure2.xml'), 'Submission of valid_Configure2.xml was not successful when it should have passed.');
         $this::assertTrue($this->submit('valid_Build.xml'), 'Submission of valid_Build.xml was not successful when it should have passed.');
+        $this::assertTrue($this->submit('valid_instrumentation_Build.xml'), 'Submission of valid_instrumentation_Build.xml was not successful when it should have passed.');
     }
 
     public function tearDown(): void

--- a/tests/data/XmlValidation/valid_instrumentation_Build.xml
+++ b/tests/data/XmlValidation/valid_instrumentation_Build.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site BuildName="dummy_build_name"
+  BuildStamp="dummy_stamp"
+  Name="dummy_name"
+  >
+	<Build>
+		<StartDateTime>Aug 04 09:20 EDT</StartDateTime>
+		<StartBuildTime>1785849630</StartBuildTime>
+		<SourceDirectory>../cdash-examples/shared-src</SourceDirectory>
+		<BinaryDirectory>../cdash-examples/5-instrumentation/bin</BinaryDirectory>
+		<BuildCommand>cmake --build . --config "Release"</BuildCommand>
+		<Failure type="Error">
+			<!-- Meta-information about the build action -->
+			<Action>
+				<TargetName>error</TargetName>
+				<Language>C++</Language>
+				<SourceFile>error.cxx</SourceFile>
+				<OutputFile>CMakeFiles/error.dir/error.cxx.o</OutputFile>
+				<OutputType>object file</OutputType>
+			</Action>
+			<!-- Details of command -->
+			<Command>
+				<WorkingDirectory>./cdash-examples/5-instrumentation/bin</WorkingDirectory>
+				<Argument>/usr/bin/c++</Argument>
+				<Argument>--coverage</Argument>
+				<Argument>-g</Argument>
+				<Argument>-MD</Argument>
+				<Argument>-MT</Argument>
+				<Argument>CMakeFiles/error.dir/error.cxx.o</Argument>
+				<Argument>-MF</Argument>
+				<Argument>CMakeFiles/error.dir/error.cxx.o.d</Argument>
+				<Argument>-o</Argument>
+				<Argument>CMakeFiles/error.dir/error.cxx.o</Argument>
+				<Argument>-c</Argument>
+				<Argument>../cdash-examples/shared-src/error.cxx</Argument>
+			</Command>
+			<!-- Result of command -->
+			<Result>
+				<StdOut/>
+				<StdErr>../cdash-examples/shared-src/error.cxx: In function ‘int main(int, char**)’:
+../cdash-examples/shared-src/error.cxx:3:3: error: ‘asdf’ was not declared in this scope
+    3 |   asdf();
+      |   ^~~~</StdErr>
+				<ExitCondition>1</ExitCondition>
+			</Result>
+		</Failure>
+		<Targets>
+			<Target name="fails" type="EXECUTABLE">
+				<Commands>
+					<Compile cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/usr/bin/c++ (truncated)" config="Debug" duration="446" language="C++" result="0" source="/home/softhat/Work/LANL/cdash-examples/shared-src/fails.cxx" timeStart="1785849631748" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>1.5283203125</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="CMakeFiles/fails.dir/fails.cxx.o" size="31464"/>
+						</Outputs>
+					</Compile>
+					<Link cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/usr/bin/c++ (truncated)" config="Debug" duration="128" language="C++" result="0" timeStart="1785849632222" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>1.5283203125</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="fails" size="43104"/>
+						</Outputs>
+					</Link>
+				</Commands>
+			</Target>
+			<Target name="error" type="EXECUTABLE">
+				<Commands>
+					<Compile cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/usr/bin/c++ (truncated)" config="Debug" duration="25" language="C++" result="1" source="/home/softhat/Work/LANL/cdash-examples/shared-src/error.cxx" timeStart="1785849632402" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>1.5283203125</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="CMakeFiles/error.dir/error.cxx.o" size="0"/>
+						</Outputs>
+					</Compile>
+				</Commands>
+			</Target>
+			<Target name="passes" type="EXECUTABLE">
+				<Commands>
+					<Link cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/usr/bin/c++ (truncated)" config="Debug" duration="186" language="C++" result="0" timeStart="1785849631503" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>1.5283203125</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="passes" size="43056"/>
+						</Outputs>
+					</Link>
+					<Compile cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/usr/bin/c++ (truncated)" config="Debug" duration="513" language="C++" result="0" source="/home/softhat/Work/LANL/cdash-examples/shared-src/passes.cxx" timeStart="1785849630954" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+						<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+							<Value>1.5283203125</Value>
+						</NamedMeasurement>
+						<Outputs>
+							<Output name="CMakeFiles/passes.dir/passes.cxx.o" size="31024"/>
+						</Outputs>
+					</Compile>
+				</Commands>
+			</Target>
+		</Targets>
+		<Commands>
+			<CmakeBuild cmakeContent="content/cmake-2026-08-04T13-20-30-0838.json" command="/home/softhat/Work/cmake-build/bin/cmake (truncated)" duration="1566" result="2" timeStart="1785849630867" workingDir="/home/softhat/Work/LANL/cdash-examples/5-instrumentation/bin">
+				<NamedMeasurement type="numeric/double" name="AfterCPULoadAverage">
+					<Value>1.5283203125</Value>
+				</NamedMeasurement>
+			</CmakeBuild>
+		</Commands>
+		<Log Encoding="base64" Compression="bin/gzip"/>
+		<EndDateTime>Aug 04 09:20 EDT</EndDateTime>
+		<EndBuildTime>1785849632</EndBuildTime>
+		<ElapsedMinutes>0</ElapsedMinutes>
+	</Build>
+</Site>


### PR DESCRIPTION
Following the updates to CMake in
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11251 and
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/12117

update the schema for the Build.xml files to allow the new `cmakeContent` attribute and remove the required flag for the `version` attribute