### PR TITLE
Fix flaky `ProjectsPageTest`

### DIFF
--- a/tests/Browser/Pages/ProjectsPageTest.php
+++ b/tests/Browser/Pages/ProjectsPageTest.php
@@ -58,10 +58,9 @@ class ProjectsPageTest extends BrowserTestCase
         parent::tearDown();
     }
 
-    public function testCreateProjectButtonOnlyVisibleToAdminsByDefault(): void
+    public function testCreateProjectButtonVisibleToAdmins(): void
     {
         $this->users['admin'] = User::factory()->adminUser()->create();
-        $this->users['normal'] = User::factory()->create();
 
         $this->browse(function (Browser $browser): void {
             $browser->loginAs($this->users['admin'])
@@ -69,14 +68,29 @@ class ProjectsPageTest extends BrowserTestCase
                 ->whenAvailable('@projects-page', function (Browser $browser): void {
                     $browser->assertVisible('@create-project-button');
                 });
+        });
+    }
+
+    public function testCreateProjectButtonNotVisibleToRegularUsers(): void
+    {
+        $this->users['normal'] = User::factory()->create();
+
+        $this->browse(function (Browser $browser): void {
             $browser->loginAs($this->users['normal'])
                 ->visit('/projects')
                 ->whenAvailable('@projects-page', function (Browser $browser): void {
                     $browser->assertMissing('@create-project-button');
                 });
+        });
+    }
 
-            $browser
-                ->visit('/projects')
+    public function testCreateProjectButtonNotVisibleWhenSignedOut(): void
+    {
+        // Avoid redirecting to login page due to no projects
+        $this->projects['project1'] = $this->makePublicProject();
+
+        $this->browse(function (Browser $browser): void {
+            $browser->visit('/projects')
                 ->whenAvailable('@projects-page', function (Browser $browser): void {
                     $browser->assertMissing('@create-project-button');
                 });


### PR DESCRIPTION
`ProjectsPageTest::testCreateProjectButtonOnlyVisibleToAdminsByDefault` is currently flaky because the same Selenium session is used by three groups of assertions but the user session isn't wiped between them.  This PR fixes the issue by splitting the test into three distinct test cases, each with their own Selenium session, with proper logouts between them.