### PR TITLE
Factor out check database offline check

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -10,6 +10,7 @@ use App\Models\Site;
 use App\Rules\ProjectNameRule;
 use App\Utils\AuthTokenUtil;
 use App\Utils\SubmissionUtils;
+use App\Utils\SystemUtils;
 use App\Utils\UnparsedSubmissionProcessor;
 use CDash\Model\Build;
 use CDash\Model\Project;
@@ -129,12 +130,7 @@ final class SubmissionController extends AbstractProjectController
         }
 
         // Check if we can connect to the database before proceeding any further.
-        try {
-            DB::connection()->getPdo();
-            if (app()->isDownForMaintenance()) {
-                throw new Exception();
-            }
-        } catch (Exception) {
+        if (!SystemUtils::isDatabaseOnline()) {
             // Write a marker file so we know to process these files when the DB comes back up.
             if (!Storage::exists('DB_WAS_DOWN')) {
                 Storage::put('DB_WAS_DOWN', '');

--- a/app/Utils/SystemUtils.php
+++ b/app/Utils/SystemUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utils;
+
+use Exception;
+use Illuminate\Support\Facades\DB;
+
+class SystemUtils
+{
+    public static function isDatabaseOnline(): bool
+    {
+        // We consider the database to be offline if migrations are running.
+        if (app()->isDownForMaintenance()) {
+            return false;
+        }
+
+        try {
+            DB::connection()->getPdo();
+            return true;
+        } catch (Exception) {
+            return false;
+        }
+    }
+}

--- a/app/Utils/UnparsedSubmissionProcessor.php
+++ b/app/Utils/UnparsedSubmissionProcessor.php
@@ -86,7 +86,7 @@ class UnparsedSubmissionProcessor
         // Thus function will throw an exception if invalid data provided
         $this->parseBuildMetadata();
 
-        if ($this->checkDatabaseConnection() && !app()->isDownForMaintenance()) {
+        if (SystemUtils::isDatabaseOnline()) {
             return $this->initializeBuild();
         }
 
@@ -213,7 +213,7 @@ class UnparsedSubmissionProcessor
         $this->parseDataFileParameters();
         $ext = pathinfo($this->backupfilename, PATHINFO_EXTENSION);
 
-        $db_up = $this->checkDatabaseConnection() && !app()->isDownForMaintenance();
+        $db_up = SystemUtils::isDatabaseOnline();
         if ($db_up) {
             if (!is_numeric($this->buildid) || $this->buildid < 1) {
                 abort(Response::HTTP_NOT_FOUND, 'Build not found');
@@ -368,17 +368,6 @@ class UnparsedSubmissionProcessor
         $this->backupfilename = request()->query('filename');
 
         $this->getAuthTokenHash();
-    }
-
-    /** Check if CDash's database is down. */
-    private function checkDatabaseConnection(): bool
-    {
-        try {
-            DB::connection()->getPdo();
-            return true;
-        } catch (Exception) {
-            return false;
-        }
     }
 
     /** Write build metadata to disk in JSON format. */


### PR DESCRIPTION
The offline database check logic is duplicated.  There's no reason for it to be in the middle of submission processing business logic anyway.  This PR factors it out into a new `SystemUtils` utility class.