### PR TITLE
Reduce build notes pagination count from 100 to 10

### DIFF
--- a/resources/js/vue/components/BuildNotesPage.vue
+++ b/resources/js/vue/components/BuildNotesPage.vue
@@ -104,7 +104,7 @@ export default {
         query($buildId: ID!, $after: String) {
           build(id: $buildId) {
             id
-            notes(after: $after) {
+            notes(after: $after, first: 10) {
               edges {
                 node {
                   id


### PR DESCRIPTION
Notes are often quite large, meaning that a page of 100 notes can be 1MB+.  This PR reduces the pagination count from 100 to 10 to put initial content on the page faster.