### PR TITLE
Fix global admin vs project admin index page bug

### DIFF
--- a/app/cdash/include/common.php
+++ b/app/cdash/include/common.php
@@ -610,8 +610,12 @@ function get_dashboard_JSON($projectname, $date, &$response): void
     $userid = Auth::id();
     if ($userid) {
         $project = App\Models\Project::findOrFail((int) $project->Id);
-        $response['projectrole'] = $project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? ProjectRole::USER;
-        if ($response['projectrole'] === ProjectRole::ADMINISTRATOR) {
+        $projectrole = $project->users()->withPivot('role')->find((int) $userid)->pivot->role ?? ProjectRole::USER;
+        if (!$projectrole instanceof ProjectRole) {
+            $projectrole = ProjectRole::from($projectrole);
+        }
+        $response['projectrole'] = $projectrole->value;
+        if ($projectrole === ProjectRole::ADMINISTRATOR) {
             $response['user']['admin'] = 1;
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11896,6 +11896,18 @@ parameters:
 			path: app/cdash/include/common.php
 
 		-
+			rawMessage: 'Function get_dashboard_JSON() throws checked exception TypeError but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
+			rawMessage: 'Function get_dashboard_JSON() throws checked exception ValueError but it''s missing from the PHPDoc @throws tag.'
+			identifier: missingType.checkedException
+			count: 1
+			path: app/cdash/include/common.php
+
+		-
 			rawMessage: 'Function get_dates() has parameter $date with no type specified.'
 			identifier: missingType.parameter
 			count: 1


### PR DESCRIPTION
#3877 introduced a bug where the build management controls are visible to global administrators, but not project administrators.  This PR fixes the issue.