### PR TITLE
Improve `testoutput` ID type migration efficiency

### DIFF
--- a/database/migrations/2026_08_19_200553_testoutput_id_column_type.php
+++ b/database/migrations/2026_08_19_200553_testoutput_id_column_type.php
@@ -6,9 +6,54 @@ use Illuminate\Support\Facades\DB;
 return new class extends Migration {
     public function up(): void
     {
+        // Disable triggers temporarily
+        DB::statement('ALTER TABLE build2test DISABLE TRIGGER ALL');
+        DB::statement('ALTER TABLE testoutput DISABLE TRIGGER ALL');
+
+        // Dynamically find and drop all indexes on testoutput EXCEPT the primary key
+        DB::statement("
+            DO $$
+            DECLARE
+                idx_name text;
+            BEGIN
+                FOR idx_name IN (
+                    SELECT i.relname
+                    FROM pg_index x
+                    JOIN pg_class c ON c.oid = x.indrelid
+                    JOIN pg_class i ON i.oid = x.indexrelid
+                    WHERE c.relname = 'testoutput'
+                      AND x.indisprimary = false
+                ) LOOP
+                    EXECUTE 'DROP INDEX IF EXISTS ' || idx_name;
+                END LOOP;
+            END $$;
+        ");
+
+        // Update build2test.outputid to bigint
         DB::statement('ALTER TABLE build2test ALTER COLUMN outputid TYPE bigint');
+
+        // Dynamically find the sequence associated with testoutput.id and alter it to bigint
+        DB::statement("
+            DO $$
+            DECLARE
+                seq_name text;
+            BEGIN
+                SELECT pg_get_serial_sequence('testoutput', 'id') INTO seq_name;
+                IF seq_name IS NOT NULL THEN
+                    EXECUTE 'ALTER SEQUENCE ' || seq_name || ' AS bigint';
+                END IF;
+            END $$;
+        ");
+
+        // Update testoutput.id to bigint
         DB::statement('ALTER TABLE testoutput ALTER COLUMN id TYPE bigint');
-        DB::statement('ALTER SEQUENCE test_id_seq AS bigint');
+
+        // Re-add only the output hash index
+        DB::statement('CREATE INDEX ON testoutput USING hash (output)');
+
+        // Re-enable triggers
+        DB::statement('ALTER TABLE build2test ENABLE TRIGGER ALL');
+        DB::statement('ALTER TABLE testoutput ENABLE TRIGGER ALL');
     }
 
     public function down(): void


### PR DESCRIPTION
#3942 added a migration which is likely to take a long time for most CDash instances.  In practice, most of the time was found to be caused by constraint validation and the need to rebuild all three `testoutput` indexes.  This PR updates the migration to create a hash index on only the most selective `output` column, and disable triggers/constraints during the update.  When these steps were run manually, the total running time on a large production system was substantially lower than the steps in the original migration.