### PR TITLE
Fix flaky `TestsIdPageTest`

### DIFF
--- a/tests/Browser/Pages/TestsIdPageTest.php
+++ b/tests/Browser/Pages/TestsIdPageTest.php
@@ -86,7 +86,6 @@ class TestsIdPageTest extends BrowserTestCase
 
             $browser->visit("/tests/{$test->id}")
                 ->waitForText($test->testname)
-                ->assertSee($this->build->name)
                 ->assertSeeIn('@test-status', 'Passed')
                 ->assertPresent('@test-name-link')
                 // Browser might decode %20 to space in href attribute


### PR DESCRIPTION
`TestsIdPageTest` contains an unnecessary build name assertion which does not wait for the text to exist first.  This PR removes the assertion, addressing the test flakiness.