### PR TITLE
Increase `testoutput` ID column type to bigint

### DIFF
--- a/database/migrations/2026_08_19_200553_testoutput_id_column_type.php
+++ b/database/migrations/2026_08_19_200553_testoutput_id_column_type.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE build2test ALTER COLUMN outputid TYPE bigint');
+        DB::statement('ALTER TABLE testoutput ALTER COLUMN id TYPE bigint');
+        DB::statement('ALTER SEQUENCE test_id_seq AS bigint');
+    }
+
+    public function down(): void
+    {
+    }
+};


### PR DESCRIPTION
#3054 updated the `build2test` ID column, but failed to consider that the `testoutput` has a roughly equivalent number of rows and is subject to the same overflow issues.  This PR fixes the issue by increasing the `testoutput` ID column type from `integer` to `bigint`.  CDash administrators should note that this migration may take hours for some instances since both the `build2test` and `testoutput` tables must be rewritten.