### PR TITLE
Add `email:test` Artisan command

### DIFF
--- a/app/Console/Commands/EmailTestCommand.php
+++ b/app/Console/Commands/EmailTestCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\TestEmail;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Validator;
+
+class EmailTestCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'email:test {--email=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send a test email';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $email = $this->option('email');
+
+        $validator = Validator::make([
+            'email' => $email,
+        ], [
+            'email' => 'required|email',
+        ], [
+            'email.required' => 'You must specify the --email option',
+            'email.email' => "Invalid email address: $email",
+        ]);
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $error) {
+                $this->error($error);
+            }
+            return;
+        }
+
+        Mail::to($email)->send(new TestEmail());
+
+        $this->info("Test email sent to $email");
+    }
+}

--- a/app/Mail/TestEmail.php
+++ b/app/Mail/TestEmail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class TestEmail extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'CDash Test Email',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            text: 'email.email-configuration-test',
+        );
+    }
+}

--- a/app/cdash/tests/CMakeLists.txt
+++ b/app/cdash/tests/CMakeLists.txt
@@ -258,6 +258,8 @@ add_feature_test_in_transaction(/Feature/Jobs/PruneAuthTokensTest)
 
 add_feature_test_in_transaction(/Feature/UserCommand)
 
+add_feature_test_in_transaction(/Feature/EmailTestCommandTest)
+
 add_feature_test_in_transaction(/Feature/Jobs/NotifyExpiringAuthTokensTest)
 
 add_feature_test_in_transaction(/Feature/Jobs/PruneUploadsTest)

--- a/resources/views/email/email-configuration-test.blade.php
+++ b/resources/views/email/email-configuration-test.blade.php
@@ -1,0 +1,3 @@
+This is a test email from CDash.
+
+CDash instance URL: {{ config('app.url') }}

--- a/tests/Feature/EmailTestCommandTest.php
+++ b/tests/Feature/EmailTestCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\TestEmail;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class EmailTestCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testEmailTestCommand(): void
+    {
+        Mail::fake();
+
+        $email = 'test@example.com';
+
+        Artisan::call('email:test', ['--email' => $email]);
+
+        Mail::assertQueued(TestEmail::class, fn ($mail) => $mail->hasTo($email));
+
+        $output = trim(Artisan::output());
+        $this->assertStringContainsString("Test email sent to $email", $output);
+    }
+
+    public function testEmailTestCommandRequiresEmail(): void
+    {
+        Mail::fake();
+        Artisan::call('email:test');
+        $output = trim(Artisan::output());
+        $this->assertStringContainsString('You must specify the --email option', $output);
+        Mail::assertNothingSent();
+        Mail::assertNothingQueued();
+    }
+
+    public function testEmailTestCommandInvalidEmail(): void
+    {
+        Mail::fake();
+        Artisan::call('email:test', ['--email' => 'not-an-email']);
+        $output = trim(Artisan::output());
+        $this->assertStringContainsString('Invalid email address: not-an-email', $output);
+        Mail::assertNothingSent();
+        Mail::assertNothingQueued();
+    }
+}


### PR DESCRIPTION
This PR adds a new `php artisan email:test --email=<email>` command which allows administrators to easily verify that email is configured correctly.

Closes https://github.com/Kitware/CDash/issues/3727.