### PR TITLE
Fix group filters for dynamic builds

### DIFF
--- a/app/cdash/app/Controller/Api/Index.php
+++ b/app/cdash/app/Controller/Api/Index.php
@@ -248,7 +248,16 @@ class Index extends ResultsApi
             $sql .= ' WHERE ' . implode(' AND ', $whereClauses);
             $sql .= ' AND b.starttime < ? ';
             $params[] = $this->endDate;
-            $sql .= $this->filterSQL;
+            // The API labels a dynamic row with the target group name ($rule->name),
+            // while g.name is the row's source group. Apply group-name filters to
+            // the target group; leave every other filter on the source row.
+            $dynamic_filter_sql = str_replace(
+                'g.name', '?', (string) $this->filterSQL, $group_filter_count);
+            $sql .= $dynamic_filter_sql;
+            $params = array_merge(
+                $params,
+                array_fill(0, $group_filter_count, $rule->name)
+            );
             $sql .= ' ORDER BY b.submittime DESC LIMIT 1 ';
 
             $union_parts[] = "($sql)";

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -709,8 +709,11 @@ set_tests_properties(donehandler PROPERTIES DEPENDS submission_assign_buildid)
 add_php_test(expiredbuildrules)
 set_tests_properties(expiredbuildrules PROPERTIES DEPENDS donehandler)
 
+add_php_test(dynamicbuildgroupfilters)
+set_tests_properties(dynamicbuildgroupfilters PROPERTIES DEPENDS expiredbuildrules)
+
 add_php_test(filterblocks)
-set_tests_properties(filterblocks PROPERTIES DEPENDS expiredbuildrules)
+set_tests_properties(filterblocks PROPERTIES DEPENDS dynamicbuildgroupfilters)
 
 add_php_test(indexnextprevious)
 set_tests_properties(indexnextprevious PROPERTIES DEPENDS filterblocks)

--- a/app/cdash/tests/test_dynamicbuildgroupfilters.php
+++ b/app/cdash/tests/test_dynamicbuildgroupfilters.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once __DIR__ . '/cdash_test_case.php';
+
+use App\Models\Project;
+use App\Models\Site;
+use CDash\Model\Build;
+use CDash\Model\BuildGroup;
+use Illuminate\Support\Facades\DB;
+
+class DynamicBuildGroupFiltersTestCase extends KWWebTestCase
+{
+    private const BUILD_NAME = 'dynamic-group-filter-build';
+    private const PROJECT_NAME = 'DynamicBuildGroupFiltersProject';
+
+    public function testGroupNameFiltersUseDisplayedGroup(): void
+    {
+        $projectid = $this->createProject(['Name' => self::PROJECT_NAME]);
+
+        $site = Site::create(['name' => 'dynamic-group-filter-site']);
+        $build = new Build();
+        $build->Name = self::BUILD_NAME;
+        $build->ProjectId = $projectid;
+        $build->SiteId = $site->id;
+        $build->SetStamp('20090223-0710-Nightly');
+        $build->StartTime = '2009-02-23 07:10:00';
+        $this->assertTrue($build->AddBuild());
+
+        $dynamic_group = new BuildGroup();
+        $dynamic_group->SetProjectId($projectid);
+        $dynamic_group->SetName('latest results');
+        $dynamic_group->SetType('Latest');
+        $dynamic_group->Save();
+
+        DB::table('build2grouprule')->insert([
+            'groupid' => $dynamic_group->GetId(),
+            'buildname' => $build->Name,
+            'siteid' => $site->id,
+            'parentgroupid' => $build->GroupId,
+            'starttime' => '1980-01-01 00:00:00',
+            'endtime' => '1980-01-01 00:00:00',
+        ]);
+
+        $this->assertGroupFilterReturnsOnly('Nightly', self::BUILD_NAME);
+        $this->assertGroupFilterReturnsOnly('latest results', self::BUILD_NAME);
+        $this->assertGroupAndBuildFilterReturnsNoGroups('latest results', 'other-build');
+
+        $dynamic_group->Delete();
+        remove_project_builds($projectid);
+        Project::findOrFail((int) $projectid)->delete();
+        $site->delete();
+    }
+
+    /** @return list<array{name: string}> */
+    private function getFilteredBuildGroups(string $group_name, string $build_name): array
+    {
+        $filter = http_build_query([
+            'filtercount' => 2,
+            'filtercombine' => 'and',
+            'showfilters' => 1,
+            'field1' => 'groupname',
+            'compare1' => 61,
+            'value1' => $group_name,
+            'field2' => 'buildname',
+            'compare2' => 61,
+            'value2' => $build_name,
+        ]);
+        $this->get(
+            $this->url . '/api/v1/index.php?project=' . self::PROJECT_NAME
+            . "&date=2009-02-23&$filter"
+        );
+        $content = $this->getBrowser()->getContent();
+        /** @var array{buildgroups: list<array{name: string}>} $response */
+        $response = json_decode($content, true);
+
+        return $response['buildgroups'];
+    }
+
+    private function assertGroupFilterReturnsOnly(string $group_name, string $build_name): void
+    {
+        $buildgroups = $this->getFilteredBuildGroups($group_name, $build_name);
+
+        $this->assertTrue(
+            count($buildgroups) > 0,
+            "Expected group-name filter to return '$group_name'"
+        );
+        foreach ($buildgroups as $buildgroup_response) {
+            $this->assertEqual($group_name, $buildgroup_response['name']);
+        }
+    }
+
+    private function assertGroupAndBuildFilterReturnsNoGroups(
+        string $group_name,
+        string $build_name,
+    ): void {
+        $this->assertEqual([], $this->getFilteredBuildGroups($group_name, $build_name));
+    }
+}


### PR DESCRIPTION
## Summary

Dynamic build rows are displayed under the target build group selected by their rule, but group-name filters were evaluated against the source build group.
This could return a row whose displayed group did not match the requested filter, while filtering for the displayed dynamic group could omit that row.

Apply group-name predicates to the dynamic rule's target group and continue applying all other predicates to the source build.

## Implementation

For each dynamic build-group rule:

- substitute the displayed target group for `g.name` predicates;
- bind the target group name as a query parameter;
- retain build name, site, date, and other filters on the source build.

## Tests

Added a dedicated integration test using a `Nightly` source build and a `Latest` target group, with the rule constrained by parent group, site, and build name. It verifies that:

- filtering for the source group does not leak a row displayed under the dynamic target group;
- filtering for the target group returns the dynamic row;
- an additional non-matching build-name filter still excludes the row.

The regression test fails without patching the controller and passes with this change.

Validation:

- PHP style check
- PHP static analysis
- Full CTest suite: 279/279 tests passed
