### PR TITLE
Include UUID in test user email addresses

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,12 +20,12 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'firstname' => fake()->unique()->firstName(),
-            'lastname' => fake()->unique()->lastName(),
-            'email' => fake()->unique()->safeEmail(),
+            'firstname' => Str::uuid()->toString(),
+            'lastname' => Str::uuid()->toString(),
+            'email' => Str::uuid()->toString() . '@example.com',
             'email_verified_at' => now(),
-            'password' => 'password',
-            'institution' => fake()->unique()->company(),
+            'password' => Str::uuid()->toString(),
+            'institution' => Str::uuid()->toString(),
             'remember_token' => Str::random(10),
             'admin' => false,
         ];
@@ -47,13 +47,6 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
-        ]);
-    }
-
-    public function normalUser(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'admin' => false,
         ]);
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,7 +20,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->createAdminUser();
-        User::factory(1000)->normalUser()->create();
+        User::factory(1000)->create();
 
         $this->createPublicProject();
         $this->createTrilinosProject();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22366,12 +22366,6 @@ parameters:
 			path: config/session.php
 
 		-
-			rawMessage: 'Method Database\Factories\UserFactory::definition() throws checked exception OverflowException but it''s missing from the PHPDoc @throws tag.'
-			identifier: missingType.checkedException
-			count: 4
-			path: database/factories/UserFactory.php
-
-		-
 			rawMessage: 'Only booleans are allowed in &&, string given on the left side.'
 			identifier: booleanAnd.leftNotBoolean
 			count: 1


### PR DESCRIPTION
The `fake()->unique()` method only produces unique test data within a single process.  CDash uses a unique CTest-based testing setup where collisions have occurred in CI due to multiple processes generating the same "unique" email address.  This PR resolves the issue by switching to a truly unique UUID for the test data.